### PR TITLE
Compatible change for the aslan api response

### DIFF
--- a/pkg/microservice/aslan/core/system/service/operation.go
+++ b/pkg/microservice/aslan/core/system/service/operation.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/system/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/system/repository/mongodb"
-	aslanclient "github.com/koderover/zadig/pkg/shared/client/aslan"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 )
 
@@ -50,14 +49,18 @@ func FindOperation(args *OperationLogArgs, log *zap.SugaredLogger) ([]*models.Op
 	return resp, count, err
 }
 
-func InsertOperation(args *models.OperationLog, log *zap.SugaredLogger) (*aslanclient.AddAuditLogResp, error) {
+type AddAuditLogResp struct {
+	OperationLogID string `json:"id"`
+}
+
+func InsertOperation(args *models.OperationLog, log *zap.SugaredLogger) (*AddAuditLogResp, error) {
 	err := mongodb.NewOperationLogColl().Insert(args)
 	if err != nil {
 		log.Errorf("insert operation log error: %v", err)
 		return nil, e.ErrCreateOperationLog
 	}
 
-	return &aslanclient.AddAuditLogResp{
+	return &AddAuditLogResp{
 		OperationLogID: args.ID.Hex(),
 	}, nil
 }

--- a/pkg/microservice/aslan/core/system/service/operation.go
+++ b/pkg/microservice/aslan/core/system/service/operation.go
@@ -19,8 +19,8 @@ package service
 import (
 	"go.uber.org/zap"
 
-	models2 "github.com/koderover/zadig/pkg/microservice/aslan/core/system/repository/models"
-	mongodb2 "github.com/koderover/zadig/pkg/microservice/aslan/core/system/repository/mongodb"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/system/repository/models"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/system/repository/mongodb"
 	aslanclient "github.com/koderover/zadig/pkg/shared/client/aslan"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 )
@@ -34,8 +34,8 @@ type OperationLogArgs struct {
 	Page        int    `json:"page"`
 }
 
-func FindOperation(args *OperationLogArgs, log *zap.SugaredLogger) ([]*models2.OperationLog, int, error) {
-	resp, count, err := mongodb2.NewOperationLogColl().Find(&mongodb2.OperationLogArgs{
+func FindOperation(args *OperationLogArgs, log *zap.SugaredLogger) ([]*models.OperationLog, int, error) {
+	resp, count, err := mongodb.NewOperationLogColl().Find(&mongodb.OperationLogArgs{
 		Username:    args.Username,
 		ProductName: args.ProductName,
 		Function:    args.Function,
@@ -50,8 +50,8 @@ func FindOperation(args *OperationLogArgs, log *zap.SugaredLogger) ([]*models2.O
 	return resp, count, err
 }
 
-func InsertOperation(args *models2.OperationLog, log *zap.SugaredLogger) (*aslanclient.AddAuditLogResp, error) {
-	err := mongodb2.NewOperationLogColl().Insert(args)
+func InsertOperation(args *models.OperationLog, log *zap.SugaredLogger) (*aslanclient.AddAuditLogResp, error) {
+	err := mongodb.NewOperationLogColl().Insert(args)
 	if err != nil {
 		log.Errorf("insert operation log error: %v", err)
 		return nil, e.ErrCreateOperationLog
@@ -62,7 +62,7 @@ func InsertOperation(args *models2.OperationLog, log *zap.SugaredLogger) (*aslan
 }
 
 func UpdateOperation(id string, status int, log *zap.SugaredLogger) error {
-	err := mongodb2.NewOperationLogColl().Update(id, status)
+	err := mongodb.NewOperationLogColl().Update(id, status)
 	if err != nil {
 		log.Errorf("update operation log error: %v", err)
 		return e.ErrUpdateOperationLog

--- a/pkg/microservice/aslan/core/system/service/operation.go
+++ b/pkg/microservice/aslan/core/system/service/operation.go
@@ -57,8 +57,9 @@ func InsertOperation(args *models.OperationLog, log *zap.SugaredLogger) (*aslanc
 		return nil, e.ErrCreateOperationLog
 	}
 
-	resp := &aslanclient.AddAuditLogResp{OperationLogID: args.ID.Hex()}
-	return resp, nil
+	return &aslanclient.AddAuditLogResp{
+		OperationLogID: args.ID.Hex(),
+	}, nil
 }
 
 func UpdateOperation(id string, status int, log *zap.SugaredLogger) error {

--- a/pkg/microservice/aslan/core/system/service/operation.go
+++ b/pkg/microservice/aslan/core/system/service/operation.go
@@ -21,6 +21,7 @@ import (
 
 	models2 "github.com/koderover/zadig/pkg/microservice/aslan/core/system/repository/models"
 	mongodb2 "github.com/koderover/zadig/pkg/microservice/aslan/core/system/repository/mongodb"
+	aslanclient "github.com/koderover/zadig/pkg/shared/client/aslan"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 )
 
@@ -49,13 +50,15 @@ func FindOperation(args *OperationLogArgs, log *zap.SugaredLogger) ([]*models2.O
 	return resp, count, err
 }
 
-func InsertOperation(args *models2.OperationLog, log *zap.SugaredLogger) (string, error) {
+func InsertOperation(args *models2.OperationLog, log *zap.SugaredLogger) (*aslanclient.AddAuditLogResp, error) {
 	err := mongodb2.NewOperationLogColl().Insert(args)
 	if err != nil {
 		log.Errorf("insert operation log error: %v", err)
-		return "", e.ErrCreateOperationLog
+		return nil, e.ErrCreateOperationLog
 	}
-	return args.ID.Hex(), nil
+
+	resp := &aslanclient.AddAuditLogResp{OperationLogID: args.ID.Hex()}
+	return resp, nil
 }
 
 func UpdateOperation(id string, status int, log *zap.SugaredLogger) error {

--- a/pkg/shared/client/aslan/audit_log.go
+++ b/pkg/shared/client/aslan/audit_log.go
@@ -41,6 +41,10 @@ type updateOperationArgs struct {
 	Status int `json:"status"`
 }
 
+type AddAuditLogResp struct {
+	OperationLogID string `json:"id"`
+}
+
 func (c *Client) AddAuditLog(username, productName, method, function, detail, permissionUUID, requestBody string, log *zap.SugaredLogger) (string, error) {
 	url := "/system/operation"
 	req := operationLog{
@@ -55,14 +59,14 @@ func (c *Client) AddAuditLog(username, productName, method, function, detail, pe
 		CreatedAt:      time.Now().Unix(),
 	}
 
-	var operationLogID string
+	var operationLogID AddAuditLogResp
 	_, err := c.Post(url, httpclient.SetBody(req), httpclient.SetResult(&operationLogID))
 	if err != nil {
 		log.Errorf("Failed to add audit log, error: %s", err)
 		return "", err
 	}
 
-	return operationLogID, nil
+	return operationLogID.OperationLogID, nil
 }
 
 func (c *Client) UpdateAuditLog(id string, status int, log *zap.SugaredLogger) error {


### PR DESCRIPTION
Signed-off-by: Min Min <minmin@koderover.com>

### What this PR does / Why we need it:
Aslan Server now changed the behavior of returning pure sting, changing from a json to a straight string. Audit log client cannot unmarshal the response from the server for now. So we changed the type of server response

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/240)
<!-- Reviewable:end -->
