### PR TITLE
fix the quick start link

### DIFF
--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -75,7 +75,7 @@ Zadig 是一款面向开发者设计的云原生持续交付(Continuous Delivery
 
 ### 快速使用
 
-请参阅 [快速入门](https://docs.koderover.com/zadig/quick-start/try-out-install)
+请参阅 [快速入门](https://docs.koderover.com/zadig/quick-start/try-out-install/)
 
 ### 训练营
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The Highlighted Features:
 
 ### How to use?
 
-Please follow [Quick Start](https://docs.koderover.com/zadig/quick-start/try-out-install)
+Please follow [Quick Start](https://docs.koderover.com/zadig/quick-start/try-out-install/)
 
 ### Bootcamps
 


### PR DESCRIPTION
### What this PR does / Why we need it:

Problem Summary:

The page which referenced by the quick start link responses the 404 not found without trailing slash in URL.

<img width="556" alt="image" src="https://user-images.githubusercontent.com/13946679/145332094-d9234974-7b89-4528-b234-e6a6834583b2.png">


### What is changed and how it works?

What's Changed:

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

- [x] No code


## More information