### PR TITLE
add attribute check in rego

### DIFF
--- a/pkg/microservice/policy/core/service/bundle/rego/test_data/bindings/data.json
+++ b/pkg/microservice/policy/core/service/bundle/rego/test_data/bindings/data.json
@@ -4,11 +4,11 @@
       "uid": "2e6c5200-358f-11ec-981f-de2269351a1e",
       "bindings": [
         {
-          "namespace": "project1",
+          "namespace": "test",
           "role_refs": [
             {
-              "name": "reader1",
-              "namespace": "project1"
+              "name": "test",
+              "namespace": "test"
             },
             {
               "name": "reader2",
@@ -45,29 +45,6 @@
         },
         {
           "namespace": "project1",
-          "role_refs": [
-            {
-              "name": "view",
-              "namespace": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "uid": "bob",
-      "bindings": [
-        {
-          "namespace": "project4",
-          "role_refs": [
-            {
-              "name": "view",
-              "namespace": ""
-            }
-          ]
-        },
-        {
-          "namespace": "project5",
           "role_refs": [
             {
               "name": "view",

--- a/pkg/microservice/policy/core/service/bundle/rego/test_data/exemptions/data.json
+++ b/pkg/microservice/policy/core/service/bundle/rego/test_data/exemptions/data.json
@@ -1,16 +1,4 @@
 {
-  "global": [
-    {
-      "method": "GET",
-      "endpoint": "/version"
-    }
-  ],
-  "namespaced": [
-    {
-      "method": "GET",
-      "endpoint": "/version1"
-    }
-  ],
   "public": [
     {
       "method": "POST",
@@ -20,7 +8,7 @@
   "registered": [
     {
       "method": "GET",
-      "endpoint": "/api/articles"
+      "endpoint": "/api/aslan/environment/environments/?*"
     }
   ]
 }

--- a/pkg/microservice/policy/core/service/bundle/rego/test_data/resources/data.json
+++ b/pkg/microservice/policy/core/service/bundle/rego/test_data/resources/data.json
@@ -1,0 +1,9 @@
+[
+  {
+    "resourceType": "Environment",
+    "projectName": "test",
+    "resourceID": "test",
+    "production": "true",
+    "production1": "true1"
+  }
+]

--- a/pkg/microservice/policy/core/service/bundle/rego/test_data/roles/data.json
+++ b/pkg/microservice/policy/core/service/bundle/rego/test_data/roles/data.json
@@ -1,104 +1,24 @@
 {
   "roles": [
     {
-      "name": "author",
-      "namespace": "project2",
+      "name": "test",
+      "namespace": "test",
       "rules": [
         {
           "method": "GET",
-          "endpoint": "/api/authors"
-        },
-        {
-          "method": "POST",
-          "endpoint": "/api/authors"
-        },
-        {
-          "method": "PUT",
-          "endpoint": "/api/authors"
-        },
-        {
-          "method": "PATCH",
-          "endpoint": "/api/authors"
-        },
-        {
-          "method": "DELETE",
-          "endpoint": "/api/authors"
-        }
-      ]
-    },
-    {
-      "name": "reader",
-      "namespace": "project2",
-      "rules": [
-        {
-          "method": "GET",
-          "endpoint": "/api/authors"
-        },
-        {
-          "method": "GET",
-          "endpoint": "/api/articles"
-        },
-        {
-          "method": "POST",
-          "endpoint": "/api/authors"
-        },
-        {
-          "method": "POST",
-          "endpoint": "/api/articles"
-        }
-      ]
-    },
-    {
-      "name": "reader1",
-      "namespace": "project1",
-      "rules": [
-        {
-          "method": "GET",
-          "endpoint": "/api/authors"
-        },
-        {
-          "method": "GET",
-          "endpoint": "/api/articles"
-        },
-        {
-          "method": "POST",
-          "endpoint": "/api/authors"
-        },
-        {
-          "method": "POST",
-          "endpoint": "/api/articles"
-        }
-      ]
-    },
-    {
-      "name": "view",
-      "namespace": "project3",
-      "rules": [
-        {
-          "method": "GET",
-          "endpoint": "/api/articles"
-        }
-      ]
-    },
-    {
-      "name": "reader2",
-      "namespace": "project1",
-      "rules": [
-        {
-          "method": "GET",
-          "endpoint": "/api/authors"
-        },
-        {
-          "method": "GET",
-          "endpoint": "/api/articles"
-        },
-        {
-          "method": "POST",
-          "endpoint": "/api/authors"
-        },
-        {
-          "method": "POST",
-          "endpoint": "/api/articles"
+          "endpoint": "/api/aslan/environment/environments/?*",
+          "resourceType": "Environment",
+          "idRegex": "/api/aslan/environment/environments/([\\w\\W]+?)$",
+          "matchAttributes": [
+            {
+              "key": "production",
+              "value": "true"
+            },
+            {
+              "key": "production1",
+              "value": "true1"
+            }
+          ]
         }
       ]
     }

--- a/pkg/microservice/policy/core/service/bundle/rego/test_input.json
+++ b/pkg/microservice/policy/core/service/bundle/rego/test_input.json
@@ -19,7 +19,7 @@
           "accept": "*/*",
           "accept-encoding": "gzip, deflate",
           "accept-language": "zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2",
-          "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiYWRtaW4xIiwiZW1haWwiOiJhZG1pbjFAa29kZXJvdmVyLmNvbSIsInVpZCI6IjJlNmM1MjAwLTM1OGYtMTFlYy05ODFmLWRlMjI2OTM1MWExZSIsImZlZGVyYXRlZF9jbGFpbXMiOnsiY29ubmVjdG9yX2lkIjoiIiwidXNlcl9pZCI6IiJ9LCJhdWQiOiJ6YWRpZyIsImV4cCI6MTYzNTI1MTQxOH0.7GAndkOICyk7QucBaUiGmd7ZJstWJfoNDw5JKZjz4TY",
+          "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoibG91dGVzdCIsImVtYWlsIjoibG91dGVzdEBleGFtcGxlLmNvbSIsInVpZCI6IjJlNmM1MjAwLTM1OGYtMTFlYy05ODFmLWRlMjI2OTM1MWExZSIsInByZWZlcnJlZF91c2VybmFtZSI6ImxvdXRlc3QiLCJmZWRlcmF0ZWRfY2xhaW1zIjp7ImNvbm5lY3Rvcl9pZCI6InN5c3RlbSIsInVzZXJfaWQiOiJsb3V0ZXN0In0sImF1ZCI6InphZGlnIiwiZXhwIjoxNzI0MDQ3NTMyfQ.H05PvCXmvPX4gpgMjfHDNUlS1s_EpYrqcFG61SYUJB8",
           "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:92.0) Gecko/20100101 Firefox/92.0",
           "x-forwarded-proto": "http",
           "x-request-id": "14404686-7a28-48a6-9be6-bdd6e119f81a"
@@ -45,11 +45,14 @@
   "parsed_body": null,
   "parsed_path": [
     "api",
-    "articles"
+    "aslan",
+    "environment",
+    "environments",
+    "test"
   ],
   "parsed_query": {
     "projectName": [
-      "project1"
+      "test"
     ]
   },
   "truncated_body": false,


### PR DESCRIPTION
### What this PR does / Why we need it:

add attributes check in rego, if a rule's matchAttributes is not empty, a request must match all attibutes in matchAttributes.