### PR TITLE
bugfix for huawei registry

### DIFF
--- a/pkg/microservice/aslan/core/common/service/registry.go
+++ b/pkg/microservice/aslan/core/common/service/registry.go
@@ -79,7 +79,9 @@ func findRegisty(regOps *mongodb.FindRegOps, getRealCredential bool, log *zap.Su
 	switch resp.RegProvider {
 	case config.RegistryTypeSWR:
 		resp.AccessKey = fmt.Sprintf("%s@%s", resp.Region, resp.AccessKey)
+		fmt.Println("Getting huawei secretkey with AK:", resp.AccessKey, ", SK:", resp.SecretKey)
 		resp.SecretKey = util.ComputeHmacSha256(resp.AccessKey, resp.SecretKey)
+		fmt.Println("The result is:", resp.SecretKey)
 	case config.RegistryTypeAWS:
 		realAK, realSK, err := getAWSRegistryCredential(resp.ID.Hex(), resp.AccessKey, resp.SecretKey, resp.Region)
 		if err != nil {

--- a/pkg/microservice/aslan/core/common/service/registry.go
+++ b/pkg/microservice/aslan/core/common/service/registry.go
@@ -78,10 +78,8 @@ func findRegisty(regOps *mongodb.FindRegOps, getRealCredential bool, log *zap.Su
 	}
 	switch resp.RegProvider {
 	case config.RegistryTypeSWR:
-		resp.AccessKey = fmt.Sprintf("%s@%s", resp.Region, resp.AccessKey)
-		fmt.Println("Getting huawei secretkey with AK:", resp.AccessKey, ", SK:", resp.SecretKey)
 		resp.SecretKey = util.ComputeHmacSha256(resp.AccessKey, resp.SecretKey)
-		fmt.Println("The result is:", resp.SecretKey)
+		resp.AccessKey = fmt.Sprintf("%s@%s", resp.Region, resp.AccessKey)
 	case config.RegistryTypeAWS:
 		realAK, realSK, err := getAWSRegistryCredential(resp.ID.Hex(), resp.AccessKey, resp.SecretKey, resp.Region)
 		if err != nil {

--- a/pkg/microservice/reaper/core/service/reaper/docker.go
+++ b/pkg/microservice/reaper/core/service/reaper/docker.go
@@ -17,14 +17,12 @@ limitations under the License.
 package reaper
 
 import (
-	"fmt"
 	"os/exec"
 )
 
 const dockerExe = "/usr/local/bin/docker"
 
 func dockerLogin(user, password, registry string) *exec.Cmd {
-	fmt.Println("login docker with credential:", "username:", user, ", password:", password, ", registry:", registry)
 	return exec.Command(
 		dockerExe,
 		"login",

--- a/pkg/microservice/reaper/core/service/reaper/docker.go
+++ b/pkg/microservice/reaper/core/service/reaper/docker.go
@@ -16,11 +16,15 @@ limitations under the License.
 
 package reaper
 
-import "os/exec"
+import (
+	"fmt"
+	"os/exec"
+)
 
 const dockerExe = "/usr/local/bin/docker"
 
 func dockerLogin(user, password, registry string) *exec.Cmd {
+	fmt.Println("login docker with credential:", "username:", user, ", password:", password, ", registry:", registry)
 	return exec.Command(
 		dockerExe,
 		"login",


### PR DESCRIPTION
Signed-off-by: Min Min <minmin@koderover.com>

### What this PR does / Why we need it:

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
Fixed a bug where huawei cloud registry cannot be used

What's Changed:
ak is set to a wrong value to compute HMAC secret key. I changed it to the right value


- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code


## More information