### PR TITLE
fix: keyword filter not working while list repo from github

### DIFF
--- a/pkg/microservice/aslan/core/code/service/project.go
+++ b/pkg/microservice/aslan/core/code/service/project.go
@@ -18,9 +18,9 @@ package service
 
 import (
 	"context"
-
 	"github.com/google/go-github/v35/github"
 	"go.uber.org/zap"
+	"strings"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/codehost"
@@ -97,6 +97,9 @@ func CodehostListProjects(codehostID int, namespace, namespaceType, keyword stri
 
 		for _, repo := range repos {
 			if repo.Owner == nil || *repo.Owner.Login != namespace {
+				continue
+			}
+			if keyword != "" && !strings.Contains(repo.GetFullName(), keyword) {
 				continue
 			}
 			projects = append(projects, getProject(repo))


### PR DESCRIPTION
### What this PR does / Why we need it:
Problem Summary: When import service template from github, can't filter repo list by keyword.
![image](https://user-images.githubusercontent.com/22141303/122759049-1573bd00-d2cc-11eb-97b2-d920e6e914e4.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/44)
<!-- Reviewable:end -->
