### PR TITLE
[WIP] add service name into error when update service fail

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -642,7 +642,8 @@ func UpdateProduct(existedProd, updateProd *commonmodels.Product, renderSet *com
 							lock.Lock()
 							switch e := err.(type) {
 							case *multierror.Error:
-								errList = multierror.Append(errList, e.Errors...)
+								//errList = multierror.Append(errList, e.Errors...)
+								errList = multierror.Append(errList, e)
 							default:
 								errList = multierror.Append(errList, e)
 							}


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

Issue Number: https://trello.com/c/5nzqUQoS

Problem Summary:
when it fails to update envionment variables in an environment with muitiple runing services, we can't find out the exact failed services by currently returned error

### What is changed and how it works?

What's Changed:
the returned error will contain service name

How it Works:
add service name into error



## More information