### PR TITLE
fixed list regisrtries will not return the correct SK for  huawei registry

### DIFF
--- a/pkg/microservice/aslan/core/common/service/registry.go
+++ b/pkg/microservice/aslan/core/common/service/registry.go
@@ -111,8 +111,8 @@ func ListRegistryNamespaces(getRealCredential bool, log *zap.SugaredLogger) ([]*
 	for _, reg := range resp {
 		switch reg.RegProvider {
 		case config.RegistryTypeSWR:
-			reg.AccessKey = fmt.Sprintf("%s@%s", reg.Region, reg.AccessKey)
 			reg.SecretKey = util.ComputeHmacSha256(reg.AccessKey, reg.SecretKey)
+			reg.AccessKey = fmt.Sprintf("%s@%s", reg.Region, reg.AccessKey)
 		case config.RegistryTypeAWS:
 			realAK, realSK, err := getAWSRegistryCredential(reg.ID.Hex(), reg.AccessKey, reg.SecretKey, reg.Region)
 			if err != nil {


### PR DESCRIPTION
…
Signed-off-by: Min Min <minmin@koderover.com>

### What this PR does / Why we need it:
fixed list regisrtries will not return the correct SK for  huawei registry

### What is changed and how it works?
now we will calculate the real sk before we reset the value of ak, which causes the problem

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
