### PR TITLE
fix service host missing bug

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment_group.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_group.go
@@ -34,6 +34,7 @@ import (
 	"github.com/koderover/zadig/pkg/shared/kube/resource"
 	"github.com/koderover/zadig/pkg/shared/kube/wrapper"
 	e "github.com/koderover/zadig/pkg/tool/errors"
+	"github.com/koderover/zadig/pkg/tool/kube/getter"
 	"github.com/koderover/zadig/pkg/tool/kube/serializer"
 	"github.com/koderover/zadig/pkg/util"
 )
@@ -151,13 +152,27 @@ func GetIngressInfo(product *commonmodels.Product, service *commonmodels.Service
 	parsedYaml = util.ReplaceWrapLine(parsedYaml)
 	yamlContentArray := releaseutil.SplitManifests(parsedYaml)
 	hostInfos := make([]resource.HostInfo, 0)
+
 	for _, item := range yamlContentArray {
-		ing, err := serializer.NewDecoder().YamlToIngress([]byte(item))
-		if err != nil || ing == nil {
+		u, err := serializer.NewDecoder().YamlToUnstructured([]byte(item))
+		if err != nil {
+			log.Warnf("Failed to decode yaml to Unstructured, err: %s", err)
 			continue
 		}
-
-		hostInfos = append(hostInfos, wrapper.Ingress(ing).HostInfo()...)
+		switch u.GetKind() {
+		case setting.Ingress:
+			kubeClient, err := kubeclient.GetKubeClient(config.HubServerAddress(), product.ClusterID)
+			if err != nil {
+				log.Errorf("failed to init kubeClient, clusterID: %s", product.ClusterID)
+				return nil
+			}
+			ing, found, err := getter.GetIngress(product.Namespace, u.GetName(), kubeClient)
+			if err != nil || !found {
+				log.Warnf("no ingress %s found in %s:%s %v", u.GetName(), service.ServiceName, product.Namespace, err)
+				continue
+			}
+			hostInfos = append(hostInfos, wrapper.Ingress(ing).HostInfo()...)
+		}
 	}
 	ingressInfo.HostInfo = hostInfos
 	return ingressInfo

--- a/pkg/microservice/aslan/core/environment/service/environment_group.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_group.go
@@ -166,6 +166,8 @@ func GetIngressInfo(product *commonmodels.Product, service *commonmodels.Service
 				log.Errorf("failed to init kubeClient, clusterID: %s", product.ClusterID)
 				return nil
 			}
+			// need to get ingress from k8s
+			// serializer.NewDecoder()YamlToIngress() only supports ingress resource with apiVersion: apiVersion: extensions/v1beta1
 			ing, found, err := getter.GetIngress(product.Namespace, u.GetName(), kubeClient)
 			if err != nil || !found {
 				log.Warnf("no ingress %s found in %s:%s %v", u.GetName(), service.ServiceName, product.Namespace, err)


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

Problem Summary:

for k8s-yaml projects, it doesn't work to show ingress data with apiversion: [networking.k8s.io/v1beta1] on service group page while on service detail page it works 

### What is changed and how it works?

chage the way of getting ingress data on service group page , keep same with the way on service detail page