### PR TITLE
optimize error display when pushing/pulling image for helm delivery version

### DIFF
--- a/pkg/microservice/aslan/core/delivery/service/version.go
+++ b/pkg/microservice/aslan/core/delivery/service/version.go
@@ -677,13 +677,6 @@ func buildChartPackage(chartData *DeliveryChartData, product *commonmodels.Produ
 	if err != nil {
 		return errors.Wrapf(err, "failed to read values.yaml for service %s", serviceObj.ServiceName)
 	}
-	err = yaml.Unmarshal(valueYamlContent, &valuesYamlData)
-	if err != nil {
-		return errors.Wrapf(err, "failed to unmarshal values.yaml for service %s", serviceObj.ServiceName)
-	}
-
-	// hold the currently running yaml data
-	chartData.ValuesInEnv = valuesYamlData
 
 	// write values.yaml file before load
 	if len(chartData.ChartData.ValuesYamlContent) > 0 { // values.yaml was edited directly
@@ -698,6 +691,15 @@ func buildChartPackage(chartData *DeliveryChartData, product *commonmodels.Produ
 			return errors.Wrapf(err, "failed to merge global variables for service: %s", serviceObj.ServiceName)
 		}
 	}
+
+	err = yaml.Unmarshal(valueYamlContent, &valuesYamlData)
+	if err != nil {
+		return errors.Wrapf(err, "failed to unmarshal values.yaml for service %s", serviceObj.ServiceName)
+	}
+
+	// hold the currently running yaml data
+	chartData.ValuesInEnv = valuesYamlData
+
 	err = os.WriteFile(valuesFilePath, valueYamlContent, 0644)
 	if err != nil {
 		return errors.Wrapf(err, "failed to write values.yaml file for service %s", serviceObj.ServiceName)

--- a/pkg/microservice/packager/core/service/service.go
+++ b/pkg/microservice/packager/core/service/service.go
@@ -97,15 +97,11 @@ func buildTargetImage(imageName, imageTag, host, nameSpace string) string {
 
 func ExtractErrorDetail(in io.Reader) error {
 	dec := json.NewDecoder(in)
-	for {
+	for dec.More() {
 		var jm jsonmessage.JSONMessage
 		if err := dec.Decode(&jm); err != nil {
-			if err == io.EOF {
-				break
-			}
 			return err
 		}
-
 		if jm.Error != nil {
 			return jm.Error
 		}
@@ -114,10 +110,7 @@ func ExtractErrorDetail(in io.Reader) error {
 }
 
 func pullImage(dockerClient *client.Client, imageUrl string, options *types.ImagePullOptions) error {
-
 	log.Infof("pulling image: %s", imageUrl)
-
-	// pull image
 	pullResponse, err := dockerClient.ImagePull(context.TODO(), imageUrl, *options)
 	if err != nil {
 		return err
@@ -130,9 +123,7 @@ func pullImage(dockerClient *client.Client, imageUrl string, options *types.Imag
 }
 
 func pushImage(dockerClient *client.Client, targetImageUrl string, options *types.ImagePushOptions) error {
-
 	log.Infof("pushing image: %s", targetImageUrl)
-
 	pushResponse, err := dockerClient.ImagePush(context.TODO(), targetImageUrl, *options)
 	if err != nil {
 		return errors.Wrapf(err, "failed to push image: %s", targetImageUrl)


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

Problem Summary:

when creating helm delivery version, the display of errors occurred in push/pull progress is not friendly, error detail is missing.

How it Works:

optimize the display of error, show detailed error message
