### PR TITLE
AWS ECR support

### DIFF
--- a/pkg/microservice/aslan/config/consts.go
+++ b/pkg/microservice/aslan/config/consts.go
@@ -202,7 +202,8 @@ const (
 )
 
 const (
-	SWRProvider = "swr"
+	RegistryTypeSWR = "swr"
+	RegistryTypeAWS = "ecr"
 )
 
 const (

--- a/pkg/microservice/aslan/core/common/repository/models/registry_namespace.go
+++ b/pkg/microservice/aslan/core/common/repository/models/registry_namespace.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 )
 
 type RegistryNamespace struct {
@@ -28,7 +30,7 @@ type RegistryNamespace struct {
 	RegType     string             `bson:"reg_type"                    json:"reg_type"`
 	RegProvider string             `bson:"reg_provider"                json:"reg_provider"`
 	IsDefault   bool               `bson:"is_default"                  json:"is_default"`
-	Namespace   string             `bson:"namespace"                   json:"namespace"`
+	Namespace   string             `bson:"namespace,omitempty"         json:"namespace,omitempty"`
 	AccessKey   string             `bson:"access_key"                  json:"access_key"`
 	SecretKey   string             `bson:"secret_key"                  json:"secret_key"`
 	Region      string             `bson:"region,omitempty"            json:"region,omitempty"`
@@ -46,7 +48,8 @@ func (ns *RegistryNamespace) Validate() error {
 		return errors.New("empty reg_provider")
 	}
 
-	if ns.Namespace == "" {
+	// if the registry type is aws ECR, then the RegAddr is the registry's full
+	if ns.Namespace == "" && ns.RegProvider != config.RegistryTypeAWS {
 		return errors.New("empty namespace")
 	}
 

--- a/pkg/microservice/aslan/core/common/repository/models/registry_namespace.go
+++ b/pkg/microservice/aslan/core/common/repository/models/registry_namespace.go
@@ -30,12 +30,14 @@ type RegistryNamespace struct {
 	RegType     string             `bson:"reg_type"                    json:"reg_type"`
 	RegProvider string             `bson:"reg_provider"                json:"reg_provider"`
 	IsDefault   bool               `bson:"is_default"                  json:"is_default"`
-	Namespace   string             `bson:"namespace,omitempty"         json:"namespace,omitempty"`
-	AccessKey   string             `bson:"access_key"                  json:"access_key"`
-	SecretKey   string             `bson:"secret_key"                  json:"secret_key"`
-	Region      string             `bson:"region,omitempty"            json:"region,omitempty"`
-	UpdateTime  int64              `bson:"update_time"                 json:"update_time"`
-	UpdateBy    string             `bson:"update_by"                   json:"update_by"`
+	// Namespace is NOT a required field, this could be empty when the registry is AWS ECR or so.
+	// use with CAUTION !!!!
+	Namespace  string `bson:"namespace,omitempty"         json:"namespace,omitempty"`
+	AccessKey  string `bson:"access_key"                  json:"access_key"`
+	SecretKey  string `bson:"secret_key"                  json:"secret_key"`
+	Region     string `bson:"region,omitempty"            json:"region,omitempty"`
+	UpdateTime int64  `bson:"update_time"                 json:"update_time"`
+	UpdateBy   string `bson:"update_by"                   json:"update_by"`
 }
 
 func (ns *RegistryNamespace) Validate() error {

--- a/pkg/microservice/aslan/core/common/service/registry.go
+++ b/pkg/microservice/aslan/core/common/service/registry.go
@@ -166,6 +166,7 @@ func getAWSRegistryCredential(ID, AK, SK, Region string) (string, string, error)
 		keypair, ok := obj.(awsKeyWithExpiration)
 		if ok {
 			if !keypair.IsExpired() {
+				fmt.Printf("Getting aws ak/sk from memory cache: ak[%s], sk[%s]", keypair.AccessKey, keypair.SecretKey)
 				return keypair.AccessKey, keypair.SecretKey, nil
 			}
 		}

--- a/pkg/microservice/aslan/core/common/service/registry.go
+++ b/pkg/microservice/aslan/core/common/service/registry.go
@@ -68,6 +68,9 @@ func findRegisty(regOps *mongodb.FindRegOps, getRealCredential bool, log *zap.Su
 			}
 			resp.AccessKey = realAK
 			resp.SecretKey = realSK
+			// for AWS, since there are no namespaces, we manually decrypt the namespace from URI
+			arr := strings.Split(resp.RegAddr, "/")
+			resp.Namespace = arr[len(arr)-1]
 		default:
 			break
 		}
@@ -101,6 +104,9 @@ func ListRegistryNamespaces(getRealCredential bool, log *zap.SugaredLogger) ([]*
 				}
 				reg.AccessKey = realAK
 				reg.SecretKey = realSK
+				// for AWS, since there are no namespaces, we manually decrypt the namespace from URI
+				arr := strings.Split(reg.RegAddr, "/")
+				reg.Namespace = arr[len(arr)-1]
 			default:
 				break
 			}

--- a/pkg/microservice/aslan/core/common/service/registry.go
+++ b/pkg/microservice/aslan/core/common/service/registry.go
@@ -71,7 +71,7 @@ func findRegisty(regOps *mongodb.FindRegOps, getRealCredential bool, log *zap.Su
 		}
 	}
 
-	if getRealCredential {
+	if !getRealCredential {
 		return resp, nil
 	}
 	switch resp.RegProvider {

--- a/pkg/microservice/aslan/core/common/service/registry.go
+++ b/pkg/microservice/aslan/core/common/service/registry.go
@@ -68,9 +68,6 @@ func findRegisty(regOps *mongodb.FindRegOps, getRealCredential bool, log *zap.Su
 			}
 			resp.AccessKey = realAK
 			resp.SecretKey = realSK
-			// for AWS, since there are no namespaces, we manually decrypt the namespace from URI
-			arr := strings.Split(resp.RegAddr, "/")
-			resp.Namespace = arr[len(arr)-1]
 		default:
 			break
 		}
@@ -104,9 +101,6 @@ func ListRegistryNamespaces(getRealCredential bool, log *zap.SugaredLogger) ([]*
 				}
 				reg.AccessKey = realAK
 				reg.SecretKey = realSK
-				// for AWS, since there are no namespaces, we manually decrypt the namespace from URI
-				arr := strings.Split(reg.RegAddr, "/")
-				reg.Namespace = arr[len(arr)-1]
 			default:
 				break
 			}

--- a/pkg/microservice/aslan/core/common/service/registry.go
+++ b/pkg/microservice/aslan/core/common/service/registry.go
@@ -39,6 +39,8 @@ import (
 	"github.com/koderover/zadig/pkg/util"
 )
 
+var expirationTime = 10 * time.Hour
+
 var awsKeyMap sync.Map
 
 type awsKeyWithExpiration struct {
@@ -201,7 +203,7 @@ func getAWSRegistryCredential(ID, AK, SK, Region string) (string, string, error)
 	awsKeyMap.Store(ID, awsKeyWithExpiration{
 		AccessKey:  keypair[0],
 		SecretKey:  keypair[1],
-		Expiration: time.Now().Add(10 * time.Hour).Unix(),
+		Expiration: time.Now().Add(expirationTime).Unix(),
 	})
 	return keypair[0], keypair[1], nil
 }

--- a/pkg/microservice/aslan/core/common/service/registry/service.go
+++ b/pkg/microservice/aslan/core/common/service/registry/service.go
@@ -490,27 +490,24 @@ func (s *EcrService) ListRepoImages(option ListRepoImagesOption, log *zap.Sugare
 	for _, repo := range option.Repos {
 		name := repo
 		wg.Start(func() {
-			input := &ecr.BatchGetImageInput{
+			input := &ecr.ListImagesInput{
 				RepositoryName: aws.String(name),
 			}
-			result, err := svc.BatchGetImage(input)
+			result, err := svc.ListImages(input)
 			if err != nil {
 				log.Errorf("Failed to get image information from aws, error: %s", err)
 				return
 			}
 			var koderoverTags, customTags, sortedTags []string
-			for _, image := range result.Images {
-				if *image.RepositoryName != name {
-					continue
-				}
-				tagArray := strings.Split(*image.ImageId.ImageTag, "-")
+			for _, image := range result.ImageIds {
+				tagArray := strings.Split(*image.ImageTag, "-")
 				if len(tagArray) > 1 && len(tagArray[0]) == 14 {
 					if _, err := time.Parse("20060102150405", tagArray[0]); err == nil {
-						koderoverTags = append(koderoverTags, *image.ImageId.ImageTag)
+						koderoverTags = append(koderoverTags, *image.ImageTag)
 						continue
 					}
 				}
-				customTags = append(customTags, *image.ImageId.ImageTag)
+				customTags = append(customTags, *image.ImageTag)
 			}
 
 			sort.Sort(sort.Reverse(sort.StringSlice(koderoverTags)))

--- a/pkg/microservice/aslan/core/delivery/service/version.go
+++ b/pkg/microservice/aslan/core/delivery/service/version.go
@@ -833,7 +833,7 @@ func prepareChartData(chartDatas []*CreateHelmDeliveryVersionChartData, productI
 }
 
 func buildRegistryMap() (map[string]*commonmodels.RegistryNamespace, error) {
-	registries, err := commonrepo.NewRegistryNamespaceColl().FindAll(&commonrepo.FindRegOps{})
+	registries, err := commonservice.ListRegistryNamespaces(true, log.SugaredLogger())
 	if err != nil {
 		return nil, fmt.Errorf("failed to query registries")
 	}

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -185,7 +185,7 @@ func ListProducts(projectName string, envNames []string, log *zap.SugaredLogger)
 	}
 
 	var res []*EnvResp
-	reg, err := commonservice.FindDefaultRegistry(log)
+	reg, err := commonservice.FindDefaultRegistry(false, log)
 	if err != nil {
 		log.Errorf("FindDefaultRegistry error: %v", err)
 		return nil, err

--- a/pkg/microservice/aslan/core/environment/service/image.go
+++ b/pkg/microservice/aslan/core/environment/service/image.go
@@ -300,7 +300,7 @@ func UpdateContainerImage(requestID string, args *UpdateContainerImageArgs, log 
 	// aws secrets needs to be refreshed
 	regs, err := commonservice.ListRegistryNamespaces(true, log)
 	if err != nil {
-		log.Errorf("Failed to get registries to update container images, the error is: %s\n", err)
+		log.Errorf("Failed to get registries to update container images, the error is: %s", err)
 		return err
 	}
 	for _, reg := range regs {

--- a/pkg/microservice/aslan/core/environment/service/product.go
+++ b/pkg/microservice/aslan/core/environment/service/product.go
@@ -170,7 +170,7 @@ func GetProduct(username, envName, productName string, log *zap.SugaredLogger) (
 	}
 
 	if len(prod.RegistryID) == 0 {
-		reg, err := commonservice.FindDefaultRegistry(log)
+		reg, err := commonservice.FindDefaultRegistry(false, log)
 		if err != nil {
 			log.Errorf("[User:%s][EnvName:%s][Product:%s] FindDefaultRegistry error: %s", username, envName, productName, err)
 			return nil, err

--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -147,6 +147,22 @@ func RestartScale(args *RestartScaleArgs, _ *zap.SugaredLogger) error {
 		return err
 	}
 
+	// aws secrets needs to be refreshed
+	regs, err := commonservice.ListRegistryNamespaces(true, log.SugaredLogger())
+	if err != nil {
+		log.Errorf("Failed to get registries to restart container, the error is: %s\n", err)
+		return err
+	}
+	for _, reg := range regs {
+		if reg.RegProvider == config.RegistryTypeAWS {
+			if err := kube.CreateOrUpdateRegistrySecret(prod.Namespace, reg, kubeClient); err != nil {
+				retErr := fmt.Errorf("failed to update pull secret for registry: %s, the error is: %s", reg.ID.Hex(), err)
+				log.Errorf("%s\n", retErr.Error())
+				return retErr
+			}
+		}
+	}
+
 	switch args.Type {
 	case setting.Deployment:
 		err = updater.RestartDeployment(prod.Namespace, args.Name, kubeClient)
@@ -327,6 +343,22 @@ func RestartService(envName string, args *SvcOptArgs, log *zap.SugaredLogger) (e
 	kubeClient, err := kubeclient.GetKubeClient(config.HubServerAddress(), productObj.ClusterID)
 	if err != nil {
 		return err
+	}
+
+	// aws secrets needs to be refreshed
+	regs, err := commonservice.ListRegistryNamespaces(true, log)
+	if err != nil {
+		log.Errorf("Failed to get registries to restart container, the error is: %s\n", err)
+		return err
+	}
+	for _, reg := range regs {
+		if reg.RegProvider == config.RegistryTypeAWS {
+			if err := kube.CreateOrUpdateRegistrySecret(productObj.Namespace, reg, kubeClient); err != nil {
+				retErr := fmt.Errorf("failed to update pull secret for registry: %s, the error is: %s", reg.ID.Hex(), err)
+				log.Errorf("%s\n", retErr.Error())
+				return retErr
+			}
+		}
 	}
 
 	switch productObj.Source {

--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -150,7 +150,7 @@ func RestartScale(args *RestartScaleArgs, _ *zap.SugaredLogger) error {
 	// aws secrets needs to be refreshed
 	regs, err := commonservice.ListRegistryNamespaces(true, log.SugaredLogger())
 	if err != nil {
-		log.Errorf("Failed to get registries to restart container, the error is: %s\n", err)
+		log.Errorf("Failed to get registries to restart container, the error is: %s", err)
 		return err
 	}
 	for _, reg := range regs {
@@ -348,7 +348,7 @@ func RestartService(envName string, args *SvcOptArgs, log *zap.SugaredLogger) (e
 	// aws secrets needs to be refreshed
 	regs, err := commonservice.ListRegistryNamespaces(true, log)
 	if err != nil {
-		log.Errorf("Failed to get registries to restart container, the error is: %s\n", err)
+		log.Errorf("Failed to get registries to restart container, the error is: %s", err)
 		return err
 	}
 	for _, reg := range regs {

--- a/pkg/microservice/aslan/core/system/service/registry.go
+++ b/pkg/microservice/aslan/core/system/service/registry.go
@@ -24,6 +24,7 @@ import (
 
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
+	commonservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/registry"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 	"github.com/koderover/zadig/pkg/util"
@@ -51,7 +52,7 @@ const (
 
 // ListRegistries 为了抹掉ak和sk的数据
 func ListRegistries(log *zap.SugaredLogger) ([]*commonmodels.RegistryNamespace, error) {
-	registryNamespaces, err := commonrepo.NewRegistryNamespaceColl().FindAll(&commonrepo.FindRegOps{})
+	registryNamespaces, err := commonservice.ListRegistryNamespaces(false, log)
 	if err != nil {
 		log.Errorf("RegistryNamespace.List error: %v", err)
 		return registryNamespaces, fmt.Errorf("RegistryNamespace.List error: %v", err)
@@ -66,25 +67,19 @@ func ListRegistries(log *zap.SugaredLogger) ([]*commonmodels.RegistryNamespace, 
 func CreateRegistryNamespace(username string, args *commonmodels.RegistryNamespace, log *zap.SugaredLogger) error {
 	regOps := new(commonrepo.FindRegOps)
 	regOps.IsDefault = true
-	registryInfoList, _ := GetRegistryNamespaces(regOps, log)
-	if args.IsDefault {
-		for _, registryInfo := range registryInfoList {
-			registryInfo.IsDefault = false
-			err := UpdateRegistryNamespaceDefault(registryInfo, log)
-			if err != nil {
-				log.Errorf("updateRegistry error: %v", err)
-				return fmt.Errorf("RegistryNamespace.Create error: %v", err)
-			}
+	defaultReg, err := commonservice.FindDefaultRegistry(false, log)
+	if err != nil {
+		log.Warnf("failed to find the default registry, the error is: %s", err)
+	}
+	if args.IsDefault && defaultReg != nil {
+		defaultReg.IsDefault = false
+		err := UpdateRegistryNamespaceDefault(defaultReg, log)
+		if err != nil {
+			log.Errorf("updateRegistry error: %v", err)
+			return fmt.Errorf("RegistryNamespace.Create error: %v", err)
 		}
 	} else {
-		hasDefault := false
-		for _, registryInfo := range registryInfoList {
-			if registryInfo.IsDefault {
-				hasDefault = true
-				break
-			}
-		}
-		if !hasDefault {
+		if defaultReg == nil {
 			log.Errorf("create registry error: There must be at least 1 default registry")
 			return fmt.Errorf("RegistryNamespace.Create error: %s", "There must be at least 1 default registry")
 		}
@@ -103,26 +98,20 @@ func CreateRegistryNamespace(username string, args *commonmodels.RegistryNamespa
 func UpdateRegistryNamespace(username, id string, args *commonmodels.RegistryNamespace, log *zap.SugaredLogger) error {
 	regOps := new(commonrepo.FindRegOps)
 	regOps.IsDefault = true
-	registryInfoList, _ := GetRegistryNamespaces(regOps, log)
-	if args.IsDefault {
-		for _, registryInfo := range registryInfoList {
-			registryInfo.IsDefault = false
-			err := UpdateRegistryNamespaceDefault(registryInfo, log)
-			if err != nil {
-				log.Errorf("updateRegistry error: %v", err)
-				return fmt.Errorf("RegistryNamespace.Update error: %v", err)
-			}
+	defaultReg, err := commonservice.FindDefaultRegistry(false, log)
+	if err != nil {
+		log.Warnf("failed to find the default registry, the error is: %s", err)
+	}
+	if args.IsDefault && defaultReg != nil {
+		defaultReg.IsDefault = false
+		err := UpdateRegistryNamespaceDefault(defaultReg, log)
+		if err != nil {
+			log.Errorf("updateRegistry error: %v", err)
+			return fmt.Errorf("RegistryNamespace.Update error: %v", err)
 		}
 	} else {
-		hasDefault := false
-		for _, registryInfo := range registryInfoList {
-			if registryInfo.ID != args.ID {
-				hasDefault = true
-				break
-			}
-		}
-		if !hasDefault {
-			log.Errorf("update registry error: There must be at least 1 default registry")
+		if defaultReg == nil {
+			log.Errorf("create registry error: There must be at least 1 default registry")
 			return fmt.Errorf("RegistryNamespace.Create error: %s", "There must be at least 1 default registry")
 		}
 	}
@@ -146,7 +135,7 @@ func DeleteRegistryNamespace(id string, log *zap.SugaredLogger) error {
 
 func ListAllRepos(log *zap.SugaredLogger) ([]*RepoInfo, error) {
 	repoInfos := make([]*RepoInfo, 0)
-	resp, err := commonrepo.NewRegistryNamespaceColl().FindAll(&commonrepo.FindRegOps{})
+	resp, err := commonservice.ListRegistryNamespaces(false, log)
 	if err != nil {
 		log.Errorf("RegistryNamespace.List error: %v", err)
 		return nil, fmt.Errorf("RegistryNamespace.List error: %v", err)
@@ -162,15 +151,6 @@ func ListAllRepos(log *zap.SugaredLogger) ([]*RepoInfo, error) {
 		repoInfos = append(repoInfos, repoInfo)
 	}
 	return repoInfos, nil
-}
-
-func GetRegistryNamespace(regOps *commonrepo.FindRegOps, log *zap.SugaredLogger) (*commonmodels.RegistryNamespace, error) {
-	resp, err := commonrepo.NewRegistryNamespaceColl().Find(regOps)
-	if err != nil {
-		log.Errorf("RegistryNamespace.get error: %v", err)
-		return nil, fmt.Errorf("RegistryNamespace.get error: %v", err)
-	}
-	return resp, nil
 }
 
 func ListReposTags(registryInfo *commonmodels.RegistryNamespace, names []string, logger *zap.SugaredLogger) ([]*RepoImgResp, error) {
@@ -240,15 +220,6 @@ func GetRepoTags(registryInfo *commonmodels.RegistryNamespace, name string, log 
 	}
 
 	return resp, err
-}
-
-func GetRegistryNamespaces(regOps *commonrepo.FindRegOps, log *zap.SugaredLogger) ([]*commonmodels.RegistryNamespace, error) {
-	resp, err := commonrepo.NewRegistryNamespaceColl().FindAll(regOps)
-	if err != nil {
-		log.Errorf("RegistryNamespace.findAll error: %+v", err)
-		return nil, fmt.Errorf("RegistryNamespace.findAll error: %v", err)
-	}
-	return resp, nil
 }
 
 func UpdateRegistryNamespaceDefault(args *commonmodels.RegistryNamespace, log *zap.SugaredLogger) error {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/artifact_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/artifact_task.go
@@ -31,14 +31,12 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/s3"
 	"github.com/koderover/zadig/pkg/setting"
 	e "github.com/koderover/zadig/pkg/tool/errors"
-	"github.com/koderover/zadig/pkg/util"
 )
 
 // get global config payload
 func CreateArtifactPackageTask(args *commonmodels.ArtifactPackageTaskArgs, taskCreator string, log *zap.SugaredLogger) (int64, error) {
-
 	configPayload := commonservice.GetConfigPayload(0)
-	repos, err := commonrepo.NewRegistryNamespaceColl().FindAll(&commonrepo.FindRegOps{})
+	repos, err := commonservice.ListRegistryNamespaces(true, log)
 
 	if err != nil {
 		log.Errorf("CreateArtifactPackageTask query registries failed, err: %s", err)
@@ -53,13 +51,6 @@ func CreateArtifactPackageTask(args *commonmodels.ArtifactPackageTaskArgs, taskC
 	for _, repo := range repos {
 		if !registriesInvolved.Has(repo.ID.Hex()) {
 			continue
-		}
-		// if the registry is SWR, we need to modify ak/sk according to the rule
-		if repo.RegProvider == config.SWRProvider {
-			ak := fmt.Sprintf("%s@%s", repo.Region, repo.AccessKey)
-			sk := util.ComputeHmacSha256(repo.AccessKey, repo.SecretKey)
-			repo.AccessKey = ak
-			repo.SecretKey = sk
 		}
 		configPayload.RepoConfigs[repo.ID.Hex()] = repo
 	}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/convert.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/convert.go
@@ -154,7 +154,7 @@ func JenkinsBuildModuleToSubTasks(jenkinsBuildOption *JenkinsBuildOption, log *z
 		return nil, e.ErrConvertSubTasks.AddErr(err)
 	}
 
-	registries, err := commonservice.ListRegistryNamespaces(log)
+	registries, err := commonservice.ListRegistryNamespaces(true, log)
 	if err != nil {
 		return nil, e.ErrConvertSubTasks.AddErr(err)
 	}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go
@@ -916,9 +916,7 @@ func upsertWorkflowStat(args *commonmodels.WorkflowStat, log *zap.SugaredLogger)
 }
 
 func getImageInfo(repoName, tag string, log *zap.SugaredLogger) (*commonmodels.DeliveryImage, error) {
-	regOps := new(commonrepo.FindRegOps)
-	regOps.IsDefault = true
-	registryInfo, err := commonrepo.NewRegistryNamespaceColl().Find(regOps)
+	registryInfo, err := commonservice.FindDefaultRegistry(false, log)
 	if err != nil {
 		log.Errorf("RegistryNamespace.get error: %v", err)
 		return nil, fmt.Errorf("RegistryNamespace.get error: %v", err)

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
@@ -114,7 +114,7 @@ func CreatePipelineTask(args *commonmodels.TaskArgs, log *zap.SugaredLogger) (*C
 			}
 
 			if build.Registries == nil {
-				registries, err := commonservice.ListRegistryNamespaces(log)
+				registries, err := commonservice.ListRegistryNamespaces(true, log)
 				if err != nil {
 					log.Errorf("ListRegistryNamespaces err:%v", err)
 				} else {
@@ -148,7 +148,7 @@ func CreatePipelineTask(args *commonmodels.TaskArgs, log *zap.SugaredLogger) (*C
 			}
 
 			if testing.Registries == nil {
-				registries, err := commonservice.ListRegistryNamespaces(log)
+				registries, err := commonservice.ListRegistryNamespaces(true, log)
 				if err != nil {
 					log.Errorf("ListRegistryNamespaces err:%v", err)
 				} else {
@@ -232,7 +232,7 @@ func CreatePipelineTask(args *commonmodels.TaskArgs, log *zap.SugaredLogger) (*C
 		}
 	}
 
-	repos, err := commonrepo.NewRegistryNamespaceColl().FindAll(&commonrepo.FindRegOps{})
+	repos, err := commonservice.ListRegistryNamespaces(false, log)
 	if err != nil {
 		return nil, e.ErrCreateTask.AddErr(err)
 	}
@@ -579,7 +579,7 @@ func TestArgsToTestSubtask(args *commonmodels.TestTaskArgs, pt *task.Task, log *
 	testTask.JobCtx.Caches = testModule.Caches
 	testTask.JobCtx.ArtifactPaths = testModule.ArtifactPaths
 	if testTask.Registries == nil {
-		registries, err := commonservice.ListRegistryNamespaces(log)
+		registries, err := commonservice.ListRegistryNamespaces(true, log)
 		if err != nil {
 			log.Errorf("ListRegistryNamespaces err:%v", err)
 		} else {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
@@ -587,6 +587,9 @@ func replaceVariable(customRule *template.CustomRule, candidate *candidate) stri
 
 // GetImage suffix 可以是 branch name 或者 pr number
 func GetImage(registry *commonmodels.RegistryNamespace, suffix string) string {
+	if registry.RegProvider == config.RegistryTypeAWS {
+		return fmt.Sprintf("%s/%s", util.TrimURLScheme(registry.RegAddr), suffix)
+	}
 	return fmt.Sprintf("%s/%s/%s", util.TrimURLScheme(registry.RegAddr), registry.Namespace, suffix)
 }
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
@@ -665,7 +665,7 @@ func SetCandidateRegistry(payload *commonmodels.ConfigPayload, log *zap.SugaredL
 		return nil
 	}
 
-	reg, err := commonservice.FindDefaultRegistry(log)
+	reg, err := commonservice.FindDefaultRegistry(true, log)
 	if err != nil {
 		log.Errorf("can't find default candidate registry: %v", err)
 		return e.ErrFindRegistry.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -524,10 +524,7 @@ func CreateWorkflowTask(args *commonmodels.WorkflowTaskArgs, taskCreator string,
 	// 获取全局configpayload
 	configPayload := commonservice.GetConfigPayload(args.CodehostID)
 	if len(env.RegistryID) == 0 {
-		op := &commonrepo.FindRegOps{
-			IsDefault: true,
-		}
-		reg, err := commonrepo.NewRegistryNamespaceColl().Find(op)
+		reg, err := commonservice.FindDefaultRegistry(false, log)
 		if err != nil {
 			log.Errorf("get default registry error: %v", err)
 			return nil, e.ErrGetCounter.AddDesc(err.Error())
@@ -793,17 +790,10 @@ func generateNextTaskID(workflowName string) (int64, error) {
 }
 
 func modifyConfigPayload(configPayload *commonmodels.ConfigPayload, ignoreCache, resetCache bool) {
-	repos, err := commonrepo.NewRegistryNamespaceColl().FindAll(&commonrepo.FindRegOps{})
+	repos, err := commonservice.ListRegistryNamespaces(true, log.SugaredLogger())
 	if err == nil {
 		configPayload.RepoConfigs = make(map[string]*commonmodels.RegistryNamespace)
 		for _, repo := range repos {
-			// if the registry is SWR, we need to modify ak/sk according to the rule
-			if repo.RegProvider == config.SWRProvider {
-				ak := fmt.Sprintf("%s@%s", repo.Region, repo.AccessKey)
-				sk := util.ComputeHmacSha256(repo.AccessKey, repo.SecretKey)
-				repo.AccessKey = ak
-				repo.SecretKey = sk
-			}
 			configPayload.RepoConfigs[repo.ID.Hex()] = repo
 		}
 	}
@@ -954,7 +944,7 @@ func AddDataToArgsOrCreateReleaseImageTask(args *commonmodels.WorkflowTaskArgs, 
 }
 
 func buildRegistryMap() (map[string]*commonmodels.RegistryNamespace, error) {
-	registries, err := commonrepo.NewRegistryNamespaceColl().FindAll(&commonrepo.FindRegOps{})
+	registries, err := commonservice.ListRegistryNamespaces(true, log.SugaredLogger())
 	if err != nil {
 		return nil, fmt.Errorf("failed to query registries")
 	}
@@ -986,7 +976,7 @@ func createReleaseImageTask(workflow *commonmodels.Workflow, args *commonmodels.
 	if err != nil {
 		log.Errorf("failed to build registry map, err: %s", err)
 		// use default registry
-		reg, err := commonservice.FindDefaultRegistry(log)
+		reg, err := commonservice.FindDefaultRegistry(true, log)
 		if err != nil {
 			log.Errorf("can't find default candidate registry, err: %s", err)
 			return nil, e.ErrFindRegistry.AddDesc(err.Error())
@@ -1436,7 +1426,7 @@ func testArgsToSubtask(args *commonmodels.WorkflowTaskArgs, pt *task.Task, log *
 	testArgs := args.Tests
 	testCreator := args.WorkflowTaskCreator
 
-	registries, err := commonservice.ListRegistryNamespaces(log)
+	registries, err := commonservice.ListRegistryNamespaces(true, log)
 	if err != nil {
 		log.Errorf("ListRegistryNamespaces err:%v", err)
 	}
@@ -1573,7 +1563,7 @@ func CreateArtifactWorkflowTask(args *commonmodels.WorkflowTaskArgs, taskCreator
 
 	// 获取全局configpayload
 	configPayload := commonservice.GetConfigPayload(args.CodehostID)
-	repos, err := commonrepo.NewRegistryNamespaceColl().FindAll(&commonrepo.FindRegOps{})
+	repos, err := commonservice.ListRegistryNamespaces(true, log)
 	if err == nil {
 		configPayload.RepoConfigs = make(map[string]*commonmodels.RegistryNamespace)
 		for _, repo := range repos {
@@ -1832,7 +1822,7 @@ func BuildModuleToSubTasks(args *commonmodels.BuildModuleArgs, log *zap.SugaredL
 		return nil, e.ErrConvertSubTasks.AddErr(err)
 	}
 
-	registries, err := commonservice.ListRegistryNamespaces(log)
+	registries, err := commonservice.ListRegistryNamespaces(true, log)
 	if err != nil {
 		return nil, e.ErrConvertSubTasks.AddErr(err)
 	}
@@ -2085,14 +2075,14 @@ func ensurePipelineTask(pt *task.Task, envName string, log *zap.SugaredLogger) e
 				// 注意: 其他任务从 pt.TaskArgs.Deploy.Image 获取, 必须要有编译任务
 				var reg *commonmodels.RegistryNamespace
 				if len(exitedProd.RegistryID) > 0 {
-					reg, err = commonservice.FindRegistryById(exitedProd.RegistryID, log)
+					reg, err = commonservice.FindRegistryById(exitedProd.RegistryID, true, log)
 					if err != nil {
 						log.Errorf("service.EnsureRegistrySecret: failed to find registry: %s error msg:%v",
 							exitedProd.RegistryID, err)
 						return e.ErrFindRegistry.AddDesc(err.Error())
 					}
 				} else {
-					reg, err = commonservice.FindDefaultRegistry(log)
+					reg, err = commonservice.FindDefaultRegistry(true, log)
 					if err != nil {
 						log.Errorf("can't find default candidate registry: %v", err)
 						return e.ErrFindRegistry.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -2131,10 +2131,14 @@ func ensurePipelineTask(pt *task.Task, envName string, log *zap.SugaredLogger) e
 				//		}
 				//	}
 				//}
+				registryRepo := reg.RegAddr + "/" + reg.Namespace
+				if reg.RegProvider == config.RegistryTypeAWS {
+					registryRepo = reg.RegAddr
+				}
 
 				t.DockerBuildStatus = &task.DockerBuildStatus{
 					ImageName:    t.JobCtx.Image,
-					RegistryRepo: reg.RegAddr + "/" + reg.Namespace,
+					RegistryRepo: registryRepo,
 				}
 				t.UTStatus = &task.UTStatus{}
 				t.StaticCheckStatus = &task.StaticCheckStatus{}
@@ -2187,7 +2191,11 @@ func ensurePipelineTask(pt *task.Task, envName string, log *zap.SugaredLogger) e
 					pt.TaskArgs = &commonmodels.TaskArgs{PipelineName: pt.WorkflowArgs.WorkflowName, TaskCreator: pt.WorkflowArgs.WorkflowTaskCreator}
 				}
 				registry := pt.ConfigPayload.RepoConfigs[pt.WorkflowArgs.RegistryID]
-				t.Image = fmt.Sprintf("%s/%s/%s", util.TrimURLScheme(registry.RegAddr), registry.Namespace, t.Image)
+				if registry.RegProvider == config.RegistryTypeAWS {
+					t.Image = fmt.Sprintf("%s/%s", util.TrimURLScheme(registry.RegAddr), t.Image)
+				} else {
+					t.Image = fmt.Sprintf("%s/%s/%s", util.TrimURLScheme(registry.RegAddr), registry.Namespace, t.Image)
+				}
 				pt.TaskArgs.Deploy.Image = t.Image
 				t.RegistryID = pt.WorkflowArgs.RegistryID
 

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -464,6 +464,11 @@ func buildJobWithLinkedNs(taskType config.TaskType, jobImage, jobName, serviceNa
 	for _, reg := range registries {
 		arr := strings.Split(reg.Namespace, "/")
 		namespaceInRegistry := arr[len(arr)-1]
+		// for AWS ECR, there are no namespace, thus we need to find the NS from the URI
+		if namespaceInRegistry == "" {
+			uriDecipher := strings.Split(reg.RegAddr, "/")
+			namespaceInRegistry = uriDecipher[len(uriDecipher)-1]
+		}
 		secretName := namespaceInRegistry + registrySecretSuffix
 		if reg.RegType != "" {
 			secretName = namespaceInRegistry + "-" + reg.RegType + registrySecretSuffix
@@ -574,6 +579,11 @@ func createOrUpdateRegistrySecrets(namespace, registryID string, registries []*t
 
 		arr := strings.Split(reg.Namespace, "/")
 		namespaceInRegistry := arr[len(arr)-1]
+		// for AWS ECR, there are no namespace, thus we need to find the NS from the URI
+		if namespaceInRegistry == "" {
+			uriDecipher := strings.Split(reg.RegAddr, "/")
+			namespaceInRegistry = uriDecipher[len(uriDecipher)-1]
+		}
 		filteredName, err := formatRegistryName(namespaceInRegistry)
 		if err != nil {
 			return err

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -466,8 +466,8 @@ func buildJobWithLinkedNs(taskType config.TaskType, jobImage, jobName, serviceNa
 		namespaceInRegistry := arr[len(arr)-1]
 		// for AWS ECR, there are no namespace, thus we need to find the NS from the URI
 		if namespaceInRegistry == "" {
-			uriDecipher := strings.Split(reg.RegAddr, "/")
-			namespaceInRegistry = uriDecipher[len(uriDecipher)-1]
+			uriDecipher := strings.Split(reg.RegAddr, ".")
+			namespaceInRegistry = uriDecipher[0]
 		}
 		secretName := namespaceInRegistry + registrySecretSuffix
 		if reg.RegType != "" {
@@ -581,8 +581,8 @@ func createOrUpdateRegistrySecrets(namespace, registryID string, registries []*t
 		namespaceInRegistry := arr[len(arr)-1]
 		// for AWS ECR, there are no namespace, thus we need to find the NS from the URI
 		if namespaceInRegistry == "" {
-			uriDecipher := strings.Split(reg.RegAddr, "/")
-			namespaceInRegistry = uriDecipher[len(uriDecipher)-1]
+			uriDecipher := strings.Split(reg.RegAddr, ".")
+			namespaceInRegistry = uriDecipher[0]
 		}
 		filteredName, err := formatRegistryName(namespaceInRegistry)
 		if err != nil {

--- a/pkg/util/url.go
+++ b/pkg/util/url.go
@@ -42,9 +42,15 @@ func GetURLHostName(urlAddr string) string {
 
 func ReplaceRepo(origin, addr, namespace string) string {
 	parts := strings.SplitN(origin, "/", -1)
+	if namespace != "" {
+		return strings.Join([]string{
+			TrimURLScheme(addr),
+			namespace,
+			parts[len(parts)-1],
+		}, "/")
+	}
 	return strings.Join([]string{
 		TrimURLScheme(addr),
-		namespace,
 		parts[len(parts)-1],
 	}, "/")
 }


### PR DESCRIPTION
### What this PR does / Why we need it:

Issue Number: close #653 

Problem Summary:
Currently user cannot use AWS ECR as docker registry. This PR adds this feature to zadig system.
### What is changed and how it works?

What's Changed:
Since AWS has a very different authentication system. So the current AK/SK system won't work. Instead I add a transformation layer that exchange the user AK/SK for the real registry login credential.


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information