### PR TITLE
add registry image data compatible

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/180.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/180.go
@@ -23,7 +23,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 
 	internalmongodb "github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/repository/mongodb"
-
 	"github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/upgradepath"
 	"github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/policy/core/repository/models"
@@ -66,12 +65,12 @@ func patchProductRegistryID() error {
 	// get all products
 	products, err := internalmongodb.NewProductColl().List(&internalmongodb.ProductListOptions{})
 	if err != nil {
-		log.Errorf("fail to list products, err: %s", err)
+		log.Errorf("Fail to list products, err: %s", err)
 		return err
 	}
 	registry, err := internalmongodb.NewRegistryNamespaceColl().Find(&internalmongodb.FindRegOps{IsDefault: true})
 	if err != nil {
-		log.Errorf("fail to find default registry, err: %s", err)
+		log.Errorf("Fail to find default registry, err: %s", err)
 		return err
 	}
 	// change type to readable string
@@ -82,7 +81,7 @@ func patchProductRegistryID() error {
 	}
 	err = internalmongodb.NewProductColl().UpdateAllRegistry(products)
 	if err != nil {
-		log.Errorf("fail to update products, err: %s", err)
+		log.Errorf("Fail to update products, err: %s", err)
 		return err
 	}
 	return nil

--- a/pkg/cli/upgradeassistant/cmd/migrate/180.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/180.go
@@ -65,12 +65,12 @@ func patchProductRegistryID() error {
 	// get all products
 	products, err := internalmongodb.NewProductColl().List(&internalmongodb.ProductListOptions{})
 	if err != nil {
-		log.Errorf("Fail to list products, err: %s", err)
+		log.Errorf("Failed to list products, err: %s", err)
 		return err
 	}
 	registry, err := internalmongodb.NewRegistryNamespaceColl().Find(&internalmongodb.FindRegOps{IsDefault: true})
 	if err != nil {
-		log.Errorf("Fail to find default registry, err: %s", err)
+		log.Errorf("Failed to find default registry, err: %s", err)
 		return err
 	}
 	// change type to readable string
@@ -81,7 +81,7 @@ func patchProductRegistryID() error {
 	}
 	err = internalmongodb.NewProductColl().UpdateAllRegistry(products)
 	if err != nil {
-		log.Errorf("Fail to update products, err: %s", err)
+		log.Errorf("Failed to update products, err: %s", err)
 		return err
 	}
 	return nil

--- a/pkg/cli/upgradeassistant/cmd/migrate/180.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/180.go
@@ -22,6 +22,8 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 
+	internalmongodb "github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/repository/mongodb"
+
 	"github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/upgradepath"
 	"github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/policy/core/repository/models"
@@ -45,11 +47,44 @@ func V171ToV180() error {
 		return err
 	}
 
+	log.Info("Start to patchProductRegistryID")
+	err := patchProductRegistryID()
+	if err != nil {
+		log.Errorf("Failed to patchProductRegistryID, err: %s", err)
+		return err
+	}
+
 	return nil
 }
 
 func V180ToV171() error {
 	log.Info("Rollback data from 1.8.0 to 1.7.1")
+	return nil
+}
+
+func patchProductRegistryID() error {
+	// get all products
+	products, err := internalmongodb.NewProductColl().List(&internalmongodb.ProductListOptions{})
+	if err != nil {
+		log.Errorf("fail to list products, err: %s", err)
+		return err
+	}
+	registry, err := internalmongodb.NewRegistryNamespaceColl().Find(&internalmongodb.FindRegOps{IsDefault: true})
+	if err != nil {
+		log.Errorf("fail to find default registry, err: %s", err)
+		return err
+	}
+	// change type to readable string
+	for _, v := range products {
+		if len(v.RegistryID) == 0 {
+			v.RegistryID = registry.ID.Hex()
+		}
+	}
+	err = internalmongodb.NewProductColl().UpdateAllRegistry(products)
+	if err != nil {
+		log.Errorf("fail to update products, err: %s", err)
+		return err
+	}
 	return nil
 }
 

--- a/pkg/cli/upgradeassistant/internal/repository/models/product.go
+++ b/pkg/cli/upgradeassistant/internal/repository/models/product.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2021 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	templatemodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/template"
+)
+
+type ProductAuthType string
+type ProductPermission string
+
+// Vars不做保存，只做input参数
+type Product struct {
+	ID              primitive.ObjectID            `bson:"_id,omitempty"             json:"id,omitempty"`
+	ProductName     string                        `bson:"product_name"              json:"product_name"`
+	CreateTime      int64                         `bson:"create_time"               json:"create_time"`
+	UpdateTime      int64                         `bson:"update_time"               json:"update_time"`
+	Namespace       string                        `bson:"namespace,omitempty"       json:"namespace,omitempty"`
+	Status          string                        `bson:"status"                    json:"status"`
+	Revision        int64                         `bson:"revision"                  json:"revision"`
+	Enabled         bool                          `bson:"enabled"                   json:"enabled"`
+	EnvName         string                        `bson:"env_name"                  json:"env_name"`
+	UpdateBy        string                        `bson:"update_by"                 json:"update_by"`
+	Auth            []*ProductAuth                `bson:"auth"                      json:"auth"`
+	Visibility      string                        `bson:"-"                         json:"visibility"`
+	Services        [][]*ProductService           `bson:"services"                  json:"services"`
+	Render          *RenderInfo                   `bson:"render"                    json:"render"`
+	Error           string                        `bson:"error"                     json:"error"`
+	Vars            []*templatemodels.RenderKV    `bson:"vars,omitempty"            json:"vars,omitempty"`
+	ChartInfos      []*templatemodels.RenderChart `bson:"-"                         json:"chart_infos,omitempty"`
+	IsPublic        bool                          `bson:"is_public"                 json:"isPublic"`
+	RoleIDs         []int64                       `bson:"role_ids"                  json:"roleIds"`
+	ClusterID       string                        `bson:"cluster_id,omitempty"      json:"cluster_id,omitempty"`
+	RecycleDay      int                           `bson:"recycle_day"               json:"recycle_day"`
+	Source          string                        `bson:"source"                    json:"source"`
+	IsOpenSource    bool                          `bson:"is_opensource"             json:"is_opensource"`
+	RegistryID      string                        `bson:"registry_id"               json:"registry_id"`
+	IsForkedProduct bool                          `bson:"-" json:"-"`
+}
+
+type RenderInfo struct {
+	Name        string `bson:"name"                     json:"name"`
+	Revision    int64  `bson:"revision"                 json:"revision"`
+	ProductTmpl string `bson:"product_tmpl"             json:"product_tmpl"`
+	Description string `bson:"description"              json:"description"`
+}
+
+type ProductAuth struct {
+	Type        ProductAuthType     `bson:"type"          json:"type"`
+	Name        string              `bson:"name"          json:"name"`
+	Permissions []ProductPermission `bson:"permissions"   json:"permissions"`
+}
+
+// ImagePathSpec paths in yaml used to parse image
+type ImagePathSpec struct {
+	Repo  string `bson:"repo,omitempty"           json:"repo,omitempty"`
+	Image string `bson:"image,omitempty"           json:"image,omitempty"`
+	Tag   string `bson:"tag,omitempty"           json:"tag,omitempty"`
+}
+
+// Container ...
+type Container struct {
+	Name      string         `bson:"name"           json:"name"`
+	Image     string         `bson:"image"          json:"image"`
+	ImagePath *ImagePathSpec `bson:"image_path,omitempty"          json:"imagePath,omitempty"`
+}
+
+type EnvConfig struct {
+	EnvName string   `bson:"env_name,omitempty" json:"env_name"`
+	HostIDs []string `bson:"host_ids,omitempty" json:"host_ids"`
+	Labels  []string `bson:"labels,omitempty"   json:"labels"`
+}
+
+type ProductService struct {
+	ServiceName string       `bson:"service_name"               json:"service_name"`
+	ProductName string       `bson:"product_name"               json:"product_name"`
+	Type        string       `bson:"type"                       json:"type"`
+	Revision    int64        `bson:"revision"                   json:"revision"`
+	Containers  []*Container `bson:"containers"                 json:"containers,omitempty"`
+	Render      *RenderInfo  `bson:"render,omitempty"           json:"render,omitempty"` // 记录每个服务render信息 便于更新单个服务
+	EnvConfigs  []*EnvConfig `bson:"-"                          json:"env_configs,omitempty"`
+}
+
+type ServiceConfig struct {
+	ConfigName string `bson:"config_name"           json:"config_name"`
+	Revision   int64  `bson:"revision"              json:"revision"`
+}
+
+func (Product) TableName() string {
+	return "product"
+}
+
+func (p *Product) GetNamespace() string {
+	return p.ProductName + "-env-" + p.EnvName
+}
+
+func (p *Product) GetGroupServiceNames() [][]string {
+	var resp [][]string
+	for _, group := range p.Services {
+		services := make([]string, 0, len(group))
+		for _, service := range group {
+			services = append(services, service.ServiceName)
+		}
+		resp = append(resp, services)
+	}
+	return resp
+}
+
+func (p *Product) GetServiceMap() map[string]*ProductService {
+	ret := make(map[string]*ProductService)
+	for _, group := range p.Services {
+		for _, svc := range group {
+			ret[svc.ServiceName] = svc
+		}
+	}
+
+	return ret
+}

