### PR TITLE
fix bug of scheduling build/test tasks

### DIFF
--- a/pkg/microservice/aslan/core/log/service/sse.go
+++ b/pkg/microservice/aslan/core/log/service/sse.go
@@ -140,9 +140,15 @@ func TaskContainerLogStream(ctx context.Context, streamChan chan interface{}, op
 			})
 		}
 		// Compatible with the situation where the old data has not been modified
-		if build != nil && build.PreBuild != nil && build.PreBuild.ClusterID != "" && build.PreBuild.Namespace != "" {
+		if build != nil && build.PreBuild != nil && build.PreBuild.ClusterID != "" {
 			options.ClusterID = build.PreBuild.ClusterID
-			options.Namespace = build.PreBuild.Namespace
+
+			switch build.PreBuild.ClusterID {
+			case setting.LocalClusterID:
+				options.Namespace = config.Namespace()
+			default:
+				options.Namespace = setting.AttachedClusterNamespace
+			}
 		}
 	}
 
@@ -159,9 +165,15 @@ func TestJobContainerLogStream(ctx context.Context, streamChan chan interface{},
 	// get cluster ID
 	testing, _ := commonrepo.NewTestingColl().Find(getTestName(options.ServiceName), "")
 	// Compatible with the situation where the old data has not been modified
-	if testing != nil && testing.PreTest != nil && testing.PreTest.ClusterID != "" && testing.PreTest.Namespace != "" {
+	if testing != nil && testing.PreTest != nil && testing.PreTest.ClusterID != "" {
 		options.ClusterID = testing.PreTest.ClusterID
-		options.Namespace = testing.PreTest.Namespace
+
+		switch testing.PreTest.ClusterID {
+		case setting.LocalClusterID:
+			options.Namespace = config.Namespace()
+		default:
+			options.Namespace = setting.AttachedClusterNamespace
+		}
 	}
 
 	waitAndGetLog(ctx, streamChan, selector, options, log)

--- a/pkg/microservice/aslan/core/multicluster/service/cache.go
+++ b/pkg/microservice/aslan/core/multicluster/service/cache.go
@@ -47,7 +47,7 @@ func ListStorageClasses(ctx context.Context, clusterID string) ([]string, error)
 		// For cluster-level resources, we need to explicitly configure the namespace to be empty.
 		namespace = ""
 	default:
-		namespace = AttachedClusterNamespace
+		namespace = setting.AttachedClusterNamespace
 	}
 
 	scList := &storagev1.StorageClassList{}
@@ -80,8 +80,8 @@ func ListPVCs(ctx context.Context, clusterID, namespace string) ([]PVC, error) {
 		// For now caller may not know exactly which namespace Zadig is deployed to, so a correction is made here.
 		namespace = config.Namespace()
 	default:
-		if namespace != AttachedClusterNamespace {
-			return nil, fmt.Errorf("invalid namespace in attached cluster: %s. Valid: %s", namespace, AttachedClusterNamespace)
+		if namespace != setting.AttachedClusterNamespace {
+			return nil, fmt.Errorf("invalid namespace in attached cluster: %s. Valid: %s", namespace, setting.AttachedClusterNamespace)
 		}
 	}
 

--- a/pkg/microservice/aslan/core/multicluster/service/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/service/clusters.go
@@ -257,7 +257,7 @@ func UpdateCluster(id string, args *K8SCluster, logger *zap.SugaredLogger) (*com
 		case setting.LocalClusterID:
 			namespace = config.Namespace()
 		default:
-			namespace = AttachedClusterNamespace
+			namespace = setting.AttachedClusterNamespace
 		}
 
 		pvcName := fmt.Sprintf("cache-%s-%d", args.Cache.NFSProperties.StorageClass, args.Cache.NFSProperties.StorageSizeInGiB)

--- a/pkg/microservice/aslan/core/multicluster/service/constants.go
+++ b/pkg/microservice/aslan/core/multicluster/service/constants.go
@@ -18,10 +18,6 @@ package service
 
 import "strings"
 
-// AttachedClusterNamespace is the namespace Zadig uses in attached cluster.
-// Note: **Restricted because of product design since v1.9.0**.
-const AttachedClusterNamespace = "koderover-agent"
-
 // StorageProvisioner is a storage type
 type StorageProvisioner string
 

--- a/pkg/microservice/warpdrive/core/service/taskplugin/build.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/build.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	zadigconfig "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/config"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/types/task"
 	"github.com/koderover/zadig/pkg/setting"
@@ -113,9 +114,12 @@ func (p *BuildTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipe
 
 	// TODO: Since the namespace field has been used continuously since v1.10.0, the processing logic related to namespace needs to
 	// be deleted in v1.11.0.
-	p.KubeNamespace = pipelineTask.ConfigPayload.Build.KubeNamespace
-	if p.Task.Namespace != "" {
-		p.KubeNamespace = p.Task.Namespace
+	switch p.Task.ClusterID {
+	case setting.LocalClusterID:
+		p.KubeNamespace = zadigconfig.Namespace()
+	default:
+		p.KubeNamespace = setting.AttachedClusterNamespace
+
 		kubeClient, err := kubeclient.GetKubeClient(pipelineTask.ConfigPayload.HubServerAddr, p.Task.ClusterID)
 		if err != nil {
 			msg := fmt.Sprintf("failed to get kube client: %s", err)

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -612,3 +612,7 @@ const (
 const (
 	InformerNamingConvention = "%s-%s"
 )
+
+// AttachedClusterNamespace is the namespace Zadig uses in attached cluster.
+// Note: **Restricted because of product design since v1.9.0**.
+const AttachedClusterNamespace = "koderover-agent"


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

In the latest version, the namespace of the `build/test` task is limited to `namespace of zadig installation` for local cluster and `koderover-agent` for attached cluster, and this part of the logic needs to be adapted. 


### What is changed and how it works?

Determine the namespace based on the cluster type. 


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
