### PR TITLE
Bugfix/copy chart bug

### DIFF
--- a/pkg/microservice/aslan/core/service/service/helm.go
+++ b/pkg/microservice/aslan/core/service/service/helm.go
@@ -266,6 +266,11 @@ func CreateOrUpdateHelmServiceFromChartTemplate(projectName string, args *HelmSe
 	// copy template to service path and update the values.yaml
 	from := filepath.Join(localBase, base)
 	to := filepath.Join(config.LocalServicePath(projectName, args.Name), args.Name)
+	// remove old files
+	if err = os.RemoveAll(to); err != nil {
+		logger.Errorf("Failed to remove dir to %s, err: %s", to, err)
+		return err
+	}
 	if err = copy.Copy(from, to); err != nil {
 		logger.Errorf("Failed to copy file from %s to %s, err: %s", from, to, err)
 		return err
@@ -564,6 +569,11 @@ func handleSingleService(projectName string, repoConfig *commonservice.RepoConfi
 	serviceName = strings.TrimSuffix(serviceName, filepath.Ext(serviceName))
 
 	to := filepath.Join(config.LocalServicePath(projectName, serviceName), serviceName)
+	// remove old files
+	if err = os.RemoveAll(to); err != nil {
+		logger.Errorf("Failed to remove dir to %s, err: %s", to, err)
+		return nil, err
+	}
 	if err = copy.Copy(fromPath, to); err != nil {
 		logger.Errorf("Failed to copy file from %s to %s, err: %s", fromPath, to, err)
 		return nil, err

--- a/pkg/microservice/aslan/core/service/service/helm.go
+++ b/pkg/microservice/aslan/core/service/service/helm.go
@@ -268,7 +268,7 @@ func CreateOrUpdateHelmServiceFromChartTemplate(projectName string, args *HelmSe
 	to := filepath.Join(config.LocalServicePath(projectName, args.Name), args.Name)
 	// remove old files
 	if err = os.RemoveAll(to); err != nil {
-		logger.Errorf("Failed to remove dir to %s, err: %s", to, err)
+		logger.Errorf("Failed to remove dir %s, err: %s", to, err)
 		return err
 	}
 	if err = copy.Copy(from, to); err != nil {
@@ -571,7 +571,7 @@ func handleSingleService(projectName string, repoConfig *commonservice.RepoConfi
 	to := filepath.Join(config.LocalServicePath(projectName, serviceName), serviceName)
 	// remove old files
 	if err = os.RemoveAll(to); err != nil {
-		logger.Errorf("Failed to remove dir to %s, err: %s", to, err)
+		logger.Errorf("Failed to remove dir %s, err: %s", to, err)
 		return nil, err
 	}
 	if err = copy.Copy(fromPath, to); err != nil {


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

when helm chart template updates, new service instantiated from the template may have residual files if service name remains same.

How it Works:
remove old files before copy
