### PR TITLE
adjust job completion logic to ensure wd logic works as expected

### DIFF
--- a/pkg/microservice/reaper/core/service/reaper/reaper.go
+++ b/pkg/microservice/reaper/core/service/reaper/reaper.go
@@ -441,20 +441,7 @@ func (r *Reaper) AfterExec(upStreamErr error) error {
 		}
 	}
 
-	// Create dog food file to tell wd that task has finished.
-	dogFoodErr := ioutil.WriteFile(setting.DogFood, []byte(time.Now().Format(time.RFC3339)), 0644)
-	if dogFoodErr != nil {
-		log.Errorf("Failed to create dog food: %s", dogFoodErr)
-	} else {
-		r.dogFeed = true
-		log.Infof("Build end. Duration: %.2f seconds.", time.Since(r.StartTime).Seconds())
-	}
-
 	return nil
-}
-
-func (r *Reaper) DogFeed() bool {
-	return r.dogFeed
 }
 
 func (r *Reaper) maskSecret(secrets []string, message string) string {

--- a/pkg/microservice/reaper/executor/executor.go
+++ b/pkg/microservice/reaper/executor/executor.go
@@ -17,14 +17,15 @@ limitations under the License.
 package executor
 
 import (
+	"fmt"
+	"io/ioutil"
 	"time"
-
-	"github.com/hashicorp/go-multierror"
 
 	commonconfig "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/reaper/core/service/reaper"
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/tool/log"
+	"github.com/koderover/zadig/pkg/types"
 )
 
 func Execute() error {
@@ -36,34 +37,50 @@ func Execute() error {
 	})
 
 	start := time.Now()
-	log.Info("build start")
+	log.Info("Build start.")
 
-	r, err := reaper.NewReaper()
-	if err != nil {
-		log.Fatal(err)
-	}
-
+	var err error
 	defer func() {
-		// when dog is feed, the following log has been printed
-		if !r.DogFeed() {
-			log.Infof("build end. duration: %.2f seconds", time.Since(start).Seconds())
+		// Create dog food file to tell wd that task has finished.
+		resultMsg := types.JobSuccess
+		if err != nil {
+			resultMsg = types.JobFail
 		}
+		log.Infof("Job Status: %s", resultMsg)
+
+		dogFoodErr := ioutil.WriteFile(setting.DogFood, []byte(resultMsg), 0644)
+		if dogFoodErr != nil {
+			log.Errorf("Failed to create dog food: %s", dogFoodErr)
+		} else {
+			log.Infof("Build end. Duration: %.2f seconds.", time.Since(start).Seconds())
+		}
+
+		// Note: Mark the task has been completed through the dogfood file, indirectly notify wd to do follow-up
+		//       operations, and wait for a fixed time.
+		//       Since `wd` will automatically delete the job after detecting the dogfile, this time has little
+		//       effect on the overall construction time.
+		time.Sleep(1 * time.Minute)
 	}()
 
-	var errs *multierror.Error
+	var r *reaper.Reaper
+	r, err = reaper.NewReaper()
+	if err != nil {
+		return fmt.Errorf("failed to new reaper: %s", err)
+	}
+
 	if err = r.BeforeExec(); err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("failed to prepare before building: %s", err)
 	}
 
 	if r.Ctx.ArtifactInfo == nil {
 		if err = r.Exec(); err != nil {
-			errs = multierror.Append(errs, err)
+			return fmt.Errorf("failed to build: %s", err)
 		}
 	}
 
 	if err = r.AfterExec(err); err != nil {
-		errs = multierror.Append(errs, err)
+		return fmt.Errorf("failed to work after building: %s", err)
 	}
 
-	return errs.ErrorOrNil()
+	return nil
 }

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -846,7 +846,7 @@ func waitJobEndWithFile(ctx context.Context, taskTimeout int, namespace, jobName
 					if !ipod.Finished() {
 						jobStatus, exists, err = checkDogFoodExistsInContainer(namespace, ipod.Name, ipod.ContainerNames()[0])
 						if err != nil {
-							xl.Errorf("Failed to check dog food file %s %v", pods[0].Name, err)
+							xl.Errorf("Failed to check dog food file %s: %s.", pods[0].Name, err)
 							break
 						}
 						if !exists {

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -832,7 +832,8 @@ func waitJobEndWithFile(ctx context.Context, taskTimeout int, namespace, jobName
 					return config.StatusFailed
 				}
 
-				var done bool
+				var done, exists bool
+				var jobStatus commontypes.JobStatus
 				for _, pod := range pods {
 					ipod := wrapper.Pod(pod)
 					if ipod.Pending() {
@@ -843,9 +844,9 @@ func waitJobEndWithFile(ctx context.Context, taskTimeout int, namespace, jobName
 					}
 
 					if !ipod.Finished() {
-						exists, err := checkDogFoodExistsInContainer(namespace, ipod.Name, ipod.ContainerNames()[0])
+						jobStatus, exists, err = checkDogFoodExistsInContainer(namespace, ipod.Name, ipod.ContainerNames()[0])
 						if err != nil {
-							xl.Infof("failed to check dog food file %s %v", pods[0].Name, err)
+							xl.Errorf("Failed to check dog food file %s %v", pods[0].Name, err)
 							break
 						}
 						if !exists {
@@ -856,8 +857,14 @@ func waitJobEndWithFile(ctx context.Context, taskTimeout int, namespace, jobName
 				}
 
 				if done {
-					xl.Infof("dog food is found, stop to wait %s", job.Name)
-					return config.StatusPassed
+					xl.Infof("Dog food is found, stop to wait %s. Job status: %s.", job.Name, jobStatus)
+
+					switch jobStatus {
+					case commontypes.JobFail:
+						return config.StatusFailed
+					default:
+						return config.StatusPassed
+					}
 				}
 			} else if job.Status.Succeeded != 0 {
 				return config.StatusPassed
@@ -871,15 +878,15 @@ func waitJobEndWithFile(ctx context.Context, taskTimeout int, namespace, jobName
 
 }
 
-func checkDogFoodExistsInContainer(namespace string, pod string, container string) (bool, error) {
-	_, _, success, err := podexec.ExecWithOptions(podexec.ExecOptions{
-		Command:       []string{"test", "-f", setting.DogFood},
+func checkDogFoodExistsInContainer(namespace string, pod string, container string) (commontypes.JobStatus, bool, error) {
+	stdout, _, success, err := podexec.ExecWithOptions(podexec.ExecOptions{
+		Command:       []string{"/bin/sh", "-c", fmt.Sprintf("test -f %[1]s && cat %[1]s", setting.DogFood)},
 		Namespace:     namespace,
 		PodName:       pod,
 		ContainerName: container,
 	})
 
-	return success, err
+	return commontypes.JobStatus(stdout), success, err
 }
 
 func addNodeAffinity(clusterID string, K8SClusters []*task.K8SCluster) *corev1.Affinity {

--- a/pkg/types/job.go
+++ b/pkg/types/job.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+type JobStatus string
+
+const (
+	JobSuccess JobStatus = "success"
+	JobFail    JobStatus = "fail"
+)


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

At present, when the job is completed, `wd` may not be able to perform exec/log operations on the job, which may cause problems such as the inability to obtain the log when the job is abnormal. 

### What is changed and how it works?

When the job is completed, write the result of this execution to the `dogfood` file, and wait for `wd` to actively delete the job. `wd` judges whether the job is executed successfully or not according to the dogfood file, not the status of the job itself. 


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
