### PR TITLE
mask secret envs when running user's script

### DIFF
--- a/pkg/microservice/reaper/core/service/reaper/script.go
+++ b/pkg/microservice/reaper/core/service/reaper/script.go
@@ -431,7 +431,7 @@ func (r *Reaper) handleCmdOutput(pipe io.ReadCloser, needPersistentLog bool, log
 			break
 		}
 
-		fmt.Printf("%s", string(lineBytes))
+		fmt.Printf("%s", r.maskSecretEnvs(string(lineBytes)))
 
 		if needPersistentLog {
 			err := util.WriteFile(logFile, lineBytes, 0700)


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

Mask sensitive information when executing user build scripts. 

### What is changed and how it works?

Use `maskSecretEnvs` method to mask sensitive information.


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
