### PR TITLE
Fixed a bug where s3 subpath will have an influence on job creation

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -501,7 +501,6 @@ func buildJobWithLinkedNs(taskType config.TaskType, jobImage, jobName, serviceNa
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            labels["s-type"],
 							Image:           jobImage,
-							WorkingDir:      pipelineTask.ConfigPayload.S3Storage.Path,
 							Env: []corev1.EnvVar{
 								{
 									Name:  "JOB_CONFIG_FILE",


### PR DESCRIPTION
Signed-off-by: Min Min <minmin@koderover.com>

### What this PR does / Why we need it:
Fixed a bug which set the subPath for object storage will cause job creation failure.

What's Changed:
Now the working directory for the job will no longer be the same as the subPath of the object storage, which is totally nonsense.


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information