### PR TITLE
fix helm delivery error

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/delivery_version.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/delivery_version.go
@@ -197,11 +197,28 @@ func (c *DeliveryVersionColl) Insert(args *models.DeliveryVersion) error {
 	return nil
 }
 
-func (c *DeliveryVersionColl) UpdateStatusByName(versionName, status, errorStr string) error {
-	query := bson.M{"version": versionName, "deleted_at": 0}
+func (c *DeliveryVersionColl) UpdateStatusByName(versionName, projectName, status, errorStr string) error {
+	query := bson.M{
+		"version":      versionName,
+		"product_name": projectName,
+		"deleted_at":   0,
+	}
 	change := bson.M{"$set": bson.M{
 		"status": status,
 		"error":  errorStr,
+	}}
+	_, err := c.UpdateOne(context.TODO(), query, change)
+	return err
+}
+
+func (c *DeliveryVersionColl) UpdateTaskID(versionName, projectName string, taskID int32) error {
+	query := bson.M{
+		"version":      versionName,
+		"product_name": projectName,
+		"deleted_at":   0,
+	}
+	change := bson.M{"$set": bson.M{
+		"task_id": taskID,
 	}}
 	_, err := c.UpdateOne(context.TODO(), query, change)
 	return err


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

Problem Summary:

1. when creating delivery verison for helm sevices, if releases not deployed by zadig are selected, error occurs
2. errors from building delivery version may be incomplete

What's Changed:
How it Works:

fix bugs