### PR TITLE
support parse envs in cache dir

### DIFF
--- a/pkg/microservice/reaper/core/service/meta/types.go
+++ b/pkg/microservice/reaper/core/service/meta/types.go
@@ -86,6 +86,7 @@ type Context struct {
 	// Git Github/Gitlab 配置
 	Git *Git `yaml:"git"`
 
+	// TODO: Deprecated.
 	// Caches Caches配置
 	Caches []string `yaml:"caches"`
 


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

User-defined cache directories may use environment variables and need to be able to resolve correctly.
User-defined directory scenarios were not handled correctly in previous releases, resulting in the default use of the /workspace directory as the cache directory. 

### What is changed and how it works?

For user-defined cache directories:
- use environment variables to resolve correctly
- correctly extract the data to the target directory 


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
