### PR TITLE
develop cli download bug

### DIFF
--- a/pkg/microservice/aslan/core/common/handler/tool.go
+++ b/pkg/microservice/aslan/core/common/handler/tool.go
@@ -33,5 +33,5 @@ func GetToolDownloadURL(c *gin.Context) {
 	// mac、linux、windows
 	os := c.Query("os")
 
-	ctx.Resp = fmt.Sprintf("http://resource.koderover.com/kodespace-%s-%s", os, version)
+	ctx.Resp = fmt.Sprintf("https://resource.koderover.com/kodespace-%s-%s", os, version)
 }


### PR DESCRIPTION
Signed-off-by: mouuii <zhouchengbin@koderover.com>

### What this PR does / Why we need it:

P0 KodeSpace CLI 下载 API 返回 HTTPS 资源下载链接，否则会触发浏览器安全机制导致无法下载

### What is changed and how it works?
change download link to  https
How it Works:

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/126)
<!-- Reviewable:end -->
