### PR TITLE
Feature/helm service name

### DIFF
--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -87,15 +87,11 @@ type IngressInfo struct {
 }
 
 // fill service display name if necessary
-func fillServiceDisplayName(svcList []*ServiceResp, projectInfo *models.Product) {
-	if projectInfo.Source == setting.SourceFromHelm {
-		prefix := fmt.Sprintf("%s%s", projectInfo.Namespace, "-")
+func fillServiceDisplayName(svcList []*ServiceResp, productInfo *models.Product) {
+	if productInfo.Source == setting.SourceFromHelm {
+		prefix := fmt.Sprintf("%s%s", productInfo.Namespace, "-")
 		for _, svc := range svcList {
 			svc.ServiceDisplayName = strings.TrimPrefix(svc.ServiceName, prefix)
-		}
-	} else {
-		for _, svc := range svcList {
-			svc.ServiceDisplayName = svc.ServiceName
 		}
 	}
 }

--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -22,6 +22,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/koderover/zadig/pkg/util"
+
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -89,9 +91,8 @@ type IngressInfo struct {
 // fill service display name if necessary
 func fillServiceDisplayName(svcList []*ServiceResp, productInfo *models.Product) {
 	if productInfo.Source == setting.SourceFromHelm {
-		prefix := fmt.Sprintf("%s%s", productInfo.Namespace, "-")
 		for _, svc := range svcList {
-			svc.ServiceDisplayName = strings.TrimPrefix(svc.ServiceName, prefix)
+			svc.ServiceDisplayName = util.ExtraServiceName(svc.ServiceName, productInfo.Namespace)
 		}
 	}
 }

--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -22,8 +22,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/koderover/zadig/pkg/util"
-
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -38,6 +36,7 @@ import (
 	"github.com/koderover/zadig/pkg/shared/kube/wrapper"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 	"github.com/koderover/zadig/pkg/tool/kube/getter"
+	"github.com/koderover/zadig/pkg/util"
 	jsonutil "github.com/koderover/zadig/pkg/util/json"
 )
 

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -27,6 +27,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/koderover/zadig/pkg/util"
+
 	"github.com/hashicorp/go-multierror"
 	helmclient "github.com/mittwald/go-helm-client"
 	"github.com/pkg/errors"
@@ -2544,7 +2546,7 @@ func installOrUpdateHelmChart(user, envName, requestID string, args *commonmodel
 				}
 
 				chartSpec := &helmclient.ChartSpec{
-					ReleaseName: fmt.Sprintf("%s-%s", args.Namespace, service.ServiceName),
+					ReleaseName: util.GeneHelmReleaseName(args.Namespace, service.ServiceName),
 					ChartName:   chartPath,
 					Namespace:   args.Namespace,
 					Wait:        true,
@@ -2659,7 +2661,7 @@ func updateProductGroup(productName, envName, updateType string, productResp *co
 			go func(namespace, serviceName string) {
 				log.Infof("ready to uninstall release:%s", fmt.Sprintf("%s-%s", namespace, serviceName))
 				if err = helmClient.UninstallRelease(&helmclient.ChartSpec{
-					ReleaseName: fmt.Sprintf("%s-%s", namespace, serviceName),
+					ReleaseName: util.GeneHelmReleaseName(namespace, serviceName),
 					Namespace:   namespace,
 					Wait:        true,
 					Force:       true,
@@ -2736,7 +2738,7 @@ func updateProductGroup(productName, envName, updateType string, productResp *co
 				}
 
 				chartSpec := helmclient.ChartSpec{
-					ReleaseName: fmt.Sprintf("%s-%s", productResp.Namespace, service.ServiceName),
+					ReleaseName: util.GeneHelmReleaseName(productResp.Namespace, service.ServiceName),
 					ChartName:   chartPath,
 					Namespace:   productResp.Namespace,
 					Wait:        true,
@@ -2989,7 +2991,7 @@ func updateProductVariable(productName, envName string, productResp *commonmodel
 					}
 
 					chartSpec := helmclient.ChartSpec{
-						ReleaseName: fmt.Sprintf("%s-%s", productResp.Namespace, tmpRenderChart.ServiceName),
+						ReleaseName: util.GeneHelmReleaseName(productResp.Namespace, tmpRenderChart.ServiceName),
 						ChartName:   chartPath,
 						Namespace:   productResp.Namespace,
 						Wait:        true,

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -27,8 +27,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/koderover/zadig/pkg/util"
-
 	"github.com/hashicorp/go-multierror"
 	helmclient "github.com/mittwald/go-helm-client"
 	"github.com/pkg/errors"
@@ -62,6 +60,7 @@ import (
 	"github.com/koderover/zadig/pkg/tool/kube/serializer"
 	"github.com/koderover/zadig/pkg/tool/kube/updater"
 	"github.com/koderover/zadig/pkg/types/permission"
+	"github.com/koderover/zadig/pkg/util"
 	"github.com/koderover/zadig/pkg/util/converter"
 	"github.com/koderover/zadig/pkg/util/fs"
 )

--- a/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
@@ -463,7 +463,7 @@ func (p *DeployTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, _ *
 				}
 
 				chartSpec := helmclient.ChartSpec{
-					ReleaseName: fmt.Sprintf("%s-%s", p.Task.Namespace, p.Task.ServiceName),
+					ReleaseName: util.GeneHelmReleaseName(p.Task.Namespace, p.Task.ServiceName),
 					ChartName:   chartPath,
 					Namespace:   p.Task.Namespace,
 					ReuseValues: true,

--- a/pkg/util/helm.go
+++ b/pkg/util/helm.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2021 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+func GeneHelmReleaseName(namespace, serviceName string) string {
+	return fmt.Sprintf("%s-%s", namespace, serviceName)
+}
+
+func ExtraServiceName(releaseName, namespace string) string {
+	return strings.TrimPrefix(releaseName, fmt.Sprintf("%s-", namespace))
+}


### PR DESCRIPTION
What this PR does / Why we need it:
service names in helm environments are too long

remove {projectname-env} prefix