### PR TITLE
fix(dockerfile):fix the problem of upgrade git to the latest version in 16.04.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ allpush.arm64: $(ALL_PUSH:=.arm64) $(ALL_REAPER_PUSH:=.arm64)
 	@sed -i -e '/#alpine.Dockerfile/ {' -e 'r docker/base/amd64/alpine.Dockerfile' -e 'd' -e '}' docker/dist/amd64/reaper-plugin-$*.Dockerfile
 	@sed -i -e '/#nginx.Dockerfile/ {' -e 'r docker/base/amd64/nginx.Dockerfile' -e 'd' -e '}' docker/dist/amd64/reaper-plugin-$*.Dockerfile
 	@sed -i -e '/#alpine-git.Dockerfile/ {' -e 'r docker/base/amd64/alpine-git.Dockerfile' -e 'd' -e '}' docker/dist/amd64/reaper-plugin-$*.Dockerfile
-	@docker build -f docker/dist/amd64/reaper-plugin-$*.Dockerfile --tag ${MAKE_IMAGE} .
+	@docker build --progress=plain --no-cache -f docker/dist/amd64/reaper-plugin-$*.Dockerfile --tag ${MAKE_IMAGE} .
 
 %.push.amd64: MAKE_IMAGE ?= ${IMAGE_REPOSITORY}/$*:${VERSION}-amd64
 %.push.amd64: %.image.amd64

--- a/docker/base/amd64/ubuntu-xenial.Dockerfile
+++ b/docker/base/amd64/ubuntu-xenial.Dockerfile
@@ -1,16 +1,1 @@
 FROM ubuntu:xenial
