### PR TITLE
update rolebinding naming rule

### DIFF
--- a/pkg/cli/initconfig/cmd/init.go
+++ b/pkg/cli/initconfig/cmd/init.go
@@ -20,7 +20,6 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -169,9 +168,9 @@ func reportRegister(domain, email string) error {
 
 func presetRoleBinding(uid string) error {
 	return policy.NewDefault().CreateOrUpdateSystemRoleBinding(&policy.RoleBinding{
-		Name: fmt.Sprintf(setting.RoleBindingNameFmt, setting.RoleAdmin, setting.PresetAccount, ""),
+		Name: config.RoleBindingNameFromUIDAndRole(uid, setting.SystemAdmin, "*"),
 		UID:  uid,
-		Role: setting.RoleAdmin,
+		Role: string(setting.SystemAdmin),
 	})
 
 }

--- a/pkg/cli/upgradeassistant/cmd/migrate.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate.go
@@ -63,7 +63,11 @@ var migrateCmd = &cobra.Command{
 }
 
 func run() error {
-	err := upgradepath.UpgradeWithBestPath(viper.GetString("fromVersion"), viper.GetString("toVersion"))
+	from := viper.GetString("fromVersion")
+	to := viper.GetString("toVersion")
+
+	log.Infof("Migrating from %s to %s", from, to)
+	err := upgradepath.UpgradeWithBestPath(from, to)
 	if err == nil {
 		log.Info("Migration finished")
 	}

--- a/pkg/cli/upgradeassistant/cmd/migrate/180.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/180.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package migrate
 
 import (

--- a/pkg/cli/upgradeassistant/cmd/migrate/180.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/180.go
@@ -43,6 +43,7 @@ func updateAllRoleBindingNames() error {
 	rbs, err := coll.List()
 	if err != nil {
 		log.Errorf("Failed to list roleBindings, err: %s", err)
+		return err
 	}
 
 	var lastErr error

--- a/pkg/cli/upgradeassistant/cmd/migrate/180.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/180.go
@@ -1,0 +1,90 @@
+package migrate
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+
+	"github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/upgradepath"
+	"github.com/koderover/zadig/pkg/config"
+	"github.com/koderover/zadig/pkg/microservice/policy/core/repository/models"
+	"github.com/koderover/zadig/pkg/microservice/policy/core/repository/mongodb"
+	"github.com/koderover/zadig/pkg/setting"
+	"github.com/koderover/zadig/pkg/tool/log"
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
+)
+
+func init() {
+	upgradepath.AddHandler(upgradepath.V171, upgradepath.V180, V171ToV180)
+	upgradepath.AddHandler(upgradepath.V180, upgradepath.V171, V180ToV171)
+}
+
+// V171ToV180 update all the roleBinding names in this format "{uid}-{roleName}-{roleNamespace}"
+// Caution: this migration contains unrecoverable changes, please back up the database in advance
+func V171ToV180() error {
+	log.Info("Migrating data from 1.7.1 to 1.8.0")
+
+	if err := updateAllRoleBindingNames(); err != nil {
+		log.Errorf("Failed to update roleBinding names, err: %s", err)
+		return err
+	}
+
+	return nil
+}
+
+func V180ToV171() error {
+	log.Info("Rollback data from 1.8.0 to 1.7.1")
+	return nil
+}
+
+func updateAllRoleBindingNames() error {
+	coll := newRoleBindingColl()
+	rbs, err := coll.List()
+	if err != nil {
+		log.Errorf("Failed to list roleBindings, err: %s", err)
+	}
+
+	var lastErr error
+	for _, rb := range rbs {
+		newName := roleBindingName(rb)
+		if newName == "" || rb.Name == newName {
+			continue
+		}
+
+		log.Infof("Update roleBinding name in namespace %s from %s to %s", rb.Namespace, rb.Name, newName)
+		if err = updateRoleBindingName(coll, rb, newName); err != nil {
+			log.Warnf("Failed to update roleBinding, err: %s", err)
+			lastErr = err
+			continue
+		}
+	}
+
+	return lastErr
+}
+
+func roleBindingName(rb *models.RoleBinding) string {
+	if len(rb.Subjects) != 1 || rb.Subjects[0].Kind != models.UserKind {
+		return ""
+	}
+
+	return config.RoleBindingNameFromUIDAndRole(rb.Subjects[0].UID, setting.RoleType(rb.RoleRef.Name), rb.RoleRef.Namespace)
+}
+
+func updateRoleBindingName(c *mongodb.RoleBindingColl, rb *models.RoleBinding, newName string) error {
+	query := bson.M{"name": rb.Name, "namespace": rb.Namespace}
+
+	change := bson.M{"$set": bson.M{
+		"name": newName,
+	}}
+
+	_, err := c.UpdateOne(context.TODO(), query, change)
+	return err
+}
+
+func newRoleBindingColl() *mongodb.RoleBindingColl {
+	name := models.RoleBinding{}.TableName()
+	return &mongodb.RoleBindingColl{
+		Collection: mongotool.Database(fmt.Sprintf("%s_policy", config.MongoDatabase())).Collection(name),
+	}
+}

--- a/pkg/cli/upgradeassistant/internal/upgradepath/versions.go
+++ b/pkg/cli/upgradeassistant/internal/upgradepath/versions.go
@@ -31,6 +31,7 @@ const (
 	V160
 	V170
 	V171
+	V180
 )
 
 var versionMap versions = map[string]int{
@@ -41,6 +42,7 @@ var versionMap versions = map[string]int{
 	"1.6.0": V160,
 	"1.7.0": V170,
 	"1.7.1": V171,
+	"1.8.0": V180,
 }
 
 type versions map[string]int

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -265,3 +265,7 @@ func AdminPassword() string {
 func Namespace() string {
 	return viper.GetString(setting.ENVNamespace)
 }
+
+func RoleBindingNameFromUIDAndRole(uid string, role setting.RoleType, roleNamespace string) string {
+	return fmt.Sprintf("%s-%s-%s", uid, role, roleNamespace)
+}

--- a/pkg/microservice/aslan/core/project/service/product.go
+++ b/pkg/microservice/aslan/core/project/service/product.go
@@ -546,13 +546,12 @@ func ForkProduct(username, uid, requestID string, args *template.ForkProject, lo
 		UpdateBy:  username,
 	}
 	err = policy.NewDefault().CreateOrUpdateRoleBinding(args.ProductName, &policy.RoleBinding{
-		Name:   fmt.Sprintf(setting.RoleBindingNameFmt, args.ProductName, uid, args.ProductName),
 		UID:    uid,
 		Role:   string(setting.Contributor),
 		Public: true,
 	})
 	if err != nil {
-		log.Error("rolebinding error")
+		log.Errorf("Failed to create or update roleBinding, err: %s", err)
 		return e.ErrForkProduct
 	}
 
@@ -568,10 +567,10 @@ func UnForkProduct(userID string, username, productName, workflowName, envName, 
 		}
 	}
 
-	policyClient := policy.New()
-	err := policyClient.DeleteRoleBinding(fmt.Sprintf(setting.RoleBindingNameFmt, userID, setting.Contributor, productName), productName)
+	policyClient := policy.NewDefault()
+	err := policyClient.DeleteRoleBinding(configbase.RoleBindingNameFromUIDAndRole(userID, setting.Contributor, ""), productName)
 	if err != nil {
-		log.Error("rolebinding delete error")
+		log.Errorf("Failed to delete roleBinding, err: %s", err)
 		return e.ErrForkProduct
 	}
 	if err := commonservice.DeleteProduct(username, envName, productName, requestID, log); err != nil {

--- a/pkg/microservice/aslan/core/service.go
+++ b/pkg/microservice/aslan/core/service.go
@@ -79,7 +79,7 @@ func StartControllers(stopCh <-chan struct{}) {
 }
 
 func registerPolicies() {
-	policyClient := policy.New()
+	policyClient := policy.NewWithRetry()
 	var policies []*policy.Policy
 	for _, r := range []policyGetter{
 		new(workflowhandler.Router),

--- a/pkg/microservice/aslan/core/workflow/service/webhook/github_testing_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github_testing_task.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package webhook
 
 import (

--- a/pkg/microservice/picket/client/aslan/artifact.go
+++ b/pkg/microservice/picket/client/aslan/artifact.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package aslan
 
 import (

--- a/pkg/microservice/picket/client/aslan/delivery.go
+++ b/pkg/microservice/picket/client/aslan/delivery.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package aslan
 
 import (

--- a/pkg/microservice/policy/core/repository/mongodb/role_binding.go
+++ b/pkg/microservice/policy/core/repository/mongodb/role_binding.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/policy/core/repository/models"
+	"github.com/koderover/zadig/pkg/tool/log"
 	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
 )
 
@@ -182,7 +183,11 @@ func (c *RoleBindingColl) BulkCreate(objs []*models.RoleBinding) error {
 		ois = append(ois, obj)
 	}
 
-	_, err := c.InsertMany(context.TODO(), ois)
+	res, err := c.InsertMany(context.TODO(), ois)
+	if mongo.IsDuplicateKeyError(err) {
+		log.Warnf("Duplicate key found, inserted IDs is %v", res.InsertedIDs)
+		return nil
+	}
 
 	return err
 }

--- a/pkg/microservice/policy/core/service/role_binding.go
+++ b/pkg/microservice/policy/core/service/role_binding.go
@@ -21,8 +21,10 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/policy/core/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/policy/core/repository/mongodb"
+	"github.com/koderover/zadig/pkg/setting"
 )
 
 type RoleBinding struct {
@@ -135,6 +137,8 @@ func createRoleBindingObject(ns string, rb *RoleBinding, logger *zap.SugaredLogg
 		return nil, fmt.Errorf("role %s not found", rb.Role)
 	}
 
+	ensureRoleBindingName(ns, rb)
+
 	return &models.RoleBinding{
 		Name:      rb.Name,
 		Namespace: ns,
@@ -144,4 +148,17 @@ func createRoleBindingObject(ns string, rb *RoleBinding, logger *zap.SugaredLogg
 			Namespace: role.Namespace,
 		},
 	}, nil
+}
+
+func ensureRoleBindingName(ns string, rb *RoleBinding) {
+	if rb.Name != "" {
+		return
+	}
+
+	nsRole := ns
+	if rb.Public {
+		nsRole = ""
+	}
+
+	rb.Name = config.RoleBindingNameFromUIDAndRole(rb.UID, setting.RoleType(rb.Role), nsRole)
 }

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -356,18 +356,8 @@ const (
 	NormalModeProduct = "normal"
 )
 
-// roles
 const (
-	RoleOwnerID = 3
-	RoleUserID  = 4
-
-	RoleUser        = "user"        // 普通用户
-	RoleOwner       = "owner"       // 项目管理员
-	RoleAdmin       = "admin"       // 超级管理员
-	RoleContributor = "contributor" //开源项目贡献者
-	SystemUser      = "system"
-
-	GuestAccount = "guest2019"
+	SystemUser = "system"
 )
 
 // events
@@ -567,10 +557,10 @@ const ChartTemplatesPath = "charts"
 type RoleType string
 
 const (
-	Contributor        RoleType = "contributor"
-	ReadOnly           RoleType = "read-only"
-	Admin              RoleType = "project-admin"
-	RoleBindingNameFmt string   = "user:%s,role:%s,project:%s"
+	Contributor  RoleType = "contributor"
+	ReadOnly     RoleType = "read-only"
+	ProjectAdmin RoleType = "project-admin"
+	SystemAdmin  RoleType = "admin"
 )
 
 // ModernWorkflowType 自由编排工作流

--- a/pkg/shared/client/policy/client.go
+++ b/pkg/shared/client/policy/client.go
@@ -31,7 +31,7 @@ type Client struct {
 	host string
 }
 
-func New() *Client {
+func NewWithRetry() *Client {
 	host := config.PolicyServiceAddress()
 
 	c := httpclient.New(


### PR DESCRIPTION
### What this PR does / Why we need it:

update the rolebinding naming rule to "{uid}-{roleName}-{roleNamespace}" for both user created ones and service created ones. changes:
1. update pre-defined roleBinding naming rule
2. update project default roleBindings naming rule
3. generate a name for user created roleBindings
4. migrate the data in database to align the new rule (caution: this migration changes the roleBinding's name and it is not recoverable, user should back up the database in next upgrade)