### PR TITLE
cherry-pick #1149

### DIFF
--- a/pkg/microservice/reaper/executor/executor.go
+++ b/pkg/microservice/reaper/executor/executor.go
@@ -59,7 +59,7 @@ func Execute() error {
 		//       operations, and wait for a fixed time.
 		//       Since `wd` will automatically delete the job after detecting the dogfile, this time has little
 		//       effect on the overall construction time.
-		time.Sleep(1 * time.Minute)
+		time.Sleep(30 * time.Second)
 	}()
 
 	var r *reaper.Reaper

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -111,7 +111,7 @@ func saveContainerLog(pipelineTask *task.Task, namespace, clusterID, fileName st
 	}
 
 	if err := containerlog.GetContainerLogs(namespace, pods[0].Name, pods[0].Spec.Containers[0].Name, false, int64(0), buf, clientSet); err != nil {
-		return err
+		return fmt.Errorf("failed to get container logs: %s", err)
 	}
 
 	if tempFileName, err := util.GenerateTmpFile(); err == nil {


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

Cherry-pick https://github.com/koderover/zadig/pull/1149

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
