### PR TITLE
protection when pre_build.cluster_id and pre_test.cluster_id is empty

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
@@ -664,6 +664,13 @@ func TestArgsToTestSubtask(args *commonmodels.TestTaskArgs, pt *task.Task, log *
 
 			testArg.TestModuleName = args.TestName
 
+			// In some old testing configurations, the `pre_test.cluster_id` field is empty indicating that's a local cluster.
+			// We do a protection here to avoid query failure.
+			// Resaving the testing configuration after v1.8.0 will automatically populate this field.
+			if testing.PreTest.ClusterID == "" {
+				testing.PreTest.ClusterID = setting.LocalClusterID
+			}
+
 			clusterInfo, err := commonrepo.NewK8SClusterColl().Get(testing.PreTest.ClusterID)
 			if err != nil {
 				return resp, e.ErrListTestModule.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -1852,6 +1852,13 @@ func BuildModuleToSubTasks(args *commonmodels.BuildModuleArgs, log *zap.SugaredL
 			ClusterID:    module.PreBuild.ClusterID,
 		}
 
+		// In some old build configurations, the `pre_build.cluster_id` field is empty indicating that's a local cluster.
+		// We do a protection here to avoid query failure.
+		// Resaving the build configuration after v1.8.0 will automatically populate this field.
+		if module.PreBuild.ClusterID == "" {
+			module.PreBuild.ClusterID = setting.LocalClusterID
+		}
+
 		clusterInfo, err := commonrepo.NewK8SClusterColl().Get(module.PreBuild.ClusterID)
 		if err != nil {
 			return nil, e.ErrConvertSubTasks.AddErr(err)


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

In some old build/test configurations, the `pre_build.cluster_id` / `pre_test.cluster_id` field is empty indicating that's a local cluster.
In the current version, if this field is empty, it will cause the build / test to fail. 

Resaving the build / test configuration after `v1.8.0` will automatically populate this field or we do a protection here.

### What is changed and how it works?

If `pre_build.cluster_id` / `pre_test.cluster_id` field is empty, set it to ID of local cluster explicitly.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
