### PR TITLE
add global rolebinding & add new policy user_visible_projects and user_allowed_projects

### DIFF
--- a/pkg/microservice/policy/core/handler/role_binding.go
+++ b/pkg/microservice/policy/core/handler/role_binding.go
@@ -42,3 +42,16 @@ func CreateRoleBinding(c *gin.Context) {
 
 	ctx.Err = service.CreateRoleBinding(projectName, args, ctx.Logger)
 }
+
+func CreateGlobalRoleBinding(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	args := &service.RoleBinding{}
+	if err := c.ShouldBindJSON(args); err != nil {
+		ctx.Err = err
+		return
+	}
+
+	ctx.Err = service.CreateRoleBinding("", args, ctx.Logger)
+}

--- a/pkg/microservice/policy/core/handler/router.go
+++ b/pkg/microservice/policy/core/handler/router.go
@@ -38,6 +38,11 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		roleBindings.POST("", CreateRoleBinding)
 	}
 
+	globalRoleBindings := router.Group("global-rolebindings")
+	{
+		globalRoleBindings.POST("", CreateGlobalRoleBinding)
+	}
+
 	bundles := router.Group("bundles")
 	{
 		bundles.GET("/:name", DownloadBundle)

--- a/pkg/microservice/policy/core/service/bundle/rego/test_data/bindings/data.json
+++ b/pkg/microservice/policy/core/service/bundle/rego/test_data/bindings/data.json
@@ -4,6 +4,15 @@
       "user": "alice",
       "bindings": [
         {
+          "namespace": "",
+          "role_refs": [
+            {
+              "name": "admin",
+              "namespace": ""
+            }
+          ]
+        },
+        {
           "namespace": "project1",
           "role_refs": [
             {

--- a/pkg/microservice/policy/core/service/bundle/rego/test_data/roles/data.json
+++ b/pkg/microservice/policy/core/service/bundle/rego/test_data/roles/data.json
@@ -71,6 +71,16 @@
       ]
     },
     {
+      "name": "view",
+      "namespace": "project3",
+      "rules": [
+        {
+          "method": "GET",
+          "endpoint": "/api/articles"
+        }
+      ]
+    },
+    {
       "name": "reader2",
       "namespace": "project1",
       "rules": [

--- a/pkg/microservice/policy/core/service/role_binding.go
+++ b/pkg/microservice/policy/core/service/role_binding.go
@@ -33,11 +33,6 @@ type RoleBinding struct {
 }
 
 func CreateRoleBinding(ns string, rb *RoleBinding, logger *zap.SugaredLogger) error {
-	if ns == "" {
-		logger.Errorf("Namespace is empty")
-		return fmt.Errorf("empty namespace")
-	}
-
 	nsRole := ns
 	if rb.Global {
 		nsRole = ""


### PR DESCRIPTION
### What this PR does / Why we need it:

1. add global rolebinding api
2. add new policy user_visible_projects(all visible projects for a user) and user_allowed_projects(all allowed projects for a user for a certain action(method+endpoint))