### PR TITLE
Improvements for slow cluster resource querys

### DIFF
--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -41,6 +41,7 @@ import (
 	"github.com/koderover/zadig/pkg/shared/kube/wrapper"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 	"github.com/koderover/zadig/pkg/tool/kube/getter"
+	"github.com/koderover/zadig/pkg/tool/kube/informer"
 	"github.com/koderover/zadig/pkg/util"
 	jsonutil "github.com/koderover/zadig/pkg/util/json"
 )
@@ -217,14 +218,14 @@ func ListWorkloads(envName, clusterID, namespace, productName string, perPage, p
 	log.Infof("Start to list workloads in namespace %s", namespace)
 
 	var resp = make([]*ServiceResp, 0)
-	kubeClient, err := kubeclient.GetKubeClient(config.HubServerAddress(), clusterID)
+	cls, err := kubeclient.GetKubeClientSet(config.HubServerAddress(), clusterID)
 	if err != nil {
 		log.Errorf("[%s][%s] error: %v", envName, namespace, err)
 		return 0, resp, e.ErrListGroups.AddDesc(err.Error())
 	}
-
+	informer := informer.NewInformer(clusterID, namespace, cls)
 	var workLoads []*Workload
-	listDeployments, err := getter.ListDeployments(namespace, nil, kubeClient)
+	listDeployments, err := getter.ListDeploymentsWithCache(nil, informer)
 	if err != nil {
 		log.Errorf("[%s][%s] create product record error: %v", envName, namespace, err)
 		return 0, resp, e.ErrListGroups.AddDesc(err.Error())
@@ -232,7 +233,7 @@ func ListWorkloads(envName, clusterID, namespace, productName string, perPage, p
 	for _, v := range listDeployments {
 		workLoads = append(workLoads, &Workload{Name: v.Name, Spec: v.Spec.Template, Type: setting.Deployment, Images: wrapper.Deployment(v).ImageInfos(), Ready: wrapper.Deployment(v).Ready()})
 	}
-	statefulSets, err := getter.ListStatefulSets(namespace, nil, kubeClient)
+	statefulSets, err := getter.ListStatefulSetsWithCache(nil, informer)
 	if err != nil {
 		log.Errorf("[%s][%s] create product record error: %v", envName, namespace, err)
 		return 0, resp, e.ErrListGroups.AddDesc(err.Error())
@@ -268,15 +269,14 @@ func ListWorkloads(envName, clusterID, namespace, productName string, perPage, p
 	}
 
 	hostInfos := make([]resource.HostInfo, 0)
-	// get all ingresses
-	if ingresses, err := getter.ListIngresses(namespace, nil, kubeClient); err == nil {
+	if ingresses, err := getter.ListIngresses(nil, informer); err == nil {
 		for _, ingress := range ingresses {
 			hostInfos = append(hostInfos, wrapper.Ingress(ingress).HostInfo()...)
 		}
 	}
 
 	// get all services
-	allServices, err := getter.ListServices(namespace, nil, kubeClient)
+	allServices, err := getter.ListServicesWithCache(nil, informer)
 	if err != nil {
 		log.Errorf("[%s][%s] list service error: %s", envName, namespace, err)
 	}

--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -269,10 +269,13 @@ func ListWorkloads(envName, clusterID, namespace, productName string, perPage, p
 	}
 
 	hostInfos := make([]resource.HostInfo, 0)
-	if ingresses, err := getter.ListIngresses(nil, informer); err == nil {
+	ingresses, err := getter.ListIngresses(nil, informer)
+	if err == nil {
 		for _, ingress := range ingresses {
 			hostInfos = append(hostInfos, wrapper.Ingress(ingress).HostInfo()...)
 		}
+	} else {
+		log.Warnf("Failed to list ingresses, the error is: %s", err)
 	}
 
 	// get all services

--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -223,7 +223,11 @@ func ListWorkloads(envName, clusterID, namespace, productName string, perPage, p
 		log.Errorf("[%s][%s] error: %v", envName, namespace, err)
 		return 0, resp, e.ErrListGroups.AddDesc(err.Error())
 	}
-	informer := informer.NewInformer(clusterID, namespace, cls)
+	informer, err := informer.NewInformer(clusterID, namespace, cls)
+	if err != nil {
+		log.Errorf("[%s][%s] error: %v", envName, namespace, err)
+		return 0, resp, e.ErrListGroups.AddDesc(err.Error())
+	}
 	var workLoads []*Workload
 	listDeployments, err := getter.ListDeploymentsWithCache(nil, informer)
 	if err != nil {

--- a/pkg/microservice/aslan/core/common/service/kube/status.go
+++ b/pkg/microservice/aslan/core/common/service/kube/status.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/informers"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/koderover/zadig/pkg/setting"
@@ -31,6 +32,49 @@ import (
 // TODO: improve this function
 func GetSelectedPodsInfo(ns string, selector labels.Selector, kubeClient client.Client, log *zap.SugaredLogger) (string, string, []string) {
 	pods, err := getter.ListPods(ns, selector, kubeClient)
+	if err != nil {
+		return setting.PodError, setting.PodNotReady, nil
+	}
+
+	if len(pods) == 0 {
+		return setting.PodNonStarted, setting.PodNotReady, nil
+	}
+
+	imageSet := sets.String{}
+	for _, pod := range pods {
+		ipod := wrapper.Pod(pod)
+		imageSet.Insert(ipod.Containers()...)
+	}
+	images := imageSet.List()
+
+	ready := setting.PodReady
+
+	succeededPods := 0
+	for _, pod := range pods {
+		iPod := wrapper.Pod(pod)
+
+		// skip if pod is a succeeded job
+		if iPod.Succeeded() {
+			succeededPods++
+			continue
+		}
+
+		// 如果服务中任意一个pod不在running状态，返回unstable
+		if !iPod.Ready() {
+			return setting.PodUnstable, setting.PodNotReady, images
+		}
+	}
+
+	// return "Succeeded, Completed" if all pods are succeeded Job pods
+	if len(pods) == succeededPods {
+		return string(corev1.PodSucceeded), setting.JobReady, images
+	}
+
+	return setting.PodRunning, ready, images
+}
+
+func GetSelectedPodsInfoWithCache(selector labels.Selector, informer informers.SharedInformerFactory, log *zap.SugaredLogger) (string, string, []string) {
+	pods, err := getter.ListPodsWithCache(selector, informer)
 	if err != nil {
 		return setting.PodError, setting.PodNotReady, nil
 	}

--- a/pkg/microservice/aslan/core/common/service/product.go
+++ b/pkg/microservice/aslan/core/common/service/product.go
@@ -36,6 +36,7 @@ import (
 	kubeclient "github.com/koderover/zadig/pkg/shared/kube/client"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 	helmtool "github.com/koderover/zadig/pkg/tool/helmclient"
+	"github.com/koderover/zadig/pkg/tool/kube/informer"
 	"github.com/koderover/zadig/pkg/tool/kube/updater"
 )
 
@@ -50,6 +51,9 @@ func DeleteProduct(username, envName, productName, requestID string, log *zap.Su
 		log.Errorf("find product error: %v", err)
 		return e.ErrDeleteEnv.AddDesc("not found")
 	}
+
+	// delete informer's cache
+	informer.DeleteInformer(productInfo.ClusterID, productInfo.Namespace)
 
 	kubeClient, err := kubeclient.GetKubeClient(config.HubServerAddress(), productInfo.ClusterID)
 	if err != nil {

--- a/pkg/microservice/aslan/core/environment/service/env.go
+++ b/pkg/microservice/aslan/core/environment/service/env.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"go.uber.org/zap"
+	"k8s.io/client-go/informers"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
@@ -27,9 +28,9 @@ import (
 
 type envHandle interface {
 	createGroup(envName, productName, username string, group []*commonmodels.ProductService, renderSet *commonmodels.RenderSet, kubeClient client.Client) error
-	listGroupServices(allServices []*commonmodels.ProductService, envName, productName string, kubeClient client.Client, productInfo *commonmodels.Product) []*commonservice.ServiceResp
+	listGroupServices(allServices []*commonmodels.ProductService, envName, productName string, informer informers.SharedInformerFactory, productInfo *commonmodels.Product) []*commonservice.ServiceResp
 	updateService(args *SvcOptArgs) error
-	queryServiceStatus(namespace, envName, productName string, serviceTmpl *commonmodels.Service, kubeClient client.Client) (string, string, []string)
+	queryServiceStatus(namespace, envName, productName string, serviceTmpl *commonmodels.Service, kubeClient informers.SharedInformerFactory) (string, string, []string)
 }
 
 func envHandleFunc(projectType string, log *zap.SugaredLogger) envHandle {

--- a/pkg/microservice/aslan/core/environment/service/environment_group.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_group.go
@@ -74,7 +74,11 @@ func ListGroups(serviceName, envName, productName string, perPage, page int, log
 		log.Errorf("[%s][%s] error: %v", envName, productName, err)
 		return resp, count, e.ErrListGroups.AddDesc(err.Error())
 	}
-	inf := informer.NewInformer(productInfo.ClusterID, productInfo.Namespace, cls)
+	inf, err := informer.NewInformer(productInfo.ClusterID, productInfo.Namespace, cls)
+	if err != nil {
+		log.Errorf("[%s][%s] error: %v", envName, productName, err)
+		return resp, count, e.ErrListGroups.AddDesc(err.Error())
+	}
 
 	//这种针对的是获取所有数据的接口，内部调用
 	if page == 0 && perPage == 0 {

--- a/pkg/microservice/aslan/core/environment/service/environment_group.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_group.go
@@ -22,7 +22,7 @@ import (
 
 	"go.uber.org/zap"
 	"helm.sh/helm/v3/pkg/releaseutil"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/client-go/informers"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
@@ -35,6 +35,7 @@ import (
 	"github.com/koderover/zadig/pkg/shared/kube/wrapper"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 	"github.com/koderover/zadig/pkg/tool/kube/getter"
+	"github.com/koderover/zadig/pkg/tool/kube/informer"
 	"github.com/koderover/zadig/pkg/tool/kube/serializer"
 	"github.com/koderover/zadig/pkg/util"
 )
@@ -68,22 +69,23 @@ func ListGroups(serviceName, envName, productName string, perPage, page int, log
 	//将获取到的所有服务按照名称进行排序
 	sort.SliceStable(allServices, func(i, j int) bool { return allServices[i].ServiceName < allServices[j].ServiceName })
 
-	kubeClient, err := kubeclient.GetKubeClient(config.HubServerAddress(), productInfo.ClusterID)
+	cls, err := kubeclient.GetKubeClientSet(config.HubServerAddress(), productInfo.ClusterID)
 	if err != nil {
 		log.Errorf("[%s][%s] error: %v", envName, productName, err)
 		return resp, count, e.ErrListGroups.AddDesc(err.Error())
 	}
+	inf := informer.NewInformer(productInfo.ClusterID, productInfo.Namespace, cls)
 
 	//这种针对的是获取所有数据的接口，内部调用
 	if page == 0 && perPage == 0 {
-		resp = envHandleFunc(getProjectType(productName), log).listGroupServices(allServices, envName, productName, kubeClient, productInfo)
+		resp = envHandleFunc(getProjectType(productName), log).listGroupServices(allServices, envName, productName, inf, productInfo)
 		return resp, count, nil
 	}
 
 	//针对获取环境状态的接口请求，这里不需要一次性获取所有的服务，先获取十条的数据，有异常的可以直接返回，不需要继续往下获取
 	if page == -1 && perPage == -1 {
 		// 获取环境的状态
-		resp = listGroupServiceStatus(allServices, envName, productName, kubeClient, productInfo, log)
+		resp = listGroupServiceStatus(allServices, envName, productName, inf, productInfo, log)
 		return resp, count, nil
 	}
 
@@ -96,11 +98,11 @@ func ListGroups(serviceName, envName, productName string, perPage, page int, log
 		}
 		currentServices = allServices[currentPage*perPage:]
 	}
-	resp = envHandleFunc(getProjectType(productName), log).listGroupServices(currentServices, envName, productName, kubeClient, productInfo)
+	resp = envHandleFunc(getProjectType(productName), log).listGroupServices(currentServices, envName, productName, inf, productInfo)
 	return resp, count, nil
 }
 
-func listGroupServiceStatus(allServices []*commonmodels.ProductService, envName, productName string, kubeClient client.Client, productInfo *commonmodels.Product, log *zap.SugaredLogger) []*commonservice.ServiceResp {
+func listGroupServiceStatus(allServices []*commonmodels.ProductService, envName, productName string, informer informers.SharedInformerFactory, productInfo *commonmodels.Product, log *zap.SugaredLogger) []*commonservice.ServiceResp {
 	var (
 		count           = len(allServices)
 		currentServices = make([]*commonmodels.ProductService, 0)
@@ -113,7 +115,7 @@ func listGroupServiceStatus(allServices []*commonmodels.ProductService, envName,
 		} else {
 			currentServices = allServices[page*perPage:]
 		}
-		resp = envHandleFunc(getProjectType(productName), log).listGroupServices(currentServices, envName, productName, kubeClient, productInfo)
+		resp = envHandleFunc(getProjectType(productName), log).listGroupServices(currentServices, envName, productName, informer, productInfo)
 		allRunning := true
 		for _, serviceResp := range resp {
 			// Service是物理机部署时，无需判断状态

--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -25,6 +25,7 @@ import (
 	"helm.sh/helm/v3/pkg/releaseutil"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
@@ -444,7 +445,7 @@ func RestartService(envName string, args *SvcOptArgs, log *zap.SugaredLogger) (e
 	return nil
 }
 
-func queryPodsStatus(namespace, productName, serviceName string, kubeClient client.Client, log *zap.SugaredLogger) (string, string, []string) {
+func queryPodsStatus(namespace, productName, serviceName string, informer informers.SharedInformerFactory, log *zap.SugaredLogger) (string, string, []string) {
 	ls := labels.Set{}
 	if productName != "" {
 		ls[setting.ProductLabel] = productName
@@ -452,7 +453,7 @@ func queryPodsStatus(namespace, productName, serviceName string, kubeClient clie
 	if serviceName != "" {
 		ls[setting.ServiceLabel] = serviceName
 	}
-	return kube.GetSelectedPodsInfo(namespace, ls.AsSelector(), kubeClient, log)
+	return kube.GetSelectedPodsInfoWithCache(ls.AsSelector(), informer, log)
 }
 
 // validateServiceContainer validate container with envName like dev

--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -453,7 +453,7 @@ func queryPodsStatus(namespace, productName, serviceName string, informer inform
 	if serviceName != "" {
 		ls[setting.ServiceLabel] = serviceName
 	}
-	return kube.GetSelectedPodsInfoWithCache(ls.AsSelector(), informer, log)
+	return kube.GetSelectedPodsInfo(ls.AsSelector(), informer, log)
 }
 
 // validateServiceContainer validate container with envName like dev

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -608,3 +608,7 @@ const UpdateEnvTimeout = 60 * 5 * time.Second
 const (
 	ListNamespaceTypeCreate = "create"
 )
+
+const (
+	InformerNamingConvention = "%s-%s"
+)

--- a/pkg/shared/kube/client/client.go
+++ b/pkg/shared/kube/client/client.go
@@ -33,6 +33,14 @@ func GetKubeClient(hubServerAddr, clusterID string) (client.Client, error) {
 	return multicluster.GetKubeClient(hubServerAddr, clusterID)
 }
 
+func GetKubeClientSet(hubServerAddr, clusterID string) (*kubernetes.Clientset, error) {
+	if clusterID == setting.LocalClusterID {
+		clusterID = ""
+	}
+
+	return multicluster.GetKubeClientSet(hubServerAddr, clusterID)
+}
+
 func GetKubeAPIReader(hubServerAddr, clusterID string) (client.Reader, error) {
 	if clusterID == setting.LocalClusterID {
 		clusterID = ""

--- a/pkg/tool/kube/client/cluster.go
+++ b/pkg/tool/kube/client/cluster.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -34,6 +35,7 @@ import (
 var once sync.Once
 
 var c cluster.Cluster
+var k *kubernetes.Clientset
 
 // Cluster is a singleton, it will be initialized only once.
 func Cluster() cluster.Cluster {
@@ -46,6 +48,21 @@ func Cluster() cluster.Cluster {
 	})
 
 	return c
+}
+
+func NewClientSet() *kubernetes.Clientset {
+	if k != nil {
+		return k
+	}
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		panic(err)
+	}
+	k, err = kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err)
+	}
+	return k
 }
 
 func Client() client.Client {

--- a/pkg/tool/kube/client/cluster.go
+++ b/pkg/tool/kube/client/cluster.go
@@ -35,7 +35,6 @@ import (
 var once sync.Once
 
 var c cluster.Cluster
-var k *kubernetes.Clientset
 
 // Cluster is a singleton, it will be initialized only once.
 func Cluster() cluster.Cluster {
@@ -50,19 +49,16 @@ func Cluster() cluster.Cluster {
 	return c
 }
 
-func NewClientSet() *kubernetes.Clientset {
-	if k != nil {
-		return k
-	}
+func NewClientSet() (*kubernetes.Clientset, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	k, err = kubernetes.NewForConfig(config)
+	k, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return k
+	return k, nil
 }
 
 func Client() client.Client {

--- a/pkg/tool/kube/client/cluster.go
+++ b/pkg/tool/kube/client/cluster.go
@@ -54,11 +54,7 @@ func NewClientSet() (*kubernetes.Clientset, error) {
 	if err != nil {
 		return nil, err
 	}
-	k, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	return k, nil
+	return kubernetes.NewForConfig(config)
 }
 
 func Client() client.Client {

--- a/pkg/tool/kube/getter/deployment.go
+++ b/pkg/tool/kube/getter/deployment.go
@@ -20,6 +20,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -45,6 +46,13 @@ func ListDeployments(ns string, selector labels.Selector, cl client.Client) ([]*
 		res = append(res, &ss.Items[i])
 	}
 	return res, err
+}
+
+func ListDeploymentsWithCache(selector labels.Selector, lister informers.SharedInformerFactory) ([]*appsv1.Deployment, error) {
+	if selector == nil {
+		selector = labels.NewSelector()
+	}
+	return lister.Apps().V1().Deployments().Lister().List(selector)
 }
 
 func ListDeploymentsYaml(ns string, selector labels.Selector, cl client.Client) ([][]byte, error) {

--- a/pkg/tool/kube/getter/pod.go
+++ b/pkg/tool/kube/getter/pod.go
@@ -19,6 +19,7 @@ package getter
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -44,4 +45,12 @@ func ListPods(ns string, selector labels.Selector, cl client.Client) ([]*corev1.
 		res = append(res, &ps.Items[i])
 	}
 	return res, err
+}
+
+func ListPodsWithCache(selector labels.Selector, informer informers.SharedInformerFactory) ([]*corev1.Pod, error) {
+	if selector == nil {
+		selector = labels.NewSelector()
+	}
+
+	return informer.Core().V1().Pods().Lister().List(selector)
 }

--- a/pkg/tool/kube/getter/service.go
+++ b/pkg/tool/kube/getter/service.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -45,6 +46,13 @@ func ListServices(ns string, selector labels.Selector, cl client.Client) ([]*cor
 		res = append(res, &ss.Items[i])
 	}
 	return res, err
+}
+
+func ListServicesWithCache(selector labels.Selector, lister informers.SharedInformerFactory) ([]*corev1.Service, error) {
+	if selector == nil {
+		selector = labels.NewSelector()
+	}
+	return lister.Core().V1().Services().Lister().List(selector)
 }
 
 func ListServicesYaml(ns string, selector labels.Selector, cl client.Client) ([][]byte, error) {

--- a/pkg/tool/kube/getter/statefulset.go
+++ b/pkg/tool/kube/getter/statefulset.go
@@ -20,6 +20,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -45,6 +46,13 @@ func ListStatefulSets(ns string, selector labels.Selector, cl client.Client) ([]
 		res = append(res, &ss.Items[i])
 	}
 	return res, err
+}
+
+func ListStatefulSetsWithCache(selector labels.Selector, lister informers.SharedInformerFactory) ([]*appsv1.StatefulSet, error) {
+	if selector == nil {
+		selector = labels.NewSelector()
+	}
+	return lister.Apps().V1().StatefulSets().Lister().List(selector)
 }
 
 func ListStatefulSetsYaml(ns string, selector labels.Selector, cl client.Client) ([][]byte, error) {

--- a/pkg/tool/kube/informer/informer.go
+++ b/pkg/tool/kube/informer/informer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The KodeRover Authors.
+Copyright 2022 The KodeRover Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/tool/kube/informer/informer.go
+++ b/pkg/tool/kube/informer/informer.go
@@ -1,0 +1,48 @@
+package informer
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/koderover/zadig/pkg/setting"
+)
+
+var InformersMap sync.Map
+
+// NewInformer initialize and start an informer for specific namespace in given cluster.
+// Currently the informer will NOT stop unless the service is down
+// If you want to watch a new resource, remember to register here
+// Current list:
+// - Deployment
+// - StatefulSet
+// - Service
+// - Pod
+// - Ingress (extentions/v1beta1) <- as of version 1.9.0, this is the resource we watch
+func NewInformer(clusterID, namespace string, cls *kubernetes.Clientset) informers.SharedInformerFactory {
+	// this is a stupid compatibility code
+	if clusterID == "" {
+		clusterID = setting.LocalClusterID
+	}
+	key := fmt.Sprintf("%s-%s", clusterID, namespace)
+	if informer, ok := InformersMap.Load(key); ok {
+		return informer.(informers.SharedInformerFactory)
+	}
+	opts := informers.WithNamespace(namespace)
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(cls, time.Minute, opts)
+	// register the resources to be watched
+	informerFactory.Apps().V1().Deployments().Lister()
+	informerFactory.Apps().V1().StatefulSets().Lister()
+	informerFactory.Core().V1().Services().Lister()
+	informerFactory.Core().V1().Pods().Lister()
+	informerFactory.Extensions().V1beta1().Ingresses().Lister()
+	// Never stops unless the pod is killed
+	informerFactory.Start(make(<-chan struct{}))
+	// wait for the cache to be synced for the first time
+	informerFactory.WaitForCacheSync(make(<-chan struct{}))
+	InformersMap.Store(key, informerFactory)
+	return informerFactory
+}

--- a/pkg/tool/kube/multicluster/service.go
+++ b/pkg/tool/kube/multicluster/service.go
@@ -44,6 +44,19 @@ func GetKubeClient(hubServerAddr, clusterID string) (client.Client, error) {
 	return clusterService.GetKubeClient(clusterID)
 }
 
+func GetKubeClientSet(hubServerAddr, clusterID string) (*kubernetes.Clientset, error) {
+	if clusterID == "" {
+		return krkubeclient.NewClientSet(), nil
+	}
+
+	clusterService, err := NewAgent(hubServerAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get clusterService: %v", err)
+	}
+
+	return clusterService.GetClientGoKubeClient(clusterID)
+}
+
 func GetKubeAPIReader(hubServerAddr, clusterID string) (client.Reader, error) {
 	if clusterID == "" {
 		return krkubeclient.APIReader(), nil
@@ -126,6 +139,15 @@ func (s *Agent) GetKubeClient(clusterID string) (client.Client, error) {
 	return krkubeclient.NewClientFromAPIConfig(generateAPIConfig(clusterID, s.hubServerAddr))
 }
 
+func (s *Agent) GetClientGoKubeClient(clusterID string) (*kubernetes.Clientset, error) {
+	config := generateRestConfig(clusterID, s.hubServerAddr)
+	cl, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return cl, nil
+}
+
 func (s *Agent) ClusterConnected(clusterID string) bool {
 	if err := s.hubClient.HasSession(clusterID); err != nil {
 		return false
@@ -162,5 +184,14 @@ func generateAPIConfig(clusterID, hubServerAddr string) *api.Config {
 			},
 		},
 		CurrentContext: "hubserver",
+	}
+}
+
+func generateRestConfig(clusterID, hubServerAddr string) *rest.Config {
+	return &rest.Config{
+		Host: fmt.Sprintf("%s/kube/%s", hubServerAddr, clusterID),
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: true,
+		},
 	}
 }

--- a/pkg/tool/kube/multicluster/service.go
+++ b/pkg/tool/kube/multicluster/service.go
@@ -46,7 +46,7 @@ func GetKubeClient(hubServerAddr, clusterID string) (client.Client, error) {
 
 func GetKubeClientSet(hubServerAddr, clusterID string) (*kubernetes.Clientset, error) {
 	if clusterID == "" {
-		return krkubeclient.NewClientSet(), nil
+		return krkubeclient.NewClientSet()
 	}
 
 	clusterService, err := NewAgent(hubServerAddr)
@@ -141,11 +141,7 @@ func (s *Agent) GetKubeClient(clusterID string) (client.Client, error) {
 
 func (s *Agent) GetClientGoKubeClient(clusterID string) (*kubernetes.Clientset, error) {
 	config := generateRestConfig(clusterID, s.hubServerAddr)
-	cl, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	return cl, nil
+	return kubernetes.NewForConfig(config)
 }
 
 func (s *Agent) ClusterConnected(clusterID string) bool {

--- a/pkg/tool/remotedialer/session.go
+++ b/pkg/tool/remotedialer/session.go
@@ -127,6 +127,7 @@ func (s *Session) Serve(ctx context.Context) (int, error) {
 
 	for {
 		msType, reader, err := s.conn.NextReader()
+		s.conn.conn.ReadMessage()
 		if err != nil {
 			return 400, err
 		}

--- a/pkg/tool/remotedialer/session.go
+++ b/pkg/tool/remotedialer/session.go
@@ -127,7 +127,6 @@ func (s *Session) Serve(ctx context.Context) (int, error) {
 
 	for {
 		msType, reader, err := s.conn.NextReader()
-		s.conn.conn.ReadMessage()
 		if err != nil {
 			return 400, err
 		}


### PR DESCRIPTION
Signed-off-by: Min Min <minmin@koderover.com>

### What this PR does / Why we need it:
Currently the multi cluster reponse time is very long since we are calling the API server every time we make a request.
This PR improves the response the time of multiple environment APIs.

### What is changed and how it works?
I switch the API server request from controller runtime's direct request to the client-go's informer request, making this much faster than before.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
