### PR TITLE
Bugfix webhook can't trigger synchronization of service templates

### DIFF
--- a/pkg/microservice/aslan/core/service/service/helm.go
+++ b/pkg/microservice/aslan/core/service/service/helm.go
@@ -930,6 +930,16 @@ func createOrUpdateHelmService(fsTree fs.FS, args *helmServiceCreationArgs, logg
 		return nil, err
 	}
 
+	// update status of current service template to deleting
+	if currentSvcTmpl != nil {
+		err = commonrepo.NewServiceColl().UpdateStatus(args.ServiceName, args.ProductName, setting.ProductStatusDeleting)
+		if err != nil {
+			log.Errorf("Failed to set status of current service templates, serviceName: %s, err: %s", args.ServiceName, err)
+			return nil, err
+		}
+	}
+
+	// create new service template
 	if err = commonrepo.NewServiceColl().Create(serviceObj); err != nil {
 		log.Errorf("Failed to create service %s error: %s", args.ServiceName, err)
 		return nil, err

--- a/pkg/microservice/aslan/core/workflow/service/webhook/codehub.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/codehub.go
@@ -168,11 +168,7 @@ func SyncServiceTemplateFromCodehub(service *commonmodels.Service, log *zap.Suga
 		log.Errorf("ensureServiceTmpl error: %+v", err)
 		return e.ErrValidateTemplate.AddDesc(err.Error())
 	}
-	// 更新到数据库，revision+1
-	if err := commonrepo.NewServiceColl().Create(service); err != nil {
-		log.Errorf("Failed to sync service %s from codehub path %s error: %v", service.ServiceName, service.SrcPath, err)
-		return e.ErrCreateTemplate.AddDesc(err.Error())
-	}
+
 	log.Infof("End of sync service template %s from codehub path %s", service.ServiceName, service.SrcPath)
 	return nil
 }

--- a/pkg/microservice/aslan/core/workflow/service/webhook/github.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github.go
@@ -561,8 +561,7 @@ func updateServiceTemplateByGithubPush(pushEvent *github.PushEvent, log *zap.Sug
 	errs := &multierror.Error{}
 
 	for _, service := range serviceTmpls {
-		srcPath := service.SrcPath
-		_, _, _, _, path, _, err := GetOwnerRepoBranchPath(srcPath)
+		path, err := getServiceSrcPath(service)
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		}
@@ -670,11 +669,7 @@ func SyncServiceTemplateFromGithub(service *commonmodels.Service, latestCommitID
 		log.Errorf("ensure github serviceTmpl failed, error: %+v", err)
 		return e.ErrValidateTemplate.AddDesc(err.Error())
 	}
-	// 更新到数据库，revision+1
-	if err := commonrepo.NewServiceColl().Create(service); err != nil {
-		log.Errorf("Failed to sync service %s from github path %s error: %v", service.ServiceName, service.SrcPath, err)
-		return e.ErrCreateTemplate.AddDesc(err.Error())
-	}
+
 	log.Infof("End of sync service template %s from github path %s", service.ServiceName, service.SrcPath)
 	return nil
 }

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab.go
@@ -300,8 +300,7 @@ func updateServiceTemplateByPushEvent(event *EventPush, log *zap.SugaredLogger) 
 	errs := &multierror.Error{}
 
 	for _, service := range serviceTmpls {
-		srcPath := service.SrcPath
-		_, _, _, _, path, _, err := GetOwnerRepoBranchPath(srcPath)
+		path, err := getServiceSrcPath(service)
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		}
@@ -366,11 +365,6 @@ func SyncServiceTemplateFromGitlab(service *commonmodels.Service, log *zap.Sugar
 	if err := fillServiceTmpl(setting.WebhookTaskCreator, service, log); err != nil {
 		log.Errorf("ensureServiceTmpl error: %+v", err)
 		return e.ErrValidateTemplate.AddDesc(err.Error())
-	}
-	// 更新到数据库，revision+1
-	if err := commonrepo.NewServiceColl().Create(service); err != nil {
-		log.Errorf("Failed to sync service %s from gitlab path %s error: %v", service.ServiceName, service.SrcPath, err)
-		return e.ErrCreateTemplate.AddDesc(err.Error())
 	}
 	log.Infof("End of sync service template %s from gitlab path %s", service.ServiceName, service.SrcPath)
 	return nil

--- a/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
@@ -202,14 +202,25 @@ func syncLatestCommit(service *commonmodels.Service) error {
 		return err
 	}
 
+	if len(service.BranchName) > 0 {
+		branch = service.BranchName
+	}
+	if len(service.LoadPath) > 0 {
+		path = service.LoadPath
+	}
+
 	commit, err := GitlabGetLatestCommit(client, owner, repo, branch, path)
 	if err != nil {
 		return err
 	}
-	service.Commit = &commonmodels.Commit{
-		SHA:     commit.ID,
-		Message: commit.Message,
+
+	if commit != nil {
+		service.Commit = &commonmodels.Commit{
+			SHA:     commit.ID,
+			Message: commit.Message,
+		}
 	}
+
 	return nil
 }
 

--- a/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
@@ -151,7 +151,7 @@ func fillServiceTmpl(userName string, args *commonmodels.Service, log *zap.Sugar
 		}
 		log.Infof("find %d containers in service %s", len(args.Containers), args.ServiceName)
 
-		// 设置新的版本号
+		// generate new revision
 		serviceTemplate := fmt.Sprintf(setting.ServiceTemplateCounterName, args.ServiceName, args.ProductName)
 		rev, err := commonrepo.NewCounterColl().GetNextSeq(serviceTemplate)
 		if err != nil {
@@ -159,7 +159,7 @@ func fillServiceTmpl(userName string, args *commonmodels.Service, log *zap.Sugar
 		}
 
 		args.Revision = rev
-		// 更新到数据库，revision+1
+		// update service template
 		if err := commonrepo.NewServiceColl().Create(args); err != nil {
 			log.Errorf("Failed to sync service %s from github path %s error: %v", args.ServiceName, args.SrcPath, err)
 			return e.ErrCreateTemplate.AddDesc(err.Error())


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
webhooks auto created by zadig when importing services from git repo can't work as expected if target branch contains separator '/', because the file path parsed from entire url is not correct

### What is changed and how it works?
use the 'load_path' from db directly instead of parsing file path from entire url

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
