### PR TITLE
fix disordered build info bug

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -538,7 +538,8 @@ func CreateWorkflowTask(args *commonmodels.WorkflowTaskArgs, taskCreator string,
 			buildModuleArgs := &commonmodels.BuildModuleArgs{
 				Target:      target.Name,
 				ServiceName: target.ServiceName,
-				ProductName: target.ProductName,
+				//ProductName: target.ProductName,				// TODO productName may be nil in some situation, need to figure out reason
+				ProductName: args.ProductTmplName,
 				Variables:   target.Envs,
 				Env:         env,
 			}


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

Problem Summary:

parameter 'product_name' may be missing in some situations when starting a workflow with multiple services, if there are services in different projects with same name, build info may be disordered.

### What is changed and how it works?

use correct product_name to fix bug