### PR TITLE
change productName to projectName

### DIFF
--- a/pkg/microservice/aslan/core/environment/handler/renderset.go
+++ b/pkg/microservice/aslan/core/environment/handler/renderset.go
@@ -56,7 +56,7 @@ func GetProductDefaultValues(c *gin.Context) {
 		return
 	}
 
-	ctx.Resp, ctx.Err = service.GetDefaultValues(c.Query("productName"), c.Query("envName"), ctx.Logger)
+	ctx.Resp, ctx.Err = service.GetDefaultValues(c.Query("projectName"), c.Query("envName"), ctx.Logger)
 }
 
 func GetYamlContent(c *gin.Context) {

--- a/pkg/microservice/aslan/core/service/handler/helm.go
+++ b/pkg/microservice/aslan/core/service/handler/helm.go
@@ -80,7 +80,7 @@ func CreateOrUpdateBulkHelmServices(c *gin.Context) {
 	}
 	args.CreatedBy = ctx.UserName
 
-	ctx.Resp, ctx.Err = svcservice.CreateOrUpdateBulkHelmService(c.Query("productName"), args, ctx.Logger)
+	ctx.Resp, ctx.Err = svcservice.CreateOrUpdateBulkHelmService(c.Query("projectName"), args, ctx.Logger)
 }
 
 func UpdateHelmService(c *gin.Context) {

--- a/pkg/microservice/aslan/core/workflow/handler/build.go
+++ b/pkg/microservice/aslan/core/workflow/handler/build.go
@@ -30,7 +30,7 @@ func BuildModuleToSubTasks(c *gin.Context) {
 
 	args := &models.BuildModuleArgs{
 		BuildName:   c.Param("name"),
-		ProductName: c.Query("productName"),
+		ProductName: c.Query("projectName"),
 	}
 	resp, err := workflow.BuildModuleToSubTasks(args, ctx.Logger)
 	if err != nil {

--- a/pkg/microservice/aslan/core/workflow/handler/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/handler/workflow.go
@@ -118,7 +118,7 @@ func ListWorkflows(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
-	ctx.Resp, ctx.Err = workflow.ListWorkflows(c.Query("type"), c.Query("productName"), ctx.UserID, ctx.Logger)
+	ctx.Resp, ctx.Err = workflow.ListWorkflows(c.Query("type"), c.Query("projectName"), ctx.UserID, ctx.Logger)
 }
 
 func ListTestWorkflows(c *gin.Context) {

--- a/pkg/microservice/picket/core/public/handler/public.go
+++ b/pkg/microservice/picket/core/public/handler/public.go
@@ -100,7 +100,7 @@ func ListWorkflowTask(c *gin.Context) {
 func ListDelivery(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
-	productName := c.Query("productName")
+	productName := c.Query("projectName")
 	workflowName := c.Query("workflowName")
 	taskIDStr := c.Query("taskId")
 	perPageStr := c.Query("perPage")


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

What's Changed:

use projectName instead of productName  when parsing http query parameters