### PR TITLE
clear webhook when deleting test modules

### DIFF
--- a/pkg/microservice/aslan/core/common/service/testing.go
+++ b/pkg/microservice/aslan/core/common/service/testing.go
@@ -57,7 +57,7 @@ func Delete(name, productName string, log *zap.SugaredLogger) error {
 	// find test data to delete webhook
 	testModule, err := commonrepo.NewTestingColl().Find(name, productName)
 	if err != nil {
-		log.Errorf("Workflow.Find error: %v", err)
+		log.Errorf("failed to find test module: %s", err)
 		return e.ErrDeleteTestModule.AddDesc(err.Error())
 	}
 

--- a/pkg/microservice/aslan/core/common/service/testing.go
+++ b/pkg/microservice/aslan/core/common/service/testing.go
@@ -57,7 +57,6 @@ func Delete(name, productName string, log *zap.SugaredLogger) error {
 	// find test data to delete webhook
 	testModule, err := commonrepo.NewTestingColl().Find(name, productName)
 	if err != nil {
-		log.Errorf("failed to find test module: %s", err)
 		return e.ErrDeleteTestModule.AddDesc(err.Error())
 	}
 

--- a/pkg/microservice/aslan/core/common/service/testing.go
+++ b/pkg/microservice/aslan/core/common/service/testing.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
+	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/webhook"
 	"github.com/koderover/zadig/pkg/setting"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 )
@@ -52,7 +54,20 @@ func Delete(name, productName string, log *zap.SugaredLogger) error {
 		return e.ErrDeleteTestModule.AddDesc("empty Name")
 	}
 
-	err := mongodb.NewTestingColl().Delete(name, productName)
+	// find test data to delete webhook
+	testModule, err := commonrepo.NewTestingColl().Find(name, productName)
+	if err != nil {
+		log.Errorf("Workflow.Find error: %v", err)
+		return e.ErrDeleteTestModule.AddDesc(err.Error())
+	}
+
+	// delete webhooks of test
+	err = ProcessWebhook(nil, testModule.HookCtl.Items, webhook.TestingPrefix+name, log)
+	if err != nil {
+		return e.ErrDeleteTestModule.AddErr(err)
+	}
+
+	err = mongodb.NewTestingColl().Delete(name, productName)
 	if err != nil {
 		log.Errorf("[Testing.Delete] %s error: %v", name, err)
 		return e.ErrDeleteTestModule.AddErr(err)

--- a/pkg/microservice/aslan/core/workflow/testing/handler/testing.go
+++ b/pkg/microservice/aslan/core/workflow/testing/handler/testing.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	commonservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/workflow/testing/service"
 	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
 	e "github.com/koderover/zadig/pkg/tool/errors"
@@ -127,7 +128,7 @@ func DeleteTestModule(c *gin.Context) {
 		return
 	}
 
-	ctx.Err = service.DeleteTestModule(name, c.Query("projectName"), ctx.RequestID, ctx.Logger)
+	ctx.Err = commonservice.DeleteTestModule(name, c.Query("projectName"), ctx.RequestID, ctx.Logger)
 }
 
 func GetHTMLTestReport(c *gin.Context) {


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
webhooks of test modules are not cleaned when deleting test modules/projects

### What is changed and how it works?
delete releated webhooks when test modules/projects are deleted

### Does this PR introduce a user-facing change?
no

