### PR TITLE
non user

### DIFF
--- a/pkg/microservice/picket/core/filter/service/rolebinding.go
+++ b/pkg/microservice/picket/core/filter/service/rolebinding.go
@@ -88,7 +88,15 @@ func ListBindings(header http.Header, qs url.Values, logger *zap.SugaredLogger) 
 		uidToPolicyBindings[pb.UID] = append(uidToPolicyBindings[pb.UID], &policyBinding{PolicyBinding: pb})
 	}
 	if uidSets.Len() == 0 {
-		return []*Binding{}, nil
+		// add all 'ALLUsers' roles
+		AllUserBinding := &Binding{
+			Roles:    uidToRoleBinding[ALLUsers],
+			Policies: uidToPolicyBindings[ALLUsers],
+			UserName: "*",
+			Email:    "",
+			Uid:      "*",
+		}
+		return []*Binding{AllUserBinding}, nil
 	}
 	users, err := user.New().ListUsers(&user.SearchArgs{UIDs: uidSets.List()})
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: mouuii <zhouchengbin@koderover.com>

### What this PR does / Why we need it:

if non user's rolebinding exist， can not show all user‘s rolebinding
