### PR TITLE
fix Dockerfile for voting-app demo

### DIFF
--- a/examples/voting-app/worker/Dockerfile
+++ b/examples/voting-app/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.0.0-sdk
+FROM mcr.microsoft.com/dotnet/sdk
 
 WORKDIR /code
 


### PR DESCRIPTION
Problem Summary:

`microsoft/dotnet:2.0.0-sdk` is out of date.
 