### PR TITLE
minor improvement to the validate bucket function

### DIFF
--- a/pkg/tool/s3/client.go
+++ b/pkg/tool/s3/client.go
@@ -65,18 +65,13 @@ func NewClient(endpoint, ak, sk string, insecure, forcedPathStyle bool) (*Client
 
 // Validate the existence of bucket
 func (c *Client) ValidateBucket(bucketName string) error {
-	listBucketInput := &s3.ListBucketsInput{}
-	bucketListResp, err := c.ListBuckets(listBucketInput)
+	listObjectInput := &s3.ListObjectsInput{Bucket: aws.String(bucketName)}
+	_, err := c.ListObjects(listObjectInput)
 	if err != nil {
 		return fmt.Errorf("validate S3 error: %s", err.Error())
 	}
-	for _, bucket := range bucketListResp.Buckets {
-		if *bucket.Name == bucketName {
-			return nil
-		}
-	}
 
-	return fmt.Errorf("validate s3 error: given bucket does not exist")
+	return nil
 }
 
 func (c *Client) DownloadWithOption(bucketName, objectKey, dest string, option *DownloadOption) error {


### PR DESCRIPTION
Signed-off-by: Min Min <jamsman94@gmail.com>

### What this PR does / Why we need it:
Currenly The Validate bucket for object storage requires admin authorization to work. This is to much power to ask. So now instead of list bucket, we list file in the given bucket to verify the given identity

### What is changed and how it works?
Change listBucket In the ValidateBucket to ListObjects, which requires only a read/write authorization instead of admin.


### Check List <!--REMOVE the items that are not applicable-->
- [ ] Docs have been added / updated
- [ ] Unit test / Integration test for the changes have been added
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code
