### PR TITLE
make test result file optional

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskplugin/testing.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/testing.go
@@ -393,7 +393,7 @@ func (p *TestPlugin) Complete(ctx context.Context, pipelineTask *task.Task, serv
 		return
 	}
 
-	if p.Task.JobCtx.TestType == setting.FunctionTest {
+	if p.Task.JobCtx.TestType == setting.FunctionTest && p.Task.JobCtx.TestResultPath != "" {
 		b, err := os.ReadFile(tmpFilename)
 		if err != nil {
 			p.Log.Error(fmt.Sprintf("get test result file error: %v", err))


### PR DESCRIPTION
Signed-off-by: Min Min <minmin@koderover.com>

### What this PR does / Why we need it:
make test result file optional

### What is changed and how it works?
now if the test result file is empty, zadig no longer checks for the result and just use the job result as its result.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
