### PR TITLE
add service display name

### DIFF
--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -87,15 +87,11 @@ type IngressInfo struct {
 }
 
 // fill service display name if necessary
-func fillServiceDisplayName(svcList []*ServiceResp, projectInfo *models.Product) {
-	if projectInfo.Source == setting.SourceFromHelm {
-		prefix := fmt.Sprintf("%s%s", projectInfo.Namespace, "-")
+func fillServiceDisplayName(svcList []*ServiceResp, productInfo *models.Product) {
+	if productInfo.Source == setting.SourceFromHelm {
+		prefix := fmt.Sprintf("%s%s", productInfo.Namespace, "-")
 		for _, svc := range svcList {
 			svc.ServiceDisplayName = strings.TrimPrefix(svc.ServiceName, prefix)
-		}
-	} else {
-		for _, svc := range svcList {
-			svc.ServiceDisplayName = svc.ServiceName
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

service names in helm environments are too long

remove {projectname-env} prefix