### PR TITLE
K8s YAML template permission remove

### DIFF
--- a/pkg/microservice/aslan/core/project/handler/policy.yaml
+++ b/pkg/microservice/aslan/core/project/handler/policy.yaml
@@ -54,10 +54,6 @@ rules:
         endpoint: "/api/aslan/service/loader/load/?*/?*"
       - method: POST
         endpoint: "/api/aslan/service/helm/services"
-      - method: GET
-        endpoint: "/api/aslan/template/yaml"
-      - method: GET
-        endpoint: "/api/aslan/template/yaml/?*"
       - method: POST
         endpoint: "/api/aslan/service/template/load"
       - method: GET


### PR DESCRIPTION
Signed-off-by: fansi <fansi404@koderover.com>

### What this PR does / Why we need it:

K8s YAML template permission is strictly set in project / service module. It is necessary for now.