### PR TITLE
optimize ua logic

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate.go
@@ -88,7 +88,7 @@ func run() error {
 	sort.Strings(upgradepath.VersionDatas)
 
 	// add default handlers
-	for i := 0; i < len(upgradepath.VersionDatas); i++ {
+	for i := 0; i < len(upgradepath.VersionDatas)-1; i++ {
 		upgradepath.AddHandler(i, i+1, upgradepath.DefaultUpgradeHandler)
 		upgradepath.AddHandler(i+1, i, upgradepath.DefaultRollBackHandler)
 	}

--- a/pkg/cli/upgradeassistant/cmd/migrate.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate.go
@@ -19,17 +19,18 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	_ "github.com/koderover/zadig/pkg/cli/upgradeassistant/cmd/migrate"
 	"github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/upgradepath"
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/tool/log"
 	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
-	"github.com/koderover/zadig/version"
 )
 
 const oldestVersion = "1.3.0"
@@ -38,7 +39,7 @@ func init() {
 	rootCmd.AddCommand(migrateCmd)
 
 	migrateCmd.PersistentFlags().StringP("from-version", "f", oldestVersion, "current version to migrate from")
-	migrateCmd.PersistentFlags().StringP("to-version", "t", version.Version, "target version to migrate to")
+	migrateCmd.PersistentFlags().StringP("to-version", "t", "", "target version to migrate to")
 	_ = viper.BindPFlag("fromVersion", migrateCmd.PersistentFlags().Lookup("from-version"))
 	_ = viper.BindPFlag("toVersion", migrateCmd.PersistentFlags().Lookup("to-version"))
 }
@@ -67,6 +68,36 @@ func run() error {
 	to := viper.GetString("toVersion")
 
 	log.Infof("Migrating from %s to %s", from, to)
+
+	versionSets := sets.NewString()
+
+	for _, rh := range upgradepath.RegisteredHandlers {
+		versionSets.Insert(rh.FromVersion, rh.ToVersion)
+	}
+	upgradepath.VersionDatas = versionSets.List()
+	sort.Strings(upgradepath.VersionDatas)
+
+	if len(from) == 0 {
+		from = oldestVersion
+	}
+	if len(to) == 0 {
+		to = upgradepath.VersionDatas[len(upgradepath.VersionDatas)-1]
+	}
+	versionSets.Insert(from, to)
+	upgradepath.VersionDatas = versionSets.List()
+	sort.Strings(upgradepath.VersionDatas)
+
+	// add default handlers
+	for i := 0; i < len(upgradepath.VersionDatas); i++ {
+		upgradepath.AddHandler(i, i+1, upgradepath.DefaultUpgradeHandler)
+		upgradepath.AddHandler(i+1, i, upgradepath.DefaultRollBackHandler)
+	}
+
+	// add custom handlers
+	for _, rh := range upgradepath.RegisteredHandlers {
+		upgradepath.AddHandler(upgradepath.VersionDatas.VersionIndex(rh.FromVersion), upgradepath.VersionDatas.VersionIndex(rh.ToVersion), rh.Fn)
+	}
+
 	err := upgradepath.UpgradeWithBestPath(from, to)
 	if err == nil {
 		log.Info("Migration finished")

--- a/pkg/cli/upgradeassistant/cmd/migrate/150.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/150.go
@@ -39,7 +39,6 @@ func init() {
 // use preset rules as patterns: {"image": "repository", "tag": "tag"}, {"image": "image"}
 func V140ToV150() error {
 	log.Info("Migrating data from 1.4.0 to 1.5.0")
-	return nil
 	products, err := mongodb.NewProductColl().List(&mongodb.ProductListOptions{
 		ExcludeStatus: setting.ProductStatusDeleting,
 		Source:        setting.SourceFromHelm,

--- a/pkg/cli/upgradeassistant/cmd/migrate/150.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/150.go
@@ -31,15 +31,15 @@ import (
 )
 
 func init() {
-	upgradepath.AddHandler(upgradepath.V140, upgradepath.V150, V140ToV150)
-	upgradepath.AddHandler(upgradepath.V150, upgradepath.V140, V150ToV140)
+	upgradepath.RegisterHandler("1.4.0", "1.5.0", V140ToV150)
+	upgradepath.RegisterHandler("1.5.0", "1.4.0", V150ToV140)
 }
 
 // V140ToV150 fill image path data for old data in product.services.containers
 // use preset rules as patterns: {"image": "repository", "tag": "tag"}, {"image": "image"}
 func V140ToV150() error {
 	log.Info("Migrating data from 1.4.0 to 1.5.0")
-
+	return nil
 	products, err := mongodb.NewProductColl().List(&mongodb.ProductListOptions{
 		ExcludeStatus: setting.ProductStatusDeleting,
 		Source:        setting.SourceFromHelm,

--- a/pkg/cli/upgradeassistant/cmd/migrate/170.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/170.go
@@ -37,7 +37,6 @@ func init() {
 // V160ToV170 refreshes the secret of all webhooks
 func V160ToV170() error {
 	log.Info("Migrating data from 1.6.0 to 1.7.0")
-	return nil
 	log.Info("Start to change codeHost type")
 	err := changeCodehostType()
 	if err != nil {
@@ -62,7 +61,6 @@ func V160ToV170() error {
 
 func V170ToV160() error {
 	log.Info("Rollback data from 1.7.0 to 1.6.0")
-	return nil
 	err := rollbackEmailhostType()
 	if err != nil {
 		log.Errorf("Failed to rollback emailhost type, err: %s", err)

--- a/pkg/cli/upgradeassistant/cmd/migrate/170.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/170.go
@@ -30,14 +30,14 @@ import (
 )
 
 func init() {
-	upgradepath.AddHandler(upgradepath.V160, upgradepath.V170, V160ToV170)
-	upgradepath.AddHandler(upgradepath.V170, upgradepath.V160, V170ToV160)
+	upgradepath.RegisterHandler("1.6.0", "1.7.0", V160ToV170)
+	upgradepath.RegisterHandler("1.7.0", "1.6.0", V170ToV160)
 }
 
 // V160ToV170 refreshes the secret of all webhooks
 func V160ToV170() error {
 	log.Info("Migrating data from 1.6.0 to 1.7.0")
-
+	return nil
 	log.Info("Start to change codeHost type")
 	err := changeCodehostType()
 	if err != nil {
@@ -62,7 +62,7 @@ func V160ToV170() error {
 
 func V170ToV160() error {
 	log.Info("Rollback data from 1.7.0 to 1.6.0")
-
+	return nil
 	err := rollbackEmailhostType()
 	if err != nil {
 		log.Errorf("Failed to rollback emailhost type, err: %s", err)

--- a/pkg/cli/upgradeassistant/cmd/migrate/180.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/180.go
@@ -40,7 +40,6 @@ func init() {
 // Caution: this migration contains unrecoverable changes, please back up the database in advance
 func V171ToV180() error {
 	log.Info("Migrating data from 1.7.1 to 1.8.0")
-	return nil
 	if err := updateAllRoleBindingNames(); err != nil {
 		log.Errorf("Failed to update roleBinding names, err: %s", err)
 		return err

--- a/pkg/cli/upgradeassistant/cmd/migrate/180.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/180.go
@@ -32,15 +32,15 @@ import (
 )
 
 func init() {
-	upgradepath.AddHandler(upgradepath.V171, upgradepath.V180, V171ToV180)
-	upgradepath.AddHandler(upgradepath.V180, upgradepath.V171, V180ToV171)
+	upgradepath.RegisterHandler("1.7.1", "1.8.0", V171ToV180)
+	upgradepath.RegisterHandler("1.8.0", "1.7.1", V180ToV171)
 }
 
 // V171ToV180 update all the roleBinding names in this format "{uid}-{roleName}-{roleNamespace}"
 // Caution: this migration contains unrecoverable changes, please back up the database in advance
 func V171ToV180() error {
 	log.Info("Migrating data from 1.7.1 to 1.8.0")
-
+	return nil
 	if err := updateAllRoleBindingNames(); err != nil {
 		log.Errorf("Failed to update roleBinding names, err: %s", err)
 		return err

--- a/pkg/cli/upgradeassistant/cmd/migrate/migrate.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/migrate.go
@@ -31,7 +31,7 @@ import (
 const oldServiceTemplateCounterName = "service:%s&type:%s"
 
 func init() {
-	upgradepath.AddHandler(upgradepath.V130, upgradepath.V131, V130ToV131)
+	upgradepath.RegisterHandler("1.3.0", "1.3.1", V130ToV131)
 	// upgradepath.AddHandler(upgradepath.V131, upgradepath.V130, V131ToV130)
 }
 
@@ -41,6 +41,7 @@ func init() {
 // 3. Change the ServiceTemplateCounterName format
 func V130ToV131() error {
 	log.Info("Migrating data from 1.3.0 to 1.3.1")
+	return nil
 
 	allServices, err := mongodb.NewServiceColl().ListMaxRevisions(nil)
 	if err != nil {

--- a/pkg/cli/upgradeassistant/cmd/migrate/migrate.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/migrate.go
@@ -41,7 +41,6 @@ func init() {
 // 3. Change the ServiceTemplateCounterName format
 func V130ToV131() error {
 	log.Info("Migrating data from 1.3.0 to 1.3.1")
-	return nil
 
 	allServices, err := mongodb.NewServiceColl().ListMaxRevisions(nil)
 	if err != nil {

--- a/pkg/cli/upgradeassistant/internal/upgradepath/dag.go
+++ b/pkg/cli/upgradeassistant/internal/upgradepath/dag.go
@@ -31,6 +31,22 @@ type upgradePath struct {
 var dag = dijkstra.NewGraph()
 var handlerMap = make(map[upgradePath]handler)
 
+type RegisteredHandler struct {
+	FromVersion string
+	ToVersion   string
+	Fn          handler
+}
+
+var RegisteredHandlers = make([]*RegisteredHandler, 0)
+
+func RegisterHandler(fromVersion, toVersion string, fn handler) {
+	RegisteredHandlers = append(RegisteredHandlers, &RegisteredHandler{
+		FromVersion: fromVersion,
+		ToVersion:   toVersion,
+		Fn:          fn,
+	})
+}
+
 func AddHandler(from, to int, fn handler) {
 	if v, err := dag.GetVertex(from); err != nil || v.ID != from {
 		dag.AddVertex(from)
@@ -46,7 +62,7 @@ func AddHandler(from, to int, fn handler) {
 }
 
 func UpgradeWithBestPath(from, to string) error {
-	return upgradeWithBestPath(versionMap.From(from), versionMap.To(to))
+	return upgradeWithBestPath(VersionDatas.VersionIndex(from), VersionDatas.VersionIndex(to))
 }
 
 func upgradeWithBestPath(from, to int) error {

--- a/pkg/cli/upgradeassistant/internal/upgradepath/versions.go
+++ b/pkg/cli/upgradeassistant/internal/upgradepath/versions.go
@@ -17,98 +17,34 @@ limitations under the License.
 package upgradepath
 
 import (
-	"sort"
-
 	"github.com/blang/semver/v4"
+	"github.com/koderover/zadig/pkg/tool/log"
 )
 
-const (
-	Latest = iota + 1
-	V130
-	V131
-	V140
-	V150
-	V160
-	V170
-	V171
-	V180
-)
+var VersionDatas versionList
 
-var versionMap versions = map[string]int{
-	"1.3.0": V130,
-	"1.3.1": V131,
-	"1.4.0": V140,
-	"1.5.0": V150,
-	"1.6.0": V160,
-	"1.7.0": V170,
-	"1.7.1": V171,
-	"1.8.0": V180,
-}
+type versionList []string
 
-type versions map[string]int
-
-func (v versions) From(version string) int {
-	f, err := semver.Make(version)
-	if err != nil {
-		return Latest
-	}
-	res, ok := v[f.FinalizeVersion()]
-	if !ok {
-		return Latest
-	}
-
-	return res
-}
-
-func (v versions) To(version string) int {
+func (v versionList) VersionIndex(version string) int {
 	t, err := semver.Make(version)
 	if err != nil {
-		return Latest
-	}
-	res, ok := v[t.FinalizeVersion()]
-	if !ok {
-		return Latest
+		return 0
 	}
 
-	return res
-}
-
-func (v versions) Max() int {
-	return v[v.MaxVersionString()]
-}
-
-func (v versions) MaxVersionString() string {
-	max, _ := semver.Make("0.0.1")
-	for ver := range v {
-		sv, _ := semver.Make(ver)
-		if sv.GT(max) {
-			max = sv
+	for index, _version := range VersionDatas {
+		if _version == t.FinalizeVersion() {
+			return index
 		}
 	}
-
-	return max.FinalizeVersion()
+	return 0
 }
 
-func init() {
-	versionList := make([]string, 0, len(versionMap))
-	for v := range versionMap {
-		versionList = append(versionList, v)
-	}
-
-	sort.Strings(versionList)
-
-	for i := 0; i < len(versionList)-1; i++ {
-		lowVersion := versionList[i]
-		highVersion := versionList[i+1]
-		AddHandler(versionMap[lowVersion], versionMap[highVersion], defaultUpgradeHandler)
-		AddHandler(versionMap[highVersion], versionMap[lowVersion], defaultRollBackHandler)
-	}
-}
-
-func defaultUpgradeHandler() error {
+func DefaultUpgradeHandler() error {
+	log.Info("default upgrade handler ")
 	return nil
 }
 
-func defaultRollBackHandler() error {
+func DefaultRollBackHandler() error {
+	log.Info("default rollback handler ")
 	return nil
 }

--- a/version/version.go
+++ b/version/version.go
@@ -17,7 +17,7 @@ limitations under the License.
 package version
 
 var (
-	Version     = "1.7.1"
+	Version     = "1.8.0"
 	BuildNumber = "0"
 	GitCommit   = ""
 )


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

Problem Summary:

the current implementation of upgrade-assistant requires all versions of zadig be explicitly declared in code, any missing of declaration will make upgrade-assistant panic.

What's Changed:

How it Works:

optimize the requirement of version declaration, only the versions with upgrade/rollback hook logic need to be declared

- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information