### PR TITLE
fix(permission):adding exception routes '/workflows'

### DIFF
--- a/pkg/microservice/policy/core/service/bundle/exemption_urls.go
+++ b/pkg/microservice/policy/core/service/bundle/exemption_urls.go
@@ -74,7 +74,7 @@ var publicURLs = []*policyRule{
 	},
 	{
 		Methods:   []string{"GET"},
-		Endpoints: []string{"", "signin", "setup", "static/**", "v1/**", "mobile/**", "productpipelines/**", "favicon.ico"},
+		Endpoints: []string{"", "signin", "setup", "static/**", "v1/**", "mobile/**", "workflows/**", "favicon.ico"},
 	},
 	{
 		Methods:   []string{"GET"},


### PR DESCRIPTION
Signed-off-by: leozhang2018 <leozhang2018@gmail.com>
Cherry pick for https://github.com/koderover/zadig/pull/812

### What this PR does / Why we need it:
Adding exception routes for '/workflows'.

![image](https://user-images.githubusercontent.com/6907296/147308468-a1e4f702-1758-436b-bfb3-47b84a4781ff.png)

**Problem Summary:**

Refresh page will get 401 in production environment.
Frontend routing definition:[zadig-portal/blob/main/src/router/index.js#L601](https://github.com/koderover/zadig-portal/blob/main/src/router/index.js#L601)

**What's Changed:**

Change  `productpipelines/**`  to `workflows/**`


### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information