### PR TITLE
support to deploy relese with status superseded

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
@@ -578,6 +578,7 @@ func (p *DeployTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, _ *
 			UpgradeCRDs: true,
 			Timeout:     time.Second * setting.DeployTimeout,
 			Wait:        true,
+			Replace:     true,
 		}
 
 		done := make(chan bool)


### PR DESCRIPTION
### What this PR does / Why we need it:
when helm release is stuck in some exceptional status like 'superseded' or 'pending-install', error occurs when deploying chart by workflow.

### What is changed and how it works?
add ability to deal with release with exceptional status, make sure the follow-up deploy can execute successfully.

### Does this PR introduce a user-facing change?
no
