### PR TITLE
fix convert panic

### DIFF
--- a/lib/tool/kube/serializer/decoder.go
+++ b/lib/tool/kube/serializer/decoder.go
@@ -55,7 +55,12 @@ func (d *decoder) YamlToUnstructured(manifest []byte) (*unstructured.Unstructure
 	obj := &unstructured.Unstructured{}
 	decoded, _, err := d.unstructuredSerializer.Decode(manifest, nil, obj)
 
-	return decoded.(*unstructured.Unstructured), err
+	u, ok := decoded.(*unstructured.Unstructured)
+	if !ok {
+		return nil, fmt.Errorf("object is not an Unstructured")
+	}
+
+	return u, err
 }
 
 func (d *decoder) YamlToRuntimeObject(manifest []byte) (runtime.Object, error) {


### PR DESCRIPTION
### What this PR does / Why we need it:

Problem Summary: function `YamlToUnstructured` will panic if the inupt yaml is bad. This pr fixed it.