### PR TITLE
print error msg when failing to run reaper

### DIFF
--- a/pkg/microservice/reaper/executor/executor.go
+++ b/pkg/microservice/reaper/executor/executor.go
@@ -45,6 +45,7 @@ func Execute() error {
 		resultMsg := types.JobSuccess
 		if err != nil {
 			resultMsg = types.JobFail
+			log.Errorf("Failed to run: %s.", err)
 		}
 		log.Infof("Job Status: %s", resultMsg)
 


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

When reaper fails, the error message is not printed out, which is inconvenient for users to check themselves. 

### What is changed and how it works?

Print error messages when reaper fails.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
