### PR TITLE
add local cluster project relation

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/180.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/180.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	internalmodels "github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/repository/models"
 	internalmongodb "github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/repository/mongodb"
@@ -162,12 +163,20 @@ func initProjectClusterRelation() error {
 		log.Errorf("Failed to list clusters, err: %s", err)
 		return err
 	}
+	clusterIDs := sets.NewString()
+	for _, cluster := range clusters {
+		clusterIDs.Insert(cluster.ID.Hex())
+	}
+
+	if !clusterIDs.Has(setting.LocalClusterID) {
+		clusterIDs.Insert(setting.LocalClusterID)
+	}
 
 	for _, project := range projects {
-		for _, cluster := range clusters {
+		for _, clusterID := range clusterIDs.List() {
 			if err := internalmongodb.NewProjectClusterRelationColl().Create(&internalmodels.ProjectClusterRelation{
 				ProjectName: project.ProductName,
-				ClusterID:   cluster.ID.Hex(),
+				ClusterID:   clusterID,
 			}); err != nil {
 				log.Warnf("Failed to create projectClusterRelation, err: %s", err)
 			}


### PR DESCRIPTION
Signed-off-by: liu deyi <andrew@koderover.com>

### What is changed and how it works?

What's Changed:
1. If there is no local cluster that has not been created yet, first increase the relationship between the local cluster and the project