### PR TITLE
Remove the limit of creating environment on existing namespace for helm

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -160,6 +160,7 @@ type CreateHelmProductArg struct {
 	ChartValues   []*commonservice.RenderChartArg `json:"chartValues"`
 	BaseEnvName   string                          `json:"baseEnvName"`
 	BaseName      string                          `json:"base_name,omitempty"`
+	IsExisted     bool                            `json:"is_existed"`
 }
 
 type UpdateMultiHelmProductArg struct {
@@ -789,6 +790,7 @@ func createSingleHelmProduct(templateProduct *templatemodels.Product, requestID,
 		ChartInfos:      templateProduct.ChartInfos,
 		IsForkedProduct: false,
 		RegistryID:      registryID,
+		IsExisted:       arg.IsExisted,
 	}
 
 	customChartValueMap := make(map[string]*commonservice.RenderChartArg)

--- a/pkg/microservice/aslan/core/environment/service/environment_creator.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_creator.go
@@ -18,7 +18,6 @@ package service
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"go.uber.org/zap"
@@ -33,7 +32,6 @@ import (
 	kubeclient "github.com/koderover/zadig/pkg/shared/kube/client"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 	"github.com/koderover/zadig/pkg/tool/helmclient"
-	"github.com/koderover/zadig/pkg/tool/kube/getter"
 	"github.com/koderover/zadig/pkg/tool/kube/informer"
 )
 
@@ -147,15 +145,6 @@ func (creator *HelmProductCreator) Create(user, requestID string, args *models.P
 	namespace := args.GetNamespace()
 	if args.Namespace == "" {
 		args.Namespace = namespace
-	}
-	_, found, err := getter.GetNamespace(args.Namespace, kubeClient)
-	if err != nil {
-		log.Errorf("GetNamespace error: %v", err)
-		return e.ErrCreateEnv.AddDesc(err.Error())
-	}
-	if found {
-		log.Warnf("%s[%s]%s", "namespace", args.Namespace, "已经存在,请换个环境名称尝试!")
-		return e.ErrCreateEnv.AddDesc(fmt.Sprintf("%s[%s]%s", "namespace", args.Namespace, "已经存在,请换个环境名称尝试!"))
 	}
 
 	restConfig, err := kube.GetRESTConfig(args.ClusterID)


### PR DESCRIPTION
Signed-off-by: Min Min <minmin@koderover.com>

### What this PR does / Why we need it:
Currently an environment cannot be created from an existing namespace. This PR removes this limit.

### What is changed and how it works?
Only removing the namespace check for helm creating namespace will do.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
