### PR TITLE
fix error be overrided bug

### DIFF
--- a/pkg/util/fs/file.go
+++ b/pkg/util/fs/file.go
@@ -123,25 +123,37 @@ func Tar(src fs.FS, dst string) error {
 
 // Untar extracts the src tarball and saves to disk with path dst.
 func Untar(src, dst string) (err error) {
-	fr, err := os.Open(src)
+	var (
+		fr   *os.File
+		gr   *gzip.Reader
+		hdr  *tar.Header
+		file *os.File
+	)
+	fr, err = os.Open(src)
 	if err != nil {
 		return err
 	}
 	defer func() {
-		err = fr.Close()
+		err1 := fr.Close()
+		if err == nil {
+			err = err1
+		}
 	}()
 
-	gr, err := gzip.NewReader(fr)
+	gr, err = gzip.NewReader(fr)
 	if err != nil {
 		return err
 	}
 	defer func() {
-		err = gr.Close()
+		err1 := gr.Close()
+		if err == nil {
+			err = err1
+		}
 	}()
 
 	tr := tar.NewReader(gr)
 	for {
-		hdr, err := tr.Next()
+		hdr, err = tr.Next()
 		if err != nil {
 			if err == io.EOF {
 				return nil
@@ -160,7 +172,7 @@ func Untar(src, dst string) (err error) {
 				return err
 			}
 		case tar.TypeReg:
-			file, err := os.OpenFile(dirOrFile, os.O_CREATE|os.O_RDWR, os.FileMode(hdr.Mode))
+			file, err = os.OpenFile(dirOrFile, os.O_CREATE|os.O_RDWR, os.FileMode(hdr.Mode))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

Problem Summary:

those errors occourred when uncompressing .tar.gz file are overrided in defer function, incorrect error data will be returned

What's Changed:
How it Works:

return origin error



## More information