### PR TITLE
Fix the build log could not be displayed if workflow names were in uppercase letters

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -124,9 +124,9 @@ func saveContainerLog(pipelineTask *task.Task, namespace, clusterID, fileName st
 				return err
 			}
 			if store.Subfolder != "" {
-				store.Subfolder = fmt.Sprintf("%s/%s/%d/%s", store.Subfolder, pipelineTask.PipelineName, pipelineTask.TaskID, "log")
+				store.Subfolder = fmt.Sprintf("%s/%s/%d/%s", store.Subfolder, strings.ToLower(pipelineTask.PipelineName), pipelineTask.TaskID, "log")
 			} else {
-				store.Subfolder = fmt.Sprintf("%s/%d/%s", pipelineTask.PipelineName, pipelineTask.TaskID, "log")
+				store.Subfolder = fmt.Sprintf("%s/%d/%s", strings.ToLower(pipelineTask.PipelineName), pipelineTask.TaskID, "log")
 			}
 			forcedPathStyle := true
 			if store.Provider == setting.ProviderSourceAli {


### PR DESCRIPTION
Signed-off-by: ddh27 <duandehua@koderover.com>

### What this PR does / Why we need it:
Fixed an issue where the build log could not be displayed if workflow names were in uppercase letters

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information