### PR TITLE
remove uninstall release logic

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
@@ -547,17 +547,8 @@ func (p *DeployTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, _ *
 			rel := hrs[0]
 
 			// for release in superseded status or stuck in pending status , uninstall the service first
-			if rel.Info.Status == helmrelease.StatusSuperseded || (rel.Info.Status.IsPending() && time.Now().Sub(rel.Info.LastDeployed.Time).Seconds() > setting.DeployTimeout) {
-				p.Log.Infof("uninstalling release: %s in status: %s", releaseName, rel.Info.Status)
-				removeSpec := &helmclient.ChartSpec{
-					ReleaseName: releaseName,
-					ChartName:   chartPath,
-					Namespace:   p.Task.Namespace,
-					Timeout:     time.Second * setting.DeployTimeout,
-					Wait:        true,
-				}
-				err = helmClient.UninstallRelease(removeSpec)
-				return errors.Wrapf(err, "failed to uninstall superseded release: %s, err: %s", removeSpec.ReleaseName, err)
+			if rel.Info.Status == helmrelease.StatusSuperseded || rel.Info.Status.IsPending() {
+				return fmt.Errorf("failed to upgrade release: %s with exceptional status: %s", releaseName, rel.Info.Status)
 			}
 			return nil
 		}


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:

when meeting release with status 'superseded'/'pending-upgrade'/'pending-install' in the progress of deploying helm chart, currently the release will be uninstalled first and then be reinstalled, this may bring some unexpected problem since all releated resources are recreated.

### What is changed and how it works?
remove the uninstall logic, only renture error when meet unexpected status

### Does this PR introduce a user-facing change?
no
