### PR TITLE
change label bot :  delete issue_label_bot && add service labeler for pull request 

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,0 @@
-blank_issues_enabled: false
-contact_links:
-  - name: xx
-    url: xx
-    about: xx

--- a/.github/issue_label_bot.yaml
+++ b/.github/issue_label_bot.yaml
@@ -1,5 +1,0 @@
-# for https://mlbot.net
-label-alias:
-  bug: 'kind/bug'
-  feature: 'kind/feature'
-  question: 'kind/question'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,21 @@
+# Add 'service/x' label to any change to microservice files within the source dir
+service/aslan:
+- pkg/microservice/aslan/*
+
+service/cron:
+- pkg/microservice/cron/*
+
+service/podexec:
+- pkg/microservice/podexec/*
+
+service/predator:
+- pkg/microservice/predator/*
+
+service/reaper:
+- pkg/microservice/reaper/*
+
+service/warpdrive:
+- pkg/microservice/warpdrive/*
+
+service/hubserver:
+- pkg/microservice/hubserver/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Signed-off-by: landylee007 <liqian@koderover.com>

### What this PR does / Why we need it:

1. for issue template : the issue_label_bot is no longer live, We use GitHub standard issue template way.
2. for pull request : add service labeler, Automatically label new pull requests based on the paths of files being changed.