-
-# 修改镜像源和时区
-RUN sed -i -E "s/[a-zA-Z0-9]+.ubuntu.com/mirrors.aliyun.com/g" /etc/apt/sources.list \
-    && apt-get clean && apt-get update && apt-get install -y apt-transport-https ca-certificates \
-    && apt-get install -y \
-    tzdata \
-    net-tools \
-    dnsutils \
-	ca-certificates \
-	git \
-	curl \
-	lsof \
-    telnet \
-    && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
-    && rm -rf /var/lib/apt/lists/*

--- a/docker/base/arm64/ubuntu-xenial.Dockerfile
+++ b/docker/base/arm64/ubuntu-xenial.Dockerfile
@@ -1,16 +1,1 @@
 FROM arm64v8/ubuntu:xenial
-
-# 修改镜像源和时区
-RUN sed -i -E "s/[a-zA-Z0-9]+.ubuntu.com/mirrors.aliyun.com/g" /etc/apt/sources.list \
-    && apt-get clean && apt-get update && apt-get install -y apt-transport-https ca-certificates \
-    && apt-get install -y \
-    tzdata \
-    net-tools \
-    dnsutils \
-	ca-certificates \
-	git \
-	curl \
-	lsof \
-    telnet \
-    && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
-    && rm -rf /var/lib/apt/lists/*

--- a/docker/service/reaper-plugin-xenial.Dockerfile
+++ b/docker/service/reaper-plugin-xenial.Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get clean && apt-get update && apt-get install -y \
   librrd-dev \
   sudo
 
-# Upgrade Git to latest version
-RUN apt-get install -y software-properties-common && add-apt-repository -y ppa:git-core/ppa && apt-get update && apt-get install -y git
+# Upgrade Git to latest version,forcing IPv4 transport with apt-get
+RUN apt-get -o Acquire::ForceIPv4=true install -y software-properties-common && add-apt-repository -y ppa:git-core/ppa && apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true install -y git
 
 # 修改时区
 RUN ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime

--- a/docker/service/reaper-plugin-xenial.Dockerfile
+++ b/docker/service/reaper-plugin-xenial.Dockerfile
@@ -10,7 +10,6 @@ RUN sed -i s:http:https:g /etc/apt/sources.list
 RUN DEBIAN_FRONTEND=noninteractive apt install -y tzdata
 RUN apt-get clean && apt-get update && apt-get install -y \
 	curl \
-  git \
   netcat-openbsd \
   wget \
   build-essential \

--- a/docker/service/reaper-plugin-xenial.Dockerfile
+++ b/docker/service/reaper-plugin-xenial.Dockerfile
@@ -24,11 +24,12 @@ RUN apt-get clean && apt-get update && apt-get install -y \
   sudo
 
 # Upgrade Git to latest version,forcing IPv4 transport with apt-get
-
 RUN echo "deb http://launchpad.proxy.ustclug.org/git-core/ppa/ubuntu xenial main" >> /etc/apt/sources.list
 
+# Using 'launchpad.proxy.ustclug.org' to reverse proxy for 'launchpad.net'. Detail:https://lug.ustc.edu.cn/wiki/mirrors/help/revproxy/
 RUN echo "deb-src http://launchpad.proxy.ustclug.org/git-core/ppa/ubuntu xenial main" >> /etc/apt/sources.list
 
+# Import key manually to solve bad network problems
 RUN echo  '-----BEGIN PGP PUBLIC KEY BLOCK----- \nVersion:  \nComment: Hostname: keyserver.ubuntu.com \n \nxo0ESXjaGwEEAMA26F3+mnRW8uRqASMsEa5EsmgvUpLD7EKpC7903OpiMGSvZ2sE \n34g7W6nUQY0R//AZS2iW4ZXfvdhQTQuuPlHM6Q3iUAt+nyXcf9xBlscs8Gm722u4 \njAtFtBS4BMQRhRRfWTHwJIOM6OpGIccjPe8pQfIeoRxkKJxlehzw2mU1ABEBAAHN \nKExhdW5jaHBhZCBQUEEgZm9yIFVidW50dSBHaXQgTWFpbnRhaW5lcnPCtgQTAQIA \nIAUCSXjaGwIbAwYLCQgHAwIEFQIIAwQWAgMBAh4BAheAAAoJEKFxXYjh3x8k/zMD \n/RKBMjavvFl71YBazSOGl2YfSsZiR/ANsby3+rUaULb8uxzCHXAQnlH5vdtLSPry \naLBvzCU8C3C02qNT8jRacU2752zsCkCi1SLRSOXdI/ATJHza5aTvYV93rTITBhU4 \nsJQeK9RW0CtaDRAxJsn/Dr6J3lL/c9m9cT5fFpxOIsF4 \n=7kFR \n-----END PGP PUBLIC KEY BLOCK----- \n' > key
 
 RUN apt-key add key
@@ -38,16 +39,16 @@ RUN apt-get -o Acquire::ForceIPv4=true update
 
 RUN apt-get -o Acquire::ForceIPv4=true install -y git
 
-# 修改时区
+# Change timezone to Asia/Shanghai
 RUN ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 
-# 安装 docker client
+# Install docker client
 RUN curl -fsSL "http://resources.koderover.com/docker-cli-v19.03.2.tar.gz" -o docker.tgz &&\
     tar -xvzf docker.tgz &&\
     mv docker/* /usr/local/bin
 
 
-# 替换tar（适配cephfs）
+# Replaces the default tar（for cephfs）
 RUN rm /bin/tar && curl -fsSL http://resource.koderover.com/tar -o /bin/tar && chmod +x /bin/tar
 
 COPY --from=build /reaper /usr/local/bin

--- a/docker/service/reaper-plugin-xenial.Dockerfile
+++ b/docker/service/reaper-plugin-xenial.Dockerfile
@@ -30,7 +30,7 @@ RUN echo "deb http://ppa.launchpad.net/git-core/ppa/ubuntu xenial main" >> /etc/
 
 RUN echo "deb-src http://ppa.launchpad.net/git-core/ppa/ubuntu xenial main" >> /etc/apt/sources.list
 
-RUN  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E1DD270288B4E6030699E45FA1715D88E1DF1F24
+RUN  apt-key adv --keyserver keyserver.ubuntu.com:80 --recv-keys E1DD270288B4E6030699E45FA1715D88E1DF1F24
 
 # Forcing IPv4 transport with apt-get
 RUN apt-get -o Acquire::ForceIPv4=true update 

--- a/docker/service/reaper-plugin-xenial.Dockerfile
+++ b/docker/service/reaper-plugin-xenial.Dockerfile
@@ -24,13 +24,14 @@ RUN apt-get clean && apt-get update && apt-get install -y \
   sudo
 
 # Upgrade Git to latest version,forcing IPv4 transport with apt-get
-RUN apt-get -o Acquire::ForceIPv4=true install -y software-properties-common
 
 RUN echo "deb http://ppa.launchpad.net/git-core/ppa/ubuntu xenial main" >> /etc/apt/sources.list
 
 RUN echo "deb-src http://ppa.launchpad.net/git-core/ppa/ubuntu xenial main" >> /etc/apt/sources.list
 
-RUN  apt-key adv --keyserver keyserver.ubuntu.com:80 --recv-keys E1DD270288B4E6030699E45FA1715D88E1DF1F24
+RUN echo  '-----BEGIN PGP PUBLIC KEY BLOCK----- \nVersion:  \nComment: Hostname: keyserver.ubuntu.com \n \nxo0ESXjaGwEEAMA26F3+mnRW8uRqASMsEa5EsmgvUpLD7EKpC7903OpiMGSvZ2sE \n34g7W6nUQY0R//AZS2iW4ZXfvdhQTQuuPlHM6Q3iUAt+nyXcf9xBlscs8Gm722u4 \njAtFtBS4BMQRhRRfWTHwJIOM6OpGIccjPe8pQfIeoRxkKJxlehzw2mU1ABEBAAHN \nKExhdW5jaHBhZCBQUEEgZm9yIFVidW50dSBHaXQgTWFpbnRhaW5lcnPCtgQTAQIA \nIAUCSXjaGwIbAwYLCQgHAwIEFQIIAwQWAgMBAh4BAheAAAoJEKFxXYjh3x8k/zMD \n/RKBMjavvFl71YBazSOGl2YfSsZiR/ANsby3+rUaULb8uxzCHXAQnlH5vdtLSPry \naLBvzCU8C3C02qNT8jRacU2752zsCkCi1SLRSOXdI/ATJHza5aTvYV93rTITBhU4 \nsJQeK9RW0CtaDRAxJsn/Dr6J3lL/c9m9cT5fFpxOIsF4 \n=7kFR \n-----END PGP PUBLIC KEY BLOCK----- \n' > key
+
+RUN apt-key add key
 
 # Forcing IPv4 transport with apt-get
 RUN apt-get -o Acquire::ForceIPv4=true update 

--- a/docker/service/reaper-plugin-xenial.Dockerfile
+++ b/docker/service/reaper-plugin-xenial.Dockerfile
@@ -24,9 +24,11 @@ RUN apt-get clean && apt-get update && apt-get install -y \
   sudo
 
 # Upgrade Git to latest version,forcing IPv4 transport with apt-get
-RUN apt-get -o Acquire::ForceIPv4=true install -y software-properties-common 
+RUN apt-get -o Acquire::ForceIPv4=true install -y software-properties-common
 
-RUN add-apt-repository -y ppa:git-core/ppa 
+RUN echo "deb http://ppa.launchpad.net/git-core/ppa/ubuntu xenial main" >> /etc/apt/sources.list
+
+RUN echo "deb-src http://ppa.launchpad.net/git-core/ppa/ubuntu xenial main" >> /etc/apt/sources.list
 
 # Forcing IPv4 transport with apt-get
 RUN apt-get -o Acquire::ForceIPv4=true update 

--- a/docker/service/reaper-plugin-xenial.Dockerfile
+++ b/docker/service/reaper-plugin-xenial.Dockerfile
@@ -24,7 +24,14 @@ RUN apt-get clean && apt-get update && apt-get install -y \
   sudo
 
 # Upgrade Git to latest version,forcing IPv4 transport with apt-get
-RUN apt-get -o Acquire::ForceIPv4=true install -y software-properties-common && add-apt-repository -y ppa:git-core/ppa && apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true install -y git
+RUN apt-get -o Acquire::ForceIPv4=true install -y software-properties-common 
+
+RUN add-apt-repository -y ppa:git-core/ppa 
+
+# Forcing IPv4 transport with apt-get
+RUN apt-get -o Acquire::ForceIPv4=true update 
+
+RUN apt-get -o Acquire::ForceIPv4=true install -y git
 
 # 修改时区
 RUN ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime

--- a/docker/service/reaper-plugin-xenial.Dockerfile
+++ b/docker/service/reaper-plugin-xenial.Dockerfile
@@ -25,9 +25,9 @@ RUN apt-get clean && apt-get update && apt-get install -y \
 
 # Upgrade Git to latest version,forcing IPv4 transport with apt-get
 
-RUN echo "deb http://ppa.launchpad.net/git-core/ppa/ubuntu xenial main" >> /etc/apt/sources.list
+RUN echo "deb http://launchpad.proxy.ustclug.org/git-core/ppa/ubuntu xenial main" >> /etc/apt/sources.list
 
-RUN echo "deb-src http://ppa.launchpad.net/git-core/ppa/ubuntu xenial main" >> /etc/apt/sources.list
+RUN echo "deb-src http://launchpad.proxy.ustclug.org/git-core/ppa/ubuntu xenial main" >> /etc/apt/sources.list
 
 RUN echo  '-----BEGIN PGP PUBLIC KEY BLOCK----- \nVersion:  \nComment: Hostname: keyserver.ubuntu.com \n \nxo0ESXjaGwEEAMA26F3+mnRW8uRqASMsEa5EsmgvUpLD7EKpC7903OpiMGSvZ2sE \n34g7W6nUQY0R//AZS2iW4ZXfvdhQTQuuPlHM6Q3iUAt+nyXcf9xBlscs8Gm722u4 \njAtFtBS4BMQRhRRfWTHwJIOM6OpGIccjPe8pQfIeoRxkKJxlehzw2mU1ABEBAAHN \nKExhdW5jaHBhZCBQUEEgZm9yIFVidW50dSBHaXQgTWFpbnRhaW5lcnPCtgQTAQIA \nIAUCSXjaGwIbAwYLCQgHAwIEFQIIAwQWAgMBAh4BAheAAAoJEKFxXYjh3x8k/zMD \n/RKBMjavvFl71YBazSOGl2YfSsZiR/ANsby3+rUaULb8uxzCHXAQnlH5vdtLSPry \naLBvzCU8C3C02qNT8jRacU2752zsCkCi1SLRSOXdI/ATJHza5aTvYV93rTITBhU4 \nsJQeK9RW0CtaDRAxJsn/Dr6J3lL/c9m9cT5fFpxOIsF4 \n=7kFR \n-----END PGP PUBLIC KEY BLOCK----- \n' > key
 

--- a/docker/service/reaper-plugin-xenial.Dockerfile
+++ b/docker/service/reaper-plugin-xenial.Dockerfile
@@ -30,6 +30,8 @@ RUN echo "deb http://ppa.launchpad.net/git-core/ppa/ubuntu xenial main" >> /etc/
 
 RUN echo "deb-src http://ppa.launchpad.net/git-core/ppa/ubuntu xenial main" >> /etc/apt/sources.list
 
+RUN  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E1DD270288B4E6030699E45FA1715D88E1DF1F24
+
 # Forcing IPv4 transport with apt-get
 RUN apt-get -o Acquire::ForceIPv4=true update 
 


### PR DESCRIPTION
Signed-off-by: leozhang2018 <leozhang2018@gmail.com>

### What this PR does / Why we need it:

**Background：**
https://github.com/koderover/zadig/pull/363

**Range of influence:**
ccr.ccs.tencentyun.com/koderover-rc/reaper-plugin:1.7.1-amd64-xenial

**Detail:** 
When installing a new version of Git using the PPA upgrade by default, the upgrade will be failed and fall back to the default version (2.7.4)due to network issues.

![image](https://user-images.githubusercontent.com/6907296/146500611-0fe35206-a513-432d-9b56-e35786a526e1.png)
![image](https://user-images.githubusercontent.com/6907296/146503587-d2891095-7276-45f7-8dcc-35ec9906b7bf.png)
![image](https://user-images.githubusercontent.com/6907296/146395196-2ce2da91-d22f-4824-8db9-67bcba19209d.png)

On rebuild, since the dockerfile is not changed, this step is not re-executed due to caching,the wrong image will never be updated,git version is still 2.7.4.

**How works:**

- Install manually and use a proxy to resolve package source issues
- Install third-party software sources using IPv4 to avoid installation failure due to IPv6 instability on dual-stack networks
- Docker build reaper image without cache, rebuild every time, may increase the time consumption

![image](https://user-images.githubusercontent.com/6907296/146502291-ff411ade-c0e0-40f2-8029-d34df4d314c4.png)

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information