### PR TITLE
add apis to support import helm serivces from chart repo

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/service.go
+++ b/pkg/microservice/aslan/core/common/repository/models/service.go
@@ -85,6 +85,12 @@ type CreateFromChartTemplate struct {
 	Variables    []*Variable                `bson:"variables" json:"variables"`
 }
 
+type CreateFromChartRepo struct {
+	ChartRepoName string `json:"chart_repo_name" bson:"chart_repo_name"`
+	ChartName     string `json:"chart_name"      bson:"chart_name"`
+	ChartVersion  string `json:"chart_version"   bson:"chart_version"`
+}
+
 type GUIConfig struct {
 	Deployment interface{} `bson:"deployment,omitempty"           json:"deployment,omitempty"`
 	Ingress    interface{} `bson:"ingress,omitempty"              json:"ingress,omitempty"`

--- a/pkg/microservice/aslan/core/common/service/service.go
+++ b/pkg/microservice/aslan/core/common/service/service.go
@@ -502,7 +502,7 @@ func DeleteServiceWebhookByName(serviceName, productName string, logger *zap.Sug
 
 func needProcessWebhook(source string) bool {
 	if source == setting.ServiceSourceTemplate || source == setting.SourceFromZadig || source == setting.SourceFromGerrit ||
-		source == "" || source == setting.SourceFromExternal || source == setting.SourceFromChartTemplate {
+		source == "" || source == setting.SourceFromExternal || source == setting.SourceFromChartTemplate || source == setting.SourceFromChartRepo {
 		return false
 	}
 	return true

--- a/pkg/microservice/aslan/core/delivery/service/version.go
+++ b/pkg/microservice/aslan/core/delivery/service/version.go
@@ -20,8 +20,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -745,32 +743,6 @@ func handleSingleChart(chartData *DeliveryChartData, product *commonmodels.Produ
 		return nil, errors.Wrapf(err, "failed to prepare pushing chart: %s", chartPackagePath)
 	}
 	return imageDetail, nil
-}
-
-func handlePushResponse(resp *http.Response) error {
-	if resp.StatusCode != 201 && resp.StatusCode != 202 {
-		b, err := ioutil.ReadAll(resp.Body)
-		defer func(Body io.ReadCloser) {
-			_ = Body.Close()
-		}(resp.Body)
-		if err != nil {
-			return err
-		}
-		return getChartmuseumError(b, resp.StatusCode)
-	}
-	log.Infof("push chart to chart repo done")
-	return nil
-}
-
-func getChartmuseumError(b []byte, code int) error {
-	var er struct {
-		Error string `json:"error"`
-	}
-	err := json.Unmarshal(b, &er)
-	if err != nil || er.Error == "" {
-		return errors.Errorf("%d: could not properly parse response JSON: %s", code, string(b))
-	}
-	return errors.Errorf("%d: %s", code, er.Error)
 }
 
 func makeChartTGZFileDir(productName, versionName string) (string, error) {

--- a/pkg/microservice/aslan/core/delivery/service/version.go
+++ b/pkg/microservice/aslan/core/delivery/service/version.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
-	cm "github.com/chartmuseum/helm-push/pkg/chartmuseum"
 	"github.com/chartmuseum/helm-push/pkg/helm"
 	"github.com/hashicorp/go-multierror"
 	"github.com/otiai10/copy"
@@ -523,21 +522,16 @@ func getProductEnvInfo(productName, envName string) (*commonmodels.Product, erro
 	return productInfo, nil
 }
 
-func getChartRepoData(repoName string) (*commonmodels.HelmRepo, error) {
-	return commonrepo.NewHelmRepoColl().Find(&commonrepo.HelmRepoFindOption{RepoName: repoName})
+func createChartRepoClient(repoName string) (*helmtool.ChartRepoClient, error) {
+	chartRepo, err := getChartRepoData(repoName)
+	if err != nil {
+		return nil, err
+	}
+	return helmtool.NewHelmChartRepoClient(chartRepo.URL, chartRepo.Username, chartRepo.Password)
 }
 
-func createChartRepoClient(repo *commonmodels.HelmRepo) (*cm.Client, error) {
-	client, err := cm.NewClient(
-		cm.URL(repo.URL),
-		cm.Username(repo.Username),
-		cm.Password(repo.Password),
-		// need support more auth types
-	)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create chart repo client, repoName: %s", repo.RepoName)
-	}
-	return client, nil
+func getChartRepoData(repoName string) (*commonmodels.HelmRepo, error) {
+	return commonrepo.NewHelmRepoColl().Find(&commonrepo.HelmRepoFindOption{RepoName: repoName})
 }
 
 // ensure chart files exist
@@ -740,19 +734,15 @@ func handleSingleChart(chartData *DeliveryChartData, product *commonmodels.Produ
 		return nil, err
 	}
 
-	client, err := createChartRepoClient(chartRepo)
+	client, err := createChartRepoClient(chartRepo.RepoName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create chart repo client, repoName: %s", chartRepo.RepoName)
 	}
 
 	log.Infof("pushing chart %s to %s...", filepath.Base(chartPackagePath), chartRepo.URL)
-	resp, err := client.UploadChartPackage(chartPackagePath, false)
+	err = client.PushChart(chartPackagePath, false)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to prepare pushing chart: %s", chartPackagePath)
-	}
-	err = handlePushResponse(resp)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to push chart: %s ", chartPackagePath)
 	}
 	return imageDetail, nil
 }
@@ -1426,50 +1416,12 @@ func downloadChart(deliveryVersion *commonmodels.DeliveryVersion, chartInfo *com
 		return chartTGZFilePath, nil
 	}
 
-	chartRepo, err := getChartRepoData(chartInfo.ChartRepoName)
-	if err != nil {
-		return "", fmt.Errorf("failed to query chart-repo info, repoName %s", chartInfo.ChartRepoName)
-	}
-
-	client, err := createChartRepoClient(chartRepo)
+	client, err := createChartRepoClient(chartInfo.ChartRepoName)
 	if err != nil {
 		return "", err
 	}
 
-	if err = os.MkdirAll(chartTGZFileParent, 0644); err != nil {
-		return "", errors.Wrapf(err, "failed to craete tgz parent dir")
-	}
-
-	out, err := os.Create(chartTGZFilePath)
-	if err != nil {
-		_ = os.RemoveAll(chartTGZFilePath)
-		return "", errors.Wrapf(err, "failed to create chart tgz file")
-	}
-
-	response, err := client.DownloadFile(fmt.Sprintf("charts/%s", chartTGZName))
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to download file")
-	}
-
-	if response.StatusCode != 200 {
-		return "", errors.Wrapf(err, "download file failed %s", chartTGZName)
-	}
-	defer func() { _ = response.Body.Close() }()
-
-	b, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to read response data")
-	}
-
-	defer func(out *os.File) {
-		_ = out.Close()
-	}(out)
-
-	err = ioutil.WriteFile(chartTGZFilePath, b, 0644)
-	if err != nil {
-		return "", err
-	}
-	return chartTGZFilePath, nil
+	return chartTGZFilePath, client.DownloadChart(chartTGZFileParent, chartInfo.ChartName, chartInfo.ChartVersion)
 }
 
 func getChartDistributeInfo(releaseID, chartName string, log *zap.SugaredLogger) (*commonmodels.DeliveryDistribute, error) {
@@ -1525,39 +1477,11 @@ func preDownloadChart(projectName, versionName, chartName string, log *zap.Sugar
 }
 
 func getIndexInfoFromChartRepo(chartRepoName string) (*helm.Index, error) {
-	chartRepo, err := getChartRepoData(chartRepoName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query chart-repo info, repoName %s", chartRepoName)
-	}
-
-	client, err := createChartRepoClient(chartRepo)
+	client, err := createChartRepoClient(chartRepoName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create chart repo client")
 	}
-
-	resp, err := client.DownloadFile("index.yaml")
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to download index.yaml")
-	}
-
-	defer func(Body io.ReadCloser) {
-		_ = Body.Close()
-	}(resp.Body)
-
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != 200 {
-		return nil, errors.Wrapf(getChartmuseumError(b, resp.StatusCode), "failed to download index.yaml")
-	}
-
-	index, err := helm.LoadIndex(b)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse index.yaml")
-	}
-	return index, nil
+	return client.FetchIndexYaml()
 }
 
 func fillChartUrl(charts []*DeliveryVersionPayloadChart, chartRepoName string) error {
@@ -1571,7 +1495,6 @@ func fillChartUrl(charts []*DeliveryVersionPayloadChart, chartRepoName string) e
 	}
 
 	for name, entries := range index.Entries {
-
 		chart, ok := chartMap[name]
 		if !ok {
 			continue
@@ -1647,7 +1570,6 @@ func GetChartVersion(chartName, chartRepoName string) ([]*ChartVersionResp, erro
 }
 
 func preDownloadAndUncompressChart(projectName, versionName, chartName string, log *zap.SugaredLogger) (string, error) {
-
 	deliveryInfo, err := GetDeliveryVersion(&commonrepo.DeliveryVersionArgs{
 		ProductName: projectName,
 		Version:     versionName,
@@ -1683,7 +1605,6 @@ func preDownloadAndUncompressChart(projectName, versionName, chartName string, l
 }
 
 func PreviewDeliveryChart(projectName, version, chartName string, log *zap.SugaredLogger) (*DeliveryChartResp, error) {
-
 	dstDir, err := preDownloadAndUncompressChart(projectName, version, chartName, log)
 	if err != nil {
 		return nil, err

--- a/pkg/microservice/aslan/core/service/handler/helm.go
+++ b/pkg/microservice/aslan/core/service/handler/helm.go
@@ -76,6 +76,12 @@ func CreateOrUpdateHelmService(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
+	projectName := c.Query("projectName")
+	if projectName == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("projectName can't be nil")
+		return
+	}
+
 	args := new(svcservice.HelmServiceCreationArgs)
 	if err := c.BindJSON(args); err != nil {
 		ctx.Err = e.ErrInvalidParam.AddDesc("invalid HelmService json args")
@@ -83,12 +89,18 @@ func CreateOrUpdateHelmService(c *gin.Context) {
 	}
 	args.CreatedBy = ctx.UserName
 
-	ctx.Resp, ctx.Err = svcservice.CreateOrUpdateHelmService(c.Query("projectName"), args, ctx.Logger)
+	ctx.Resp, ctx.Err = svcservice.CreateOrUpdateHelmService(projectName, args, ctx.Logger)
 }
 
 func CreateOrUpdateBulkHelmServices(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	projectName := c.Query("projectName")
+	if projectName == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("projectName can't be nil")
+		return
+	}
 
 	args := new(svcservice.BulkHelmServiceCreationArgs)
 	if err := c.BindJSON(args); err != nil {
@@ -97,7 +109,7 @@ func CreateOrUpdateBulkHelmServices(c *gin.Context) {
 	}
 	args.CreatedBy = ctx.UserName
 
-	ctx.Resp, ctx.Err = svcservice.CreateOrUpdateBulkHelmService(c.Query("projectName"), args, ctx.Logger)
+	ctx.Resp, ctx.Err = svcservice.CreateOrUpdateBulkHelmService(projectName, args, ctx.Logger)
 }
 
 func UpdateHelmService(c *gin.Context) {

--- a/pkg/microservice/aslan/core/service/service/helm.go
+++ b/pkg/microservice/aslan/core/service/service/helm.go
@@ -46,6 +46,7 @@ import (
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/shared/client/systemconfig"
 	e "github.com/koderover/zadig/pkg/tool/errors"
+	"github.com/koderover/zadig/pkg/tool/helmclient"
 	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/koderover/zadig/pkg/types"
 	yamlutil "github.com/koderover/zadig/pkg/util/yaml"
@@ -101,6 +102,7 @@ type helmServiceCreationArgs struct {
 	ValuePaths       []string
 	ValuesYaml       string
 	Variables        []*Variable
+	ChartRepoName    string
 }
 
 type ChartTemplateData struct {
@@ -326,9 +328,130 @@ func CreateOrUpdateHelmService(projectName string, args *HelmServiceCreationArgs
 		return CreateOrUpdateHelmServiceFromGitRepo(projectName, args, logger)
 	case LoadFromChartTemplate:
 		return CreateOrUpdateHelmServiceFromChartTemplate(projectName, args, logger)
+	case LoadFromChartRepo:
+		return CreateOrUpdateHelmServiceFromChartRepo(projectName, args, logger)
 	default:
 		return nil, fmt.Errorf("invalid source")
 	}
+}
+
+func CreateOrUpdateHelmServiceFromChartRepo(projectName string, args *HelmServiceCreationArgs, log *zap.SugaredLogger) (*BulkHelmServiceCreationResponse, error) {
+	chartRepoArgs, ok := args.CreateFrom.(*CreateFromChartRepo)
+	if !ok {
+		return nil, e.ErrCreateTemplate.AddDesc("invalid argument")
+	}
+
+	chartRepo, err := commonrepo.NewHelmRepoColl().Find(&commonrepo.HelmRepoFindOption{RepoName: chartRepoArgs.ChartRepoName})
+	if err != nil {
+		log.Errorf("failed to query chart-repo info, productName: %s, err: %s", projectName, err)
+		return nil, e.ErrCreateTemplate.AddDesc(fmt.Sprintf("failed to query chart-repo info, productName: %s, repoName: %s", projectName, chartRepoArgs.ChartRepoName))
+	}
+
+	chartClient, err := helmclient.NewHelmChartRepoClient(chartRepo.URL, chartRepo.Username, chartRepo.Password)
+	if err != nil {
+		return nil, e.ErrCreateTemplate.AddErr(errors.Wrapf(err, "failed to init chart client for repo: %s", chartRepo.RepoName))
+	}
+
+	index, err := chartClient.FetchIndexYaml()
+	if err != nil {
+		return nil, e.ErrCreateTemplate.AddErr(err)
+	}
+
+	// validate chart with specific version exists in repo
+	foundChart := false
+	for name, entries := range index.Entries {
+		if name != chartRepoArgs.ChartName {
+			continue
+		}
+		for _, entry := range entries {
+			if entry.Version == chartRepoArgs.ChartVersion {
+				foundChart = true
+				break
+			}
+		}
+		break
+	}
+	if !foundChart {
+		return nil, e.ErrCreateTemplate.AddDesc(fmt.Sprintf("failed to find chart: %s-%s from chart repo", chartRepoArgs.ChartName, chartRepoArgs.ChartVersion))
+	}
+
+	localPath := config.LocalServicePath(projectName, chartRepoArgs.ChartName)
+	err = chartClient.DownloadAndExpand(chartRepoArgs.ChartName, chartRepoArgs.ChartVersion, localPath)
+	if err != nil {
+		return nil, e.ErrCreateTemplate.AddErr(err)
+	}
+
+	serviceName := chartRepoArgs.ChartName
+	rev, err := getNextServiceRevision(projectName, serviceName)
+	if err != nil {
+		log.Errorf("Failed to get next revision for service %s, err: %s", serviceName, err)
+		return nil, e.ErrCreateTemplate.AddErr(err)
+	}
+
+	var finalErr error
+	// clear files from both s3 and local when error occurred in next stages
+	defer func() {
+		if finalErr != nil {
+			clearChartFiles(projectName, serviceName, rev, log)
+		}
+	}()
+
+	// read values.yaml
+	fsTree := os.DirFS(config.LocalServicePath(projectName, chartRepoArgs.ChartName))
+	valuesYAML, err := readValuesYAML(fsTree, chartRepoArgs.ChartName, log)
+	if err != nil {
+		finalErr = e.ErrCreateTemplate.AddErr(err)
+		return nil, finalErr
+	}
+
+	// upload to s3 storage
+	s3Base := config.ObjectStorageServicePath(projectName, serviceName)
+	err = fsservice.ArchiveAndUploadFilesToS3(fsTree, []string{serviceName, fmt.Sprintf("%s-%d", serviceName, rev)}, s3Base, log)
+	if err != nil {
+		finalErr = e.ErrCreateTemplate.AddErr(err)
+		return nil, finalErr
+	}
+
+	// copy service revision data from latest
+	err = copyChartRevision(projectName, serviceName, rev)
+	if err != nil {
+		log.Errorf("Failed to copy file %s, err: %s", serviceName, err)
+		finalErr = errors.Wrapf(err, "Failed to copy chart info, service %s", serviceName)
+		return nil, finalErr
+	}
+
+	svc, err := createOrUpdateHelmService(
+		fsTree,
+		&helmServiceCreationArgs{
+			ChartName:       chartRepoArgs.ChartName,
+			ChartVersion:    chartRepoArgs.ChartVersion,
+			ChartRepoName:   chartRepoArgs.ChartRepoName,
+			ServiceRevision: rev,
+			MergedValues:    string(valuesYAML),
+			ServiceName:     serviceName,
+			ProductName:     projectName,
+			CreateBy:        args.CreatedBy,
+			Source:          setting.SourceFromChartRepo,
+		},
+		log,
+	)
+	if err != nil {
+		log.Errorf("Failed to create service %s in project %s, error: %s", serviceName, projectName, err)
+		finalErr = e.ErrCreateTemplate.AddErr(err)
+		return nil, finalErr
+	}
+
+	compareHelmVariable([]*templatemodels.RenderChart{
+		{
+			ServiceName:  args.Name,
+			ChartVersion: svc.HelmChart.Version,
+			ValuesYaml:   svc.HelmChart.ValuesYaml,
+		},
+	}, projectName, args.CreatedBy, log)
+
+	return &BulkHelmServiceCreationResponse{
+		SuccessServices: []string{serviceName},
+	}, nil
 }
 
 func CreateOrUpdateHelmServiceFromChartTemplate(projectName string, args *HelmServiceCreationArgs, logger *zap.SugaredLogger) (*BulkHelmServiceCreationResponse, error) {
@@ -842,6 +965,12 @@ func geneCreationDetail(args *helmServiceCreationArgs) interface{} {
 			TemplateName: args.HelmTemplateName,
 			ServiceName:  args.ServiceName,
 			Variables:    variables,
+		}
+	case setting.SourceFromChartRepo:
+		return models.CreateFromChartRepo{
+			ChartRepoName: args.ChartRepoName,
+			ChartName:     args.ChartName,
+			ChartVersion:  args.ChartVersion,
 		}
 	}
 	return nil

--- a/pkg/microservice/aslan/core/service/service/helm.go
+++ b/pkg/microservice/aslan/core/service/service/helm.go
@@ -443,7 +443,7 @@ func CreateOrUpdateHelmServiceFromChartRepo(projectName string, args *HelmServic
 
 	compareHelmVariable([]*templatemodels.RenderChart{
 		{
-			ServiceName:  args.Name,
+			ServiceName:  chartRepoArgs.ChartName,
 			ChartVersion: svc.HelmChart.Version,
 			ValuesYaml:   svc.HelmChart.ValuesYaml,
 		},

--- a/pkg/microservice/aslan/core/service/service/types.go
+++ b/pkg/microservice/aslan/core/service/service/types.go
@@ -30,6 +30,7 @@ const (
 	LoadFromRepo          LoadSource = "repo"
 	LoadFromPublicRepo    LoadSource = "publicRepo"
 	LoadFromChartTemplate LoadSource = "chartTemplate"
+	LoadFromChartRepo     LoadSource = "chartRepo"
 )
 
 type HelmLoadSource struct {
@@ -84,6 +85,12 @@ type CreateFromChartTemplate struct {
 	Variables    []*Variable `json:"variables"`
 }
 
+type CreateFromChartRepo struct {
+	ChartRepoName string `json:"chartRepoName"`
+	ChartName     string `json:"chartName"`
+	ChartVersion  string `json:"chartVersion"`
+}
+
 func PublicRepoToPrivateRepoArgs(args *CreateFromPublicRepo) (*CreateFromRepo, error) {
 	if args.RepoLink == "" {
 		return nil, fmt.Errorf("empty link")
@@ -113,6 +120,8 @@ func (a *HelmServiceCreationArgs) UnmarshalJSON(data []byte) error {
 		a.CreateFrom = &CreateFromPublicRepo{}
 	case LoadFromChartTemplate:
 		a.CreateFrom = &CreateFromChartTemplate{}
+	case LoadFromChartRepo:
+		a.CreateFrom = &CreateFromChartRepo{}
 	}
 
 	type tmp HelmServiceCreationArgs

--- a/pkg/microservice/aslan/core/system/handler/helm.go
+++ b/pkg/microservice/aslan/core/system/handler/helm.go
@@ -72,3 +72,10 @@ func DeleteHelmRepo(c *gin.Context) {
 
 	ctx.Err = service.DeleteHelmRepo(c.Param("id"), ctx.Logger)
 }
+
+func ListCharts(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	ctx.Resp, ctx.Err = service.ListCharts(c.Param("name"), ctx.Logger)
+}

--- a/pkg/microservice/aslan/core/system/handler/router.go
+++ b/pkg/microservice/aslan/core/system/handler/router.go
@@ -152,6 +152,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		integration.POST("", CreateHelmRepo)
 		integration.PUT("/:id", UpdateHelmRepo)
 		integration.DELETE("/:id", DeleteHelmRepo)
+		integration.GET("/:name/index", ListCharts)
 	}
 
 	// ---------------------------------------------------------------------------------------

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -240,6 +240,8 @@ const (
 	SourceFromChartTemplate = "chartTemplate"
 	// SourceFromPublicRepo 配置来源为publicRepo
 	SourceFromPublicRepo = "publicRepo"
+	// SourceFromChartRepo
+	SourceFromChartRepo = "chartRepo"
 
 	// SourceFromGUI 配置来源为gui
 	SourceFromGUI = "gui"

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -240,8 +240,7 @@ const (
 	SourceFromChartTemplate = "chartTemplate"
 	// SourceFromPublicRepo 配置来源为publicRepo
 	SourceFromPublicRepo = "publicRepo"
-	// SourceFromChartRepo
-	SourceFromChartRepo = "chartRepo"
+	SourceFromChartRepo  = "chartRepo"
 
 	// SourceFromGUI 配置来源为gui
 	SourceFromGUI = "gui"

--- a/pkg/tool/helmclient/chartclient.go
+++ b/pkg/tool/helmclient/chartclient.go
@@ -76,11 +76,6 @@ func (client *ChartRepoClient) FetchIndexYaml() (*helm.Index, error) {
 func (client *ChartRepoClient) DownloadChart(chartName, chartVersion, basePath string) error {
 	chartTGZName := fmt.Sprintf("%s-%s.tgz", chartName, chartVersion)
 	chartTGZFilePath := filepath.Join(basePath, chartTGZName)
-	//out, err := os.Create(chartTGZFilePath)
-	//if err != nil {
-	//	_ = os.RemoveAll(chartTGZFilePath)
-	//	return errors.Wrapf(err, "failed to create chart tgz file")
-	//}
 
 	response, err := client.DownloadFile(fmt.Sprintf("charts/%s", chartTGZName))
 	if err != nil {
@@ -96,11 +91,6 @@ func (client *ChartRepoClient) DownloadChart(chartName, chartVersion, basePath s
 	if err != nil {
 		return errors.Wrapf(err, "failed to read response data")
 	}
-
-	//defer func(out *os.File) {
-	//	_ = out.Close()
-	//}(out)
-
 	return ioutil.WriteFile(chartTGZFilePath, b, 0644)
 }
 

--- a/pkg/tool/helmclient/chartclient.go
+++ b/pkg/tool/helmclient/chartclient.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2022 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helmclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	cm "github.com/chartmuseum/helm-push/pkg/chartmuseum"
+	"github.com/chartmuseum/helm-push/pkg/helm"
+	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/chartutil"
+
+	"github.com/koderover/zadig/pkg/tool/log"
+)
+
+type ChartRepoClient struct {
+	*cm.Client
+}
+
+func NewHelmChartRepoClient(url, userName, password string) (*ChartRepoClient, error) {
+	client, err := cm.NewClient(
+		cm.URL(url),
+		cm.Username(userName),
+		cm.Password(password),
+		// TODO need support more auth types
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &ChartRepoClient{client}, nil
+}
+
+// FetchIndexYaml fetch index.yaml from remote chart repo
+func (client *ChartRepoClient) FetchIndexYaml() (*helm.Index, error) {
+	resp, err := client.DownloadFile("index.yaml")
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to download index.yaml")
+	}
+
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(resp.Body)
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, errors.Wrapf(getChartmuseumError(b, resp.StatusCode), "failed to download index.yaml")
+	}
+
+	index, err := helm.LoadIndex(b)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse index.yaml")
+	}
+	return index, nil
+}
+
+func (client *ChartRepoClient) DownloadChart(chartName, chartVersion, basePath string) error {
+	chartTGZName := fmt.Sprintf("%s-%s.tgz", chartName, chartVersion)
+	chartTGZFilePath := filepath.Join(basePath, chartTGZName)
+	out, err := os.Create(chartTGZFilePath)
+	if err != nil {
+		_ = os.RemoveAll(chartTGZFilePath)
+		return errors.Wrapf(err, "failed to create chart tgz file")
+	}
+
+	response, err := client.DownloadFile(fmt.Sprintf("charts/%s", chartTGZName))
+	if err != nil {
+		return errors.Wrapf(err, "failed to download file")
+	}
+
+	if response.StatusCode != 200 {
+		return errors.Wrapf(err, "download file failed")
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	b, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read response data")
+	}
+
+	defer func(out *os.File) {
+		_ = out.Close()
+	}(out)
+
+	return ioutil.WriteFile(chartTGZFilePath, b, 0644)
+}
+
+// DownloadAndExpand downloads chart from repo and expand chart files from tarball
+func (client *ChartRepoClient) DownloadAndExpand(chartName, chartVersion, localPath string) error {
+	chartTGZName := fmt.Sprintf("%s-%s.tgz", chartName, chartVersion)
+	response, err := client.DownloadFile(fmt.Sprintf("charts/%s", chartTGZName))
+	if err != nil {
+		return errors.Wrapf(err, "failed to download file")
+	}
+
+	if response.StatusCode != 200 {
+		return errors.Wrapf(err, "download file failed")
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	return chartutil.Expand(localPath, response.Body)
+}
+
+// PushChart push chart to remote repo
+func (client *ChartRepoClient) PushChart(chartPackagePath string, force bool) error {
+	log.Infof("pushing chart %s", filepath.Base(chartPackagePath))
+	resp, err := client.UploadChartPackage(chartPackagePath, false)
+	if err != nil {
+		return errors.Wrapf(err, "failed to prepare pushing chart: %s", chartPackagePath)
+	}
+	err = handlePushResponse(resp)
+	if err != nil {
+		return errors.Wrapf(err, "failed to push chart: %s ", chartPackagePath)
+	}
+	return nil
+}
+
+func getChartmuseumError(b []byte, code int) error {
+	var er struct {
+		Error string `json:"error"`
+	}
+	err := json.Unmarshal(b, &er)
+	if err != nil || er.Error == "" {
+		return errors.Errorf("%d: could not properly parse response JSON: %s", code, string(b))
+	}
+	return errors.Errorf("%d: %s", code, er.Error)
+}
+
+func handlePushResponse(resp *http.Response) error {
+	if resp.StatusCode != 201 && resp.StatusCode != 202 {
+		b, err := ioutil.ReadAll(resp.Body)
+		defer func(Body io.ReadCloser) {
+			_ = Body.Close()
+		}(resp.Body)
+		if err != nil {
+			return err
+		}
+		return getChartmuseumError(b, resp.StatusCode)
+	}
+	log.Infof("push chart to chart repo done")
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
currenly importing helm services from chart repo is not supported 

### What is changed and how it works?
1.  add support of importing services from helm chart repo
2. optimze code of chart-repo client to reduce code duplication

### Does this PR introduce a user-facing change?
yes

- [x] API change
- [x] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
