### PR TITLE
remove permission

### DIFF
--- a/pkg/microservice/aslan/core/project/handler/policy.yaml
+++ b/pkg/microservice/aslan/core/project/handler/policy.yaml
@@ -46,8 +46,6 @@ rules:
         endpoint: "/api/aslan/service/pm/?*"
       - method: POST
         endpoint: "/api/aslan/service/services"
-      - method: GET
-        endpoint: "/api/aslan/service/loader/preload/?*/?*"
       - method: POST
         endpoint: "/api/aslan/service/loader/load/?*/?*"
       - method: POST

--- a/pkg/microservice/aslan/core/project/handler/policy.yaml
+++ b/pkg/microservice/aslan/core/project/handler/policy.yaml
@@ -38,8 +38,6 @@ rules:
         endpoint: "/api/aslan/project/products/?*"
       - method: PUT
         endpoint: "/api/aslan/project/products/?*/searching-rules"
-      - method: POST
-        endpoint: "/api/aslan/service/template/reload"
   - action: create_service
     alias: "新建服务"
     description: ""
@@ -54,10 +52,6 @@ rules:
         endpoint: "/api/aslan/service/loader/load/?*/?*"
       - method: POST
         endpoint: "/api/aslan/service/helm/services"
-      - method: POST
-        endpoint: "/api/aslan/service/template/load"
-      - method: GET
-        endpoint: "/api/aslan/template/charts/?*/variables"
       - method: POST
         endpoint: "/api/aslan/service/helm/services/bulk"
   - action: delete_service


### PR DESCRIPTION
Signed-off-by: fansi <fansi404@koderover.com>

### What this PR does / Why we need it:

1. There's no necessary to control permission for using K8s/Helm Chart template when creating service.
2. the same for /api/aslan/service/loader/preload
