### PR TITLE
helm service add webhook

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/service.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/service.go
@@ -37,15 +37,16 @@ import (
 )
 
 type ServiceFindOption struct {
-	ServiceName   string
-	Revision      int64
-	Type          string
-	Source        string
-	ProductName   string
-	ExcludeStatus string
-	CodehostID    int
-	RepoName      string
-	BranchName    string
+	ServiceName         string
+	Revision            int64
+	Type                string
+	Source              string
+	ProductName         string
+	ExcludeStatus       string
+	CodehostID          int
+	RepoName            string
+	BranchName          string
+	IgnoreNoDocumentErr bool
 }
 
 type ServiceListOption struct {
@@ -206,6 +207,9 @@ func (c *ServiceColl) Find(opt *ServiceFindOption) (*models.Service, error) {
 
 	err := c.FindOne(context.TODO(), query, opts).Decode(service)
 	if err != nil {
+		if err == mongo.ErrNoDocuments && opt.IgnoreNoDocumentErr {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/pkg/microservice/aslan/core/workflow/service/webhook/github.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github.go
@@ -429,14 +429,11 @@ func ProcessGithubWebHook(payload []byte, req *http.Request, requestID string, l
 		return err
 	}
 
-	//go collie.CallGithubWebHook(forwardedProto, forwardedHost, payload, github.WebHookType(req), log)
-
 	deliveryID := github.DeliveryID(req)
 	log.Infof("[Webhook] event: %s delivery id: %s received", hookType, deliveryID)
 
 	switch et := event.(type) {
 	case *github.PullRequestEvent:
-		log.Infof("###### the PullRequestEvent is %+v", *et)
 		if *et.Action != "opened" && *et.Action != "synchronize" {
 			return nil
 		}
@@ -595,7 +592,6 @@ func updateServiceTemplateByGithubPush(pushEvent *github.PushEvent, log *zap.Sug
 
 func GetGithubServiceTemplates() ([]*commonmodels.Service, error) {
 	opt := &commonrepo.ServiceListOption{
-		//Type:   setting.K8SDeployType,
 		Source: setting.SourceFromGithub,
 	}
 	return commonrepo.NewServiceColl().ListMaxRevisions(opt)

--- a/pkg/microservice/aslan/core/workflow/service/webhook/github.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github.go
@@ -33,7 +33,6 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
-	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/collie"
 	gitservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/git"
 	workflowservice "github.com/koderover/zadig/pkg/microservice/aslan/core/workflow/service/workflow"
 	"github.com/koderover/zadig/pkg/setting"
@@ -430,13 +429,14 @@ func ProcessGithubWebHook(payload []byte, req *http.Request, requestID string, l
 		return err
 	}
 
-	go collie.CallGithubWebHook(forwardedProto, forwardedHost, payload, github.WebHookType(req), log)
+	//go collie.CallGithubWebHook(forwardedProto, forwardedHost, payload, github.WebHookType(req), log)
 
 	deliveryID := github.DeliveryID(req)
 	log.Infof("[Webhook] event: %s delivery id: %s received", hookType, deliveryID)
 
 	switch et := event.(type) {
 	case *github.PullRequestEvent:
+		log.Infof("###### the PullRequestEvent is %+v", *et)
 		if *et.Action != "opened" && *et.Action != "synchronize" {
 			return nil
 		}
@@ -448,11 +448,9 @@ func ProcessGithubWebHook(payload []byte, req *http.Request, requestID string, l
 		}
 
 	case *github.PushEvent:
-		//触发更新服务模板webhook
-		if pushEvent, isPush := event.(*github.PushEvent); isPush {
-			if err = updateServiceTemplateByGithubPush(pushEvent, log); err != nil {
-				log.Errorf("updateServiceTemplateByGithubPush failed, error:%v", err)
-			}
+		// sync service template
+		if err = updateServiceTemplateByGithubPush(et, log); err != nil {
+			log.Errorf("updateServiceTemplateByGithubPush failed, error:%v", err)
 		}
 
 		//add webhook user
@@ -597,7 +595,7 @@ func updateServiceTemplateByGithubPush(pushEvent *github.PushEvent, log *zap.Sug
 
 func GetGithubServiceTemplates() ([]*commonmodels.Service, error) {
 	opt := &commonrepo.ServiceListOption{
-		Type:   setting.K8SDeployType,
+		//Type:   setting.K8SDeployType,
 		Source: setting.SourceFromGithub,
 	}
 	return commonrepo.NewServiceColl().ListMaxRevisions(opt)

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab.go
@@ -332,7 +332,7 @@ func updateServiceTemplateByPushEvent(event *EventPush, log *zap.SugaredLogger) 
 
 func GetGitlabServiceTemplates() ([]*commonmodels.Service, error) {
 	opt := &commonrepo.ServiceListOption{
-		Type:   setting.K8SDeployType,
+		//Type:   setting.K8SDeployType,
 		Source: setting.SourceFromGitlab,
 	}
 	return commonrepo.NewServiceColl().ListMaxRevisions(opt)

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab.go
@@ -332,7 +332,6 @@ func updateServiceTemplateByPushEvent(event *EventPush, log *zap.SugaredLogger) 
 
 func GetGitlabServiceTemplates() ([]*commonmodels.Service, error) {
 	opt := &commonrepo.ServiceListOption{
-		//Type:   setting.K8SDeployType,
 		Source: setting.SourceFromGitlab,
 	}
 	return commonrepo.NewServiceColl().ListMaxRevisions(opt)

--- a/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
@@ -149,7 +149,6 @@ func fillServiceTmpl(userName string, args *commonmodels.Service, log *zap.Sugar
 		if err := setCurrentContainerImages(args); err != nil {
 			return err
 		}
-
 		log.Infof("find %d containers in service %s", len(args.Containers), args.ServiceName)
 	} else if args.Type == setting.HelmDeployType {
 		if args.Source == setting.SourceFromGitlab {
@@ -163,7 +162,6 @@ func fillServiceTmpl(userName string, args *commonmodels.Service, log *zap.Sugar
 				log.Errorf("Sync content from gitlab failed, error: %s", err)
 				return err
 			}
-
 		} else if args.Source == setting.SourceFromGithub {
 			if err := reloadServiceTmplFromGit(args, log); err != nil {
 				log.Errorf("Sync content from github failed, error: %s", err)


### PR DESCRIPTION
### What this PR does / Why we need it:
helm service imported from git repo will not be updated automatically when service files update on remote repo

### What is changed and how it works?
add webhook trigger to receive change events from remote repo, and the update service

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
