### PR TITLE
replace image registry when build helm delivery version

### DIFF
--- a/pkg/microservice/aslan/core/common/service/image.go
+++ b/pkg/microservice/aslan/core/common/service/image.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2021 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/koderover/zadig/pkg/setting"
+	"github.com/koderover/zadig/pkg/util/converter"
+	yamlutil "github.com/koderover/zadig/pkg/util/yaml"
+)
+
+// parse image url to map: repo=>xxx/xx/xx image=>xx tag=>xxx
+func resolveImageUrl(imageUrl string) map[string]string {
+	subMatchAll := imageParseRegex.FindStringSubmatch(imageUrl)
+	result := make(map[string]string)
+	exNames := imageParseRegex.SubexpNames()
+	for i, matchedStr := range subMatchAll {
+		if i != 0 && matchedStr != "" && matchedStr != ":" {
+			result[exNames[i]] = matchedStr
+		}
+	}
+	return result
+}
+
+// AssignImageData assign image url data into match data
+// matchData: image=>absolute-path repo=>absolute-path tag=>absolute-path
+// return: absolute-image-path=>image-value  absolute-repo-path=>repo-value absolute-tag-path=>tag-value
+func AssignImageData(imageUrl string, matchData map[string]string) (map[string]interface{}, error) {
+	ret := make(map[string]interface{})
+	// total image url assigned into one single value
+	if len(matchData) == 1 {
+		for _, v := range matchData {
+			ret[v] = imageUrl
+		}
+		return ret, nil
+	}
+
+	resolvedImageUrl := resolveImageUrl(imageUrl)
+
+	// image url assigned into repo/image+tag
+	if len(matchData) == 3 {
+		ret[matchData[setting.PathSearchComponentRepo]] = strings.TrimSuffix(resolvedImageUrl[setting.PathSearchComponentRepo], "/")
+		ret[matchData[setting.PathSearchComponentImage]] = resolvedImageUrl[setting.PathSearchComponentImage]
+		ret[matchData[setting.PathSearchComponentTag]] = resolvedImageUrl[setting.PathSearchComponentTag]
+		return ret, nil
+	}
+
+	if len(matchData) == 2 {
+		// image url assigned into repo/image + tag
+		if tagPath, ok := matchData[setting.PathSearchComponentTag]; ok {
+			ret[tagPath] = resolvedImageUrl[setting.PathSearchComponentTag]
+			for k, imagePath := range matchData {
+				if k == setting.PathSearchComponentTag {
+					continue
+				}
+				ret[imagePath] = fmt.Sprintf("%s%s", resolvedImageUrl[setting.PathSearchComponentRepo], resolvedImageUrl[setting.PathSearchComponentImage])
+				break
+			}
+			return ret, nil
+		}
+		// image url assigned into repo + image(tag)
+		ret[matchData[setting.PathSearchComponentRepo]] = strings.TrimSuffix(resolvedImageUrl[setting.PathSearchComponentRepo], "/")
+		ret[matchData[setting.PathSearchComponentImage]] = fmt.Sprintf("%s:%s", resolvedImageUrl[setting.PathSearchComponentImage], resolvedImageUrl[setting.PathSearchComponentTag])
+		return ret, nil
+	}
+
+	return nil, fmt.Errorf("match data illegal, expect length: 1-3, actual length: %d", len(matchData))
+}
+
+// ReplaceImage replace image defines in yaml by new version
+func ReplaceImage(sourceYaml string, imageValuesMap map[string]interface{}) (string, error) {
+	nestedMap, err := converter.Expand(imageValuesMap)
+	if err != nil {
+		return "", err
+	}
+	bs, err := yaml.Marshal(nestedMap)
+	if err != nil {
+		return "", err
+	}
+	mergedBs, err := yamlutil.Merge([][]byte{[]byte(sourceYaml), bs})
+	if err != nil {
+		return "", err
+	}
+	return string(mergedBs), nil
+}

