### PR TITLE
Bugfix/helm version hook

### DIFF
--- a/pkg/microservice/aslan/core/delivery/service/version.go
+++ b/pkg/microservice/aslan/core/delivery/service/version.go
@@ -1097,7 +1097,7 @@ func sendVersionDeliveryHook(deliveryVersion *commonmodels.DeliveryVersion, host
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("hook request send to url: %s got error code : %d", targetPath, resp.StatusCode)
+		return fmt.Errorf("hook request send to url: %s got error resp code : %d", targetPath, resp.StatusCode)
 	}
 
 	return nil
@@ -1112,7 +1112,7 @@ func updateVersionStatus(versionName, projectName, status, errStr string) {
 			Version:     versionName,
 		})
 		if err != nil {
-			log.Errorf("failed to find version: %s of project %s", versionName, projectName)
+			log.Errorf("failed to find version: %s of project %s, err: %s", versionName, projectName, err)
 			return
 		}
 		if versionInfo.Status == status {


### PR DESCRIPTION
### What this PR does / Why we need it:
the hook url used to notify when delivery version finished doesn't support url parameters 

### What is changed and how it works?
add support of url parameters for delivery hook urls

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
