### PR TITLE
fix bug of displaying real-time build logs

### DIFF
--- a/pkg/microservice/aslan/core/log/service/sse.go
+++ b/pkg/microservice/aslan/core/log/service/sse.go
@@ -120,24 +120,41 @@ func TaskContainerLogStream(ctx context.Context, streamChan chan interface{}, op
 		return
 	}
 	log.Debugf("Start to get task container log.")
-	// Cloud host scenario reads real-time logs from the environment, so pipelineName is empty
+
+	var serviceName string
+	serviceNames := strings.Split(options.ServiceName, "_")
+	switch len(serviceNames) {
+	case 1:
+		serviceName = serviceNames[0]
+	case 2:
+		// Note: Starting from V1.10.0, this field will be in the format of `ServiceComponent_ServiceName`.
+		serviceName = serviceNames[1]
+	}
+
+	// Cloud host scenario reads real-time logs from the environment, so pipelineName is empty.
 	if options.EnvName != "" && options.ProductName != "" && options.PipelineName == "" {
-		//修改pipelineName，判断pipelineName是否为空，为空代表是来自环境里面请求，不为空代表是来自工作流任务的请求
-		options.PipelineName = fmt.Sprintf("%s-%s-%s", options.ServiceName, options.EnvName, "job")
+		// Modify pipelineName to check whether pipelineName is empty:
+		// - Empty pipelineName indicates requests from the environment
+		// - Non-empty pipelineName indicate requests from workflow tasks
+		options.PipelineName = fmt.Sprintf("%s-%s-%s", serviceName, options.EnvName, "job")
 		if taskObj, err := commonrepo.NewTaskColl().FindTask(options.PipelineName, config.ServiceType); err == nil {
 			options.TaskID = taskObj.TaskID
 		}
-		// Need to get build info based on the project name and service component name, then get clusterID and namespace
 	} else if options.ProductName != "" {
 		build, err := commonrepo.NewBuildColl().Find(&commonrepo.BuildFindOption{
 			ProductName: options.ProductName,
-			Targets:     []string{options.ServiceName},
+			Targets:     []string{serviceName},
 		})
 		if err != nil {
 			// Maybe this service is a shared service
 			build, err = commonrepo.NewBuildColl().Find(&commonrepo.BuildFindOption{
-				Targets: []string{options.ServiceName},
+				Targets: []string{serviceName},
 			})
+
+			if err != nil {
+				log.Errorf("Failed to query build for service %s: %s", serviceName, err)
+				return
+			}
 		}
 		// Compatible with the situation where the old data has not been modified
 		if build != nil && build.PreBuild != nil && build.PreBuild.ClusterID != "" {
@@ -194,16 +211,19 @@ func waitAndGetLog(ctx context.Context, streamChan chan interface{}, selector la
 		log.Errorf("GetContainerLogs, get client set error: %s", err)
 		return
 	}
+
 	err = watcher.WaitUntilPodRunning(PodCtx, options.Namespace, selector, clientSet)
 	if err != nil {
 		log.Errorf("GetContainerLogs, wait pod running error: %s", err)
 		return
 	}
+
 	kubeClient, err := kubeclient.GetKubeClient(config.HubServerAddress(), options.ClusterID)
 	if err != nil {
 		log.Errorf("GetContainerLogs, get kube client error: %s", err)
 		return
 	}
+
 	pods, err := getter.ListPods(options.Namespace, selector, kubeClient)
 	if err != nil {
 		log.Errorf("GetContainerLogs, get pod error: %+v", err)

--- a/pkg/microservice/aslan/core/multicluster/service/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/service/clusters.go
@@ -375,7 +375,12 @@ func setClusterCache(args *K8SCluster) error {
 
 	// Since the attached cluster cannot access the minio in the local cluster, if the default object storage
 	// is minio, the attached cluster cannot be configured to use minio as a cache.
-	if args.ID != setting.LocalClusterID && strings.Contains(defaultStorage.Endpoint, ZadigMinioSVC) {
+	//
+	// Note:
+	// - Since the local cluster will be written to the database when Zadig is created, empty ID indicates
+	//   that the cluster is attached.
+	// - Currently, we do not support attaching the local cluster again.
+	if (args.ID == "" || args.ID != setting.LocalClusterID) && strings.Contains(defaultStorage.Endpoint, ZadigMinioSVC) {
 		return nil
 	}
 


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

The service name has been modified in https://github.com/koderover/zadig/pull/1068 , and an adaptation is required when printing real-time logs.
When creating a new cluster, it is necessary to strictly judge whether to configure object storage as a cache.

### What is changed and how it works?

- When printing real-time logs, adapt to the new serviceName format
- When creating a new cluster, carefully determine whether object storage can be configured as a cache 


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
