### PR TITLE
do not break workflow deletion when webhook deletion is failed

### DIFF
--- a/pkg/microservice/aslan/core/common/service/webhook/controller.go
+++ b/pkg/microservice/aslan/core/common/service/webhook/controller.go
@@ -143,6 +143,8 @@ func removeWebhook(t *task, logger *zap.Logger) {
 		t.doneCh <- struct{}{}
 		return
 	}
+
+	logger = logger.With(zap.String("hookID", webhook.HookID))
 	logger.Info("Removing webhook")
 	updated, err := coll.RemoveReference(t.owner, t.repo, t.address, t.ref)
 	if err != nil {
@@ -212,12 +214,12 @@ func addWebhook(t *task, logger *zap.Logger) {
 		if err = coll.Delete(t.owner, t.repo, t.address); err != nil {
 			logger.Error("Failed to delete webhook record in db", zap.Error(err))
 		}
-	}
-
-	if hookID != "" {
-		if err = coll.Update(t.owner, t.repo, t.address, hookID); err != nil {
-			t.err = err
-			logger.Error("Failed to update webhook", zap.Error(err))
+	} else {
+		if hookID != "" {
+			if err = coll.Update(t.owner, t.repo, t.address, hookID); err != nil {
+				t.err = err
+				logger.Error("Failed to update webhook", zap.Error(err))
+			}
 		}
 	}
 

--- a/pkg/microservice/aslan/core/common/service/workflow.go
+++ b/pkg/microservice/aslan/core/common/service/workflow.go
@@ -89,7 +89,6 @@ func DeleteWorkflow(workflowName, requestID string, isDeletingProductTmpl bool, 
 	err = ProcessWebhook(nil, workflow.HookCtl.Items, webhook.WorkflowPrefix+workflow.Name, log)
 	if err != nil {
 		log.Errorf("Failed to process webhook, err: %s", err)
-		return e.ErrUpsertWorkflow.AddDesc(err.Error())
 	}
 
 	go gerrit.DeleteGerritWebhook(workflow, log)


### PR DESCRIPTION
### What this PR does / Why we need it:

Problem Summary: project deletion failed becasue of a failure of webhook operation

### What is changed and how it works?

What's Changed:

do not break workflow deletion when webhook deletion is failed
