### PR TITLE
remove permission for GET api/aslan/system/registry/namespaces

### DIFF
--- a/pkg/microservice/policy/core/service/bundle/exemption_urls.go
+++ b/pkg/microservice/policy/core/service/bundle/exemption_urls.go
@@ -137,7 +137,7 @@ var systemAdminURLs = []*policyRule{
 		Endpoints: []string{"api/aslan/system/proxyManage/?*"},
 	},
 	{
-		Methods:   []string{"GET", "POST"},
+		Methods:   []string{"POST"},
 		Endpoints: []string{"api/aslan/system/registry/namespaces"},
 	},
 	{


### PR DESCRIPTION
Signed-off-by: fansi <fansiqiong@koderover.com>

### What this PR does / Why we need it:

`GET api/aslan/system/registry/namespaces` can be used by all users. For now, it's under system admin's permission