### PR TITLE
added missing proxy setting for aslan code pull

### DIFF
--- a/pkg/microservice/aslan/core/common/service/command/git_cmd.go
+++ b/pkg/microservice/aslan/core/common/service/command/git_cmd.go
@@ -97,7 +97,7 @@ func RunGitCmds(codehostDetail *systemconfig.CodeHost, repoOwner, repoName, bran
 	tokens = append(tokens, repo.OauthToken)
 	cmds = append(cmds, buildGitCommands(repo)...)
 
-	if repo.Source == setting.SourceFromGithub {
+	if codehostDetail.EnableProxy {
 		httpsProxy := config.ProxyHTTPSAddr()
 		httpProxy := config.ProxyHTTPAddr()
 		if httpsProxy != "" {


### PR DESCRIPTION
Signed-off-by: Min Min <minmin@koderover.com>

### What this PR does / Why we need it:
#1083 enables proxy for codehost other than github. There is a bug where aslan does not use proxy as expected. This is the PR to fix it.

### What is changed and how it works?
changed the conditions for proxy check in  RunGitCmd. 

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
