### PR TITLE
ignore dotnet objects which are generated by vscode automatically

### DIFF
--- a/examples/voting-app/.gitignore
+++ b/examples/voting-app/.gitignore
@@ -1,0 +1,1 @@
+/*/dotnet/*/obj


### PR DESCRIPTION
### What this PR does / Why we need it:

Problem Summary:

Multiple files and dirs in dotnet samples are generated automatically in vscode editor with dotnet extension enabled, they should be excluded

What's Changed:

Add a .gitignore file to ignore them

How it Works:

Just Ignore them

## More information