### PR TITLE
add resource filter rules

### DIFF
--- a/pkg/microservice/policy/core/service/bundle/rego/test_data/exemptions/data.json
+++ b/pkg/microservice/policy/core/service/bundle/rego/test_data/exemptions/data.json
@@ -9,6 +9,10 @@
     {
       "method": "GET",
       "endpoint": "/api/aslan/environment/environments/?*"
+    },
+    {
+      "method": "GET",
+      "endpoint": "/api/aslan/environment/environments"
     }
   ]
 }

--- a/pkg/microservice/policy/core/service/bundle/rego/test_data/resources/data.json
+++ b/pkg/microservice/policy/core/service/bundle/rego/test_data/resources/data.json
@@ -1,9 +1,22 @@
-[
-  {
-    "resourceType": "Environment",
-    "projectName": "test",
-    "resourceID": "test",
-    "production": "true",
-    "production1": "true1"
-  }
-]
+{
+  "Environment": [
+    {
+      "projectName": "test",
+      "resourceID": "test",
+      "production": "true",
+      "production1": "true1"
+    },
+    {
+      "projectName": "test",
+      "resourceID": "test1",
+      "production": "true",
+      "production1": "true1"
+    },
+    {
+      "projectName": "test",
+      "resourceID": "test2",
+      "production": "false",
+      "production1": "true1"
+    }
+  ]
+}

--- a/pkg/microservice/policy/core/service/bundle/rego/test_data/roles/data.json
+++ b/pkg/microservice/policy/core/service/bundle/rego/test_data/roles/data.json
@@ -19,6 +19,17 @@
               "value": "true1"
             }
           ]
+        },
+        {
+          "method": "GET",
+          "endpoint": "/api/aslan/environment/environments",
+          "resourceType": "Environment",
+          "matchAttributes": [
+            {
+              "key": "production",
+              "value": "true"
+            }
+          ]
         }
       ]
     }

--- a/pkg/microservice/policy/core/service/bundle/rego/test_input.json
+++ b/pkg/microservice/policy/core/service/bundle/rego/test_input.json
@@ -47,8 +47,7 @@
     "api",
     "aslan",
     "environment",
-    "environments",
-    "test"
+    "environments"
   ],
   "parsed_query": {
     "projectName": [


### PR DESCRIPTION
### What this PR does / Why we need it:

Add resource filter rules, when a user calls `GET /enviroments`, all allowed env names will be returns from OPA as a http header "Resources" in this format: "env1,env2,..."