### PR TITLE
add index

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/service.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/service.go
@@ -96,6 +96,10 @@ func (c *ServiceColl) EnsureIndex(ctx context.Context) error {
 			Options: options.Index().SetUnique(false),
 		},
 		{
+			Keys:    bson.M{"revision": 1},
+			Options: options.Index().SetUnique(false),
+		},
+		{
 			Keys: bson.D{
 				bson.E{Key: "service_name", Value: 1},
 				bson.E{Key: "type", Value: 1},


### PR DESCRIPTION
### What this PR does / Why we need it:

Problem Summary: mongodb cpu usage is high

### What is changed and how it works?

add an index for collection "template_service"