### PR TITLE
Update Ingress grammar for nginx and microservice-demo examples

### DIFF
--- a/examples/microservice-demo/k8s-yaml/frontend/ingress.yaml
+++ b/examples/microservice-demo/k8s-yaml/frontend/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: frontend
@@ -14,5 +14,7 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: frontend
-          servicePort: 80
+          service:
+            name: frontend
+            port:
+              number: 80

--- a/examples/nginx/yaml/nginx.yaml
+++ b/examples/nginx/yaml/nginx.yaml
@@ -46,7 +46,7 @@ spec:
           configMap:
             name: static-page
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: nginx-expose
@@ -56,8 +56,10 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: nginx
-          servicePort: 80
+          service:
+            name: nginx
+            port:
+              number: 80
         path: /
 ---
 apiVersion: v1


### PR DESCRIPTION
### What this PR does / Why we need it:

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

Ingress has updated to v1 stabled in Kubernetes 1.19, the old ingress file grammar is not suitable anymore.

### What is changed and how it works?

What's Changed:

Has changed to ingress file for the examples to help them success run

How it Works:

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information