### PR TITLE
Bugfix/superseded release status

### DIFF
--- a/pkg/microservice/aslan/core/common/service/webhook/controller.go
+++ b/pkg/microservice/aslan/core/common/service/webhook/controller.go
@@ -50,7 +50,7 @@ var c *controller
 func webhookController() *controller {
 	once.Do(func() {
 		c = &controller{
-			queue:  make(chan *task, 100),
+			queue:  make(chan *task, 500),
 			logger: log.Logger(),
 		}
 	})

--- a/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
@@ -24,8 +24,6 @@ import (
 	"strings"
 	"time"
 
-	helmrelease "helm.sh/helm/v3/pkg/release"
-
 	helmclient "github.com/mittwald/go-helm-client"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -55,6 +53,7 @@ import (
 	"github.com/koderover/zadig/pkg/util/converter"
 	fsutil "github.com/koderover/zadig/pkg/util/fs"
 	yamlutil "github.com/koderover/zadig/pkg/util/yaml"
+	helmrelease "helm.sh/helm/v3/pkg/release"
 )
 
 // InitializeDeployTaskPlugin to initiate deploy task plugin and return ref
@@ -537,6 +536,7 @@ func (p *DeployTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, _ *
 		ensureUpgrade := func() error {
 			hrs, errHistory := helmClient.ListReleaseHistory(releaseName, 10)
 			if errHistory != nil {
+				// list history should not block deploy operation, error will be logged instead of returned
 				p.Log.Errorf("failed to list release history, release: %s, err: %s", releaseName, errHistory)
 				return nil
 			}

--- a/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
@@ -24,8 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/koderover/zadig/pkg/tool/log"
-
 	helmclient "github.com/mittwald/go-helm-client"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -538,7 +536,7 @@ func (p *DeployTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, _ *
 		ensureUpgrade := func() error {
 			hrs, errHistory := helmClient.ListReleaseHistory(releaseName, 10)
 			if errHistory != nil {
-				log.Errorf("failed to list release history, release: %s, err: %s", releaseName, errHistory)
+				p.Log.Errorf("failed to list release history, release: %s, err: %s", releaseName, errHistory)
 				return nil
 			}
 			if len(hrs) == 0 {
@@ -549,7 +547,7 @@ func (p *DeployTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, _ *
 
 			// for release in superseded status or stuck in pending status , uninstall the service first
 			if rel.Info.Status == helmrelease.StatusSuperseded || (rel.Info.Status.IsPending() && time.Now().Sub(rel.Info.LastDeployed.Time).Seconds() > setting.DeployTimeout) {
-				log.Infof("uninstalling release: %s in status: %s", releaseName, rel.Info.Status)
+				p.Log.Infof("uninstalling release: %s in status: %s", releaseName, rel.Info.Status)
 				removeSpec := &helmclient.ChartSpec{
 					ReleaseName: releaseName,
 					ChartName:   chartPath,


### PR DESCRIPTION
### What this PR does / Why we need it:
when helm release is stuck in some exceptional status like 'superseded' or 'pending-install', error occurs when deploying chart by workflow.

### What is changed and how it works?
add ability to deal with release with exceptional status, make sure the follow-up deploy can execute successfully.

### Does this PR introduce a user-facing change?
no
