### PR TITLE
remove list all renderset logic

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/render_set.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/render_set.go
@@ -19,6 +19,7 @@ package mongodb
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -32,15 +33,16 @@ import (
 
 type RenderSetListOption struct {
 	// if Revision == 0 then search max revision of RenderSet
-	Revision    int64
-	ProductTmpl string
+	ProductTmpl   string
+	Revisions     []int64
+	RendersetName string
 }
 
 // RenderSetFindOption ...
 type RenderSetFindOption struct {
 	// if Revision == 0 then search max revision of RenderSet
-	Revision       int64
-	Name           string
+	Revision int64
+	Name     string
 }
 
 type RenderSetPipeResp struct {
@@ -78,6 +80,36 @@ func (c *RenderSetColl) EnsureIndex(ctx context.Context) error {
 	_, err := c.Indexes().CreateOne(ctx, mod)
 
 	return err
+}
+
+func (c *RenderSetColl) ListRendersets(opt *RenderSetListOption) ([]*models.RenderSet, error) {
+	query := bson.M{}
+	if len(opt.ProductTmpl) > 0 {
+		query["product_tmpl"] = opt.ProductTmpl
+	}
+	if len(opt.RendersetName) > 0 {
+		query["name"] = opt.RendersetName
+	}
+	if len(opt.Revisions) > 0 {
+		query["revision"] = bson.M{"$in": opt.Revisions}
+	}
+
+	if len(query) == 0 {
+		return nil, fmt.Errorf("query with no filter is not allowed")
+	}
+
+	var rendersets []*models.RenderSet
+	cursor, err := c.Collection.Find(context.TODO(), query)
+	if err != nil {
+		return nil, err
+	}
+	err = cursor.All(context.TODO(), &rendersets)
+	if err != nil {
+		return nil, err
+	}
+
+	return rendersets, err
+
 }
 
 func (c *RenderSetColl) List(opt *RenderSetListOption) ([]*models.RenderSet, error) {

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -376,25 +376,17 @@ func UpdateProduct(existedProd, updateProd *commonmodels.Product, renderSet *com
 	updateProd.Namespace = existedProd.Namespace
 
 	var allServices []*commonmodels.Service
-	var allRenders []*commonmodels.RenderSet
 	var prodRevs *ProductRevision
 
-	allServices, err = commonrepo.NewServiceColl().ListAllRevisions()
+	// list services with max revision of project
+	allServices, err = commonrepo.NewServiceColl().ListMaxRevisions(&commonrepo.ServiceListOption{ProductName: productName})
 	if err != nil {
-		log.Errorf("ListAllRevisions error: %v", err)
+		log.Errorf("ListAllRevisions error: %s", err)
 		err = e.ErrUpdateEnv.AddDesc(err.Error())
 		return
 	}
 
-	// 获取所有渲染配置最新模板信息
-	allRenders, err = commonrepo.NewRenderSetColl().ListAllRenders()
-	if err != nil {
-		log.Errorf("ListAllRevisions error: %v", err)
-		err = e.ErrUpdateEnv.AddDesc(err.Error())
-		return
-	}
-
-	prodRevs, err = GetProductRevision(existedProd, allServices, allRenders, renderSet, log)
+	prodRevs, err = GetProductRevision(existedProd, allServices, log)
 	if err != nil {
 		err = e.ErrUpdateEnv.AddDesc(e.GetEnvRevErrMsg)
 		return

--- a/pkg/microservice/aslan/core/environment/service/revision.go
+++ b/pkg/microservice/aslan/core/environment/service/revision.go
@@ -19,6 +19,8 @@ package service
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"go.uber.org/zap"
 
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
@@ -32,29 +34,15 @@ import (
 func ListProductsRevision(productName, envName string, log *zap.SugaredLogger) (prodRevs []*ProductRevision, err error) {
 	products, err := commonrepo.NewProductColl().List(&commonrepo.ProductListOptions{Name: productName, IsSortByProductName: true, EnvName: envName})
 
-	// 获取所有服务模板最新模板信息
-	allServiceTmpls, err := commonrepo.NewServiceColl().ListAllRevisions()
-	if err != nil {
-		log.Errorf("ListAllRevisions error: %v", err)
-		return prodRevs, e.ErrListProducts.AddDesc(err.Error())
-	}
-	// 获取所有渲染配置最新模板信息
-	allRenders, err := commonrepo.NewRenderSetColl().ListAllRenders()
+	// list services with max revision of project
+	allServiceTmpls, err := commonrepo.NewServiceColl().ListMaxRevisions(&commonrepo.ServiceListOption{ProductName: productName})
 	if err != nil {
 		log.Errorf("ListAllRevisions error: %v", err)
 		return prodRevs, e.ErrListProducts.AddDesc(err.Error())
 	}
 
 	for _, prod := range products {
-		newRender := &commonmodels.RenderSet{}
-		if prod.Render != nil {
-			newRender, err = commonservice.GetRenderSet(prod.Render.Name, 0, log)
-			if err != nil {
-				return prodRevs, err
-			}
-		}
-
-		prodRev, err := GetProductRevision(prod, allServiceTmpls, allRenders, newRender, log)
+		prodRev, err := GetProductRevision(prod, allServiceTmpls, log)
 		if err != nil {
 			log.Error(err)
 			return prodRevs, err
@@ -64,6 +52,7 @@ func ListProductsRevision(productName, envName string, log *zap.SugaredLogger) (
 	return prodRevs, nil
 }
 
+// ListProductsRevisionByFacility called by service cron
 func ListProductsRevisionByFacility(basicFacility string, log *zap.SugaredLogger) ([]*ProductRevision, error) {
 	var (
 		err          error
@@ -88,30 +77,16 @@ func ListProductsRevisionByFacility(basicFacility string, log *zap.SugaredLogger
 		return prodRevs, e.ErrListProducts.AddDesc(err.Error())
 	}
 
-	// 获取所有服务模板最新模板信息
-	allServiceTmpls, err := commonrepo.NewServiceColl().ListAllRevisions()
-	if err != nil {
-		log.Errorf("ListAllRevisions error: %s", err)
-		return prodRevs, e.ErrListProducts.AddDesc(err.Error())
-	}
-
-	// 获取所有渲染配置最新模板信息
-	allRenders, err := commonrepo.NewRenderSetColl().ListAllRenders()
-	if err != nil {
-		log.Errorf("ListAllRevisions error: %s", err)
-		return prodRevs, e.ErrListProducts.AddDesc(err.Error())
-	}
-
 	for _, prod := range products {
-		newRender := &commonmodels.RenderSet{}
-		if prod.Render != nil {
-			newRender, err = commonservice.GetRenderSet(prod.Render.Name, 0, log)
-			if err != nil {
-				return prodRevs, err
-			}
+
+		// find all service templates with max revisions
+		allServiceTmpls, err := commonrepo.NewServiceColl().ListMaxRevisions(&commonrepo.ServiceListOption{ProductName: prod.ProductName})
+		if err != nil {
+			log.Errorf("ListAllRevisions error: %s", err)
+			return prodRevs, e.ErrListProducts.AddDesc(err.Error())
 		}
 
-		prodRev, err := GetProductRevision(prod, allServiceTmpls, allRenders, newRender, log)
+		prodRev, err := GetProductRevision(prod, allServiceTmpls, log)
 		if err != nil {
 			log.Error(err)
 			return prodRevs, err
@@ -121,7 +96,7 @@ func ListProductsRevisionByFacility(basicFacility string, log *zap.SugaredLogger
 	return prodRevs, nil
 }
 
-func GetProductRevision(product *commonmodels.Product, allServiceTmpls []*commonmodels.Service, allRender []*commonmodels.RenderSet, newRender *commonmodels.RenderSet, log *zap.SugaredLogger) (*ProductRevision, error) {
+func GetProductRevision(product *commonmodels.Product, allServiceTmpls []*commonmodels.Service, log *zap.SugaredLogger) (*ProductRevision, error) {
 
 	prodRev := new(ProductRevision)
 
@@ -150,8 +125,38 @@ func GetProductRevision(product *commonmodels.Product, allServiceTmpls []*common
 		prodRev.Updatable = true
 	}
 
+	var allRenders []*commonmodels.RenderSet
+	var newRender *commonmodels.RenderSet
+	if prodTmpl.ProductFeature != nil && prodTmpl.ProductFeature.DeployType == setting.K8SDeployType {
+		rendersetName := ""
+		if product.Render != nil {
+			rendersetName = product.Render.Name
+			newRender, err = commonservice.GetRenderSet(product.Render.Name, 0, log)
+			if err != nil {
+				return prodRev, err
+			}
+		}
+
+		// get all rendersets used by product services
+		renderRevision := sets.NewInt64()
+		for _, productService := range product.GetServiceMap() {
+			if productService.Render != nil {
+				renderRevision.Insert(productService.Render.Revision)
+			}
+		}
+		allRenders, err = commonrepo.NewRenderSetColl().ListRendersets(&commonrepo.RenderSetListOption{
+			Revisions:     renderRevision.List(),
+			ProductTmpl:   productTemplatName,
+			RendersetName: rendersetName,
+		})
+		if err != nil {
+			log.Errorf("ListAllRevisions error: %s", err)
+			return prodRev, e.ErrListProducts.AddDesc(err.Error())
+		}
+	}
+
 	// 交叉对比已创建的服务组和服务组模板
-	prodRev.ServiceRevisions, err = compareGroupServicesRev(prodTmpl.Services, product, allServiceTmpls, allRender, newRender, log)
+	prodRev.ServiceRevisions, err = compareGroupServicesRev(prodTmpl.Services, product, allServiceTmpls, allRenders, newRender, log)
 	if err != nil {
 		log.Error(err)
 		return nil, e.ErrGetProductRevision.AddDesc(err.Error())
@@ -204,9 +209,9 @@ func compareServicesRev(serviceTmplNames []string, services []*commonmodels.Prod
 
 	serviceRevs := make([]*SvcRevision, 0)
 
-	serviceMap := make(map[string]*commonmodels.ProductService)
+	productServiceMap := make(map[string]*commonmodels.ProductService)
 	for _, service := range services {
-		serviceMap[service.ServiceName] = service
+		productServiceMap[service.ServiceName] = service
 	}
 
 	serviceTmplMap := make(map[string]string)
@@ -217,7 +222,7 @@ func compareServicesRev(serviceTmplNames []string, services []*commonmodels.Prod
 	for _, serviceTmplName := range serviceTmplNames {
 		// 如果已创建的服务不包括新增的服务模板, 则认为是新增服务
 		// 新增服务如果涉及多个部署方式，目前把所有部署方式都默认加进来
-		if _, ok := serviceMap[serviceTmplName]; !ok {
+		if _, ok := productServiceMap[serviceTmplName]; !ok {
 			newServiceTmpls, err := getMaxServices(allServiceTmpls, serviceTmplName)
 			if err != nil {
 				log.Error(err)

--- a/pkg/microservice/aslan/core/environment/service/revision.go
+++ b/pkg/microservice/aslan/core/environment/service/revision.go
@@ -19,9 +19,8 @@ package service
 import (
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

Problem Summary:

the current logic of hanlding http request 'api/aslan/environment/revision/products' will read all rendersets from db, this will cause high memory usage, even make aslan be kulled of OOM.

### What is changed and how it works?

optimize the logic to avoid reading all rendersets, only read the renderset data involved for necessity.

