### PR TITLE
[DO NOT MERGE,Fix later] fixed gitlab name vs path difference bug

### DIFF
--- a/pkg/microservice/aslan/core/code/service/types.go
+++ b/pkg/microservice/aslan/core/code/service/types.go
@@ -61,6 +61,7 @@ type Project struct {
 	Namespace     string `json:"namespace"`
 	RepoUUID      string `json:"repo_uuid,omitempty"`
 	RepoID        string `json:"repo_id,omitempty"`
+	Path          string `json:"path,omitempty"`
 }
 
 type Tag struct {
@@ -215,6 +216,7 @@ func ToProjects(obj interface{}) []*Project {
 				Namespace:     o.Namespace.FullPath,
 				Description:   o.Description,
 				DefaultBranch: o.DefaultBranch,
+				Path:          o.Path,
 			})
 		}
 	case []*gerrit.ProjectInfo:

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -259,6 +259,11 @@ func (b *JobCtxBuilder) BuildReaperContext(pipelineTask *task.Task, serviceName 
 			User:         build.Username,
 			Password:     build.Password,
 		}
+		if build.Source == setting.SourceFromGitlab {
+			if build.RepoPath != "" {
+				repo.Name = build.RepoPath
+			}
+		}
 		ctx.Repos = append(ctx.Repos, repo)
 	}
 

--- a/pkg/microservice/warpdrive/core/service/types/task/build.go
+++ b/pkg/microservice/warpdrive/core/service/types/task/build.go
@@ -238,6 +238,7 @@ type Repository struct {
 	Source        string `bson:"source,omitempty"          json:"source,omitempty"`
 	RepoOwner     string `bson:"repo_owner"                json:"repo_owner"`
 	RepoName      string `bson:"repo_name"                 json:"repo_name"`
+	RepoPath      string `bson:"repo_path"                 json:"repo_path"`
 	RemoteName    string `bson:"remote_name,omitempty"     json:"remote_name,omitempty"`
 	Branch        string `bson:"branch"                    json:"branch"`
 	PR            int    `bson:"pr,omitempty"              json:"pr,omitempty"`

--- a/pkg/types/repo.go
+++ b/pkg/types/repo.go
@@ -28,6 +28,7 @@ type Repository struct {
 	Source        string `bson:"source,omitempty"          json:"source,omitempty"`
 	RepoOwner     string `bson:"repo_owner"                json:"repo_owner"`
 	RepoName      string `bson:"repo_name"                 json:"repo_name"`
+	RepoPath      string `bson:"repo_path"                 json:"repo_path"`
 	RemoteName    string `bson:"remote_name,omitempty"     json:"remote_name,omitempty"`
 	Branch        string `bson:"branch"                    json:"branch"`
 	PR            int    `bson:"pr,omitempty"              json:"pr,omitempty"`


### PR DESCRIPTION
Signed-off-by: Min Min <minmin@koderover.com>

### What this PR does / Why we need it:

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
Fixed a bug when gitlab project name is not its path name, aslan will return 404.
### What is changed and how it works?

What's Changed:
Added a path field in the project response. Using path instead of name for gitlab projects.

How it Works:

### Check List <!--REMOVE the items that are not applicable-->


- [ ] Docs have been added / updated
- [x] Unit test / Integration test for the changes have been added
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information