### PR TITLE
DO NOT MERGE: enable system proxy for gitlab

### DIFF
--- a/pkg/microservice/aslan/core/code/service/branch.go
+++ b/pkg/microservice/aslan/core/code/service/branch.go
@@ -37,7 +37,7 @@ func CodeHostListBranches(codeHostID int, projectName, namespace, key string, pa
 	}
 
 	if ch.Type == codeHostGitlab {
-		client, err := gitlab.NewClient(ch.Address, ch.AccessToken)
+		client, err := gitlab.NewClient(ch.Address, ch.AccessToken, config.ProxyHTTPSAddr())
 		if err != nil {
 			log.Errorf("get gitlab client failed, err:%v", err)
 			return nil, e.ErrCodehostListBranches.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/code/service/merge_request.go
+++ b/pkg/microservice/aslan/core/code/service/merge_request.go
@@ -37,7 +37,7 @@ func CodeHostListPRs(codeHostID int, projectName, namespace, targetBr string, lo
 	}
 
 	if ch.Type == codeHostGitlab {
-		client, err := gitlab.NewClient(ch.Address, ch.AccessToken)
+		client, err := gitlab.NewClient(ch.Address, ch.AccessToken, config.ProxyHTTPSAddr())
 		if err != nil {
 			log.Error(err)
 			return nil, e.ErrCodehostListPrs.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/code/service/namespace.go
+++ b/pkg/microservice/aslan/core/code/service/namespace.go
@@ -45,7 +45,7 @@ func CodeHostListNamespaces(codeHostID int, keyword string, log *zap.SugaredLogg
 	}
 
 	if ch.Type == codeHostGitlab {
-		client, err := gitlab.NewClient(ch.Address, ch.AccessToken)
+		client, err := gitlab.NewClient(ch.Address, ch.AccessToken, config.ProxyHTTPSAddr())
 		if err != nil {
 			log.Error(err)
 			return nil, e.ErrCodehostListNamespaces.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/code/service/project.go
+++ b/pkg/microservice/aslan/core/code/service/project.go
@@ -37,7 +37,7 @@ func CodeHostListProjects(codeHostID int, namespace, namespaceType string, page,
 		return nil, e.ErrCodehostListProjects.AddDesc("git client is nil")
 	}
 	if ch.Type == codeHostGitlab {
-		client, err := gitlab.NewClient(ch.Address, ch.AccessToken)
+		client, err := gitlab.NewClient(ch.Address, ch.AccessToken, config.ProxyHTTPSAddr())
 		if err != nil {
 			log.Error(err)
 			return nil, e.ErrCodehostListProjects.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/code/service/tag.go
+++ b/pkg/microservice/aslan/core/code/service/tag.go
@@ -38,7 +38,7 @@ func CodeHostListTags(codeHostID int, projectName string, namespace string, log 
 	}
 
 	if ch.Type == codeHostGitlab {
-		client, err := gitlab.NewClient(ch.Address, ch.AccessToken)
+		client, err := gitlab.NewClient(ch.Address, ch.AccessToken, config.ProxyHTTPSAddr())
 		if err != nil {
 			log.Error(err)
 			return nil, e.ErrCodehostListTags.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/common/service/gitlab/client.go
+++ b/pkg/microservice/aslan/core/common/service/gitlab/client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gitlab
 
 import (
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/tool/git/gitlab"
 )
 
@@ -25,7 +26,7 @@ type Client struct {
 }
 
 func NewClient(address, accessToken string) (*Client, error) {
-	c, err := gitlab.NewClient(address, accessToken)
+	c, err := gitlab.NewClient(address, accessToken, config.ProxyHTTPSAddr())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/microservice/aslan/core/common/service/scmnotify/client.go
+++ b/pkg/microservice/aslan/core/common/service/scmnotify/client.go
@@ -61,7 +61,7 @@ func (c *Client) Comment(notify *models.Notification) error {
 	}
 	if strings.ToLower(codeHostDetail.Type) == "gitlab" {
 		var note *gitlab.Note
-		cli, err := gitlabtool.NewClient(codeHostDetail.Address, codeHostDetail.AccessToken)
+		cli, err := gitlabtool.NewClient(codeHostDetail.Address, codeHostDetail.AccessToken, config.ProxyHTTPSAddr())
 		if err != nil {
 			c.logger.Errorf("create gitlab client failed err: %v", err)
 			return fmt.Errorf("create gitlab client failed err: %v", err)

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflow_task.go
@@ -212,7 +212,7 @@ func (gpem *gitlabPushEventMatcher) Match(hookRepo *commonmodels.MainHookRepo) (
 			return false, err
 		}
 
-		client, err := gitlabtool.NewClient(detail.Address, detail.AccessToken)
+		client, err := gitlabtool.NewClient(detail.Address, detail.AccessToken, config.ProxyHTTPSAddr())
 		if err != nil {
 			gpem.log.Errorf("NewClient error: %s", err)
 			return false, err
@@ -280,7 +280,7 @@ func UpdateWorkflowTaskArgs(triggerYaml *TriggerYaml, workflow *commonmodels.Wor
 	if err != nil {
 		return fmt.Errorf("GetCodeHost codehostId:%d err:%s", item.MainRepo.CodehostID, err)
 	}
-	cli, err := gitlabtool.NewClient(ch.Address, ch.AccessToken)
+	cli, err := gitlabtool.NewClient(ch.Address, ch.AccessToken, config.ProxyHTTPSAddr())
 	if err != nil {
 		return fmt.Errorf("gitlabtool.NewClient codehostId:%d err:%s", item.MainRepo.CodehostID, err)
 	}
@@ -583,7 +583,7 @@ func findChangedFilesOfMergeRequest(event *gitlab.MergeEvent, codehostID int) ([
 		return nil, fmt.Errorf("failed to find codehost %d: %v", codehostID, err)
 	}
 
-	client, err := gitlabtool.NewClient(detail.Address, detail.AccessToken)
+	client, err := gitlabtool.NewClient(detail.Address, detail.AccessToken, config.ProxyHTTPSAddr())
 	if err != nil {
 		log.Error(err)
 		return nil, e.ErrCodehostListProjects.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
@@ -224,7 +224,7 @@ func getGitlabClientByAddress(address string) (*gitlabtool.Client, error) {
 		log.Error(err)
 		return nil, e.ErrCodehostListProjects.AddDesc("git client is nil")
 	}
-	client, err := gitlabtool.NewClient(codehost.Address, codehost.AccessToken)
+	client, err := gitlabtool.NewClient(codehost.Address, codehost.AccessToken, config.ProxyHTTPSAddr())
 	if err != nil {
 		log.Error(err)
 		return nil, e.ErrCodehostListProjects.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go
@@ -222,7 +222,7 @@ func getRawFileContent(codehostID int, repo, owner, branch, filePath string) ([]
 	}
 	switch ch.Type {
 	case setting.SourceFromGitlab:
-		cli, err := gitlab.NewClient(ch.Address, ch.AccessToken)
+		cli, err := gitlab.NewClient(ch.Address, ch.AccessToken, config.ProxyHTTPSAddr())
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed to get gitlab client")
 		}

--- a/pkg/microservice/reaper/core/service/reaper/git.go
+++ b/pkg/microservice/reaper/core/service/reaper/git.go
@@ -46,10 +46,11 @@ func (r *Reaper) runGitCmds() error {
 	envs := r.getUserEnvs()
 
 	// 如果存在github代码库，则设置代理，同时保证非github库不走代理
+	// Now gitlab codehost can also use proxy
 	if r.Ctx.Proxy.EnableRepoProxy && r.Ctx.Proxy.Type == "http" {
 		noProxy := ""
 		for _, repo := range r.Ctx.Repos {
-			if repo.Source == meta.ProviderGithub {
+			if repo.Source == meta.ProviderGithub || repo.Source == meta.ProviderGitlab {
 				envs = append(envs, fmt.Sprintf("http_proxy=%s", r.Ctx.Proxy.GetProxyURL()))
 				envs = append(envs, fmt.Sprintf("https_proxy=%s", r.Ctx.Proxy.GetProxyURL()))
 			} else {

--- a/pkg/tool/git/gitlab/client.go
+++ b/pkg/tool/git/gitlab/client.go
@@ -19,6 +19,8 @@ package gitlab
 import (
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 
 	"github.com/xanzy/go-gitlab"
 
@@ -43,8 +45,14 @@ type Client struct {
 	*gitlab.Client
 }
 
-func NewClient(address, accessToken string) (*Client, error) {
-	cli, err := gitlab.NewOAuthClient(accessToken, gitlab.WithBaseURL(address))
+func NewClient(address, accessToken, proxyAddr string) (*Client, error) {
+	proxyURL, err := url.Parse(proxyAddr)
+	if err != nil {
+		return nil, err
+	}
+	transport := &http.Transport{Proxy: http.ProxyURL(proxyURL)}
+	client := &http.Client{Transport: transport}
+	cli, err := gitlab.NewOAuthClient(accessToken, gitlab.WithBaseURL(address), gitlab.WithHTTPClient(client))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gitlab client, err: %s", err)
 	}


### PR DESCRIPTION
Signed-off-by: Min Min <jamsman94@gmail.com>

### What this PR does / Why we need it:
Previously the system proxy is only applied on github related logic. This PR enables system proxy for gitlab logic too.

### What is changed and how it works?
Changed the gitlab.NewClient function to make it take one more argument: the proxy settings. With this additional parameter we are able to create gitlab client with proxy.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
