### PR TITLE
fix pm create namespace bug

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/product.go
+++ b/pkg/microservice/aslan/core/environment/service/product.go
@@ -116,6 +116,9 @@ func GetInitProduct(productTmplName string, log *zap.SugaredLogger) (*commonmode
 	ret.Render = &commonmodels.RenderInfo{Name: "", Description: ""}
 	ret.Vars = prodTmpl.Vars
 	ret.ChartInfos = prodTmpl.ChartInfos
+	if prodTmpl.ProductFeature.BasicFacility == setting.BasicFacilityCVM {
+		ret.Source = setting.PMDeployType
+	}
 
 	allServiceInfoMap := prodTmpl.AllServiceInfoMap()
 	for _, names := range prodTmpl.Services {


### PR DESCRIPTION
Signed-off-by: mouuii <zhouchengbin@koderover.com>

### What this PR does / Why we need it:
When user create pm onboarding project , if there is already a namespace exist , create env fail .
in this version , create pm does not create a real namespace, so there's no need to check the namespace first .