### PR TITLE
skip if counter is updated & fix UpdateAll

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -48,7 +49,7 @@ var migrateCmd = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := run(); err != nil {
-			fmt.Println(err)
+			log.Fatal(err)
 		}
 	},
 	PostRun: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/upgradeassistant/cmd/migrate.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate.go
@@ -35,7 +35,7 @@ func init() {
 	rootCmd.AddCommand(migrateCmd)
 
 	migrateCmd.PersistentFlags().StringP("from-version", "f", "MOST_RECENT_PREVIOUS_VERSION", "current version to migrate from, e.g. 1.3.0")
-	migrateCmd.PersistentFlags().StringP("to-version", "t", "MOST_RECENT_VERSION", "target version to migrate to, e.g. 1.4.0")
+	migrateCmd.PersistentFlags().StringP("to-version", "t", "MOST_RECENT_VERSION", "target version to migrate to, e.g. 1.3.1")
 	_ = viper.BindPFlag("fromVersion", migrateCmd.PersistentFlags().Lookup("from-version"))
 	_ = viper.BindPFlag("toVersion", migrateCmd.PersistentFlags().Lookup("to-version"))
 }

--- a/pkg/cli/upgradeassistant/cmd/migrate/migrate.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/migrate.go
@@ -58,7 +58,7 @@ func V130ToV131() error {
 		return err
 	}
 
-	if skipUpgrade(allServices, setting.ServiceTemplateCounterName) {
+	if skipMigration(allServices, setting.ServiceTemplateCounterName) {
 		log.Info("Migration skipped")
 		return nil
 	}
@@ -158,7 +158,7 @@ func V131ToV130() error {
 		return err
 	}
 
-	if skipUpgrade(allServices, oldServiceTemplateCounterName) {
+	if skipMigration(allServices, oldServiceTemplateCounterName) {
 		log.Info("Migration skipped")
 		return nil
 	}
@@ -215,7 +215,6 @@ func RevertServiceCounter(allServices []*models.Service) error {
 
 func updateServiceCounter(allServices []*models.Service, oldTemplate, newTemplate string) error {
 	coll := mongodb.NewCounterColl()
-	
 	for _, s := range allServices {
 		oldName := fmt.Sprintf(oldTemplate, s.ServiceName, s.Type)
 		newName := fmt.Sprintf(newTemplate, s.ServiceName, s.ProductName)
@@ -228,7 +227,7 @@ func updateServiceCounter(allServices []*models.Service, oldTemplate, newTemplat
 	return nil
 }
 
-func skipUpgrade(allServices []*models.Service, newTemplate string) bool {
+func skipMigration(allServices []*models.Service, newTemplate string) bool {
 	if len(allServices) == 0 {
 		return true
 	}

--- a/pkg/cli/upgradeassistant/cmd/migrate/migrate.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/migrate.go
@@ -47,6 +47,12 @@ func V130ToV131() error {
 		log.Errorf("Failed to get services, err: %s", err)
 		return err
 	}
+
+	if skipMigration(allServices, setting.ServiceTemplateCounterName) {
+		log.Info("Migration skipped")
+		return nil
+	}
+
 	allProjects, err := templaterepo.NewProductColl().List()
 	if err != nil {
 		log.Errorf("Failed to get projects, err: %s", err)
@@ -56,11 +62,6 @@ func V130ToV131() error {
 	if err != nil {
 		log.Errorf("Failed to get envs, err: %s", err)
 		return err
-	}
-
-	if skipMigration(allServices, setting.ServiceTemplateCounterName) {
-		log.Info("Migration skipped")
-		return nil
 	}
 
 	var updatedProjects []*templatemodels.Product
@@ -147,6 +148,12 @@ func V131ToV130() error {
 		log.Errorf("Failed to get services, err: %s", err)
 		return err
 	}
+
+	if skipMigration(allServices, oldServiceTemplateCounterName) {
+		log.Info("Migration skipped")
+		return nil
+	}
+
 	allProjects, err := templaterepo.NewProductColl().List()
 	if err != nil {
 		log.Errorf("Failed to get projects, err: %s", err)
@@ -156,11 +163,6 @@ func V131ToV130() error {
 	if err != nil {
 		log.Errorf("Failed to get envs, err: %s", err)
 		return err
-	}
-
-	if skipMigration(allServices, oldServiceTemplateCounterName) {
-		log.Info("Migration skipped")
-		return nil
 	}
 
 	var updatedProjects []*templatemodels.Product

--- a/pkg/cli/upgradeassistant/cmd/migrate/migrate.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/migrate.go
@@ -198,6 +198,15 @@ func RevertServiceCounter(allServices []*models.Service) error {
 
 func updateServiceCounter(allServices []*models.Service, oldTemplate, newTemplate string) error {
 	coll := mongodb.NewCounterColl()
+
+	if len(allServices) > 0 {
+		newName := fmt.Sprintf(newTemplate, allServices[0].ServiceName, allServices[0].ProductName)
+		// skip if any new names exist.
+		if counter, _ := coll.Find(newName); counter != nil {
+			return nil
+		}
+	}
+	
 	for _, s := range allServices {
 		oldName := fmt.Sprintf(oldTemplate, s.ServiceName, s.Type)
 		newName := fmt.Sprintf(newTemplate, s.ServiceName, s.ProductName)

--- a/pkg/cli/upgradeassistant/cmd/root.go
+++ b/pkg/cli/upgradeassistant/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/koderover/zadig/pkg/setting"
+	"github.com/koderover/zadig/pkg/tool/log"
 )
 
 var rootCmd = &cobra.Command{
@@ -46,4 +47,9 @@ func init() {
 
 func initConfig() {
 	viper.AutomaticEnv()
+
+	log.Init(&log.Config{
+		Level:       "debug",
+		NoCaller:    true,
+	})
 }

--- a/pkg/microservice/aslan/core/common/repository/mongodb/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/product.go
@@ -283,6 +283,10 @@ func (c *ProductColl) Count(productName string) (int, error) {
 // Note: A bulk operation can have at most 1000 operations, but the client will do it for us.
 // see https://stackoverflow.com/questions/24237887/what-is-mongodb-batch-operation-max-size
 func (c *ProductColl) UpdateAll(envs []*models.Product) error {
+	if len(envs) == 0 {
+		return nil
+	}
+
 	var ms []mongo.WriteModel
 	for _, env := range envs {
 		ms = append(ms,

--- a/pkg/microservice/aslan/core/common/repository/mongodb/template/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/template/product.go
@@ -185,6 +185,10 @@ func (c *ProductColl) Update(productName string, args *template.Product) error {
 // Note: A bulk operation can have at most 1000 operations, but the client will do it for us.
 // see https://stackoverflow.com/questions/24237887/what-is-mongodb-batch-operation-max-size
 func (c *ProductColl) UpdateAll(projects []*template.Product) error {
+	if len(projects) == 0 {
+		return nil
+	}
+
 	var ms []mongo.WriteModel
 	for _, p := range projects {
 		ms = append(ms,


### PR DESCRIPTION
### What this PR does / Why we need it:

Problem Summary: releated to #178, upgrading from 1.3.0 to 1.3.1 succeeded, but there are probelms using this version.

### What is changed and how it works?

What's Changed:

fix the upgrade assistant to skip if counter is already updated and fix the UpdateAll function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/183)
<!-- Reviewable:end -->
