### PR TITLE
Upgrade Git to latest version in 16.04

### DIFF
--- a/docker/service/reaper-plugin-xenial.Dockerfile
+++ b/docker/service/reaper-plugin-xenial.Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get clean && apt-get update && apt-get install -y \
   sudo
 
 # Upgrade Git to latest version
-RUN apt-get install -y software-properties-common && add-apt-repository -y ppa:git-core/ppa && apt-get update && apt-get install -y git
+RUN apt-get install -y software-properties-common && add-apt-repository -y ppa:git-core/ppa && apt-get update && apt-get install -y git=1:2.33.0-0ppa1~ubuntu16.04.1
 
 # 修改时区
 RUN ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime


### PR DESCRIPTION
Signed-off-by: leozhang2018 <leozhang2018@gmail.com>

### What this PR does / Why we need it:

Upgrade Git to latest version in Ubuntu 16.04.

`git fetch --deepen` available in [2.11.4](https://git-scm.com/docs/fetch-options/2.11.4).

See difference between [2.9.5](https://git-scm.com/docs/fetch-options/2.9.5) and [2.11.4](https://git-scm.com/docs/fetch-options/2.11.4).

Reference:
https://gist.github.com/YuMS/6d7639480b17523f6f01490f285da509

Default version：
git version 2.7.4

Latest version:
git version 2.33.0


### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information