### PR TITLE
added the system aes key to reaper

### DIFF
--- a/lib/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/lib/microservice/warpdrive/core/service/taskplugin/job.go
@@ -561,6 +561,11 @@ func getVolumeMounts(ctx *task.PipelineCtx, pipelineTask *task.Task) []corev1.Vo
 		Name:      "job-config",
 		MountPath: ctx.ConfigMapMountDir,
 	})
+	resp = append(resp, corev1.VolumeMount{
+		Name:             "aes-key",
+		ReadOnly:         true,
+		MountPath:        "/etc/encryption",
+	})
 
 	return resp
 }
@@ -574,6 +579,18 @@ func getVolumes(jobName string) []corev1.Volume {
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: jobName,
 				},
+			},
+		},
+	})
+	resp = append(resp, corev1.Volume{
+		Name:         "aes-key",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName:  "zadig-aes-key",
+				Items:   []corev1.KeyToPath{{
+					Key:  "aesKey",
+					Path: "aes",
+				}},
 			},
 		},
 	})

--- a/lib/tool/crypto/aes.go
+++ b/lib/tool/crypto/aes.go
@@ -48,7 +48,7 @@ type Aes struct {
 func init() {
 	keyByte, err := ioutil.ReadFile(aesKeyFile)
 	if err != nil {
-		panic("Failed to read ")
+		panic("Failed to read aes encryption key from secret")
 	}
 	aesKey = string(keyByte)
 	S3key = string(keyByte)


### PR DESCRIPTION
### What this PR does / Why we need it:

Added the system integrated aes secret to reaper job

Problem Summary:

The reaper job will now mount a secret called zadig-aes-key to make sure it is using the system encryption key to do encryption/decryption

What's Changed:

-

How it Works:


## More information