### PR TITLE
changed image pull secret name to avoid conflict

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/actions.go
+++ b/pkg/microservice/aslan/core/common/service/kube/actions.go
@@ -58,7 +58,7 @@ func CreateOrUpdateRegistrySecret(namespace string, reg *commonmodels.RegistryNa
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      setting.DefaultCandidateImagePullSecret,
+			Name:      setting.DefaultImagePullSecret,
 		},
 		Data: data,
 		Type: corev1.SecretTypeDockercfg,

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2048,13 +2048,13 @@ func applySystemResourceRequirements(podSpec *corev1.PodSpec) {
 
 func applySystemImagePullSecrets(podSpec *corev1.PodSpec) {
 	for _, secret := range podSpec.ImagePullSecrets {
-		if secret.Name == setting.DefaultCandidateImagePullSecret {
+		if secret.Name == setting.DefaultImagePullSecret {
 			return
 		}
 	}
 	podSpec.ImagePullSecrets = append(podSpec.ImagePullSecrets,
 		corev1.LocalObjectReference{
-			Name: setting.DefaultCandidateImagePullSecret,
+			Name: setting.DefaultImagePullSecret,
 		})
 }
 

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -410,7 +410,7 @@ func buildJobWithLinkedNs(taskType config.TaskType, jobImage, jobName, serviceNa
 	// 引用集成到系统中的私有镜像仓库的访问权限
 	ImagePullSecrets := []corev1.LocalObjectReference{
 		{
-			Name: "default-registry-secret",
+			Name: setting.DefaultCandidateImagePullSecret,
 		},
 	}
 	for _, reg := range registries {
@@ -522,7 +522,7 @@ func createOrUpdateRegistrySecrets(namespace string, registries []*task.Registry
 			secretName = namespaceInRegistry + "-" + reg.RegType + registrySecretSuffix
 		}
 		if reg.RegAddr == config.DefaultRegistryAddr() {
-			secretName = "default-registry-secret"
+			secretName = setting.DefaultCandidateImagePullSecret
 		}
 
 		data := make(map[string][]byte)

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -410,7 +410,7 @@ func buildJobWithLinkedNs(taskType config.TaskType, jobImage, jobName, serviceNa
 	// 引用集成到系统中的私有镜像仓库的访问权限
 	ImagePullSecrets := []corev1.LocalObjectReference{
 		{
-			Name: "qn-registry-secret",
+			Name: "default-registry-secret",
 		},
 	}
 	for _, reg := range registries {
@@ -522,7 +522,7 @@ func createOrUpdateRegistrySecrets(namespace string, registries []*task.Registry
 			secretName = namespaceInRegistry + "-" + reg.RegType + registrySecretSuffix
 		}
 		if reg.RegAddr == config.DefaultRegistryAddr() {
-			secretName = "qn-registry-secret"
+			secretName = "default-registry-secret"
 		}
 
 		data := make(map[string][]byte)

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -410,7 +410,7 @@ func buildJobWithLinkedNs(taskType config.TaskType, jobImage, jobName, serviceNa
 	// 引用集成到系统中的私有镜像仓库的访问权限
 	ImagePullSecrets := []corev1.LocalObjectReference{
 		{
-			Name: setting.DefaultCandidateImagePullSecret,
+			Name: setting.DefaultImagePullSecret,
 		},
 	}
 	for _, reg := range registries {
@@ -522,7 +522,7 @@ func createOrUpdateRegistrySecrets(namespace string, registries []*task.Registry
 			secretName = namespaceInRegistry + "-" + reg.RegType + registrySecretSuffix
 		}
 		if reg.RegAddr == config.DefaultRegistryAddr() {
-			secretName = setting.DefaultCandidateImagePullSecret
+			secretName = setting.DefaultImagePullSecret
 		}
 
 		data := make(map[string][]byte)

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -176,7 +176,7 @@ const (
 
 	APIVersionAppsV1 = "apps/v1"
 
-	DefaultCandidateImagePullSecret = "default-candidate-registry-secret"
+	DefaultCandidateImagePullSecret = "default-registry-secret"
 )
 
 const (

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -176,7 +176,7 @@ const (
 
 	APIVersionAppsV1 = "apps/v1"
 
-	DefaultCandidateImagePullSecret = "default-registry-secret"
+	DefaultImagePullSecret = "default-registry-secret"
 )
 
 const (


### PR DESCRIPTION
Signed-off-by: Min Min <minmin@koderover.com>

### What this PR does / Why we need it:
Changed image pull secret in workflow to avoid conflicting with the system default pull secret.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/220)
<!-- Reviewable:end -->
