### PR TITLE
decide proxy settings on runtime instead of saving it in db

### DIFF
--- a/pkg/types/repo.go
+++ b/pkg/types/repo.go
@@ -52,7 +52,8 @@ type Repository struct {
 	RepoID      string `bson:"repo_id,omitempty"            json:"repo_id,omitempty"`
 	Username    string `bson:"username,omitempty"           json:"username,omitempty"`
 	Password    string `bson:"password,omitempty"           json:"password,omitempty"`
-	EnableProxy bool   `bson:"enable_proxy,omitempty"       json:"enable_proxy,omitempty"`
+	// Now EnableProxy is not something we store. We decide this on runtime
+	EnableProxy bool `bson:"-"       json:"enable_proxy,omitempty"`
 }
 
 // GetReleaseCandidateTag 返回待发布对象Tag


### PR DESCRIPTION
Signed-off-by: Min Min <minmin@koderover.com>

### What this PR does / Why we need it:
#1083 saves the proxy settings for build in the db, which doesn't make any sense since it is a runtime settings. In this PR we decide proxy settings of workflow when we run it.

### What is changed and how it works?
simply query for repo config when we create a workflow task

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
