### PR TITLE
fix privilege escalation

### DIFF
--- a/pkg/microservice/policy/core/handler/role_binding.go
+++ b/pkg/microservice/policy/core/handler/role_binding.go
@@ -43,7 +43,7 @@ func CreateRoleBinding(c *gin.Context) {
 	ctx.Err = service.CreateRoleBinding(projectName, args, ctx.Logger)
 }
 
-func CreateGlobalRoleBinding(c *gin.Context) {
+func CreateSystemRoleBinding(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
@@ -53,5 +53,7 @@ func CreateGlobalRoleBinding(c *gin.Context) {
 		return
 	}
 
-	ctx.Err = service.CreateRoleBinding("", args, ctx.Logger)
+	args.Global = false
+
+	ctx.Err = service.CreateRoleBinding(service.SystemScope, args, ctx.Logger)
 }

--- a/pkg/microservice/policy/core/handler/router.go
+++ b/pkg/microservice/policy/core/handler/router.go
@@ -38,9 +38,9 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		roleBindings.POST("", CreateRoleBinding)
 	}
 
-	globalRoleBindings := router.Group("global-rolebindings")
+	systemRoleBindings := router.Group("system-rolebindings")
 	{
-		globalRoleBindings.POST("", CreateGlobalRoleBinding)
+		systemRoleBindings.POST("", CreateSystemRoleBinding)
 	}
 
 	bundles := router.Group("bundles")

--- a/pkg/microservice/policy/core/service/bundle/rego/authz.rego
+++ b/pkg/microservice/policy/core/service/bundle/rego/authz.rego
@@ -49,7 +49,7 @@ user_is_admin {
     all_roles[role]
 
     role.name == "admin"
-    role.namespace == ""
+    role.namespace == "*"
 }
 
 user_is_project_admin {

--- a/pkg/microservice/policy/core/service/role_binding.go
+++ b/pkg/microservice/policy/core/service/role_binding.go
@@ -32,6 +32,8 @@ type RoleBinding struct {
 	Global bool   `json:"global"`
 }
 
+const SystemScope = "*"
+
 func CreateRoleBinding(ns string, rb *RoleBinding, logger *zap.SugaredLogger) error {
 	nsRole := ns
 	if rb.Global {


### PR DESCRIPTION
### What this PR does / Why we need it:

Problem Summary: project admin can bind a user to a system admin role.

### What is changed and how it works?

What's Changed:

system admin roles are not in global roles(ns="") now, they are under a special ns (ns="*") which means system scope