--- a/pkg/microservice/aslan/core/environment/service/image.go
+++ b/pkg/microservice/aslan/core/environment/service/image.go
@@ -18,14 +18,11 @@ package service
 
 import (
 	"fmt"
-	"regexp"
-	"strings"
 	"time"
 
 	helmclient "github.com/mittwald/go-helm-client"
 	"go.uber.org/zap"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/yaml"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
@@ -39,8 +36,6 @@ import (
 	helmtool "github.com/koderover/zadig/pkg/tool/helmclient"
 	"github.com/koderover/zadig/pkg/tool/kube/updater"
 	"github.com/koderover/zadig/pkg/tool/log"
-	"github.com/koderover/zadig/pkg/util/converter"
-	yamlutil "github.com/koderover/zadig/pkg/util/yaml"
 )
 
 type UpdateContainerImageArgs struct {
@@ -52,14 +47,6 @@ type UpdateContainerImageArgs struct {
 	ContainerName string `json:"container_name"`
 	Image         string `json:"image"`
 }
-
-const (
-	imageUrlParseRegexString = `(?P<repo>.+/)?(?P<image>[^:]+){1}(:)?(?P<tag>.+)?`
-)
-
-var (
-	imageParseRegex = regexp.MustCompile(imageUrlParseRegexString)
-)
 
 func getValidMatchData(spec *models.ImagePathSpec) map[string]string {
 	ret := make(map[string]string)
@@ -73,81 +60,6 @@ func getValidMatchData(spec *models.ImagePathSpec) map[string]string {
 		ret[setting.PathSearchComponentTag] = spec.Tag
 	}
 	return ret
-}
-
-// parse image url to map: repo=>xxx/xx/xx image=>xx tag=>xxx
-func resolveImageUrl(imageUrl string) map[string]string {
-	subMatchAll := imageParseRegex.FindStringSubmatch(imageUrl)
-	result := make(map[string]string)
-	exNames := imageParseRegex.SubexpNames()
-	for i, matchedStr := range subMatchAll {
-		if i != 0 && matchedStr != "" && matchedStr != ":" {
-			result[exNames[i]] = matchedStr
-		}
-	}
-	return result
-}
-
-// replace image defines in yaml by new version
-func replaceImage(sourceYaml string, imageValuesMap map[string]interface{}) (string, error) {
-	nestedMap, err := converter.Expand(imageValuesMap)
-	if err != nil {
-		return "", err
-	}
-	bs, err := yaml.Marshal(nestedMap)
-	if err != nil {
-		return "", err
-	}
-	mergedBs, err := yamlutil.Merge([][]byte{[]byte(sourceYaml), bs})
-	if err != nil {
-		return "", err
-	}
-	return string(mergedBs), nil
-}
-
-// AssignImageData assign image url data into match data
-// matchData: image=>absolute-path repo=>absolute-path tag=>absolute-path
-// return: absolute-image-path=>image-value  absolute-repo-path=>repo-value absolute-tag-path=>tag-value
-func assignImageData(imageUrl string, matchData map[string]string) (map[string]interface{}, error) {
-	ret := make(map[string]interface{})
-	// total image url assigned into one single value
-	if len(matchData) == 1 {
-		for _, v := range matchData {
-			ret[v] = imageUrl
-		}
-		return ret, nil
-	}
-
-	resolvedImageUrl := resolveImageUrl(imageUrl)
-
-	// image url assigned into repo/image+tag
-	if len(matchData) == 3 {
-		ret[matchData[setting.PathSearchComponentRepo]] = strings.TrimSuffix(resolvedImageUrl[setting.PathSearchComponentRepo], "/")
-		ret[matchData[setting.PathSearchComponentImage]] = resolvedImageUrl[setting.PathSearchComponentImage]
-		ret[matchData[setting.PathSearchComponentTag]] = resolvedImageUrl[setting.PathSearchComponentTag]
-		return ret, nil
-	}
-
-	if len(matchData) == 2 {
-		// image url assigned into repo/image + tag
-		if tagPath, ok := matchData[setting.PathSearchComponentTag]; ok {
-			ret[tagPath] = resolvedImageUrl[setting.PathSearchComponentTag]
-			for k, imagePath := range matchData {
-				if k == setting.PathSearchComponentTag {
-					continue
-				}
-				ret[imagePath] = fmt.Sprintf("%s%s", resolvedImageUrl[setting.PathSearchComponentRepo], resolvedImageUrl[setting.PathSearchComponentImage])
-				break
-			}
-			return ret, nil
-		}
-		// image url assigned into repo + image(tag)
-		ret[matchData[setting.PathSearchComponentRepo]] = strings.TrimSuffix(resolvedImageUrl[setting.PathSearchComponentRepo], "/")
-		ret[matchData[setting.PathSearchComponentImage]] = fmt.Sprintf("%s:%s", resolvedImageUrl[setting.PathSearchComponentImage], resolvedImageUrl[setting.PathSearchComponentTag])
-		return ret, nil
-	}
-
-	return nil, fmt.Errorf("match data illegal, expect length: 1-3, actual length: %d", len(matchData))
 }
 
 // prepare necessary data from db
@@ -228,13 +140,13 @@ func updateContainerForHelmChart(serviceName, resType, image, containerName stri
 	targetContainer.Image = image
 
 	// prepare image replace info
-	replaceValuesMap, err = assignImageData(image, getValidMatchData(targetContainer.ImagePath))
+	replaceValuesMap, err = commonservice.AssignImageData(image, getValidMatchData(targetContainer.ImagePath))
 	if err != nil {
 		return fmt.Errorf("failed to pase image uri %s/%s, err %s", namespace, serviceName, err.Error())
 	}
 
 	// replace image into service's values.yaml
-	replacedValuesYaml, err = replaceImage(targetChart.ValuesYaml, replaceValuesMap)
+	replacedValuesYaml, err = commonservice.ReplaceImage(targetChart.ValuesYaml, replaceValuesMap)
 	if err != nil {
 		return fmt.Errorf("failed to replace image uri %s/%s, err %s", namespace, serviceName, err.Error())
 
@@ -253,7 +165,7 @@ func updateContainerForHelmChart(serviceName, resType, image, containerName stri
 	}
 
 	// replace image into final merged values.yaml
-	replacedMergedValuesYaml, err = replaceImage(mergedValuesYaml, replaceValuesMap)
+	replacedMergedValuesYaml, err = commonservice.ReplaceImage(mergedValuesYaml, replaceValuesMap)
 	if err != nil {
 		return err
 	}

--- a/pkg/microservice/aslan/core/system/service/registry.go
+++ b/pkg/microservice/aslan/core/system/service/registry.go
@@ -190,7 +190,7 @@ func ListReposTags(registryInfo *commonmodels.RegistryNamespace, names []string,
 		for _, repo := range repos.Repos {
 			for _, tag := range repo.Tags {
 				img := &RepoImgResp{
-					Host:  util.GetURLHostName(registryInfo.RegAddr),
+					Host:  util.TrimURLScheme(registryInfo.RegAddr),
 					Owner: repo.Namespace,
 					Name:  repo.Name,
 					Tag:   tag,


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

Problem Summary:

when creating helm delivery version, image registries in values.yaml won't be replaced by the appointed registry address, to make  the chart OOBE, extra manually edit is required

### What is changed and how it works?

What's Changed:

replace the image registry with the specific address automatically before creating helm chart

