### PR TITLE
fix service webhook be deleted unexpected bug

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/service.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/service.go
@@ -433,7 +433,7 @@ func (c *ServiceColl) ListAllRevisions() ([]*models.Service, error) {
 	return resp, err
 }
 
-func (c *ServiceColl) ListMaxRevisionsByGroup(serviceName, serviceType string) ([]*models.Service, error) {
+func (c *ServiceColl) ListMaxRevisionsByProject(serviceName, serviceType string) ([]*models.Service, error) {
 
 	pipeline := []bson.M{
 		{

--- a/pkg/microservice/aslan/core/common/repository/mongodb/service.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/service.go
@@ -60,6 +60,10 @@ type ServiceListOption struct {
 	NotInServices  []*templatemodels.ServiceInfo
 }
 
+type ServiceAggregateResult struct {
+	ServiceID primitive.ObjectID `bson:"service_id"`
+}
+
 type ServiceColl struct {
 	*mongo.Collection
 
@@ -427,6 +431,61 @@ func (c *ServiceColl) ListAllRevisions() ([]*models.Service, error) {
 	}
 
 	return resp, err
+}
+
+func (c *ServiceColl) ListMaxRevisionsByGroup(serviceName, serviceType string) ([]*models.Service, error) {
+
+	pipeline := []bson.M{
+		{
+			"$match": bson.M{
+				"status":       bson.M{"$ne": setting.ProductStatusDeleting},
+				"service_name": serviceName,
+				"type":         serviceType,
+			},
+		},
+		{
+			"$group": bson.M{
+				"_id": bson.M{
+					"product_name": "$product_name",
+					"service_name": "$service_name",
+				},
+				"revision":   bson.M{"$max": "$revision"},
+				"service_id": bson.M{"$last": "$_id"},
+			},
+		},
+	}
+
+	cursor, err := c.Aggregate(context.TODO(), pipeline)
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]*ServiceAggregateResult, 0)
+	if err := cursor.All(context.TODO(), &res); err != nil {
+		return nil, err
+	}
+
+	var ids []primitive.ObjectID
+	for _, service := range res {
+		ids = append(ids, service.ServiceID)
+	}
+
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	var resp []*models.Service
+	query := bson.M{"_id": bson.M{"$in": ids}}
+	cursor, err = c.Collection.Find(context.TODO(), query)
+	if err != nil {
+		return nil, err
+	}
+	err = cursor.All(context.TODO(), &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }
 
 func (c *ServiceColl) ListMaxRevisions(opt *ServiceListOption) ([]*models.Service, error) {

--- a/pkg/microservice/aslan/core/common/service/webhook/controller.go
+++ b/pkg/microservice/aslan/core/common/service/webhook/controller.go
@@ -18,6 +18,7 @@ package webhook
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/codehub"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/github"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/gitlab"
+	codehostdb "github.com/koderover/zadig/pkg/microservice/systemconfig/core/codehost/repository/mongodb"
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/tool/log"
 )
@@ -114,6 +116,38 @@ func (c *controller) processNextWorkItem() bool {
 	return true
 }
 
+func ensureSafeDelete(ref, repoName, repoOwner, repoAddress string) (bool, error) {
+	// only handle webhooks created by service
+	if !strings.HasPrefix(ref, ServicePrefix) || !strings.HasSuffix(ref, "trigger") {
+		return true, nil
+	}
+
+	serviceName := strings.TrimPrefix(ref, ServicePrefix)
+	serviceName = strings.TrimSuffix(serviceName, "-trigger")
+
+	// find existing service with same name
+	services, err := mongodb.NewServiceColl().ListMaxRevisionsByGroup(serviceName, setting.K8SDeployType)
+	if err != nil {
+		return false, err
+	}
+
+	// if the webhook reference is used by other
+	for _, service := range services {
+		if service.RepoName != repoName || service.RepoOwner != repoOwner {
+			continue
+		}
+		codeHostInfo, err := codehostdb.NewCodehostColl().GetCodeHostByID(service.CodehostID)
+		if err == nil {
+			if codeHostInfo.Address != repoAddress {
+				continue
+			} else {
+				return false, nil
+			}
+		}
+	}
+	return true, nil
+}
+
 func removeWebhook(t *task, logger *zap.Logger) {
 	coll := mongodb.NewWebHookColl()
 	var cl hookCreateDeleter
@@ -146,27 +180,38 @@ func removeWebhook(t *task, logger *zap.Logger) {
 
 	logger = logger.With(zap.String("hookID", webhook.HookID))
 	logger.Info("Removing webhook")
-	updated, err := coll.RemoveReference(t.owner, t.repo, t.address, t.ref)
+
+	//ensure safe remove, same reference may be used by multiple services
+	safe, err := ensureSafeDelete(t.ref, t.repo, t.owner, t.address)
 	if err != nil {
 		t.err = err
 		t.doneCh <- struct{}{}
 		return
 	}
 
-	if len(updated.References) == 0 {
-		logger.Info("Deleting webhook")
-		err = cl.DeleteWebHook(t.owner, t.repo, webhook.HookID)
+	if safe {
+		updated, err := coll.RemoveReference(t.owner, t.repo, t.address, t.ref)
 		if err != nil {
-			logger.Error("Failed to delete webhook", zap.Error(err))
 			t.err = err
 			t.doneCh <- struct{}{}
 			return
 		}
 
-		err = coll.Delete(t.owner, t.repo, t.address)
-		if err != nil {
-			logger.Error("Failed to delete webhook record in db", zap.Error(err))
-			t.err = err
+		if len(updated.References) == 0 {
+			logger.Info("Deleting webhook")
+			err = cl.DeleteWebHook(t.owner, t.repo, webhook.HookID)
+			if err != nil {
+				logger.Error("Failed to delete webhook", zap.Error(err))
+				t.err = err
+				t.doneCh <- struct{}{}
+				return
+			}
+
+			err = coll.Delete(t.owner, t.repo, t.address)
+			if err != nil {
+				logger.Error("Failed to delete webhook record in db", zap.Error(err))
+				t.err = err
+			}
 		}
 	}
 

--- a/pkg/microservice/aslan/core/common/service/webhook/controller.go
+++ b/pkg/microservice/aslan/core/common/service/webhook/controller.go
@@ -126,12 +126,12 @@ func ensureSafeDelete(ref, repoName, repoOwner, repoAddress string) (bool, error
 	serviceName = strings.TrimSuffix(serviceName, "-trigger")
 
 	// find existing service with same name
-	services, err := mongodb.NewServiceColl().ListMaxRevisionsByGroup(serviceName, setting.K8SDeployType)
+	services, err := mongodb.NewServiceColl().ListMaxRevisionsByProject(serviceName, setting.K8SDeployType)
 	if err != nil {
 		return false, err
 	}
 
-	// if the webhook reference is used by other
+	// check if the webhook reference points to other existing service
 	for _, service := range services {
 		if service.RepoName != repoName || service.RepoOwner != repoOwner {
 			continue


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

the refrence of services in webhook config data now is not global-unique, delete one service will dieectly delete the webhook which may be used by another service with the same name.

### What is changed and how it works?

add logic to check the refrence is used by another service before delete it dieectly

### Does this PR introduce a user-facing change?
 no

