### PR TITLE
Change the type of the override key-value pair to interface when updating the environment

### DIFF
--- a/pkg/microservice/aslan/core/common/service/render.go
+++ b/pkg/microservice/aslan/core/common/service/render.go
@@ -44,8 +44,8 @@ type RepoConfig struct {
 }
 
 type KVPair struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key   string      `json:"key"`
+	Value interface{} `json:"value"`
 }
 
 type RenderChartArg struct {

--- a/pkg/tool/helmclient/helmclient.go
+++ b/pkg/tool/helmclient/helmclient.go
@@ -68,8 +68,8 @@ func NewClientFromRestConf(restConfig *rest.Config, ns string) (hc.Client, error
 }
 
 type KV struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key   string      `json:"key"`
+	Value interface{} `json:"value"`
 }
 
 // MergeOverrideValues merge override yaml and override kvs


### PR DESCRIPTION
Signed-off-by: ddh27 <duandehua@koderover.com>

### What this PR does / Why we need it:
Change the type of the override key-value pair to interface when updating the environment

### What is changed and how it works?


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
