### PR TITLE
support data migration of is_tls field in emailhost when upgrading from 1.6.0 to 1.7.0

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/170.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/170.go
@@ -44,11 +44,16 @@ func V160ToV170() error {
 		log.Errorf("Failed to change codehost type, err: %s", err)
 		return err
 	}
-
 	log.Info("Start to refresh all webhook secrets")
 	err = refreshWebHookSecret(gitservice.GetHookSecret())
 	if err != nil {
 		log.Errorf("Failed to refresh webhook secret, err: %s", err)
+		return err
+	}
+
+	err = changeEmailHostType()
+	if err != nil {
+		log.Errorf("Failed to change emailhost type , err: %s", err)
 		return err
 	}
 
@@ -58,13 +63,19 @@ func V160ToV170() error {
 func V170ToV160() error {
 	log.Info("Rollback data from 1.7.0 to 1.6.0")
 
+	err := rollbackEmailhostType()
+	if err != nil {
+		log.Errorf("Failed to rollback emailhost type, err: %s", err)
+		return err
+	}
+
 	token := getWebHookTokenFromOrganization()
 	if token == "" {
 		return nil
 	}
 
 	log.Info("Start to rollback all webhook secrets")
-	err := refreshWebHookSecret(token)
+	err = refreshWebHookSecret(token)
 	if err != nil {
 		log.Errorf("Failed to refresh webhook secret, err: %s", err)
 		return err
@@ -145,19 +156,56 @@ func getCodeHostByAddressAndOwner(address, owner string, all []*internalmodels.C
 	return nil
 }
 
+// change tls from string to bool type
+func changeEmailHostType() error {
+	emailHosts, err := internalmongodb.NewEmailHostColl().List()
+	if err != nil {
+		log.Errorf("Failed to list emailhosts , err: %s", err)
+		return err
+	}
+	for _, v := range emailHosts {
+		if value, ok := v.IsTLS.(string); ok {
+			if err := internalmongodb.NewEmailHostColl().ChangeType(v.ID, value); err != nil {
+				log.Warnf("Failed to change id:%v istls:%s , err: %s", v.ID, value, err)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// rollback  tls from bool to string type
+func rollbackEmailhostType() error {
+	// get all codehosts
+	codeHosts, err := internalmongodb.NewEmailHostColl().List()
+	if err != nil {
+		log.Errorf("Failed to list codehosts, err: %s", err)
+		return err
+	}
+	for _, v := range codeHosts {
+		if value, ok := v.IsTLS.(bool); ok {
+			if err := internalmongodb.NewEmailHostColl().RollbackType(v.ID, value); err != nil {
+				log.Warnf("Failed to rollback id:%v istls:%v , err: %s", v.ID, value, err)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // change type "1,2,3,4" to "github,gitlab..."
 func changeCodehostType() error {
 	// get all codehosts
 	codeHosts, err := internalmongodb.NewCodehostColl().List()
 	if err != nil {
-		log.Errorf("fail to list codehosts, err: %s", err)
+		log.Errorf("Failed to list codehosts, err: %s", err)
 		return err
 	}
 	var finalErr error
 	// change type to readable string
 	for _, v := range codeHosts {
 		if err := internalmongodb.NewCodehostColl().ChangeType(v.ID, v.Type); err != nil {
-			log.Warnf("fail to change id:%d type:%s , err: %s", v.ID, v.Type, err)
+			log.Warnf("Failed to change id:%d type:%s , err: %s", v.ID, v.Type, err)
 			finalErr = err
 		}
 	}
@@ -169,14 +217,14 @@ func rollbackCodehostType() error {
 	// get all codehosts
 	codeHosts, err := internalmongodb.NewCodehostColl().List()
 	if err != nil {
-		log.Errorf("fail to list codehosts, err: %s", err)
+		log.Errorf("Failed to list codehosts, err: %s", err)
 		return err
 	}
 	var finalErr error
 	// rollback change type to readable string
 	for _, v := range codeHosts {
 		if err := internalmongodb.NewCodehostColl().RollbackType(v.ID, v.Type); err != nil {
-			log.Warnf("fail to rollback id:%d type:%s , err: %s", v.ID, v.Type, err)
+			log.Warnf("Failed to rollback id:%d type:%s , err: %s", v.ID, v.Type, err)
 			finalErr = err
 			continue
 		}

--- a/pkg/cli/upgradeassistant/internal/repository/models/emailhost.go
+++ b/pkg/cli/upgradeassistant/internal/repository/models/emailhost.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2021 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type EmailHost struct {
+	ID        primitive.ObjectID `bson:"_id,omitempty"           json:"id,omitempty"`
+	Name      string             `bson:"name"       json:"name"`
+	Port      int                `bson:"port"       json:"port"`
+	Username  string             `bson:"username"   json:"username"`
+	Password  string             `bson:"password"   json:"password"`
+	IsTLS     interface{}        `bson:"is_tls"     json:"isTLS"`
+	CreatedAt int64              `bson:"created_at" json:"created_at"`
+	DeletedAt int64              `bson:"deleted_at" json:"deleted_at"`
+	UpdatedAt int64              `bson:"updated_at" json:"updated_at"`
+}
+
+func (EmailHost) TableName() string {
+	return "email_host"
+}

--- a/pkg/cli/upgradeassistant/internal/repository/mongodb/emailhost.go
+++ b/pkg/cli/upgradeassistant/internal/repository/mongodb/emailhost.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2021 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mongodb
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+
+	"github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/repository/models"
+	"github.com/koderover/zadig/pkg/config"
+	"github.com/koderover/zadig/pkg/tool/log"
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
+)
+
+func NewEmailHostColl() *EmailHostColl {
+	name := models.EmailHost{}.TableName()
+	coll := &EmailHostColl{Collection: mongotool.Database(config.MongoDatabase()).Collection(name), coll: name}
+
+	return coll
+}
+
+type EmailHostColl struct {
+	*mongo.Collection
+
+	coll string
+}
+
+func (c *EmailHostColl) List() ([]*models.EmailHost, error) {
+	emailhosts := make([]*models.EmailHost, 0)
+	query := bson.M{"deleted_at": 0}
+	cursor, err := c.Collection.Find(context.TODO(), query)
+	if err != nil {
+		return nil, err
+	}
+	err = cursor.All(context.TODO(), &emailhosts)
+	if err != nil {
+		return nil, err
+	}
+
+	return emailhosts, nil
+}
+
+func (c *EmailHostColl) ChangeType(ID primitive.ObjectID, isTLS string) error {
+	query := bson.M{"_id": ID}
+	changedTLS := false
+	if isTLS == "2" {
+		changedTLS = true
+	}
+	change := bson.M{"$set": bson.M{
+		"is_tls": changedTLS,
+	}}
+	_, err := c.Collection.UpdateOne(context.TODO(), query, change)
+	if err != nil {
+		log.Errorf("emailhost update fail,err:%s", err)
+		return err
+	}
+	log.Infof("success to change id:%v isTLS:%s to %v", ID, isTLS, changedTLS)
+	return nil
+}
+
+func (c *EmailHostColl) RollbackType(ID primitive.ObjectID, isTLS bool) error {
+	query := bson.M{"_id": ID}
+	changedTLS := "1"
+	if isTLS == true {
+		changedTLS = "2"
+	}
+	change := bson.M{"$set": bson.M{
+		"is_tls": changedTLS,
+	}}
+	_, err := c.Collection.UpdateOne(context.TODO(), query, change)
+	if err != nil {
+		log.Errorf("emailhost update fail,err:%s", err)
+		return err
+	}
+	log.Infof("success to change id:%v isTLS:%v to %s", ID, isTLS, changedTLS)
+	return nil
+}


### PR DESCRIPTION
### What this PR does / Why we need it:

emailhost upgrade from 1.6.0 -> 1.7.0 ,change emailhost is_tls type from string to bool