### PR TITLE
add new filter for projects

### DIFF
--- a/pkg/microservice/aslan/core/delivery/handler/product.go
+++ b/pkg/microservice/aslan/core/delivery/handler/product.go
@@ -24,13 +24,6 @@ import (
 	e "github.com/koderover/zadig/pkg/tool/errors"
 )
 
-func ListDeliveryProduct(c *gin.Context) {
-	ctx := internalhandler.NewContext(c)
-	defer func() { internalhandler.JSONResponse(c, ctx) }()
-
-	ctx.Resp, ctx.Err = deliveryservice.FindDeliveryProduct(ctx.Logger)
-}
-
 func GetProductByDeliveryInfo(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()

--- a/pkg/microservice/aslan/core/delivery/handler/router.go
+++ b/pkg/microservice/aslan/core/delivery/handler/router.go
@@ -37,7 +37,6 @@ func (*Router) Inject(router *gin.RouterGroup) {
 
 	deliveryProduct := router.Group("products")
 	{
-		deliveryProduct.GET("", ListDeliveryProduct)
 		deliveryProduct.GET("/:releaseId", GetProductByDeliveryInfo)
 	}
 

--- a/pkg/microservice/aslan/core/delivery/service/product.go
+++ b/pkg/microservice/aslan/core/delivery/service/product.go
@@ -24,16 +24,6 @@ import (
 	e "github.com/koderover/zadig/pkg/tool/errors"
 )
 
-func FindDeliveryProduct(log *zap.SugaredLogger) ([]string, error) {
-	productNames, err := commonrepo.NewDeliveryVersionColl().FindProducts()
-	if err != nil {
-		log.Errorf("find FindDeliveryProduct error: %v", err)
-		return []string{}, e.ErrFindDeliveryProducts
-	}
-
-	return productNames, err
-}
-
 func GetProductByDeliveryInfo(username, releaseID string, log *zap.SugaredLogger) (*commonmodels.Product, error) {
 	version := new(commonrepo.DeliveryVersionArgs)
 	version.ID = releaseID

--- a/pkg/microservice/aslan/core/project/handler/project.go
+++ b/pkg/microservice/aslan/core/project/handler/project.go
@@ -25,9 +25,10 @@ import (
 )
 
 type projectListArgs struct {
-	IgnoreNoEnvs bool     `json:"ignoreNoEnvs"    form:"ignoreNoEnvs"`
-	Verbosity    string   `json:"verbosity"       form:"verbosity"`
-	Names        []string `json:"names"           form:"names"`
+	IgnoreNoEnvs     bool     `json:"ignoreNoEnvs"     form:"ignoreNoEnvs"`
+	IgnoreNoVersions bool     `json:"ignoreNoVersions" form:"ignoreNoVersions"`
+	Verbosity        string   `json:"verbosity"        form:"verbosity"`
+	Names            []string `json:"names"            form:"names"`
 }
 
 func ListProjects(c *gin.Context) {
@@ -47,7 +48,12 @@ func ListProjects(c *gin.Context) {
 	}
 
 	ctx.Resp, ctx.Err = projectservice.ListProjects(
-		&projectservice.ProjectListOptions{IgnoreNoEnvs: args.IgnoreNoEnvs, Verbosity: projectservice.QueryVerbosity(args.Verbosity), Names: args.Names},
+		&projectservice.ProjectListOptions{
+			IgnoreNoEnvs:     args.IgnoreNoEnvs,
+			IgnoreNoVersions: args.IgnoreNoVersions,
+			Verbosity:        projectservice.QueryVerbosity(args.Verbosity),
+			Names:            args.Names,
+		},
 		ctx.Logger,
 	)
 }

--- a/pkg/microservice/aslan/core/project/service/project.go
+++ b/pkg/microservice/aslan/core/project/service/project.go
@@ -33,9 +33,10 @@ const (
 )
 
 type ProjectListOptions struct {
-	IgnoreNoEnvs bool
-	Verbosity    QueryVerbosity
-	Names        []string
+	IgnoreNoEnvs     bool
+	IgnoreNoVersions bool
+	Verbosity        QueryVerbosity
+	Names            []string
 }
 
 type ProjectDetailedRepresentation struct {
@@ -139,7 +140,40 @@ func listBriefProjectInfos(opts *ProjectListOptions, logger *zap.SugaredLogger) 
 	return res, nil
 }
 
+func listMinimalProjectInfoForDelivery(opts *ProjectListOptions, logger *zap.SugaredLogger) ([]*ProjectMinimalRepresentation, error) {
+	var res []*ProjectMinimalRepresentation
+	names, err := templaterepo.NewProductColl().ListNames(opts.Names)
+	if err != nil {
+		logger.Errorf("Failed to list project names, err: %s", err)
+		return nil, err
+	}
+
+	nameSet := sets.NewString()
+	for _, name := range names {
+		nameSet.Insert(name)
+	}
+	namesWithDelivery, err := mongodb.NewDeliveryVersionColl().FindProducts()
+	if err != nil {
+		logger.Errorf("Failed to list projects by delivery, err: %s", err)
+		return nil, err
+	}
+
+	for _, name := range namesWithDelivery {
+		// namesWithDelivery may contain projects which are already deleted.
+		if !nameSet.Has(name) {
+			continue
+		}
+		res = append(res, &ProjectMinimalRepresentation{Name: name})
+	}
+
+	return res, nil
+}
+
 func listMinimalProjectInfos(opts *ProjectListOptions, logger *zap.SugaredLogger) ([]*ProjectMinimalRepresentation, error) {
+	if opts.IgnoreNoVersions {
+		return listMinimalProjectInfoForDelivery(opts, logger)
+	}
+
 	var res []*ProjectMinimalRepresentation
 
 	names, err := templaterepo.NewProductColl().ListNames(opts.Names)

--- a/pkg/microservice/aslan/core/project/service/project.go
+++ b/pkg/microservice/aslan/core/project/service/project.go
@@ -167,11 +167,7 @@ func listMinimalProjectInfos(opts *ProjectListOptions, logger *zap.SugaredLogger
 		return nil, err
 	}
 
-	nameSet := sets.NewString()
-	for _, name := range names {
-		nameSet.Insert(name)
-	}
-
+	nameSet := sets.NewString(names...)
 	if opts.IgnoreNoVersions {
 		return listMinimalProjectInfoForDelivery(opts, nameSet, logger)
 	}


### PR DESCRIPTION
### What this PR does / Why we need it:

add new filter(ignoreNoVersions) for projects to list projects which have delivery versions
changes:
removed: /api/aslan/delivery/products
Added: /api/aslan/project/projects?ignoreNoVersions=true