### PR TITLE
fixed a logic deadlock when using custom images

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskplugin/build.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/build.go
@@ -234,7 +234,12 @@ func (p *BuildTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipe
 
 	// 将集成到KodeRover的私有镜像仓库的访问权限设置到namespace中
 	if err := createOrUpdateRegistrySecrets(p.KubeNamespace, p.Task.Registries, p.kubeClient); err != nil {
-		p.Log.Errorf("create secret error: %v", err)
+		msg := fmt.Sprintf("create secret error: %v", err)
+		p.Log.Error(msg)
+		p.Task.TaskStatus = config.StatusFailed
+		p.Task.Error = msg
+		p.SetBuildStatusCompleted(config.StatusFailed)
+		return
 	}
 	if err := updater.CreateJob(job, p.kubeClient); err != nil {
 		msg := fmt.Sprintf("create build job error: %v", err)

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -517,7 +517,10 @@ func createOrUpdateRegistrySecrets(namespace string, registries []*task.Registry
 
 		arr := strings.Split(reg.Namespace, "/")
 		namespaceInRegistry := arr[len(arr)-1]
-		secretName := namespaceInRegistry + "-" + reg.RegType + "-registry-secret"
+		secretName := namespaceInRegistry + registrySecretSuffix
+		if reg.RegType != "" {
+			secretName = namespaceInRegistry + "-" + reg.RegType + registrySecretSuffix
+		}
 		if reg.RegAddr == config.DefaultRegistryAddr() {
 			secretName = "qn-registry-secret"
 		}


### PR DESCRIPTION
Signed-off-by: Min Min <minmin@koderover.com>

### What this PR does / Why we need it:
This PR fixed a bug where the custom image from private registry cannot be pulled.

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:
Now warpdrive will return error if any of the secrets cannot be created/update. This does not fix the problem but at least there is an error message.

## More information

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/207)
<!-- Reviewable:end -->
