### PR TITLE
fix name re-use error when install/upgrade helm charts

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/image.go
+++ b/pkg/microservice/aslan/core/environment/service/image.go
@@ -268,7 +268,7 @@ func updateContainerForHelmChart(serviceName, resType, image, containerName stri
 	}
 
 	// when replace image, should not wait
-	err = installOrUpgradeHelmChartWithValues(namespace, replacedMergedValuesYaml, targetChart, serviceObj, 0, helmClient)
+	err = installOrUpgradeHelmChartWithValues(namespace, replacedMergedValuesYaml, targetChart, serviceObj, 0, false, helmClient)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

Problem Summary:

when upgrading helm charts for a release with status 'failed', error: 'cannot re-use a name that is still in use' will be returned because name of failed release can't be reused. The actual reason of deploy helm chart will be overwritten.

What's Changed:

How it Works:

add 'Replace' when retry upgrading chart.
