### PR TITLE
local cluster add schedule strategy

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/service.go
+++ b/pkg/microservice/aslan/core/common/service/kube/service.go
@@ -106,6 +106,9 @@ func (s *Service) CreateCluster(cluster *models.K8SCluster, id string, logger *z
 	if id == setting.LocalClusterID {
 		cluster.Status = setting.Normal
 		cluster.Local = true
+		cluster.AdvancedConfig = &commonmodels.AdvancedConfig{
+			Strategy: "normal",
+		}
 	}
 	err = s.coll.Create(cluster, id)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: liu deyi <andrew@koderover.com>

### What this PR does / Why we need it:
1. Add scheduling policy when local cluster is initialized
