### PR TITLE
display different information for build/test

### DIFF
--- a/pkg/microservice/reaper/core/service/reaper/reaper.go
+++ b/pkg/microservice/reaper/core/service/reaper/reaper.go
@@ -48,7 +48,9 @@ type Reaper struct {
 	StartTime       time.Time
 	ActiveWorkspace string
 	UserEnvs        map[string]string
-	cm              CacheManager
+	Type            types.ReaperType
+
+	cm CacheManager
 }
 
 func NewReaper() (*Reaper, error) {
@@ -67,6 +69,12 @@ func NewReaper() (*Reaper, error) {
 	reaper := &Reaper{
 		Ctx: ctx,
 		cm:  NewTarCacheManager(ctx.StorageURI, ctx.PipelineName, ctx.ServiceName, ctx.AesKey),
+	}
+
+	if ctx.TestType == "" {
+		reaper.Type = types.BuildReaperType
+	} else {
+		reaper.Type = types.TestReaperType
 	}
 
 	workspace := "/workspace"

--- a/pkg/microservice/reaper/executor/executor.go
+++ b/pkg/microservice/reaper/executor/executor.go
@@ -37,9 +37,9 @@ func Execute() error {
 	})
 
 	start := time.Now()
-	log.Info("====================== Build Start ======================")
 
 	var err error
+	var reaperType types.ReaperType
 	defer func() {
 		// Create dog food file to tell wd that task has finished.
 		resultMsg := types.JobSuccess
@@ -53,7 +53,7 @@ func Execute() error {
 			log.Errorf("Failed to create dog food: %s.", dogFoodErr)
 		}
 
-		log.Infof("====================== Build Ended. Duration: %.2f seconds ======================", time.Since(start).Seconds())
+		log.Infof("====================== %s End. Duration: %.2f seconds ======================", reaperType, time.Since(start).Seconds())
 
 		// Note: Mark the task has been completed through the dogfood file, indirectly notify wd to do follow-up
 		//       operations, and wait for a fixed time.
@@ -67,6 +67,9 @@ func Execute() error {
 	if err != nil {
 		return fmt.Errorf("failed to new reaper: %s", err)
 	}
+
+	reaperType = r.Type
+	log.Infof("====================== %s Start ======================", reaperType)
 
 	if err = r.BeforeExec(); err != nil {
 		return fmt.Errorf("failed to prepare before building: %s", err)

--- a/pkg/types/reaper.go
+++ b/pkg/types/reaper.go
@@ -1,0 +1,24 @@
+/*
+   Copyright 2022 The KodeRover Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package types
+
+type ReaperType string
+
+const (
+	BuildReaperType ReaperType = "Build"
+	TestReaperType  ReaperType = "Test"
+)


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

When `reaper` prints logs, it needs to distinguish between `build` and `test` tasks. 

### What is changed and how it works?

`reaper` prints logs based on task type. 


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
