### PR TITLE
add open api run workflow resp data

### DIFF
--- a/pkg/microservice/picket/core/public/handler/public.go
+++ b/pkg/microservice/picket/core/public/handler/public.go
@@ -66,6 +66,7 @@ func CreateWorkflowTask(c *gin.Context) {
 }
 
 type CreateWorkflowTaskResp struct {
+	ProjectName  string `json:"project_name"`
 	PipelineName string `json:"pipeline_name,omitempty"`
 	WorkflowName string `json:"workflow_name"`
 	TaskID       int64  `json:"task_id"`


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

What's Changed:

How it Works:

add 'project_name' to the resp body for openApi '/api/directory/workflowTask/create'

