### PR TITLE
add notes for usage of object storage as cache

### DIFF
--- a/pkg/types/cache.go
+++ b/pkg/types/cache.go
@@ -30,6 +30,11 @@ const (
 	StaticProvision  ProvisionType = "static"
 )
 
+// Note:
+// In the current design, when the object storage is used as the cache medium, the default object storage
+// will be used as the cache medium, but in the near future users may be allowed to select different object storage
+// as the cache medium according to the cluster.
+// So it is temporarily reserved in `v1.10.0`, but do not use.
 type ObjectProperties struct {
 	ID string `json:"id" bson:"id"`
 }


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

In the design of `v1.10.0`, if object storage is used as a cache medium, the default object storage is used according to the original logic. However, it does not rule out that the use of object storage will be adjusted in the future, so add comments first, and do not change the fields. 

### What is changed and how it works?

Add a comment to the object store configuration. 

### Does this PR introduce a user-facing change?

None.
