### PR TITLE
update get docker registry url logic

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
@@ -587,7 +587,7 @@ func replaceVariable(customRule *template.CustomRule, candidate *candidate) stri
 
 // GetImage suffix 可以是 branch name 或者 pr number
 func GetImage(registry *commonmodels.RegistryNamespace, suffix string) string {
-	return fmt.Sprintf("%s/%s/%s", util.GetURLHostName(registry.RegAddr), registry.Namespace, suffix)
+	return fmt.Sprintf("%s/%s/%s", util.TrimURLScheme(registry.RegAddr), registry.Namespace, suffix)
 }
 
 // GetPackageFile suffix 可以是 branch name 或者 pr number

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -2197,7 +2197,7 @@ func ensurePipelineTask(pt *task.Task, envName string, log *zap.SugaredLogger) e
 					pt.TaskArgs = &commonmodels.TaskArgs{PipelineName: pt.WorkflowArgs.WorkflowName, TaskCreator: pt.WorkflowArgs.WorkflowTaskCreator}
 				}
 				registry := pt.ConfigPayload.RepoConfigs[pt.WorkflowArgs.RegistryID]
-				t.Image = fmt.Sprintf("%s/%s/%s", util.GetURLHostName(registry.RegAddr), registry.Namespace, t.Image)
+				t.Image = fmt.Sprintf("%s/%s/%s", util.TrimURLScheme(registry.RegAddr), registry.Namespace, t.Image)
 				pt.TaskArgs.Deploy.Image = t.Image
 				t.RegistryID = pt.WorkflowArgs.RegistryID
 
@@ -2403,7 +2403,7 @@ func ensurePipelineTask(pt *task.Task, envName string, log *zap.SugaredLogger) e
 				for _, repoImage := range t.Releases {
 					if v, ok := pt.ConfigPayload.RepoConfigs[repoImage.RepoID]; ok {
 						repoImage.Name = util.ReplaceRepo(pt.TaskArgs.Deploy.Image, v.RegAddr, v.Namespace)
-						repoImage.Host = util.GetURLHostName(v.RegAddr)
+						repoImage.Host = util.TrimURLScheme(v.RegAddr)
 						repoImage.Namespace = v.Namespace
 						repos = append(repos, repoImage)
 					}

--- a/pkg/util/url.go
+++ b/pkg/util/url.go
@@ -22,6 +22,14 @@ import (
 	"strings"
 )
 
+func TrimURLScheme(urlAddr string) string {
+	uri, err := url.Parse(urlAddr)
+	if err != nil {
+		return urlAddr
+	}
+	return strings.Join([]string{uri.Host, uri.Path}, "")
+}
+
 // GetURLHostName ...
 func GetURLHostName(urlAddr string) string {
 
@@ -35,7 +43,7 @@ func GetURLHostName(urlAddr string) string {
 func ReplaceRepo(origin, addr, namespace string) string {
 	parts := strings.SplitN(origin, "/", -1)
 	return strings.Join([]string{
-		GetURLHostName(addr),
+		TrimURLScheme(addr),
 		namespace,
 		parts[len(parts)-1],
 	}, "/")

--- a/pkg/util/url.go
+++ b/pkg/util/url.go
@@ -23,11 +23,11 @@ import (
 )
 
 func TrimURLScheme(urlAddr string) string {
-	uri, err := url.Parse(urlAddr)
+	uri, err := url.Parse(strings.TrimSuffix(urlAddr, "/"))
 	if err != nil {
 		return urlAddr
 	}
-	return strings.Join([]string{uri.Host, uri.Path}, "")
+	return uri.Host + uri.Path
 }
 
 // GetURLHostName ...


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

the path of image registry url will be trimmed when tagging image, this may cause image url illegal

Problem Summary:

What's Changed:

remain the path of image registry url
