### PR TITLE
Get codehost without ilyshin type judgment

### DIFF
--- a/pkg/shared/codehost/codehost.go
+++ b/pkg/shared/codehost/codehost.go
@@ -78,12 +78,12 @@ func GetCodeHostInfo(option *Option) (*poetry.CodeHost, error) {
 			return codeHost, nil
 		} else if option.CodeHostID == 0 && option.CodeHostType != "" {
 			switch option.CodeHostType {
-			case GitLabProvider, GerritProvider, CodeHubProvider:
-				if strings.Contains(option.Address, codeHost.Address) {
-					return codeHost, nil
-				}
 			case GitHubProvider:
 				if strings.Contains(option.Address, codeHost.Address) && option.Namespace == codeHost.Namespace {
+					return codeHost, nil
+				}
+			default:
+				if strings.Contains(option.Address, codeHost.Address) {
 					return codeHost, nil
 				}
 			}


### PR DESCRIPTION
Signed-off-by: liu deyi <andrew@koderover.com>

### What this PR does / Why we need it:

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
Get codehost without ilyshin type judgment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/208)
<!-- Reviewable:end -->
