### PR TITLE
migrate to k8s 1.16

### DIFF
--- a/examples/microservice-demo/chart/templates/frontend.yaml
+++ b/examples/microservice-demo/chart/templates/frontend.yaml
@@ -74,8 +74,8 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: frontend
-          servicePort: 80
-
-
-
+          service:
+            name: frontend
+            port:
+              number: 80
+        pathType: ImplementationSpecific

--- a/examples/microservice-demo/chart/templates/frontend.yaml
+++ b/examples/microservice-demo/chart/templates/frontend.yaml
@@ -56,7 +56,7 @@ spec:
       port: 80
       targetPort: 80
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: frontend

--- a/examples/microservice-demo/k8s-yaml/frontend/ingress.yaml
+++ b/examples/microservice-demo/k8s-yaml/frontend/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: frontend

--- a/examples/microservice-demo/k8s-yaml/frontend/ingress.yaml
+++ b/examples/microservice-demo/k8s-yaml/frontend/ingress.yaml
@@ -14,5 +14,8 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: frontend
-          servicePort: 80
+          service:
+            name: frontend
+            port:
+              number: 80
+        pathType: ImplementationSpecific

--- a/examples/nginx/yaml/nginx.yaml
+++ b/examples/nginx/yaml/nginx.yaml
@@ -46,7 +46,7 @@ spec:
           configMap:
             name: static-page
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: nginx-expose

--- a/examples/nginx/yaml/nginx.yaml
+++ b/examples/nginx/yaml/nginx.yaml
@@ -56,8 +56,11 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: nginx
-          servicePort: 80
+          service:
+            name: nginx
+            port:
+              number: 80
+        pathType: ImplementationSpecific
         path: /
 ---
 apiVersion: v1

--- a/examples/voting-app/freestyle-k8s-specifications/db/db-deployment.yaml
+++ b/examples/voting-app/freestyle-k8s-specifications/db/db-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Deployment
 metadata:
   labels:

--- a/examples/voting-app/freestyle-k8s-specifications/db/db-deployment.yaml
+++ b/examples/voting-app/freestyle-k8s-specifications/db/db-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/examples/voting-app/freestyle-k8s-specifications/result/result-service.yaml
+++ b/examples/voting-app/freestyle-k8s-specifications/result/result-service.yaml
@@ -14,7 +14,7 @@ spec:
   selector:
     app: result
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: result

--- a/examples/voting-app/freestyle-k8s-specifications/result/result-service.yaml
+++ b/examples/voting-app/freestyle-k8s-specifications/result/result-service.yaml
@@ -27,5 +27,8 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: result
-          servicePort: 5001
+          service:
+            name: result
+            port:
+              number: 5001
+        pathType: ImplementationSpecific

--- a/examples/voting-app/freestyle-k8s-specifications/vote/vote-service.yaml
+++ b/examples/voting-app/freestyle-k8s-specifications/vote/vote-service.yaml
@@ -14,7 +14,7 @@ spec:
     app: vote
     version: rc-origin
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: vote

--- a/examples/voting-app/freestyle-k8s-specifications/vote/vote-service.yaml
+++ b/examples/voting-app/freestyle-k8s-specifications/vote/vote-service.yaml
@@ -27,5 +27,7 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: vote
-          servicePort: 5000
+          service:
+            name: vote
+            port:
+              number: 5000

--- a/pkg/microservice/aslan/core/common/service/kube/service.go
+++ b/pkg/microservice/aslan/core/common/service/kube/service.go
@@ -286,7 +286,7 @@ metadata:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: koderover-agent-admin-binding
@@ -342,7 +342,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                - key: beta.kubernetes.io/os
+                - key: kubernetes.io/os
                   operator: NotIn
                   values:
                     - windows
@@ -394,7 +394,7 @@ metadata:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: koderover-agent-admin-binding
@@ -447,7 +447,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                - key: beta.kubernetes.io/os
+                - key: kubernetes.io/os
                   operator: NotIn
                   values:
                     - windows

