### PR TITLE
Makefile push.*.image bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 .PHONY: all
 
 IMAGE_REPOSITORY = ccr.ccs.tencentyun.com/koderover-rc
-VERSION := $(shell date +'%Y%m%d%H%M%S')
-
+VERSION ?= $(shell date +'%Y%m%d%H%M%S')
+VERSION := $(VERSION)
 TARGETS = aslan cron hub-agent hub-server jenkins-plugin podexec predator-plugin packager-plugin resource-server ua warpdrive policy user picket config init
 REAPER_OS= focal xenial bionic
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY: all
 
 IMAGE_REPOSITORY = ccr.ccs.tencentyun.com/koderover-rc
-VERSION ?= $(shell date +'%Y%m%d%H%M%S')
+VERSION := $(shell date +'%Y%m%d%H%M%S')
 
 TARGETS = aslan cron hub-agent hub-server jenkins-plugin podexec predator-plugin packager-plugin resource-server ua warpdrive policy user picket config init
 REAPER_OS= focal xenial bionic


### PR DESCRIPTION
Signed-off-by: mouuii <chaoyueshijian@gmail.com>

### What this PR does / Why we need it:

makefile can not run make push.*.amd64 , the date is not identical .
previous we use "=" , the date will be set at runtime , so we use ":="