### PR TITLE
hotfix for malfunctioning example

### DIFF
--- a/examples/nginx/yaml/nginx.yaml
+++ b/examples/nginx/yaml/nginx.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nginx3
+  name: nginx
   labels:
-    app: nginx3
+    app: nginx
     tier: backend
     version: "{{.nginxVersion4}}"
 spec:
@@ -12,24 +12,24 @@ spec:
   ports:
   - port: 80
   selector:
-    app: nginx3
+    app: nginx
     tier: backend
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx3
+  name: nginx
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: nginx3
+      app: nginx
       tier: backend
       version: "{{.nginxVersion4}}"
   template:
     metadata:
       labels:
-        app: nginx3
+        app: nginx
         tier: backend
         version: "{{.nginxVersion4}}"
     spec:

--- a/examples/nginx/yaml/nginx.yaml
+++ b/examples/nginx/yaml/nginx.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: nginx
     tier: backend
-    version: "{{.nginxVersion4}}"
+    version: "{{.nginxVersion}}"
 spec:
   type: NodePort
   ports:
@@ -25,13 +25,13 @@ spec:
     matchLabels:
       app: nginx
       tier: backend
-      version: "{{.nginxVersion4}}"
+      version: "{{.nginxVersion}}"
   template:
     metadata:
       labels:
         app: nginx
         tier: backend
-        version: "{{.nginxVersion4}}"
+        version: "{{.nginxVersion}}"
     spec:
       containers:
       - name: nginx-test


### PR DESCRIPTION
Signed-off-by: Min Min <minmin@koderover.com>

### What this PR does / Why we need it:
This is a hotfix for a bugged example which will cause the ingress to lost its backend service.

Problem Summary:
The ingress rule  service name does not match the real service name, causing a visiting problem for this example project.

### What is changed and how it works?

What's Changed:
changed the service name to match the ingress rules.

How it Works:
-


## More information

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/47)
<!-- Reviewable:end -->
