### PR TITLE
add 2 return deploy types for listing  project

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/template/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/template/product.go
@@ -110,6 +110,8 @@ func (c *ProductColl) ListProjectBriefs(inNames []string) ([]*ProjectInfo, error
 		"onboarding_status": "$onboarding_status",
 		"public":            "$public",
 		"deploy_type":       "$product_feature.deploy_type",
+		"create_env_type":   "$product_feature.create_env_type",
+		"basic_facility":    "$product_feature.basic_facility",
 	})
 }
 

--- a/pkg/microservice/aslan/core/common/repository/mongodb/template/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/template/product.go
@@ -40,6 +40,8 @@ type ProjectInfo struct {
 	OnboardStatus int    `bson:"onboarding_status"`
 	Public        bool   `bson:"public"`
 	DeployType    string `bson:"deploy_type"`
+	CreateEnvType string `bson:"create_env_type"`
+	BasicFacility string `bson:"basic_facility"`
 }
 
 type ProductColl struct {

--- a/pkg/microservice/aslan/core/project/service/project.go
+++ b/pkg/microservice/aslan/core/project/service/project.go
@@ -94,6 +94,14 @@ func listDetailedProjectInfos(opts *ProjectListOptions, logger *zap.SugaredLogge
 
 	for name := range desiredSet {
 		info := nameMap[name]
+		var deployType string
+		if info.CreateEnvType == "external" {
+			deployType = "external"
+		} else if info.BasicFacility == "cloud_host" {
+			deployType = "cloud_host"
+		} else {
+			deployType = info.DeployType
+		}
 		res = append(res, &ProjectDetailedRepresentation{
 			ProjectBriefRepresentation: &ProjectBriefRepresentation{
 				ProjectMinimalRepresentation: &ProjectMinimalRepresentation{Name: name},
@@ -105,7 +113,7 @@ func listDetailedProjectInfos(opts *ProjectListOptions, logger *zap.SugaredLogge
 			UpdatedBy:  info.UpdatedBy,
 			Onboard:    info.OnboardStatus != 0,
 			Public:     info.Public,
-			DeployType: info.DeployType,
+			DeployType: deployType,
 		})
 	}
 


### PR DESCRIPTION
Signed-off-by: panxunying panxunying@koderover.com

### What this PR does / Why we need it:

Add 2 return deploy types for listing  project.
