### PR TITLE
fix file read bug

### DIFF
--- a/pkg/microservice/aslan/core/service/service/helm.go
+++ b/pkg/microservice/aslan/core/service/service/helm.go
@@ -341,7 +341,6 @@ func CreateOrUpdateHelmServiceFromGitRepo(projectName string, args *HelmServiceC
 				func(chartTree afero.Fs) (string, error) {
 					chartName, _, err := readChartYAML(afero.NewIOFS(chartTree), filepath.Base(filePath), log)
 					serviceName = chartName
-
 					return chartName, err
 				})
 			if err != nil {
@@ -429,13 +428,14 @@ func readValuesYAML(chartTree fs.FS, base string, logger *zap.SugaredLogger) ([]
 }
 
 func createOrUpdateHelmService(fsTree fs.FS, args *helmServiceCreationArgs, logger *zap.SugaredLogger) (*models.Service, error) {
-	chartName, chartVersion, err := readChartYAML(fsTree, filepath.Base(args.FilePath), logger)
+	chartName, chartVersion, err := readChartYAML(fsTree, filepath.Base(args.ServiceName), logger)
 	if err != nil {
 		logger.Errorf("Failed to read chart.yaml, err %s", err)
 		return nil, err
 	}
+	logger.Infof("find chart info by service name!!!!!!!!")
 
-	values, valuesMap, err := readValuesYAML(fsTree, filepath.Base(args.FilePath), logger)
+	values, valuesMap, err := readValuesYAML(fsTree, filepath.Base(args.ServiceName), logger)
 	if err != nil {
 		logger.Errorf("Failed to read values.yaml, err %s", err)
 		return nil, err

--- a/pkg/microservice/aslan/core/service/service/helm.go
+++ b/pkg/microservice/aslan/core/service/service/helm.go
@@ -433,7 +433,6 @@ func createOrUpdateHelmService(fsTree fs.FS, args *helmServiceCreationArgs, logg
 		logger.Errorf("Failed to read chart.yaml, err %s", err)
 		return nil, err
 	}
-	logger.Infof("find chart info by service name!!!!!!!!")
 
 	values, valuesMap, err := readValuesYAML(fsTree, filepath.Base(args.ServiceName), logger)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

Problem Summary:

if service name define in chart.yaml is different from the name of the parent directory, errors may occur when reading chart.yaml after the chart's downloaded 

### What is changed and how it works?

user service name as the base url to read file