--- a/pkg/cli/upgradeassistant/internal/repository/models/product.go
+++ b/pkg/cli/upgradeassistant/internal/repository/models/product.go
@@ -25,7 +25,7 @@ import (
 type ProductAuthType string
 type ProductPermission string
 
-// Vars不做保存，只做input参数
+// Vars do not save, only input parameters
 type Product struct {
 	ID              primitive.ObjectID            `bson:"_id,omitempty"             json:"id,omitempty"`
 	ProductName     string                        `bson:"product_name"              json:"product_name"`
@@ -74,7 +74,6 @@ type ImagePathSpec struct {
 	Tag   string `bson:"tag,omitempty"           json:"tag,omitempty"`
 }
 
-// Container ...
 type Container struct {
 	Name      string         `bson:"name"           json:"name"`
 	Image     string         `bson:"image"          json:"image"`
@@ -93,7 +92,7 @@ type ProductService struct {
 	Type        string       `bson:"type"                       json:"type"`
 	Revision    int64        `bson:"revision"                   json:"revision"`
 	Containers  []*Container `bson:"containers"                 json:"containers,omitempty"`
-	Render      *RenderInfo  `bson:"render,omitempty"           json:"render,omitempty"` // 记录每个服务render信息 便于更新单个服务
+	Render      *RenderInfo  `bson:"render,omitempty"           json:"render,omitempty"` // Record the render information of each service to facilitate the update of a single service
 	EnvConfigs  []*EnvConfig `bson:"-"                          json:"env_configs,omitempty"`
 }
 

--- a/pkg/cli/upgradeassistant/internal/repository/models/registry_namespace.go
+++ b/pkg/cli/upgradeassistant/internal/repository/models/registry_namespace.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2021 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"errors"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type RegistryNamespace struct {
+	ID          primitive.ObjectID `bson:"_id,omitempty"               json:"id,omitempty"`
+	RegAddr     string             `bson:"reg_addr"                    json:"reg_addr"`
+	RegType     string             `bson:"reg_type"                    json:"reg_type"`
+	RegProvider string             `bson:"reg_provider"                json:"reg_provider"`
+	IsDefault   bool               `bson:"is_default"                  json:"is_default"`
+	Namespace   string             `bson:"namespace"                   json:"namespace"`
+	AccessKey   string             `bson:"access_key"                  json:"access_key"`
+	SecretKey   string             `bson:"secret_key"                  json:"secret_key"`
+	Region      string             `bson:"region,omitempty"            json:"region,omitempty"`
+	UpdateTime  int64              `bson:"update_time"                 json:"update_time"`
+	UpdateBy    string             `bson:"update_by"                   json:"update_by"`
+}
+
+func (ns *RegistryNamespace) Validate() error {
+
+	if ns.RegAddr == "" {
+		return errors.New("empty reg_addr")
+	}
+
+	if ns.RegProvider == "" {
+		return errors.New("empty reg_provider")
+	}
+
+	if ns.Namespace == "" {
+		return errors.New("empty namespace")
+	}
+
+	return nil
+}
+
+func (RegistryNamespace) TableName() string {
+	return "registry_namespace"
+}
+
+//const CandidateRegType = "candidate"
+//
+//const DistRegType = "dist"

--- a/pkg/cli/upgradeassistant/internal/repository/models/registry_namespace.go
+++ b/pkg/cli/upgradeassistant/internal/repository/models/registry_namespace.go
@@ -37,7 +37,6 @@ type RegistryNamespace struct {
 }
 
 func (ns *RegistryNamespace) Validate() error {
-
 	if ns.RegAddr == "" {
 		return errors.New("empty reg_addr")
 	}
@@ -56,7 +55,3 @@ func (ns *RegistryNamespace) Validate() error {
 func (RegistryNamespace) TableName() string {
 	return "registry_namespace"
 }
-
-//const CandidateRegType = "candidate"
-//
-//const DistRegType = "dist"

--- a/pkg/cli/upgradeassistant/internal/repository/mongodb/product.go
+++ b/pkg/cli/upgradeassistant/internal/repository/mongodb/product.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2021 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mongodb
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
+)
+
+type ProductFindOptions struct {
+	Name      string
+	EnvName   string
+	Namespace string
+}
+
+// ClusterId is a primitive.ObjectID{}.Hex()
+type ProductListOptions struct {
+	EnvName             string
+	Name                string
+	IsPublic            bool
+	ClusterID           string
+	IsSortByUpdateTime  bool
+	IsSortByProductName bool
+	ExcludeStatus       string
+	ExcludeSource       string
+	Source              string
+	InProjects          []string
+	InEnvs              []string
+}
+
+type projectEnvs struct {
+	ID          projectID `bson:"_id"`
+	ProjectName string    `bson:"project_name"`
+	Envs        []string  `bson:"envs"`
+}
+
+type projectID struct {
+	ProductName string `bson:"product_name"`
+}
+
+type ProductColl struct {
+	*mongo.Collection
+
+	coll string
+}
+
+func NewProductColl() *ProductColl {
+	name := models.Product{}.TableName()
+	return &ProductColl{Collection: mongotool.Database(config.MongoDatabase()).Collection(name), coll: name}
+}
+
+func (c *ProductColl) GetCollectionName() string {
+	return c.coll
+}
+
+func (c *ProductColl) EnsureIndex(ctx context.Context) error {
+	mod := []mongo.IndexModel{
+		{
+			Keys: bson.D{
+				bson.E{Key: "env_name", Value: 1},
+				bson.E{Key: "product_name", Value: 1},
+			},
+			Options: options.Index().SetUnique(true),
+		},
+		{
+			Keys: bson.D{
+				bson.E{Key: "env_name", Value: 1},
+				bson.E{Key: "product_name", Value: 1},
+				bson.E{Key: "update_time", Value: 1},
+			},
+			Options: options.Index().SetUnique(false),
+		},
+	}
+
+	_, err := c.Indexes().CreateMany(ctx, mod)
+
+	return err
+}
+
+type ProductEnvFindOptions struct {
+	Name      string
+	Namespace string
+}
+
+func (c *ProductColl) FindEnv(opt *ProductEnvFindOptions) (*models.Product, error) {
+	query := bson.M{}
+	if opt.Name != "" {
+		query["product_name"] = opt.Name
+	}
+
+	if opt.Namespace != "" {
+		query["namespace"] = opt.Namespace
+	}
+
+	ret := new(models.Product)
+	err := c.FindOne(context.TODO(), query).Decode(ret)
+	return ret, err
+}
+
+func (c *ProductColl) Find(opt *ProductFindOptions) (*models.Product, error) {
+	res := &models.Product{}
+	query := bson.M{}
+	if opt.Name != "" {
+		query["product_name"] = opt.Name
+	}
+	if opt.EnvName != "" {
+		query["env_name"] = opt.EnvName
+	}
+	if opt.Namespace != "" {
+		query["namespace"] = opt.Namespace
+	}
+
+	err := c.FindOne(context.TODO(), query).Decode(res)
+	return res, err
+}
+
+func (c *ProductColl) List(opt *ProductListOptions) ([]*models.Product, error) {
+	var ret []*models.Product
+	query := bson.M{}
+
+	if opt == nil {
+		opt = &ProductListOptions{}
+	}
+	if opt.EnvName != "" {
+		query["env_name"] = opt.EnvName
+	} else if len(opt.InEnvs) > 0 {
+		query["env_name"] = bson.M{"$in": opt.InEnvs}
+	}
+	if opt.Name != "" {
+		query["product_name"] = opt.Name
+	}
+	if opt.IsPublic {
+		query["is_public"] = opt.IsPublic
+	}
+	if opt.ClusterID != "" {
+		query["cluster_id"] = opt.ClusterID
+	}
+	if opt.Source != "" {
+		query["source"] = opt.Source
+	}
+	if opt.ExcludeSource != "" {
+		query["source"] = bson.M{"$ne": opt.ExcludeSource}
+	}
+	if opt.ExcludeStatus != "" {
+		query["status"] = bson.M{"$ne": opt.ExcludeStatus}
+	}
+	if len(opt.InProjects) > 0 {
+		query["product_name"] = bson.M{"$in": opt.InProjects}
+	}
+
+	ctx := context.Background()
+	opts := options.Find()
+	if opt.IsSortByUpdateTime {
+		opts.SetSort(bson.D{{"update_time", -1}})
+	}
+	if opt.IsSortByProductName {
+		opts.SetSort(bson.D{{"product_name", 1}})
+	}
+	cursor, err := c.Collection.Find(ctx, query, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	err = cursor.All(ctx, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+func (c *ProductColl) UpdateAllRegistry(envs []*models.Product) error {
+	if len(envs) == 0 {
+		return nil
+	}
+
+	var ms []mongo.WriteModel
+	for _, env := range envs {
+		ms = append(ms,
+			mongo.NewUpdateOneModel().
+				SetFilter(bson.D{{"_id", env.ID}}).
+				SetUpdate(bson.D{{"$set", bson.D{{"registry_id", env.RegistryID}}}}),
+		)
+	}
+	_, err := c.BulkWrite(context.TODO(), ms)
+
+	return err
+}

--- a/pkg/cli/upgradeassistant/internal/repository/mongodb/registry_namespace.go
+++ b/pkg/cli/upgradeassistant/internal/repository/mongodb/registry_namespace.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2021 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mongodb
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
+)
+
+type FindRegOps struct {
+	ID          string `json:"id"`
+	RegAddr     string `json:"reg_addr"`
+	RegType     string `json:"reg_type"`
+	RegProvider string `json:"reg_provider"`
+	IsDefault   bool   `json:"is_default"`
+	Namespace   string `json:"namespace"`
+}
+
+type RegistryNamespaceColl struct {
+	*mongo.Collection
+
+	coll string
+}
+
+func NewRegistryNamespaceColl() *RegistryNamespaceColl {
+	name := models.RegistryNamespace{}.TableName()
+	coll := &RegistryNamespaceColl{Collection: mongotool.Database(config.MongoDatabase()).Collection(name), coll: name}
+
+	return coll
+}
+
+func (r *RegistryNamespaceColl) GetCollectionName() string {
+	return r.coll
+}
+
+func (r *RegistryNamespaceColl) EnsureIndex(ctx context.Context) error {
+	mod := mongo.IndexModel{
+		Keys: bson.D{
+			bson.E{Key: "org_id", Value: 1},
+			bson.E{Key: "is_default", Value: 1},
+			bson.E{Key: "reg_type", Value: 1},
+		},
+		Options: options.Index().SetUnique(false),
+	}
+
+	_, err := r.Indexes().CreateOne(ctx, mod)
+	return err
+}
+
+func (opt FindRegOps) getQuery() bson.M {
+	query := bson.M{}
+
+	if opt.ID != "" {
+		oid, err := primitive.ObjectIDFromHex(opt.ID)
+		if err == nil {
+			query["_id"] = oid
+		}
+	}
+
+	if opt.IsDefault {
+		query["is_default"] = true
+	}
+
+	if opt.RegType != "" {
+		query["reg_type"] = opt.RegType
+	}
+
+	if opt.RegAddr != "" {
+		query["reg_addr"] = opt.RegAddr
+	}
+
+	if opt.RegProvider != "" {
+		query["reg_provider"] = opt.RegProvider
+	}
+
+	if opt.Namespace != "" {
+		query["namespace"] = opt.Namespace
+	}
+	return query
+}
+
+func (r *RegistryNamespaceColl) Find(opt *FindRegOps) (*models.RegistryNamespace, error) {
+	query := opt.getQuery()
+
+	res := &models.RegistryNamespace{}
+	err := r.FindOne(context.TODO(), query).Decode(res)
+
+	return res, err
+}
+
+func (r *RegistryNamespaceColl) FindAll(opt *FindRegOps) ([]*models.RegistryNamespace, error) {
+	query := opt.getQuery()
+
+	ctx := context.Background()
+	opts := options.Find()
+	resp := make([]*models.RegistryNamespace, 0)
+
+	cursor, err := r.Collection.Find(ctx, query, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	err = cursor.All(ctx, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, err
+}


### PR DESCRIPTION
Signed-off-by: panxunying <panxunying@koderover.com>

Problem Summary:
add registry image data compatible when 1.7.1->1.8.0


What's Changed:
product will fill with default registry


