### PR TITLE
Before add cvm service, confirm whether the build exists

### DIFF
--- a/pkg/microservice/aslan/core/common/service/service.go
+++ b/pkg/microservice/aslan/core/common/service/service.go
@@ -354,6 +354,8 @@ func UpdatePmServiceTemplate(username string, args *ServiceTmplBuildObject, log 
 		return err
 	}
 
+	preBuildName := preService.BuildName
+
 	//更新服务
 	serviceTemplate := fmt.Sprintf(setting.ServiceTemplateCounterName, preService.ServiceName, preService.ProductName)
 	rev, err := commonrepo.NewCounterColl().GetNextSeq(serviceTemplate)
@@ -370,9 +372,42 @@ func UpdatePmServiceTemplate(username string, args *ServiceTmplBuildObject, log 
 		return err
 	}
 
+	if preBuildName != args.Build.Name {
+		preBuild, err := commonrepo.NewBuildColl().Find(&commonrepo.BuildFindOption{Name: preBuildName})
+		if err != nil {
+			return e.ErrUpdateService.AddDesc("get pre build failed")
+		}
+
+		var targets []*commonmodels.ServiceModuleTarget
+		for _, serviceModule := range preBuild.Targets {
+			if serviceModule.ServiceName != args.ServiceTmplObject.ServiceName {
+				targets = append(targets, serviceModule)
+			}
+		}
+		preBuild.Targets = targets
+
+		if err = UpdateBuild(username, preBuild, log); err != nil {
+			return e.ErrUpdateService.AddDesc("update pre build failed")
+		}
+
+		currentBuild, err := commonrepo.NewBuildColl().Find(&commonrepo.BuildFindOption{Name: args.Build.Name})
+		if err != nil {
+			return e.ErrUpdateService.AddDesc("get current build failed")
+		}
+		currentBuild.Targets = append(currentBuild.Targets, &commonmodels.ServiceModuleTarget{
+			ProductName:   args.ServiceTmplObject.ProductName,
+			ServiceName:   args.ServiceTmplObject.ServiceName,
+			ServiceModule: args.ServiceTmplObject.ServiceName,
+		})
+		if err = UpdateBuild(username, currentBuild, log); err != nil {
+			return e.ErrUpdateService.AddDesc("update current build failed")
+		}
+	}
+
 	if err := commonrepo.NewServiceColl().Create(preService); err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/pkg/microservice/aslan/core/common/service/service.go
