### PR TITLE
add resource-server and dind in agent.yaml

### DIFF
--- a/pkg/microservice/aslan/config/config.go
+++ b/pkg/microservice/aslan/config/config.go
@@ -98,6 +98,10 @@ func HubAgentImage() string {
 	return viper.GetString(setting.ENVHubAgentImage)
 }
 
+func ResourceServerImage() string {
+	return viper.GetString(setting.ENVResourceServerImage)
+}
+
 func KodespaceVersion() string {
 	return viper.GetString(setting.ENVKodespaceVersion)
 }

--- a/pkg/microservice/aslan/core/common/service/kube/service.go
+++ b/pkg/microservice/aslan/core/common/service/kube/service.go
@@ -221,7 +221,7 @@ func (s *Service) ListConnectedClusters(logger *zap.SugaredLogger) ([]*models.K8
 	return clusters, nil
 }
 
-func (s *Service) GetYaml(id, agentImage, aslanURL, hubURI string, useDeployment bool, logger *zap.SugaredLogger) ([]byte, error) {
+func (s *Service) GetYaml(id, agentImage, rsImage, aslanURL, hubURI string, useDeployment bool, logger *zap.SugaredLogger) ([]byte, error) {
 	var (
 		cluster *models.K8SCluster
 		err     error
@@ -250,18 +250,20 @@ func (s *Service) GetYaml(id, agentImage, aslanURL, hubURI string, useDeployment
 
 	if cluster.Namespace == "" {
 		err = YamlTemplate.Execute(buffer, TemplateSchema{
-			HubAgentImage:     agentImage,
-			ClientToken:       token,
-			HubServerBaseAddr: hubBase.String(),
-			UseDeployment:     useDeployment,
+			HubAgentImage:       agentImage,
+			ResourceServerImage: rsImage,
+			ClientToken:         token,
+			HubServerBaseAddr:   hubBase.String(),
+			UseDeployment:       useDeployment,
 		})
 	} else {
 		err = YamlTemplateForNamespace.Execute(buffer, TemplateSchema{
-			HubAgentImage:     agentImage,
-			ClientToken:       token,
-			HubServerBaseAddr: hubBase.String(),
-			UseDeployment:     useDeployment,
-			Namespace:         cluster.Namespace,
+			HubAgentImage:       agentImage,
+			ResourceServerImage: rsImage,
+			ClientToken:         token,
+			HubServerBaseAddr:   hubBase.String(),
+			UseDeployment:       useDeployment,
+			Namespace:           cluster.Namespace,
 		})
 	}
 
@@ -273,11 +275,12 @@ func (s *Service) GetYaml(id, agentImage, aslanURL, hubURI string, useDeployment
 }
 
 type TemplateSchema struct {
-	HubAgentImage     string
-	ClientToken       string
-	HubServerBaseAddr string
-	Namespace         string
-	UseDeployment     bool
+	HubAgentImage       string
+	ResourceServerImage string
+	ClientToken         string
+	HubServerBaseAddr   string
+	Namespace           string
+	UseDeployment       bool
 }
 
 var YamlTemplate = template.Must(template.New("agentYaml").Parse(`
@@ -386,13 +389,138 @@ spec:
             memory: 1Gi
           requests:
             cpu: 100m
-            memory: 256Mi 
+            memory: 256Mi
 {{- if .UseDeployment }}
   replicas: 1
 {{- else }}
   updateStrategy:
     type: RollingUpdate
 {{- end }}
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: resource-server
+  namespace: koderover-agent
+  labels:
+    app.kubernetes.io/component: resource-server
+    app.kubernetes.io/name: zadig
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: resource-server
+      app.kubernetes.io/name: zadig
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: resource-server
+        app.kubernetes.io/name: zadig
+    spec:
+      containers:
+        - image: {{.ResourceServerImage}}
+          imagePullPolicy: Always
+          name: resource-server
+          resources:
+            limits:
+              cpu: 500m
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: resource-server
+  namespace: koderover-agent
+  labels:
+    app.kubernetes.io/component: resource-server
+    app.kubernetes.io/name: zadig
+spec:
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  selector:
+    app.kubernetes.io/component: resource-server
+    app.kubernetes.io/name: zadig
+
+---
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dind
+  namespace: koderover-agent
+  labels:
+    app.kubernetes.io/component: dind
+    app.kubernetes.io/name: zadig
+spec:
+  serviceName: dind
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: dind
+      app.kubernetes.io/name: zadig
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: dind
+        app.kubernetes.io/name: zadig
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+      containers:
+        - name: dind
+          image: ccr.ccs.tencentyun.com/koderover-public/library-docker:stable-dind
+          args:
+            - --mtu=1376
+          env:
+            - name: DOCKER_TLS_CERTDIR
+              value: ""
+          securityContext:
+            privileged: true
+          ports:
+            - protocol: TCP
+              containerPort: 2375
+          resources:
+            limits:
+              cpu: "4"
+              memory: 8Gi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: dind
+  namespace: koderover-agent
+  labels:
+    app.kubernetes.io/component: dind
+    app.kubernetes.io/name: zadig
+spec:
+  ports:
+    - name: dind
+      protocol: TCP
+      port: 2375
+      targetPort: 2375
+  clusterIP: None
+  selector:
+    app.kubernetes.io/component: dind
+    app.kubernetes.io/name: zadig
 `))
 
 var YamlTemplateForNamespace = template.Must(template.New("agentYaml").Parse(`
@@ -491,11 +619,137 @@ spec:
             memory: 1Gi
           requests:
             cpu: 100m
-            memory: 256Mi 
+            memory: 256Mi
 {{- if .UseDeployment }}
   replicas: 1
 {{- else }}
   updateStrategy:
     type: RollingUpdate
 {{- end }}
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: resource-server
+  namespace: {{.Namespace}}
+  labels:
+    app.kubernetes.io/component: resource-server
+    app.kubernetes.io/name: zadig
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: resource-server
+      app.kubernetes.io/name: zadig
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: resource-server
+        app.kubernetes.io/name: zadig
+    spec:
+      containers:
+        - image: {{.ResourceServerImage}}
+          imagePullPolicy: Always
+          name: resource-server
+          resources:
+            limits:
+              cpu: 500m
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: resource-server
+  namespace: {{.Namespace}}
+  labels:
+    app.kubernetes.io/component: resource-server
+    app.kubernetes.io/instance: zadig-zadig
+    app.kubernetes.io/name: zadig
+spec:
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  selector:
+    app.kubernetes.io/component: resource-server
+    app.kubernetes.io/name: zadig
+
+---
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dind
+  namespace: {{.Namespace}}
+  labels:
+    app.kubernetes.io/component: dind
+    app.kubernetes.io/name: zadig
+spec:
+  serviceName: dind
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: dind
+      app.kubernetes.io/name: zadig
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: dind
+        app.kubernetes.io/name: zadig
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+      containers:
+        - name: dind
+          image: ccr.ccs.tencentyun.com/koderover-public/library-docker:stable-dind
+          args:
+            - --mtu=1376
+          env:
+            - name: DOCKER_TLS_CERTDIR
+              value: ""
+          securityContext:
+            privileged: true
+          ports:
+            - protocol: TCP
+              containerPort: 2375
+          resources:
+            limits:
+              cpu: "4"
+              memory: 8Gi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: dind
+  namespace: {{.Namespace}}
+  labels:
+    app.kubernetes.io/component: dind
+    app.kubernetes.io/name: zadig
+spec:
+  ports:
+    - name: dind
+      protocol: TCP
+      port: 2375
+      targetPort: 2375
+  clusterIP: None
+  selector:
+    app.kubernetes.io/component: dind
+    app.kubernetes.io/name: zadig
 `))

--- a/pkg/microservice/aslan/core/multicluster/service/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/service/clusters.go
@@ -260,5 +260,5 @@ func ProxyAgent(writer gin.ResponseWriter, request *http.Request) {
 func GetYaml(id, hubURI string, useDeployment bool, logger *zap.SugaredLogger) ([]byte, error) {
 	s, _ := kube.NewService("")
 
-	return s.GetYaml(id, config.HubAgentImage(), configbase.SystemAddress(), hubURI, useDeployment, logger)
+	return s.GetYaml(id, config.HubAgentImage(), config.ResourceServerImage(), configbase.SystemAddress(), hubURI, useDeployment, logger)
 }

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -28,6 +28,7 @@ const (
 	ENVMongoDBConnectionString = "MONGODB_CONNECTION_STRING"
 	ENVAslanDBName             = "ASLAN_DB"
 	ENVHubAgentImage           = "HUB_AGENT_IMAGE"
+	ENVResourceServerImage     = "RESOURCE_SERVER_IMAGE"
 	ENVMysqlUser               = "MYSQL_USER"
 	ENVMysqlPassword           = "MYSQL_PASSWORD"
 	ENVMysqlHost               = "MYSQL_HOST"


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

Problem Summary: We support scheduling tasks through specifying cluster. For ease of use, we need to install `resource-server` / `dind` when installing `hub-agent`. 

### What is changed and how it works?

What's Changed: Add `resource-server` / `dind` installation yaml when generating `agent.yaml`. 