### PR TITLE
wip optimize destribution-only workflow logic

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go
@@ -886,7 +886,7 @@ func (h *TaskNotificationHandler) HandleMessage(message *nsq.Message) error {
 	h.log.Infof("receive notification: %+v", n)
 
 	notifyClient := notify.NewNotifyClient()
-	if err := notifyClient.ProccessNotify(n); err != nil {
+	if err := notifyClient.ProcessNotify(n); err != nil {
 		h.log.Errorf("send notify error :%v", err)
 	}
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -951,7 +951,6 @@ func AddDataToArgsOrCreateReleaseImageTask(args *commonmodels.WorkflowTaskArgs, 
 	}
 
 	return createReleaseImageTask(workflow, args, log)
-	//return createReleaseImageTaskV2(workflow, args, log)
 }
 
 func buildRegistryMap() (map[string]*commonmodels.RegistryNamespace, error) {


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

when running 'distribution-stage-only' workflow by calling openapi with multiple images, multiple jobs will be created, this may cost long time for situations with large number of images

Problem Summary:

### What is changed and how it works?

optmize the distribution logic to support handling multiple images in single job
