### PR TITLE
support for getting logs of abnormal Pods on EKS

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -521,6 +521,8 @@ func buildJobWithLinkedNs(taskType config.TaskType, jobImage, jobName, serviceNa
 							},
 							VolumeMounts: getVolumeMounts(ctx),
 							Resources:    getResourceRequirements(resReq, resReqSpec),
+
+							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						},
 					},
 					Volumes: getVolumes(jobName),

--- a/pkg/tool/kube/containerlog/log.go
+++ b/pkg/tool/kube/containerlog/log.go
@@ -18,15 +18,30 @@ package containerlog
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/koderover/zadig/pkg/tool/log"
 )
 
 func GetContainerLogs(namespace, podName, containerName string, follow bool, tailLines int64, out io.Writer, clientset kubernetes.Interface) error {
 	readCloser, err := GetContainerLogStream(context.TODO(), namespace, podName, containerName, follow, tailLines, clientset)
 	if err != nil {
+		log.Warnf("Failed to get pod log from stream: %s. Try to get logs from pod object.", err)
+
+		// For Serverless K8s, we may not be able to get logs from Pod in the Failed state, but we can configure
+		// `container.terminationMessagePolicy=FallbackToLogsOnError` to get the latest exception information from the Pod Object.
+		pod, err := clientset.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get pod %s in %s: %s", podName, namespace, err)
+		}
+
+		_, err = out.Write([]byte(pod.Status.ContainerStatuses[0].State.Terminated.Message))
+
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

On EKS, when the Pod is abnormal, the logs cannot be obtained. This behavior will cause trouble for Zadig users. 

### What is changed and how it works?

When the Pod is abnormal, if it cannot be obtained through `GetLogs()`, try to obtain the information from the Pod Object. 

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
