### PR TITLE
If the cluster has not changed, the last httpTransport is returned

### DIFF
--- a/pkg/tool/remotedialer/server.go
+++ b/pkg/tool/remotedialer/server.go
@@ -129,10 +129,6 @@ func (r *Server) GetTransport(clusterCaCert string, clientKey string) (http.Roun
 	r.Lock()
 	defer r.Unlock()
 
-	if r.httpTransport != nil && r.caCert == clusterCaCert {
-		return r.httpTransport, nil
-	}
-
 	transport := &http.Transport{}
 	if clusterCaCert != "" {
 		certBytes, err := base64.StdEncoding.DecodeString(clusterCaCert)


### PR DESCRIPTION
Signed-off-by: liu deyi <andrew@koderover.com>

### What this PR does / Why we need it:

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:
1. If the cluster has not changed, the last httpTransport is returned