### PR TITLE
ignore error for old incomplete service data

### DIFF
--- a/pkg/microservice/aslan/core/common/service/service.go
+++ b/pkg/microservice/aslan/core/common/service/service.go
@@ -356,7 +356,7 @@ func GetServiceTemplate(serviceName, serviceType, productName, excludeStatus str
 		}
 
 		detail, err := codehost.GetCodeHostInfo(
-			&codehost.Option{CodeHostType: poetry.GitHubProvider, Address: address, Namespace: owner})
+			&codehost.Option{CodeHostType: poetry.GitHubProvider, Address: address, Namespace: owner, CodeHostID: resp.CodehostID})
 		if err != nil {
 			log.Errorf("get github codeHostInfo failed, err:%v", err)
 			return nil, err

--- a/pkg/microservice/aslan/core/common/service/template_product.go
+++ b/pkg/microservice/aslan/core/common/service/template_product.go
@@ -142,10 +142,11 @@ func GetProductTemplate(productName string, log *zap.SugaredLogger) (*template.P
 	if len(totalServices) > 0 {
 		serviceObj, err := GetServiceTemplate(totalServices[0].ServiceName, totalServices[0].Type, productName, setting.ProductStatusDeleting, totalServices[0].Revision, log)
 		if err != nil {
-			return resp, fmt.Errorf("GetServiceTemplate err : %v", err)
+			log.Errorf("GetServiceTemplate err : %v", err)
+		} else {
+			resp.LatestServiceUpdateTime = serviceObj.CreateTime
+			resp.LatestServiceUpdateBy = serviceObj.CreateBy
 		}
-		resp.LatestServiceUpdateTime = serviceObj.CreateTime
-		resp.LatestServiceUpdateBy = serviceObj.CreateBy
 	}
 	resp.TotalBuildNum = len(totalBuilds)
 	if len(totalBuilds) > 0 {

--- a/pkg/microservice/aslan/core/common/service/template_product.go
+++ b/pkg/microservice/aslan/core/common/service/template_product.go
@@ -142,7 +142,7 @@ func GetProductTemplate(productName string, log *zap.SugaredLogger) (*template.P
 	if len(totalServices) > 0 {
 		serviceObj, err := GetServiceTemplate(totalServices[0].ServiceName, totalServices[0].Type, productName, setting.ProductStatusDeleting, totalServices[0].Revision, log)
 		if err != nil {
-			log.Errorf("GetServiceTemplate err : %v", err)
+			log.Errorf("GetServiceTemplate err : %s", err)
 		} else {
 			resp.LatestServiceUpdateTime = serviceObj.CreateTime
 			resp.LatestServiceUpdateBy = serviceObj.CreateBy

--- a/pkg/shared/codehost/codehost.go
+++ b/pkg/shared/codehost/codehost.go
@@ -79,7 +79,7 @@ func GetCodeHostInfo(option *Option) (*poetry.CodeHost, error) {
 			switch option.CodeHostType {
 			case GitHubProvider:
 				ns := strings.ToLower(codeHost.Namespace)
-				if strings.Contains(option.Address, codeHost.Address) && option.Namespace == ns {
+				if strings.Contains(option.Address, codeHost.Address) && strings.ToLower(option.Namespace) == ns {
 					return codeHost, nil
 				}
 			default:


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

What's Changed:
ignore errors when getting data from incomplete service template

