### PR TITLE
set default history max parameter

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2304,6 +2304,7 @@ func installOrUpgradeHelmChartWithValues(namespace, valuesYaml string, renderCha
 		ValuesYaml:    valuesYaml,
 		UpgradeCRDs:   true,
 		CleanupOnFail: true,
+		MaxHistory:    10,
 	}
 	if isRetry {
 		chartSpec.Replace = true

--- a/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
@@ -568,6 +568,7 @@ func (p *DeployTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, _ *
 			Timeout:     time.Second * setting.DeployTimeout,
 			Wait:        true,
 			Replace:     true,
+			MaxHistory:  10,
 		}
 
 		done := make(chan bool)


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
the current history-max parameter is set to 0 when upgrading helm release, which means all history revision of helm release will be saved in namespace as secrets, this may cause a huge amount of secrets and will have effects on normal helm operation(list/upgrade).

### What is changed and how it works?
set parameter history-max to 10 explicitly to keep same with default values used by helm cli.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