--- a/pkg/microservice/aslan/core/setting/service/user.go
+++ b/pkg/microservice/aslan/core/setting/service/user.go
@@ -25,7 +25,7 @@ import (
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -136,20 +136,20 @@ func filterProductWithoutExternalCluster(products []*commonmodels.Product) []*co
 }
 
 var (
-	clusterRoleEdit = &rbacv1beta1.ClusterRole{
+	clusterRoleEdit = &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: config.RoleBindingNameEdit,
 		},
-		Rules: []rbacv1beta1.PolicyRule{rbacv1beta1.PolicyRule{
+		Rules: []rbacv1.PolicyRule{rbacv1.PolicyRule{
 			Verbs:     []string{"*"},
 			APIGroups: []string{"*"},
 			Resources: []string{"pods", "deployments", "configmaps", "crobjobs", "daemonsets", "ingresses", "jobs", "secrets", "services", "statefulsets"},
 		}}}
-	clusterRoleView = &rbacv1beta1.ClusterRole{
+	clusterRoleView = &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: config.RoleBindingNameView,
 		},
-		Rules: []rbacv1beta1.PolicyRule{rbacv1beta1.PolicyRule{
+		Rules: []rbacv1.PolicyRule{rbacv1.PolicyRule{
 			Verbs:     []string{"get", "watch", "list"},
 			APIGroups: []string{"*"},
 			Resources: []string{"*"},
@@ -281,7 +281,7 @@ users:
 
 func CreateRoleBinding(rbNamespace, saNamspace, serviceAccountName, roleBindName string) error {
 	rolebinding, found, err := getter.GetRoleBinding(rbNamespace, roleBindName, krkubeclient.Client())
-	subs := []rbacv1beta1.Subject{{
+	subs := []rbacv1.Subject{{
 		Kind:      "ServiceAccount",
 		Name:      serviceAccountName,
 		Namespace: saNamspace,
@@ -291,13 +291,13 @@ func CreateRoleBinding(rbNamespace, saNamspace, serviceAccountName, roleBindName
 		return err
 	}
 	if !found {
-		if err := updater.CreateRoleBinding(&rbacv1beta1.RoleBinding{
+		if err := updater.CreateRoleBinding(&rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      roleBindName,
 				Namespace: rbNamespace,
 			},
 			Subjects: subs,
-			RoleRef: rbacv1beta1.RoleRef{
+			RoleRef: rbacv1.RoleRef{
 				// APIGroup is the group for the resource being referenced
 				APIGroup: "rbac.authorization.k8s.io",
 				// Kind is the type of resource being referenced
@@ -322,13 +322,13 @@ func CreateRoleBinding(rbNamespace, saNamspace, serviceAccountName, roleBindName
 			subs = append(subs, rolebinding.Subjects...)
 		}
 	}
-	if err := updater.UpdateRoleBinding(&rbacv1beta1.RoleBinding{
+	if err := updater.UpdateRoleBinding(&rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      roleBindName,
 			Namespace: rbNamespace,
 		},
 		Subjects: subs,
-		RoleRef: rbacv1beta1.RoleRef{
+		RoleRef: rbacv1.RoleRef{
 			// APIGroup is the group for the resource being referenced
 			APIGroup: "rbac.authorization.k8s.io",
 			// Kind is the type of resource being referenced

--- a/pkg/shared/kube/wrapper/ingress.go
+++ b/pkg/shared/kube/wrapper/ingress.go
@@ -17,18 +17,18 @@ limitations under the License.
 package wrapper
 
 import (
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 
 	"github.com/koderover/zadig/pkg/shared/kube/resource"
 	"github.com/koderover/zadig/pkg/util"
 )
 
-// ingress is the wrapper for extensionsv1beta1.Ingress type.
+// ingress is the wrapper for Ingress type.
 type ingress struct {
-	*extensionsv1beta1.Ingress
+	*networkingv1beta1.Ingress
 }
 
-func Ingress(ing *extensionsv1beta1.Ingress) *ingress {
+func Ingress(ing *networkingv1beta1.Ingress) *ingress {
 	if ing == nil {
 		return nil
 	}
@@ -38,8 +38,8 @@ func Ingress(ing *extensionsv1beta1.Ingress) *ingress {
 	}
 }
 
-// Unwrap returns the extensionsv1beta1.Ingress object.
-func (ing *ingress) Unwrap() *extensionsv1beta1.Ingress {
+// Unwrap returns the Ingress object.
+func (ing *ingress) Unwrap() *networkingv1beta1.Ingress {
 	return ing.Ingress
 }
 

--- a/pkg/tool/kube/getter/ingress.go
+++ b/pkg/tool/kube/getter/ingress.go
@@ -17,14 +17,14 @@ limitations under the License.
 package getter
 
 import (
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetIngress(ns, name string, cl client.Client) (*extensionsv1beta1.Ingress, bool, error) {
-	g := &extensionsv1beta1.Ingress{}
+func GetIngress(ns, name string, cl client.Client) (*networkingv1beta1.Ingress, bool, error) {
+	g := &networkingv1beta1.Ingress{}
 	found, err := GetResourceInCache(ns, name, g, cl)
 	if err != nil || !found {
 		g = nil
@@ -33,15 +33,14 @@ func GetIngress(ns, name string, cl client.Client) (*extensionsv1beta1.Ingress, 
 	return g, found, err
 }
 
-func ListIngresses(ns string, selector labels.Selector, cl client.Client) ([]*extensionsv1beta1.Ingress, error) {
-	// ingress is moved to networking.k8s.io/v1beta1 from extensions/v1beta1.
-	is := &extensionsv1beta1.IngressList{}
+func ListIngresses(ns string, selector labels.Selector, cl client.Client) ([]*networkingv1beta1.Ingress, error) {
+	is := &networkingv1beta1.IngressList{}
 	err := ListResourceInCache(ns, selector, nil, is, cl)
 	if err != nil {
 		return nil, err
 	}
 
-	var res []*extensionsv1beta1.Ingress
+	var res []*networkingv1beta1.Ingress
 	for i := range is.Items {
 		res = append(res, &is.Items[i])
 	}
@@ -50,7 +49,7 @@ func ListIngresses(ns string, selector labels.Selector, cl client.Client) ([]*ex
 
 func ListIngressesYaml(ns string, selector labels.Selector, cl client.Client) ([][]byte, error) {
 	gvk := schema.GroupVersionKind{
-		Group:   "extensions",
+		Group:   "networking.k8s.io",
 		Kind:    "Ingress",
 		Version: "v1beta1",
 	}

--- a/pkg/tool/kube/getter/role.go
+++ b/pkg/tool/kube/getter/role.go
@@ -17,12 +17,12 @@ limitations under the License.
 package getter
 
 import (
-	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetRole(ns, name string, cl client.Client) (*rbacv1beta1.Role, bool, error) {
-	g := &rbacv1beta1.Role{}
+func GetRole(ns, name string, cl client.Client) (*rbacv1.Role, bool, error) {
+	g := &rbacv1.Role{}
 	found, err := GetResourceInCache(ns, name, g, cl)
 	if err != nil || !found {
 		g = nil
@@ -31,8 +31,8 @@ func GetRole(ns, name string, cl client.Client) (*rbacv1beta1.Role, bool, error)
 	return g, found, err
 }
 
-func GetClusterRole(name string, cl client.Client) (*rbacv1beta1.ClusterRole, bool, error) {
-	g := &rbacv1beta1.ClusterRole{}
+func GetClusterRole(name string, cl client.Client) (*rbacv1.ClusterRole, bool, error) {
+	g := &rbacv1.ClusterRole{}
 	found, err := GetResourceInCache("", name, g, cl)
 	if err != nil || !found {
 		g = nil

--- a/pkg/tool/kube/getter/rolebinding.go
+++ b/pkg/tool/kube/getter/rolebinding.go
@@ -17,12 +17,12 @@ limitations under the License.
 package getter
 
 import (
-	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetRoleBinding(ns, name string, cl client.Client) (*rbacv1beta1.RoleBinding, bool, error) {
-	g := &rbacv1beta1.RoleBinding{}
+func GetRoleBinding(ns, name string, cl client.Client) (*rbacv1.RoleBinding, bool, error) {
+	g := &rbacv1.RoleBinding{}
 	found, err := GetResourceInCache(ns, name, g, cl)
 	if err != nil || !found {
 		g = nil

--- a/pkg/tool/kube/serializer/decoder.go
+++ b/pkg/tool/kube/serializer/decoder.go
@@ -24,7 +24,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -102,13 +102,13 @@ func (d *decoder) YamlToStatefulSet(manifest []byte) (*appsv1.StatefulSet, error
 	return res, err
 }
 
-func (d *decoder) YamlToIngress(manifest []byte) (*extensionsv1beta1.Ingress, error) {
+func (d *decoder) YamlToIngress(manifest []byte) (*networkingv1beta1.Ingress, error) {
 	obj, err := d.YamlToRuntimeObject(manifest)
 	if err != nil {
 		return nil, err
 	}
 
-	res, ok := obj.(*extensionsv1beta1.Ingress)
+	res, ok := obj.(*networkingv1beta1.Ingress)
 	if !ok {
 		return nil, fmt.Errorf("object is not a Ingress")
 	}

--- a/pkg/tool/kube/serializer/decoder_test.go
+++ b/pkg/tool/kube/serializer/decoder_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 var testDeployment = `
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test

--- a/pkg/tool/kube/updater/clusterrole.go
+++ b/pkg/tool/kube/updater/clusterrole.go
@@ -17,15 +17,15 @@ limitations under the License.
 package updater
 
 import (
-	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func DeleteClusterRoles(selector labels.Selector, cl client.Client) error {
-	return deleteObjectsWithDefaultOptions("", selector, &rbacv1beta1.ClusterRole{}, cl)
+	return deleteObjectsWithDefaultOptions("", selector, &rbacv1.ClusterRole{}, cl)
 }
 
-func CreateClusterRole(role *rbacv1beta1.ClusterRole, cl client.Client) error {
+func CreateClusterRole(role *rbacv1.ClusterRole, cl client.Client) error {
 	return createObject(role, cl)
 }

--- a/pkg/tool/kube/updater/clusterrolebinding.go
+++ b/pkg/tool/kube/updater/clusterrolebinding.go
@@ -17,11 +17,11 @@ limitations under the License.
 package updater
 
 import (
-	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func DeleteClusterRoleBindings(selector labels.Selector, cl client.Client) error {
-	return deleteObjectsWithDefaultOptions("", selector, &rbacv1beta1.ClusterRoleBinding{}, cl)
+	return deleteObjectsWithDefaultOptions("", selector, &rbacv1.ClusterRoleBinding{}, cl)
 }

--- a/pkg/tool/kube/updater/ingress.go
+++ b/pkg/tool/kube/updater/ingress.go
@@ -17,11 +17,11 @@ limitations under the License.
 package updater
 
 import (
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func DeleteIngresses(ns string, selector labels.Selector, cl client.Client) error {
-	return deleteObjectsWithDefaultOptions(ns, selector, &extensionsv1beta1.Ingress{}, cl)
+	return deleteObjectsWithDefaultOptions(ns, selector, &networkingv1beta1.Ingress{}, cl)
 }

--- a/pkg/tool/kube/updater/role.go
+++ b/pkg/tool/kube/updater/role.go
@@ -17,19 +17,19 @@ limitations under the License.
 package updater
 
 import (
-	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func DeleteRoles(ns string, selector labels.Selector, cl client.Client) error {
-	return deleteObjectsWithDefaultOptions(ns, selector, &rbacv1beta1.Role{}, cl)
+	return deleteObjectsWithDefaultOptions(ns, selector, &rbacv1.Role{}, cl)
 }
 
-func CreateRole(role *rbacv1beta1.Role, cl client.Client) error {
+func CreateRole(role *rbacv1.Role, cl client.Client) error {
 	return createObject(role, cl)
 }
 
-func UpdateRole(role *rbacv1beta1.Role, cl client.Client) error {
+func UpdateRole(role *rbacv1.Role, cl client.Client) error {
 	return updateObject(role, cl)
 }

--- a/pkg/tool/kube/updater/rolebinding.go
+++ b/pkg/tool/kube/updater/rolebinding.go
@@ -17,20 +17,19 @@ limitations under the License.
 package updater
 
 import (
-	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func DeleteRoleBindings(ns string, selector labels.Selector, cl client.Client) error {
-	return deleteObjectsWithDefaultOptions(ns, selector, &rbacv1beta1.RoleBinding{}, cl)
+	return deleteObjectsWithDefaultOptions(ns, selector, &rbacv1.RoleBinding{}, cl)
 }
 
-func CreateRoleBinding(rb *rbacv1beta1.RoleBinding, cl client.Client) error {
+func CreateRoleBinding(rb *rbacv1.RoleBinding, cl client.Client) error {
 	return createObject(rb, cl)
 }
 
-func UpdateRoleBinding(rb *rbacv1beta1.RoleBinding, cl client.Client) error {
+func UpdateRoleBinding(rb *rbacv1.RoleBinding, cl client.Client) error {
 	return updateObject(rb, cl)
 }
-


### PR DESCRIPTION
### What this PR does / Why we need it:

support matrix for k8s is now changed to k8s 1.1.6, update the following api groups to align it:
1. extensions/v1beta1 => networking.k8s.io/v1beta1
2. rbac.authorization.k8s.io/v1beta1 => rbac.authorization.k8s.io/v1

ref: https://kubernetes.io/docs/reference/using-api/deprecation-guide/