### PR TITLE
clean up jobs asynchronously to avoid waiting for the next operation

### DIFF
--- a/pkg/microservice/reaper/executor/executor.go
+++ b/pkg/microservice/reaper/executor/executor.go
@@ -59,7 +59,7 @@ func Execute() error {
 		//       operations, and wait for a fixed time.
 		//       Since `wd` will automatically delete the job after detecting the dogfile, this time has little
 		//       effect on the overall construction time.
-		time.Sleep(1 * time.Minute)
+		time.Sleep(30 * time.Second)
 	}()
 
 	var r *reaper.Reaper

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -111,7 +111,7 @@ func saveContainerLog(pipelineTask *task.Task, namespace, clusterID, fileName st
 	}
 
 	if err := containerlog.GetContainerLogs(namespace, pods[0].Name, pods[0].Spec.Containers[0].Name, false, int64(0), buf, clientSet); err != nil {
-		return err
+		return fmt.Errorf("failed to get container logs: %s", err)
 	}
 
 	if tempFileName, err := util.GenerateTmpFile(); err == nil {


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

Previously, in order to adapt to EKS, when the build failed, it waited for `1 minute` to save the real-time log of the Pod, and this waiting time would increase the waiting time of the next operation. For now, the delete job operation is changed to be asynchronous to reduce the waiting time for the next step. 

### What is changed and how it works?

After saving the log, delete the Job and related resources asynchronously. 

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