+++ b/pkg/microservice/aslan/core/common/service/service.go
@@ -394,20 +394,30 @@ func UpdatePmServiceTemplate(username string, args *ServiceTmplBuildObject, log 
 		if err != nil {
 			return e.ErrUpdateService.AddDesc("get current build failed")
 		}
-		currentBuild.Targets = append(currentBuild.Targets, &commonmodels.ServiceModuleTarget{
-			ProductName:   args.ServiceTmplObject.ProductName,
-			ServiceName:   args.ServiceTmplObject.ServiceName,
-			ServiceModule: args.ServiceTmplObject.ServiceName,
-		})
-		if err = UpdateBuild(username, currentBuild, log); err != nil {
-			return e.ErrUpdateService.AddDesc("update current build failed")
+		var include bool
+		for _, serviceModule := range currentBuild.Targets {
+			if serviceModule.ServiceName == args.ServiceTmplObject.ServiceName {
+				include = true
+				break
+			}
 		}
+
+		if !include {
+			currentBuild.Targets = append(currentBuild.Targets, &commonmodels.ServiceModuleTarget{
+				ProductName:   args.ServiceTmplObject.ProductName,
+				ServiceName:   args.ServiceTmplObject.ServiceName,
+				ServiceModule: args.ServiceTmplObject.ServiceName,
+			})
+			if err = UpdateBuild(username, currentBuild, log); err != nil {
+				return e.ErrUpdateService.AddDesc("update current build failed")
+			}
+		}
+
 	}
 
 	if err := commonrepo.NewServiceColl().Create(preService); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/pkg/microservice/aslan/core/service/service/pm.go
+++ b/pkg/microservice/aslan/core/service/service/pm.go
@@ -89,7 +89,6 @@ func CreatePMService(username string, args *ServiceTmplBuildObject, log *zap.Sug
 		return e.ErrCreateTemplate.AddDesc(err.Error())
 	}
 
-	//创建构建
 	// Confirm whether the build exists
 	build, err := commonrepo.NewBuildColl().Find(&commonrepo.BuildFindOption{Name: args.Build.Name})
 	if err != nil {

--- a/pkg/microservice/aslan/core/service/service/pm.go
+++ b/pkg/microservice/aslan/core/service/service/pm.go
@@ -91,13 +91,23 @@ func CreatePMService(username string, args *ServiceTmplBuildObject, log *zap.Sug
 
 	//创建构建
 	// Confirm whether the build exists
-	if _, err = commonrepo.NewBuildColl().Find(&commonrepo.BuildFindOption{Name: args.Build.Name}); err != nil {
+	build, err := commonrepo.NewBuildColl().Find(&commonrepo.BuildFindOption{Name: args.Build.Name})
+	if err != nil {
 		if err := commonservice.CreateBuild(username, args.Build, log); err != nil {
 			log.Errorf("pmService.Create build %s error: %v", args.Build.Name, err)
 			if err2 := commonrepo.NewServiceColl().Delete(args.ServiceTmplObject.ServiceName, args.ServiceTmplObject.Type, args.ServiceTmplObject.ProductName, "", rev); err2 != nil {
 				log.Errorf("pmService.delete %s error: %v", args.ServiceTmplObject.ServiceName, err2)
 			}
 			return e.ErrCreateTemplate.AddDesc(err.Error())
+		}
+	} else {
+		build.Targets = append(build.Targets, &commonmodels.ServiceModuleTarget{
+			ProductName:   args.ServiceTmplObject.ProductName,
+			ServiceName:   args.ServiceTmplObject.ServiceName,
+			ServiceModule: args.ServiceTmplObject.ServiceName,
+		})
+		if err = commonservice.UpdateBuild(username, build, log); err != nil {
+			return e.ErrCreateTemplate.AddDesc("update build failed")
 		}
 	}
 

--- a/pkg/microservice/aslan/core/service/service/pm.go
+++ b/pkg/microservice/aslan/core/service/service/pm.go
@@ -90,12 +90,15 @@ func CreatePMService(username string, args *ServiceTmplBuildObject, log *zap.Sug
 	}
 
 	//创建构建
-	if err := commonservice.CreateBuild(username, args.Build, log); err != nil {
-		log.Errorf("pmService.Create build %s error: %v", args.Build.Name, err)
-		if err2 := commonrepo.NewServiceColl().Delete(args.ServiceTmplObject.ServiceName, args.ServiceTmplObject.Type, args.ServiceTmplObject.ProductName, "", rev); err2 != nil {
-			log.Errorf("pmService.delete %s error: %v", args.ServiceTmplObject.ServiceName, err2)
+	// Confirm whether the build exists
+	if _, err = commonrepo.NewBuildColl().Find(&commonrepo.BuildFindOption{Name: args.Build.Name}); err != nil {
+		if err := commonservice.CreateBuild(username, args.Build, log); err != nil {
+			log.Errorf("pmService.Create build %s error: %v", args.Build.Name, err)
+			if err2 := commonrepo.NewServiceColl().Delete(args.ServiceTmplObject.ServiceName, args.ServiceTmplObject.Type, args.ServiceTmplObject.ProductName, "", rev); err2 != nil {
+				log.Errorf("pmService.delete %s error: %v", args.ServiceTmplObject.ServiceName, err2)
+			}
+			return e.ErrCreateTemplate.AddDesc(err.Error())
 		}
-		return e.ErrCreateTemplate.AddDesc(err.Error())
 	}
 
 	if serviceNotFound {


### PR DESCRIPTION
Signed-off-by: liu deyi <andrew@koderover.com>

### What this PR does / Why we need it:

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
When the cvm service is currently added, a build will be created at the same time. If the build exists, the service creation will fail

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/206)
<!-- Reviewable:end -->
