### PR TITLE
support user-defined env when using pvc

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
@@ -737,6 +737,7 @@ func TestArgsToTestSubtask(args *commonmodels.TestTaskArgs, pt *task.Task, log *
 			}
 		}
 		envs = append(envs, &commonmodels.KeyVal{Key: "TEST_URL", Value: GetLink(pt, configbase.SystemAddress(), config.TestType)})
+		envs = append(envs, &commonmodels.KeyVal{Key: "WORKSPACE", Value: "/workspace"})
 		testTask.JobCtx.EnvVars = envs
 		testTask.ImageID = testModule.PreTest.ImageID
 		testTask.BuildOS = testModule.PreTest.BuildOS

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
@@ -618,6 +618,7 @@ func prepareTaskEnvs(pt *task.Task, log *zap.SugaredLogger) []*commonmodels.KeyV
 		&commonmodels.KeyVal{Key: "IMAGE", Value: pt.TaskArgs.Deploy.Image},
 		&commonmodels.KeyVal{Key: "PKG_FILE", Value: pt.TaskArgs.Deploy.PackageFile},
 		&commonmodels.KeyVal{Key: "LOG_FILE", Value: "/tmp/user_script.log"},
+		&commonmodels.KeyVal{Key: "WORKSPACE", Value: "/workspace"},
 	)
 
 	// 设置编译模块参数化配置信息

--- a/pkg/microservice/warpdrive/core/service/taskplugin/testing.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/testing.go
@@ -39,6 +39,7 @@ import (
 	krkubeclient "github.com/koderover/zadig/pkg/tool/kube/client"
 	"github.com/koderover/zadig/pkg/tool/kube/updater"
 	s3tool "github.com/koderover/zadig/pkg/tool/s3"
+	commontypes "github.com/koderover/zadig/pkg/types"
 	"github.com/koderover/zadig/pkg/util"
 )
 
@@ -192,6 +193,16 @@ func (p *TestPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipelineC
 
 	fileName = strings.Replace(strings.ToLower(fileName), "_", "-", -1)
 	testReportFile = strings.Replace(strings.ToLower(testReportFile), "_", "-", -1)
+
+	for _, env := range p.Task.JobCtx.EnvVars {
+		p.Log.Infof("[YIFEI] k: %s, v: %s", env.Key, env.Value)
+	}
+
+	// Since we allow users to use custom environment variables, variable resolution is required.
+	if pipelineCtx.CacheEnable && pipelineCtx.Cache.MediumType == commontypes.NFSMedium &&
+		pipelineCtx.CacheDirType == commontypes.UserDefinedCacheDir {
+		pipelineCtx.CacheUserDir = p.renderEnv(pipelineCtx.CacheUserDir)
+	}
 
 	jobCtx := JobCtxBuilder{
 		JobName:        p.JobName,
@@ -526,4 +537,22 @@ func (p *TestPlugin) IsTaskEnabled() bool {
 
 func (p *TestPlugin) ResetError() {
 	p.Task.Error = ""
+}
+
+// Note: Since there are few environment variables and few variables to be replaced,
+// this method is temporarily used.
+func (p *TestPlugin) renderEnv(data string) string {
+	mapper := func(data string) string {
+		for _, envar := range p.Task.JobCtx.EnvVars {
+			if data != envar.Key {
+				continue
+			}
+
+			return envar.Value
+		}
+
+		return fmt.Sprintf("$%s", data)
+	}
+
+	return os.Expand(data, mapper)
 }


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

Currently, custom environment variables are supported. When using PVCs, if the custom environment variables are not parsed in advance, mounting the PVC will not meet expectations. 

### What is changed and how it works?

When using PVCs, variable resolution is performed against a user-specified directory. 

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
