### PR TITLE
remove aurora and router phase 1

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -123,12 +123,30 @@ func HubServerServiceAddress() string {
 	return getServiceAddress(s.Name, s.Port)
 }
 
+func ClairServiceInfo() *setting.ServiceInfo {
+	return GetServiceByCode(setting.Clair)
+}
+
+func ClairServiceAddress() string {
+	s := ClairServiceInfo()
+	return getServiceAddress(s.Name, s.Port)
+}
+
 func CollieServiceInfo() *setting.ServiceInfo {
 	return GetServiceByCode(setting.Collie)
 }
 
 func CollieServiceAddress() string {
 	s := CollieServiceInfo()
+	return getServiceAddress(s.Name, s.Port)
+}
+
+func PoetryServiceInfo() *setting.ServiceInfo {
+	return GetServiceByCode(setting.Poetry)
+}
+
+func PoetryServiceAddress() string {
+	s := PoetryServiceInfo()
 	return getServiceAddress(s.Name, s.Port)
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,13 @@ import (
 	"github.com/koderover/zadig/pkg/setting"
 )
 
+// SystemAddress is the fully qualified domain name of the system, or an IP Address.
+// Port and protocol is required if necessary.
+// for example: foo.bar.com, https://for.bar.com, http://1.2.3.4:5678
+func SystemAddress() string {
+	return viper.GetString(setting.ENVSystemAddress)
+}
+
 func Mode() string {
 	mode := viper.GetString(setting.ENVMode)
 	if mode == "" {
@@ -61,14 +68,78 @@ func RequestLogFile() string {
 	return LogPath() + RequestLogName()
 }
 
-func AslanURL() string {
-	return viper.GetString(setting.ENVAslanURL)
-}
-
 func PoetryAPIServer() string {
 	return viper.GetString(setting.ENVPoetryAPIServer)
 }
 
 func PoetryAPIRootKey() string {
 	return viper.GetString(setting.ENVPoetryAPIRootKey)
+}
+
+func GetServiceByCode(code int) *setting.ServiceInfo {
+	return setting.Services[code]
+}
+
+func AslanServiceInfo() *setting.ServiceInfo {
+	return GetServiceByCode(setting.Aslan)
+}
+
+func AslanServiceAddress() string {
+	s := AslanServiceInfo()
+	return getServiceAddress(s.Name, s.Port)
+}
+
+func AslanServiceName() string {
+	return AslanServiceInfo().Name
+}
+
+func AslanServicePort() int32 {
+	return AslanServiceInfo().Port
+}
+
+func AslanxServiceInfo() *setting.ServiceInfo {
+	return GetServiceByCode(setting.Aslanx)
+}
+
+func AslanxServiceAddress() string {
+	s := AslanxServiceInfo()
+	return getServiceAddress(s.Name, s.Port)
+}
+
+func AslanxServiceName() string {
+	return AslanxServiceInfo().Name
+}
+
+func AslanxServicePort() int32 {
+	return AslanxServiceInfo().Port
+}
+
+func HubServerServiceInfo() *setting.ServiceInfo {
+	return GetServiceByCode(setting.HubServer)
+}
+
+func HubServerServiceAddress() string {
+	s := HubServerServiceInfo()
+	return getServiceAddress(s.Name, s.Port)
+}
+
+func CollieServiceInfo() *setting.ServiceInfo {
+	return GetServiceByCode(setting.Collie)
+}
+
+func CollieServiceAddress() string {
+	s := CollieServiceInfo()
+	return getServiceAddress(s.Name, s.Port)
+}
+
+func WarpDriveServiceInfo() *setting.ServiceInfo {
+	return GetServiceByCode(setting.WarpDrive)
+}
+
+func WarpDriveServiceName() string {
+	return WarpDriveServiceInfo().Name
+}
+
+func getServiceAddress(name string, port int32) string {
+	return fmt.Sprintf("http://%s:%d", name, port)
 }

--- a/pkg/microservice/aslan/config/config.go
+++ b/pkg/microservice/aslan/config/config.go
@@ -24,8 +24,7 @@ import (
 
 	"github.com/spf13/viper"
 
-	// init the config first
-	_ "github.com/koderover/zadig/pkg/config"
+	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/setting"
 )
 
@@ -84,7 +83,7 @@ func PoetryAPIRootKey() string {
 }
 
 func CollieAPIAddress() string {
-	return viper.GetString(setting.ENVCollieAPIAddress)
+	return configbase.CollieServiceAddress()
 }
 
 func MongoURI() string {
@@ -99,12 +98,8 @@ func NsqLookupAddrs() []string {
 	return strings.Split(viper.GetString(setting.ENVNsqLookupAddrs), ",")
 }
 
-func AslanURL() string {
-	return viper.GetString(setting.ENVAslanURL)
-}
-
 func HubServerAddress() string {
-	return viper.GetString(setting.ENVHubServerAddr)
+	return configbase.HubServerServiceAddress()
 }
 
 func HubAgentImage() string {
@@ -149,18 +144,10 @@ func S3StorageProtocol() string {
 	return viper.GetString(setting.ENVS3StorageProtocol)
 }
 
-func AslanAPIBase() string {
-	return viper.GetString(setting.ENVAslanAPIBase)
-}
-
 func SetProxy(HTTPSAddr, HTTPAddr, Socks5Addr string) {
 	viper.Set(setting.ProxyHTTPSAddr, HTTPSAddr)
 	viper.Set(setting.ProxyHTTPAddr, HTTPAddr)
 	viper.Set(setting.ProxySocks5Addr, Socks5Addr)
-}
-
-func ProxyAPIAddress() string {
-	return viper.GetString(setting.ProxyAPIAddr)
 }
 
 func ProxyHTTPSAddr() string {
@@ -189,14 +176,6 @@ func RegistrySecretKey() string {
 
 func RegistryNamespace() string {
 	return viper.GetString(setting.ENVAslanRegNamespace)
-}
-
-func ENVAslanURL() string {
-	return viper.GetString(setting.ENVAslanURL)
-}
-
-func ENVWarpdriveService() string {
-	return viper.GetString(setting.ENVWarpdriveService)
 }
 
 func GithubSSHKey() string {
@@ -243,18 +222,6 @@ func JenkinsImage() string {
 	return viper.GetString(setting.JenkinsBuildImage)
 }
 
-func SonarAddr() string {
-	return viper.GetString(setting.EnvSonarAddr)
-}
-
-func SonarRootToken() string {
-	return viper.GetString(setting.EnvSonarRootToken)
-}
-
-func SonarInternalAddr() string {
-	return viper.GetString(setting.EnvSonarInternalAddr)
-}
-
 func WebHookURL() string {
-	return fmt.Sprintf("%s/api/aslan/webhook", AslanURL())
+	return fmt.Sprintf("%s/api/aslan/webhook", configbase.SystemAddress())
 }

--- a/pkg/microservice/aslan/core/common/service/config_payload.go
+++ b/pkg/microservice/aslan/core/common/service/config_payload.go
@@ -17,7 +17,6 @@ limitations under the License.
 package service
 
 import (
-	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
@@ -27,9 +26,6 @@ import (
 
 func GetConfigPayload(codeHostID int) *models.ConfigPayload {
 	payload := &models.ConfigPayload{
-		Aslan: models.AslanConfig{
-			URL:              configbase.SystemAddress(),
-		},
 		S3Storage: models.S3Config{
 			Ak:       config.S3StorageAK(),
 			Sk:       config.S3StorageSK(),

--- a/pkg/microservice/aslan/core/common/service/config_payload.go
+++ b/pkg/microservice/aslan/core/common/service/config_payload.go
@@ -17,6 +17,7 @@ limitations under the License.
 package service
 
 import (
+	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
@@ -27,8 +28,7 @@ import (
 func GetConfigPayload(codeHostID int) *models.ConfigPayload {
 	payload := &models.ConfigPayload{
 		Aslan: models.AslanConfig{
-			URL:              config.AslanURL(),
-			WarpdriveService: config.ENVWarpdriveService(),
+			URL:              configbase.SystemAddress(),
 		},
 		S3Storage: models.S3Config{
 			Ak:       config.S3StorageAK(),

--- a/pkg/microservice/aslan/core/common/service/wechat/service.go
+++ b/pkg/microservice/aslan/core/common/service/wechat/service.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/task"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
@@ -159,7 +160,7 @@ func (w *Service) SendWechatMessage(task *task.Task) error {
 			}
 			content, err = w.createNotifyBody(&wechatNotification{
 				Task:        task,
-				BaseURI:     config.AslanURL(),
+				BaseURI:     configbase.SystemAddress(),
 				IsSingle:    true,
 				WebHookType: webHookType,
 				TotalTime:   time.Now().Unix() - task.StartTime,
@@ -194,7 +195,7 @@ func (w *Service) SendWechatMessage(task *task.Task) error {
 			}
 			content, err = w.createNotifyBody(&wechatNotification{
 				Task:        task,
-				BaseURI:     config.AslanURL(),
+				BaseURI:     configbase.SystemAddress(),
 				IsSingle:    false,
 				WebHookType: webHookType,
 				TotalTime:   time.Now().Unix() - task.StartTime,

--- a/pkg/microservice/aslan/core/multicluster/service/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/service/clusters.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 
+	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
@@ -92,5 +93,5 @@ func ProxyAgent(writer gin.ResponseWriter, request *http.Request) {
 func GetYaml(id, hubURI string, useDeployment bool, logger *zap.SugaredLogger) ([]byte, error) {
 	s, _ := kube.NewService("")
 
-	return s.GetYaml(id, config.HubAgentImage(), config.AslanURL(), hubURI, useDeployment, logger)
+	return s.GetYaml(id, config.HubAgentImage(), configbase.SystemAddress(), hubURI, useDeployment, logger)
 }

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/yaml"
 
+	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	templatemodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/template"
@@ -952,7 +953,7 @@ func addService() (bool, int) {
 	)
 	totalServices, _ := commonrepo.NewServiceColl().DistinctServices(&commonrepo.ServiceListOption{ExcludeStatus: setting.ProductStatusDeleting})
 	totalServiceCount = len(totalServices)
-	signatures, enabled, _ := aslanx.New(config.AslanURL(), config.PoetryAPIRootKey()).ListSignatures(log.NopSugaredLogger())
+	signatures, enabled, _ := aslanx.New(configbase.AslanxServiceAddress(), config.PoetryAPIRootKey()).ListSignatures(log.NopSugaredLogger())
 	if !enabled {
 		return true, limitServiceCount
 	}
@@ -1000,7 +1001,7 @@ func updateGerritWebhookByService(lastService, currentService *commonmodels.Serv
 		log.Errorf("updateGerritWebhookByService getGerritWebhook err:%v", err)
 		//创建webhook
 		gerritWebhook := &gerrit.Webhook{
-			URL:       fmt.Sprintf("%s/%s%s", config.AslanAPIBase(), "gerritHook?name=", currentService.ServiceName),
+			URL:       fmt.Sprintf("%s?name=%s", config.WebHookURL(), currentService.ServiceName),
 			MaxTries:  setting.MaxTries,
 			SslVerify: false,
 		}
@@ -1026,7 +1027,7 @@ func createGerritWebhookByService(codehostID int, serviceName, repoName, branchN
 		log.Errorf("createGerritWebhookByService getGerritWebhook err:%v", err)
 		//创建webhook
 		gerritWebhook := &gerrit.Webhook{
-			URL:       fmt.Sprintf("%s/%s%s", config.AslanAPIBase(), "gerritHook?name=", serviceName),
+			URL:       fmt.Sprintf("%s?name=%s", config.WebHookURL(), serviceName),
 			MaxTries:  setting.MaxTries,
 			SslVerify: false,
 		}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/gerrit.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/gerrit.go
@@ -54,7 +54,7 @@ func CreateGerritWebhook(workflow *commonmodels.Workflow, log *zap.SugaredLogger
 				log.Errorf("CreateGerritWebhook getGerritWebhook err:%v", err)
 				//创建webhook
 				gerritWebhook := &gerrit.Webhook{
-					URL:       fmt.Sprintf("%s/%s%s", config.AslanAPIBase(), "gerritHook?name=", workflow.Name),
+					URL:       fmt.Sprintf("%s?name=%s", config.WebHookURL(), workflow.Name),
 					MaxTries:  setting.MaxTries,
 					SslVerify: false,
 				}
@@ -129,7 +129,7 @@ func UpdateGerritWebhook(currentWorkflow *commonmodels.Workflow, log *zap.Sugare
 			webhookURL := fmt.Sprintf("/%s/%s/%s/%s", "a/config/server/webhooks~projects", gerrit.Escape(workflowWebhook.MainRepo.RepoName), "remotes", currentWorkflow.Name)
 			//创建webhook
 			gerritWebhook := &gerrit.Webhook{
-				URL:       fmt.Sprintf("%s/%s%s", config.AslanAPIBase(), "gerritHook?name=", currentWorkflow.Name),
+				URL:       fmt.Sprintf("%s?name=%s", config.WebHookURL(), currentWorkflow.Name),
 				MaxTries:  setting.MaxTries,
 				SslVerify: false,
 			}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/github.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/github.go
@@ -21,6 +21,7 @@ import (
 
 	"go.uber.org/zap"
 
+	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/task"
@@ -61,7 +62,7 @@ func createGitCheck(pt *task.Task, log *zap.SugaredLogger) error {
 			Ref:    hook.Ref,
 			IsPr:   hook.IsPr,
 
-			AslanURL:    config.AslanURL(),
+			AslanURL:    configbase.SystemAddress(),
 			PipeName:    pt.PipelineName,
 			ProductName: pt.ProductName,
 			PipeType:    pt.Type,
@@ -97,7 +98,7 @@ func createGitCheck(pt *task.Task, log *zap.SugaredLogger) error {
 		Ref:         hook.Ref,
 		State:       github.StatePending,
 		Description: fmt.Sprintf("Workflow [%s] is queued.", pt.PipelineName),
-		AslanURL:    config.AslanURL(),
+		AslanURL:    configbase.SystemAddress(),
 		PipeName:    pt.PipelineName,
 		ProductName: pt.ProductName,
 		PipeType:    pt.Type,

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_controller.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_controller.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/task"
@@ -372,7 +373,7 @@ func agentCount() int {
 		wdReplicas    int
 	)
 
-	signatures, enabled, _ := aslanx.New(config.AslanURL(), config.PoetryAPIRootKey()).ListSignatures(log.NopSugaredLogger())
+	signatures, enabled, _ := aslanx.New(configbase.AslanxServiceAddress(), config.PoetryAPIRootKey()).ListSignatures(log.NopSugaredLogger())
 	if enabled {
 		if len(signatures) == 0 {
 			log.Errorf("Not Find Token")
@@ -396,7 +397,7 @@ func agentCount() int {
 	}
 
 	kubeClient := krkubeclient.Client()
-	deployment, _, err := getter.GetDeployment(config.Namespace(), config.ENVWarpdriveService(), kubeClient)
+	deployment, _, err := getter.GetDeployment(config.Namespace(), configbase.WarpDriveServiceName(), kubeClient)
 	if err != nil {
 		log.Errorf("kubeCli.GetDeployment error: %v", err)
 		return 0

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_status.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_status.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
@@ -190,7 +191,7 @@ func FindTasks(commitID string, log *zap.SugaredLogger) ([]*TaskV2Info, error) {
 						keys.Insert(key)
 						resp = append(resp, &TaskV2Info{
 							TaskID:     workflowTask.TaskID,
-							URL:        fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/multi/%s/%d", config.ENVAslanURL(), workflowTask.ProductName, workflowTask.PipelineName, workflowTask.TaskID),
+							URL:        fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/multi/%s/%d", configbase.SystemAddress(), workflowTask.ProductName, workflowTask.PipelineName, workflowTask.TaskID),
 							Status:     string(workflowTask.Status),
 							CreateTime: workflowTask.CreateTime,
 							StartTime:  workflowTask.StartTime,

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/task"
@@ -593,7 +594,7 @@ func TestArgsToTestSubtask(args *commonmodels.TestTaskArgs, pt *task.Task, log *
 				}
 			}
 		}
-		envs = append(envs, &commonmodels.KeyVal{Key: "TEST_URL", Value: GetLink(pt, config.AslanURL(), config.TestType)})
+		envs = append(envs, &commonmodels.KeyVal{Key: "TEST_URL", Value: GetLink(pt, configbase.SystemAddress(), config.TestType)})
 		testTask.JobCtx.EnvVars = envs
 		testTask.ImageID = testModule.PreTest.ImageID
 		testTask.BuildOS = testModule.PreTest.BuildOS

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/task"
@@ -519,7 +520,7 @@ func prepareTaskEnvs(pt *task.Task, log *zap.SugaredLogger) []*commonmodels.KeyV
 	// 设置系统信息
 	envs = append(envs,
 		&commonmodels.KeyVal{Key: "SERVICE", Value: pt.ServiceName},
-		&commonmodels.KeyVal{Key: "BUILD_URL", Value: GetLink(pt, config.ENVAslanURL(), config.WorkflowType)},
+		&commonmodels.KeyVal{Key: "BUILD_URL", Value: GetLink(pt, configbase.SystemAddress(), config.WorkflowType)},
 		&commonmodels.KeyVal{Key: "DIST_DIR", Value: fmt.Sprintf("%s/%s/dist/%d", pt.ConfigPayload.S3Storage.Path, pt.PipelineName, pt.TaskID)},
 		&commonmodels.KeyVal{Key: "IMAGE", Value: pt.TaskArgs.Deploy.Image},
 		&commonmodels.KeyVal{Key: "PKG_FILE", Value: pt.TaskArgs.Deploy.PackageFile},

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/task"
@@ -1251,7 +1252,7 @@ func testArgsToSubtask(args *commonmodels.WorkflowTaskArgs, pt *task.Task, log *
 					}
 				}
 			}
-			envs = append(envs, &commonmodels.KeyVal{Key: "TEST_URL", Value: GetLink(pt, config.AslanURL(), config.WorkflowType)})
+			envs = append(envs, &commonmodels.KeyVal{Key: "TEST_URL", Value: GetLink(pt, configbase.SystemAddress(), config.WorkflowType)})
 			testTask.JobCtx.EnvVars = envs
 			testTask.ImageID = testModule.PreTest.ImageID
 			testTask.BuildOS = testModule.PreTest.BuildOS

--- a/pkg/microservice/cron/config/config.go
+++ b/pkg/microservice/cron/config/config.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/viper"
 
+	configbase "github.com/koderover/zadig/pkg/config"
 	// init the config first
 	_ "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/setting"
@@ -39,7 +40,7 @@ func RootToken() string {
 }
 
 func CollieAPI() string {
-	return viper.GetString(setting.ENVCollieAPIAddress)
+	return configbase.CollieServiceAddress()
 }
 
 func CollieToken() string {

--- a/pkg/microservice/cron/config/config.go
+++ b/pkg/microservice/cron/config/config.go
@@ -22,18 +22,8 @@ import (
 	"github.com/spf13/viper"
 
 	configbase "github.com/koderover/zadig/pkg/config"
-	// init the config first
-	_ "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/setting"
 )
-
-func AslanAPI() string {
-	return viper.GetString(setting.ENVAslanAPI)
-}
-
-func AslanxAPI() string {
-	return viper.GetString(setting.ENVAslanxAPI)
-}
 
 func RootToken() string {
 	return viper.GetString(setting.ENVRootToken)

--- a/pkg/microservice/cron/core/service/client/sonar.go
+++ b/pkg/microservice/cron/core/service/client/sonar.go
@@ -23,7 +23,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/koderover/zadig/pkg/microservice/cron/config"
+	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/setting"
 )
 
@@ -38,7 +38,7 @@ func (c *Client) InitPullSonarStatScheduler(log *zap.SugaredLogger) error {
 func (c *Client) InitPullSonarTestsMeasure(log *zap.SugaredLogger) error {
 	log.Info("start to pull sonar test measure..")
 
-	url := fmt.Sprintf("%s/quality/sonar/tests/measure/pull", config.AslanxAPI())
+	url := fmt.Sprintf("%s/api/quality/sonar/tests/measure/pull", configbase.AslanxServiceAddress())
 
 	request, err := http.NewRequest("POST", url, nil)
 	if err != nil {
@@ -69,7 +69,7 @@ func (c *Client) InitPullSonarTestsMeasure(log *zap.SugaredLogger) error {
 func (c *Client) InitPullSonarDeliveryMeasure(log *zap.SugaredLogger) error {
 	log.Info("start to pull sonar delivery measure..")
 
-	url := fmt.Sprintf("%s/quality/sonar/delivery/measure/pull", config.AslanxAPI())
+	url := fmt.Sprintf("%s/api/quality/sonar/delivery/measure/pull", configbase.AslanxServiceAddress())
 
 	request, err := http.NewRequest("POST", url, nil)
 	if err != nil {
@@ -100,7 +100,7 @@ func (c *Client) InitPullSonarDeliveryMeasure(log *zap.SugaredLogger) error {
 func (c *Client) InitPullSonarRepos(log *zap.SugaredLogger) error {
 	log.Info("start to pull sonar repos..")
 
-	url := fmt.Sprintf("%s/quality/sonar/repository/pull", config.AslanxAPI())
+	url := fmt.Sprintf("%s/api/quality/sonar/repository/pull", configbase.AslanxServiceAddress())
 
 	request, err := http.NewRequest("POST", url, nil)
 	if err != nil {

--- a/pkg/microservice/cron/core/service/client/stat.go
+++ b/pkg/microservice/cron/core/service/client/stat.go
@@ -21,26 +21,26 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/koderover/zadig/pkg/microservice/cron/config"
+	configbase "github.com/koderover/zadig/pkg/config"
 )
 
 func (c *Client) InitStatData(log *zap.SugaredLogger) error {
 	//build
-	url := fmt.Sprintf("%s/quality/stat/initBuildStat", config.AslanxAPI())
+	url := fmt.Sprintf("%s/api/quality/stat/initBuildStat", configbase.AslanxServiceAddress())
 	log.Info("start init buildStat..")
 	err := c.sendRequest(url)
 	if err != nil {
 		log.Errorf("trigger init buildStat error :%v", err)
 	}
 	//test
-	url = fmt.Sprintf("%s/quality/stat/initTestStat", config.AslanxAPI())
+	url = fmt.Sprintf("%s/api/quality/stat/initTestStat", configbase.AslanxServiceAddress())
 	log.Info("start init testStat..")
 	err = c.sendRequest(url)
 	if err != nil {
 		log.Errorf("trigger init testStat error :%v", err)
 	}
 	//deploy
-	url = fmt.Sprintf("%s/quality/stat/initDeployStat", config.AslanxAPI())
+	url = fmt.Sprintf("%s/api/quality/stat/initDeployStat", configbase.AslanxServiceAddress())
 	log.Info("start init deployStat..")
 	err = c.sendRequest(url)
 	if err != nil {
@@ -52,7 +52,7 @@ func (c *Client) InitStatData(log *zap.SugaredLogger) error {
 
 func (c *Client) InitOperationStatData(log *zap.SugaredLogger) error {
 	//operation
-	url := fmt.Sprintf("%s/operation/stat/initOperationStat", config.AslanxAPI())
+	url := fmt.Sprintf("%s/api/operation/stat/initOperationStat", configbase.AslanxServiceAddress())
 	log.Info("start init operationStat..")
 	err := c.sendRequest(url)
 	if err != nil {

--- a/pkg/microservice/cron/core/service/scheduler/scheduler.go
+++ b/pkg/microservice/cron/core/service/scheduler/scheduler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rfyiamcool/cronlib"
 	"go.uber.org/zap"
 
+	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/cron/config"
 	"github.com/koderover/zadig/pkg/microservice/cron/core/service"
 	"github.com/koderover/zadig/pkg/microservice/cron/core/service/client"
@@ -80,11 +81,9 @@ const (
 // NewCronClient ...
 // 服务初始化
 func NewCronClient() *CronClient {
-	aslanAPI := config.AslanAPI()
-	aslanToken := config.RootToken()
 	nsqLookupAddrs := config.NsqLookupAddrs()
 
-	aslanCli := client.NewAslanClient(aslanAPI, aslanToken)
+	aslanCli := client.NewAslanClient(fmt.Sprintf("%s/api", configbase.AslanServiceAddress()), config.RootToken())
 	collieCli := client.NewCollieClient(config.CollieAPI(), config.CollieToken())
 	//初始化nsq
 	config := nsq.NewConfig()
@@ -161,7 +160,7 @@ func (c *CronClient) Init() {
 }
 
 func getFeatures() (string, error) {
-	cl := poetry.New(config.AslanAPI(), config.RootToken())
+	cl := poetry.New(configbase.PoetryServiceAddress(), config.RootToken())
 	fs, err := cl.ListFeatures()
 	if err != nil {
 		return "", err

--- a/pkg/microservice/podexec/config/config.go
+++ b/pkg/microservice/podexec/config/config.go
@@ -19,6 +19,7 @@ package config
 import (
 	"github.com/spf13/viper"
 
+	configbase "github.com/koderover/zadig/pkg/config"
 	// init the config first
 	_ "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/setting"
@@ -33,7 +34,7 @@ func PoetryAPIServer() string {
 }
 
 func HubServerAddr() string {
-	return viper.GetString(setting.ENVHubServerAddr)
+	return configbase.HubServerServiceAddress()
 }
 
 func KubeCfg() string {

--- a/pkg/microservice/warpdrive/config/config.go
+++ b/pkg/microservice/warpdrive/config/config.go
@@ -38,24 +38,12 @@ func NSQLookupAddrs() []string {
 	return strings.Split(viper.GetString(setting.ENVNsqLookupAddrs), ",")
 }
 
-func PodIP() string {
-	return viper.GetString(setting.ENVPodIP)
-}
-
 func PoetryAPIAddr() string {
 	return viper.GetString(setting.ENVPoetryAPIAddr)
 }
 
 func PoetryAPIRootKey() string {
 	return viper.GetString(setting.ENVPoetryAPIRootKey)
-}
-
-func AslanAddr() string {
-	return viper.GetString(setting.ENVAslanAddr)
-}
-
-func ClairClientAddr() string {
-	return viper.GetString(setting.ENVClairClientAddr)
 }
 
 func ReleaseImageTimeout() string {

--- a/pkg/microservice/warpdrive/core/service/taskcontroller/task_helper.go
+++ b/pkg/microservice/warpdrive/core/service/taskcontroller/task_helper.go
@@ -28,6 +28,7 @@ import (
 
 	"go.uber.org/zap"
 
+	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/config"
 	plugins "github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/taskplugin"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/taskplugin/github"
@@ -312,7 +313,7 @@ func updateGitCheck(pt *task.Task) error {
 			Ref:    hook.Ref,
 			IsPr:   hook.IsPr,
 
-			AslanURL:    pt.ConfigPayload.Aslan.URL,
+			AslanURL:    configbase.SystemAddress(),
 			PipeName:    pt.PipelineName,
 			PipeType:    pt.Type,
 			ProductName: pt.ProductName,
@@ -334,7 +335,7 @@ func updateGitCheck(pt *task.Task) error {
 		Ref:         hook.Ref,
 		State:       github.StatePending,
 		Description: fmt.Sprintf("Workflow [%s] is running.", pt.PipelineName),
-		AslanURL:    pt.ConfigPayload.Aslan.URL,
+		AslanURL:    configbase.SystemAddress(),
 		PipeName:    pt.PipelineName,
 		ProductName: pt.ProductName,
 		PipeType:    pt.Type,
@@ -389,7 +390,7 @@ func completeGitCheck(pt *task.Task) error {
 			Ref:    hook.Ref,
 			IsPr:   hook.IsPr,
 
-			AslanURL:    pt.ConfigPayload.Aslan.URL,
+			AslanURL:    configbase.SystemAddress(),
 			PipeName:    pt.PipelineName,
 			PipeType:    pt.Type,
 			ProductName: pt.ProductName,
@@ -413,7 +414,7 @@ func completeGitCheck(pt *task.Task) error {
 		Ref:         hook.Ref,
 		State:       getGitHubStatusFromCIStatus(ciStatus),
 		Description: fmt.Sprintf("Workflow [%s] is %s.", pt.PipelineName, ciStatus),
-		AslanURL:    pt.ConfigPayload.Aslan.URL,
+		AslanURL:    configbase.SystemAddress(),
 		PipeName:    pt.PipelineName,
 		ProductName: pt.ProductName,
 		PipeType:    pt.Type,

--- a/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
+	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/config"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/taskplugin/s3"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/types"
@@ -58,7 +59,7 @@ func InitializeDeployTaskPlugin(taskType config.TaskType) TaskPlugin {
 		httpClient: httpclient.New(
 			httpclient.SetAuthScheme(setting.RootAPIKey),
 			httpclient.SetAuthToken(config.PoetryAPIRootKey()),
-			httpclient.SetHostURL(config.AslanAddr()),
+			httpclient.SetHostURL(configbase.AslanServiceAddress()),
 		),
 	}
 }
@@ -447,7 +448,7 @@ func (p *DeployTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, _ *
 }
 
 func (p *DeployTaskPlugin) getProductInfo(ctx context.Context, args *EnvArgs) (*types.Product, error) {
-	url := fmt.Sprintf("/environment/environments/%s/productInfo", args.ProductName)
+	url := fmt.Sprintf("/api/environment/environments/%s/productInfo", args.ProductName)
 
 	prod := &types.Product{}
 	_, err := p.httpClient.Get(url, httpclient.SetResult(prod), httpclient.SetQueryParam("envName", args.EnvName))
@@ -458,7 +459,7 @@ func (p *DeployTaskPlugin) getProductInfo(ctx context.Context, args *EnvArgs) (*
 }
 
 func (p *DeployTaskPlugin) getService(ctx context.Context, name, serviceType, productName string) (*types.ServiceTmpl, error) {
-	url := fmt.Sprintf("/service/services/%s/%s", name, serviceType)
+	url := fmt.Sprintf("/api/service/services/%s/%s", name, serviceType)
 
 	s := &types.ServiceTmpl{}
 	_, err := p.httpClient.Get(url, httpclient.SetResult(s), httpclient.SetQueryParam("productName", productName))
@@ -503,7 +504,7 @@ func (p *DeployTaskPlugin) downloadService(pipelineTask *task.Task, serviceName,
 }
 
 func (p *DeployTaskPlugin) getRenderSet(ctx context.Context, name string, revision int64) (*types.RenderSet, error) {
-	url := fmt.Sprintf("/project/renders/render/%s/revision/%d", name, revision)
+	url := fmt.Sprintf("/api/project/renders/render/%s/revision/%d", name, revision)
 
 	rs := &types.RenderSet{}
 	_, err := p.httpClient.Get(url, httpclient.SetResult(rs))
@@ -514,7 +515,7 @@ func (p *DeployTaskPlugin) getRenderSet(ctx context.Context, name string, revisi
 }
 
 func (p *DeployTaskPlugin) updateRenderSet(ctx context.Context, args *types.RenderSet) error {
-	url := "project/renders"
+	url := "/api/project/renders"
 
 	_, err := p.httpClient.Put(url, httpclient.SetBody(args))
 

--- a/pkg/microservice/warpdrive/core/service/taskplugin/docker_build_test.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/docker_build_test.go
@@ -74,7 +74,6 @@ func TestDockerBuildTaskPlugin(t *testing.T) {
 			Registry: task.RegistryConfig{
 				Addr: "127.0.0.1",
 			},
-			Aslan: task.AslanConfig{},
 		},
 		TaskArgs: &task.TaskArgs{
 			Deploy: task.DeployArgs{

--- a/pkg/microservice/warpdrive/core/service/taskplugin/security.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/security.go
@@ -25,6 +25,7 @@ import (
 
 	"go.uber.org/zap"
 
+	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/config"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/types"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/types/task"
@@ -40,7 +41,7 @@ func InitializeSecurityPlugin(taskType config.TaskType) TaskPlugin {
 		httpClient: httpclient.New(
 			httpclient.SetAuthScheme(setting.RootAPIKey),
 			httpclient.SetAuthToken(config.PoetryAPIRootKey()),
-			httpclient.SetHostURL(config.AslanAddr()),
+			httpclient.SetHostURL(configbase.AslanServiceAddress()),
 		),
 	}
 }
@@ -144,7 +145,7 @@ func (p *SecurityPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipel
 }
 
 func (p *SecurityPlugin) getSummary(ctx context.Context, imageID string) (map[string]int, error) {
-	url := "/delivery/security/stats"
+	url := "/api/delivery/security/stats"
 
 	summary := map[string]int{}
 	_, err := p.httpClient.Get(url, httpclient.SetResult(&summary), httpclient.SetQueryParam("imageId", imageID))
@@ -155,7 +156,7 @@ func (p *SecurityPlugin) getSummary(ctx context.Context, imageID string) (map[st
 }
 
 func (p *SecurityPlugin) report(ctx context.Context, imageName string, body []byte) (string, error) {
-	url := "/delivery/security"
+	url := "/api/delivery/security"
 
 	res, err := p.httpClient.Post(url, httpclient.SetBody(body))
 	if err != nil {
@@ -168,7 +169,7 @@ func (p *SecurityPlugin) report(ctx context.Context, imageName string, body []by
 }
 
 func (p *SecurityPlugin) analysis(ctx context.Context, imageName, dockerHost, namespace string) ([]byte, error) {
-	url := fmt.Sprintf("%s/analyzeLocalImage", config.ClairClientAddr())
+	url := fmt.Sprintf("%s/analyzeLocalImage", configbase.ClairServiceAddress())
 	qs := map[string]string{
 		"imageName":  imageName,
 		"dockerHost": dockerHost,

--- a/pkg/microservice/warpdrive/core/service/types/task/config_payload.go
+++ b/pkg/microservice/warpdrive/core/service/types/task/config_payload.go
@@ -65,7 +65,6 @@ func (cp *ConfigPayload) GetGitKnownHost() string {
 
 type AslanConfig struct {
 	URL              string
-	WarpdriveService string
 }
 
 type ProxyConfig struct {

--- a/pkg/microservice/warpdrive/core/service/types/task/config_payload.go
+++ b/pkg/microservice/warpdrive/core/service/types/task/config_payload.go
@@ -21,7 +21,6 @@ import (
 )
 
 type ConfigPayload struct {
-	Aslan              AslanConfig        `json:"aslan"`
 	Proxy              Proxy              `json:"proxy"`
 	S3Storage          S3Config           `json:"s3_storage"`
 	Github             GithubConfig       `json:"github"`
@@ -61,10 +60,6 @@ func (cp *ConfigPayload) GetGitKnownHost() string {
 		host = fmt.Sprintf("%s\n%s", host, cp.Gitlab.KnownHost)
 	}
 	return host
-}
-
-type AslanConfig struct {
-	URL              string
 }
 
 type ProxyConfig struct {

--- a/pkg/middleware/gin/audit_log.go
+++ b/pkg/middleware/gin/audit_log.go
@@ -32,7 +32,7 @@ func UpdateOperationLogStatus(c *gin.Context) {
 		return
 	}
 
-	err := aslanx.New(config.AslanURL(), config.PoetryAPIRootKey()).UpdateAuditLog(c.GetString("operationLogID"), c.Writer.Status(), log)
+	err := aslanx.New(config.AslanxServiceAddress(), config.PoetryAPIRootKey()).UpdateAuditLog(c.GetString("operationLogID"), c.Writer.Status(), log)
 	if err != nil {
 		log.Errorf("UpdateOperation err:%v", err)
 	}

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -21,13 +21,11 @@ const LocalConfig = "local.env"
 // envs
 const (
 	// common
+	ENVSystemAddress           = "ADDRESS"
 	ENVMode                    = "MODE"
-	ENVCollieAPIAddress        = "COLLIE_API_ADDRESS"
 	ENVNsqLookupAddrs          = "NSQLOOKUP_ADDRS"
 	ENVMongoDBConnectionString = "MONGODB_CONNECTION_STRING"
 	ENVAslanDBName             = "ASLAN_DB"
-	ENVAslanAPIBase            = "ASLAN_API_BASE"
-	ENVHubServerAddr           = "HUB_SERVER_ADDR"
 	ENVHubAgentImage           = "HUB_AGENT_IMAGE"
 	ENVPoetryAPIServer         = "POETRY_API_SERVER"
 	ENVPoetryAPIRootKey        = "POETRY_API_ROOT_KEY"
@@ -36,8 +34,6 @@ const (
 	ENVPodName              = "BE_POD_NAME"
 	ENVNamespace            = "BE_POD_NAMESPACE"
 	ENVLogLevel             = "LOG_LEVEL"
-	ENVAslanURL             = "ASLAN_URL"
-	ENVWarpdriveService     = "WARPDRIVE_SERVICE"
 	ENVServiceStartTimeout  = "SERVICE_START_TIMEOUT"
 	ENVDefaultEnvRecycleDay = "DEFAULT_ENV_RECYCLE_DAY"
 	ENVDefaultIngressClass  = "DEFAULT_INGRESS_CLASS"
@@ -67,10 +63,6 @@ const (
 	ENVS3StorageProtocol = "S3STORAGE_PROTOCOL"
 	ENVS3StoragePath     = "S3STORAGE_PATH"
 	ENVKubeServerAddr    = "KUBE_SERVER_ADDR"
-
-	EnvSonarAddr         = "SONAR_ADDR"
-	EnvSonarRootToken    = "SONAR_ROOT_TOKEN"
-	EnvSonarInternalAddr = "SONAR_INTERNAL_ADDR"
 
 	// cron
 	ENVAslanAPI        = "ASLAN_API"

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -65,14 +65,8 @@ const (
 	ENVKubeServerAddr    = "KUBE_SERVER_ADDR"
 
 	// cron
-	ENVAslanAPI        = "ASLAN_API"
-	ENVAslanxAPI       = "ASLANX_API"
 	ENVRootToken       = "ROOT_TOKEN"
-	ENVAslanAddr       = "ASLAN_ADDRESS"
-	ENVNsqdAddr        = "NSQD_ADDR"
-	ENVPodIP           = "POD_IP"
 	ENVPoetryAPIAddr   = "POETRY_API_ADDRESS"
-	ENVClairClientAddr = "CLAIR_CLIENT_ADDRESS"
 
 	ENVKodespaceVersion = "KODESPACE_VERSION"
 

--- a/pkg/setting/types.go
+++ b/pkg/setting/types.go
@@ -32,13 +32,14 @@ const (
 const (
 	Aslan     = iota + 1 // 1
 	Aslanx               // 2
-	Collie               // 3
-	Cron                 // 4
-	HubServer            // 5
-	PodExec              // 6
-	Poetry               // 7
-	SonarQube            // 8
-	WarpDrive            // 9
+	Clair                // 3
+	Collie               // 4
+	Cron                 // 5
+	HubServer            // 6
+	PodExec              // 7
+	Poetry               // 8
+	SonarQube            // 9
+	WarpDrive            // 10
 )
 
 type ServiceInfo struct {
@@ -54,6 +55,10 @@ var Services = map[int]*ServiceInfo{
 	Aslanx: {
 		Name: "aslanx",
 		Port: 25002,
+	},
+	Clair: {
+		Name: "clair",
+		Port: 34002,
 	},
 	Collie: {
 		Name: "collie-server",

--- a/pkg/setting/types.go
+++ b/pkg/setting/types.go
@@ -28,3 +28,59 @@ const (
 	// MinRequest 2 CPU 2 G
 	MinRequest Request = "min"
 )
+
+const (
+	Aslan     = iota + 1 // 1
+	Aslanx               // 2
+	Collie               // 3
+	Cron                 // 4
+	HubServer            // 5
+	PodExec              // 6
+	Poetry               // 7
+	SonarQube            // 8
+	WarpDrive            // 9
+)
+
+type ServiceInfo struct {
+	Name string
+	Port int32
+}
+
+var Services = map[int]*ServiceInfo{
+	Aslan: {
+		Name: "aslan",
+		Port: 25000,
+	},
+	Aslanx: {
+		Name: "aslanx",
+		Port: 25002,
+	},
+	Collie: {
+		Name: "collie-server",
+		Port: 28080,
+	},
+	Cron: {
+		Name: "cron",
+		Port: 80,
+	},
+	HubServer: {
+		Name: "hub-server",
+		Port: 26000,
+	},
+	PodExec: {
+		Name: "podexec",
+		Port: 27000,
+	},
+	Poetry: {
+		Name: "poetry",
+		Port: 34001,
+	},
+	SonarQube: {
+		Name: "sonarqube",
+		Port: 80,
+	},
+	WarpDrive: {
+		Name: "warpdrive",
+		Port: 80,
+	},
+}

--- a/pkg/shared/client/aslanx/audit_log.go
+++ b/pkg/shared/client/aslanx/audit_log.go
@@ -38,7 +38,7 @@ type operationLog struct {
 }
 
 func (c *Client) AddAuditLog(username, productName, method, function, detail, permissionUUID, requestBody string, log *zap.SugaredLogger) (string, error) {
-	url := "/api/aslanx/enterprise/operation"
+	url := "/api/enterprise/operation"
 	req := operationLog{
 		Username:       username,
 		ProductName:    productName,
@@ -67,7 +67,7 @@ type updateOperationArgs struct {
 }
 
 func (c *Client) UpdateAuditLog(id string, status int, log *zap.SugaredLogger) error {
-	url := fmt.Sprintf("/api/aslanx/enterprise/operation/%s", id)
+	url := fmt.Sprintf("/api/enterprise/operation/%s", id)
 	req := updateOperationArgs{
 		Status: status,
 	}

--- a/pkg/shared/client/aslanx/signature.go
+++ b/pkg/shared/client/aslanx/signature.go
@@ -34,7 +34,7 @@ type Signature struct {
 // enabled means signature control is enabled.
 // If the status code is 404, mark enabled as false.
 func (c *Client) ListSignatures(log *zap.SugaredLogger) ([]*Signature, bool, error) {
-	url := "/api/aslanx/enterprise/license"
+	url := "/api/enterprise/license"
 
 	signatures := make([]*Signature, 0)
 	_, err := c.Get(url, httpclient.SetResult(&signatures))

--- a/pkg/shared/handler/base.go
+++ b/pkg/shared/handler/base.go
@@ -82,7 +82,7 @@ func JSONResponse(c *gin.Context, ctx *Context) {
 
 // InsertOperationLog 插入操作日志
 func InsertOperationLog(c *gin.Context, username, productName, method, function, detail, permissionUUID, requestBody string, logger *zap.SugaredLogger) {
-	operationLogID, err := aslanx.New(config.AslanURL(), config.PoetryAPIRootKey()).AddAuditLog(username, productName, method, function, detail, permissionUUID, requestBody, logger)
+	operationLogID, err := aslanx.New(config.AslanxServiceAddress(), config.PoetryAPIRootKey()).AddAuditLog(username, productName, method, function, detail, permissionUUID, requestBody, logger)
 	if err != nil {
 		logger.Errorf("InsertOperation err:%v", err)
 	}


### PR DESCRIPTION
### What this PR does / Why we need it:

changes in aslan:
1. Add a new ENV called "ADDRESS" to pass the host field from the main ingress object to aslan
2. remove some ENVs like "COLLIE_API_ADDRESS", "HUB_SERVER_ADDR", they should be defiend in a config center or just hard coded (currently, hard coded)
3. For traffic between services, use service name directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/57)
<!-- Reviewable:end -->
