### PR TITLE
bugfix: delivery version create fail

### DIFF
--- a/pkg/microservice/aslan/core/delivery/service/version.go
+++ b/pkg/microservice/aslan/core/delivery/service/version.go
@@ -49,12 +49,14 @@ import (
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	commonservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/base"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/kube"
 	workflowservice "github.com/koderover/zadig/pkg/microservice/aslan/core/workflow/service/workflow"
 	"github.com/koderover/zadig/pkg/setting"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 	helmtool "github.com/koderover/zadig/pkg/tool/helmclient"
 	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/koderover/zadig/pkg/types"
+	"github.com/koderover/zadig/pkg/util/converter"
 	fsutil "github.com/koderover/zadig/pkg/util/fs"
 	yamlutil "github.com/koderover/zadig/pkg/util/yaml"
 )
@@ -105,6 +107,7 @@ type DeliveryChartData struct {
 	ProductService *commonmodels.ProductService
 	RenderChart    *template.RenderChart
 	RenderSet      *commonmodels.RenderSet
+	ValuesInEnv    map[string]interface{}
 }
 
 type DeliveryChartResp struct {
@@ -511,14 +514,36 @@ func createChartRepoClient(repo *commonmodels.HelmRepo) (*cm.Client, error) {
 }
 
 // find all images in one single chart
-func extractImages(productService *commonmodels.ProductService, registryMap map[string]*commonmodels.RegistryNamespace) (*ServiceImageDetails, error) {
+func extractImages(cData *DeliveryChartData, registryMap map[string]*commonmodels.RegistryNamespace) (*ServiceImageDetails, error) {
+
+	flatMap, err := converter.Flatten(cData.ValuesInEnv)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceObj := cData.ServiceObj
+	imagePathSpecs := make([]map[string]string, 0)
+	for _, container := range serviceObj.Containers {
+		imageSearchRule := &template.ImageSearchingRule{
+			Repo:  container.ImagePath.Repo,
+			Image: container.ImagePath.Image,
+			Tag:   container.ImagePath.Tag,
+		}
+		pattern := imageSearchRule.GetSearchingPattern()
+		imagePathSpecs = append(imagePathSpecs, pattern)
+	}
+
 	imageUrlsSet := sets.NewString()
-	for _, container := range productService.Containers {
-		imageUrlsSet.Insert(container.Image)
+	for _, spec := range imagePathSpecs {
+		imageUrl, err := commonservice.GeneImageURI(spec, flatMap)
+		if err != nil {
+			return nil, err
+		}
+		imageUrlsSet.Insert(imageUrl)
 	}
 
 	ret := &ServiceImageDetails{
-		ServiceName: productService.ServiceName,
+		ServiceName: cData.ProductService.ServiceName,
 		Images:      make([]*ImageUrlDetail, 0),
 	}
 
@@ -555,7 +580,7 @@ func extractImages(productService *commonmodels.ProductService, registryMap map[
 }
 
 // ensure chart files exist
-func ensureChartFiles(chartData *DeliveryChartData) (string, error) {
+func ensureChartFiles(chartData *DeliveryChartData, prod *commonmodels.Product) (string, error) {
 	serviceObj := chartData.ServiceObj
 	revisionBasePath := config.LocalDeliveryChartPathWithRevision(serviceObj.ProductName, serviceObj.ServiceName, serviceObj.Revision)
 	deliveryChartPath := filepath.Join(revisionBasePath, serviceObj.ServiceName)
@@ -581,11 +606,30 @@ func ensureChartFiles(chartData *DeliveryChartData) (string, error) {
 		return "", err
 	}
 
-	mergedValuesYaml, err := helmtool.MergeOverrideValues(chartData.RenderChart.ValuesYaml, chartData.RenderSet.DefaultValues, chartData.RenderChart.GetOverrideYaml(), chartData.RenderChart.OverrideValues)
+	restConfig, err := kube.GetRESTConfig(prod.ClusterID)
+	if err != nil {
+		log.Errorf("get rest config error: %v", err)
+		return "", err
+	}
+	helmClient, err := helmtool.NewClientFromRestConf(restConfig, prod.Namespace)
+	if err != nil {
+		log.Errorf("[%s][%s] init helm client error: %v", prod.ProductName, prod.Namespace, err)
+		return "", err
+	}
+
+	releaseName := fmt.Sprintf("%s-%s", prod.Namespace, serviceObj.ServiceName)
+	valuesMap, err := helmClient.GetReleaseValues(releaseName, true)
+	if err != nil {
+		log.Errorf("failed to get values map data %s", err)
+		return "", err
+	}
+
+	currentValuesYaml, err := yaml.Marshal(valuesMap)
 	if err != nil {
 		return "", err
 	}
-	err = os.WriteFile(filepath.Join(deliveryChartPath, setting.ValuesYaml), []byte(mergedValuesYaml), 0644)
+
+	err = os.WriteFile(filepath.Join(deliveryChartPath, setting.ValuesYaml), currentValuesYaml, 0644)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to write values.yaml")
 	}
@@ -593,10 +637,10 @@ func ensureChartFiles(chartData *DeliveryChartData) (string, error) {
 	return deliveryChartPath, nil
 }
 
-func buildChartPackage(chartData *DeliveryChartData, chartRepo *commonmodels.HelmRepo, dir string, globalVariables string, registryMap map[string]*commonmodels.RegistryNamespace) error {
+func buildChartPackage(chartData *DeliveryChartData, product *commonmodels.Product, chartRepo *commonmodels.HelmRepo, dir string, globalVariables string, registryMap map[string]*commonmodels.RegistryNamespace) error {
 	serviceObj := chartData.ServiceObj
 
-	deliveryChartPath, err := ensureChartFiles(chartData)
+	deliveryChartPath, err := ensureChartFiles(chartData, product)
 	if err != nil {
 		return err
 	}
@@ -611,6 +655,9 @@ func buildChartPackage(chartData *DeliveryChartData, chartRepo *commonmodels.Hel
 	if err != nil {
 		return errors.Wrapf(err, "failed to unmarshal values.yaml for service %s", serviceObj.ServiceName)
 	}
+
+	// hold the currently running yaml data
+	chartData.ValuesInEnv = valuesYamlData
 
 	// write values.yaml file before load
 	if len(chartData.ChartData.ValuesYamlContent) > 0 { // values.yaml was edited directly
@@ -886,13 +933,13 @@ func buildDeliveryCharts(chartDataMap map[string]*DeliveryChartData, deliveryVer
 		wg.Add(1)
 		go func(cData *DeliveryChartData) {
 			defer wg.Done()
-			err := buildChartPackage(cData, repoInfo, dir, args.GlobalVariables, registryMap)
+			err := buildChartPackage(cData, deliveryVersion.ProductEnvInfo, repoInfo, dir, args.GlobalVariables, registryMap)
 			if err != nil {
 				logger.Errorf("failed to build chart package, serviceName: %s err: %s", cData.ChartData.ServiceName, err)
 				appendError(err)
 				return
 			}
-			imageData, err := extractImages(cData.ProductService, registryMap)
+			imageData, err := extractImages(cData, registryMap)
 			if err != nil {
 				logger.Errorf("failed to extract image data, serviceName: %s err: %s", cData.ChartData.ServiceName, err)
 				appendError(err)

--- a/pkg/microservice/aslan/core/delivery/service/version.go
+++ b/pkg/microservice/aslan/core/delivery/service/version.go
@@ -56,6 +56,7 @@ import (
 	helmtool "github.com/koderover/zadig/pkg/tool/helmclient"
 	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/koderover/zadig/pkg/types"
+	"github.com/koderover/zadig/pkg/util"
 	"github.com/koderover/zadig/pkg/util/converter"
 	fsutil "github.com/koderover/zadig/pkg/util/fs"
 	yamlutil "github.com/koderover/zadig/pkg/util/yaml"
@@ -608,16 +609,16 @@ func ensureChartFiles(chartData *DeliveryChartData, prod *commonmodels.Product) 
 
 	restConfig, err := kube.GetRESTConfig(prod.ClusterID)
 	if err != nil {
-		log.Errorf("get rest config error: %v", err)
+		log.Errorf("get rest config error: %s", err)
 		return "", err
 	}
 	helmClient, err := helmtool.NewClientFromRestConf(restConfig, prod.Namespace)
 	if err != nil {
-		log.Errorf("[%s][%s] init helm client error: %v", prod.ProductName, prod.Namespace, err)
+		log.Errorf("[%s][%s] init helm client error: %s", prod.ProductName, prod.Namespace, err)
 		return "", err
 	}
 
-	releaseName := fmt.Sprintf("%s-%s", prod.Namespace, serviceObj.ServiceName)
+	releaseName := util.GeneHelmReleaseName(prod.Namespace, serviceObj.ServiceName)
 	valuesMap, err := helmClient.GetReleaseValues(releaseName, true)
 	if err != nil {
 		log.Errorf("failed to get values map data %s", err)

--- a/pkg/microservice/aslan/core/delivery/service/version.go
+++ b/pkg/microservice/aslan/core/delivery/service/version.go
@@ -621,7 +621,7 @@ func ensureChartFiles(chartData *DeliveryChartData, prod *commonmodels.Product) 
 	releaseName := util.GeneHelmReleaseName(prod.Namespace, serviceObj.ServiceName)
 	valuesMap, err := helmClient.GetReleaseValues(releaseName, true)
 	if err != nil {
-		log.Errorf("failed to get values map data %s", err)
+		log.Errorf("failed to get values map data, err: %s", err)
 		return "", err
 	}
 

--- a/pkg/microservice/aslan/core/environment/service/helm.go
+++ b/pkg/microservice/aslan/core/environment/service/helm.go
@@ -165,16 +165,16 @@ func prepareChartVersionData(prod *models.Product, serviceObj *models.Service, r
 
 	restConfig, err := kube.GetRESTConfig(prod.ClusterID)
 	if err != nil {
-		log.Errorf("get rest config error: %v", err)
+		log.Errorf("get rest config error: %s", err)
 		return err
 	}
 	helmClient, err := helmtool.NewClientFromRestConf(restConfig, prod.Namespace)
 	if err != nil {
-		log.Errorf("[%s][%s] init helm client error: %v", prod.EnvName, productName, err)
+		log.Errorf("[%s][%s] init helm client error: %s", prod.EnvName, productName, err)
 		return err
 	}
 
-	releaseName := fmt.Sprintf("%s-%s", prod.Namespace, serviceObj.ServiceName)
+	releaseName := util.GeneHelmReleaseName(prod.Namespace, serviceObj.ServiceName)
 	valuesMap, err := helmClient.GetReleaseValues(releaseName, true)
 	if err != nil {
 		log.Errorf("failed to get values map data %s", err)

--- a/pkg/microservice/aslan/core/environment/service/helm.go
+++ b/pkg/microservice/aslan/core/environment/service/helm.go
@@ -177,7 +177,7 @@ func prepareChartVersionData(prod *models.Product, serviceObj *models.Service, r
 	releaseName := util.GeneHelmReleaseName(prod.Namespace, serviceObj.ServiceName)
 	valuesMap, err := helmClient.GetReleaseValues(releaseName, true)
 	if err != nil {
-		log.Errorf("failed to get values map data %s", err)
+		log.Errorf("failed to get values map data, err: %s", err)
 		return err
 	}
 

--- a/pkg/microservice/aslan/core/environment/service/helm.go
+++ b/pkg/microservice/aslan/core/environment/service/helm.go
@@ -27,6 +27,7 @@ import (
 	"github.com/otiai10/copy"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
@@ -141,7 +142,8 @@ func loadChartFilesInfo(productName, serviceName string, revision int64, dir str
 }
 
 //prepare chart version data
-func prepareChartVersionData(productName string, serviceObj *models.Service, renderChart *template.RenderChart, renderset *models.RenderSet) error {
+func prepareChartVersionData(prod *models.Product, serviceObj *models.Service, renderChart *template.RenderChart, renderset *models.RenderSet) error {
+	productName := prod.ProductName
 	serviceName, revision := serviceObj.ServiceName, serviceObj.Revision
 	base := config.LocalServicePathWithRevision(productName, serviceName, revision)
 	if err := commonservice.PreloadServiceManifestsByRevision(base, serviceObj); err != nil {
@@ -161,13 +163,31 @@ func prepareChartVersionData(productName string, serviceObj *models.Service, ren
 		return err
 	}
 
-	mergedValuesYaml, err := helmtool.MergeOverrideValues(renderChart.ValuesYaml, renderset.DefaultValues, renderChart.GetOverrideYaml(), renderChart.OverrideValues)
+	restConfig, err := kube.GetRESTConfig(prod.ClusterID)
+	if err != nil {
+		log.Errorf("get rest config error: %v", err)
+		return err
+	}
+	helmClient, err := helmtool.NewClientFromRestConf(restConfig, prod.Namespace)
+	if err != nil {
+		log.Errorf("[%s][%s] init helm client error: %v", prod.EnvName, productName, err)
+		return err
+	}
+
+	releaseName := fmt.Sprintf("%s-%s", prod.Namespace, serviceObj.ServiceName)
+	valuesMap, err := helmClient.GetReleaseValues(releaseName, true)
+	if err != nil {
+		log.Errorf("failed to get values map data %s", err)
+		return err
+	}
+
+	currentValuesYaml, err := yaml.Marshal(valuesMap)
 	if err != nil {
 		return err
 	}
 
 	// write values.yaml
-	if err = os.WriteFile(filepath.Join(deliveryChartPath, setting.ValuesYaml), []byte(mergedValuesYaml), 0644); err != nil {
+	if err = os.WriteFile(filepath.Join(deliveryChartPath, setting.ValuesYaml), currentValuesYaml, 0644); err != nil {
 		return err
 	}
 
@@ -245,7 +265,7 @@ func GetChartInfos(productName, envName, serviceName string, log *zap.SugaredLog
 				errList = multierror.Append(errList, fmt.Errorf("failed to find render chart for service %s in target namespace", serviceName))
 				return
 			}
-			err = prepareChartVersionData(productName, serviceObj, renderChart, renderSet)
+			err = prepareChartVersionData(prod, serviceObj, renderChart, renderSet)
 			if err != nil {
 				errList = multierror.Append(errList, fmt.Errorf("failed to prepare chart info for service %s", serviceObj.ServiceName))
 				return


### PR DESCRIPTION
### What this PR does / Why we need it:

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

when creating delivery version for helm services from environment, the current logic of generating content of values.yaml may be incorrect

What's Changed:
How it Works:

use values.yaml actually running in environment instead of generating it

