### PR TITLE
fix gitlab webhook update service not work bug

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/webhook/codehub.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/codehub.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -107,7 +106,7 @@ func updateServiceTemplateByCodehubPushEvent(event *codehub.PushEvent, log *zap.
 		}
 
 		for _, fileName := range fileNames {
-			if strings.Contains(fileName, path) {
+			if subElem(path, fileName) {
 				affected = true
 				break
 			}

--- a/pkg/microservice/aslan/core/workflow/service/webhook/github.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github.go
@@ -568,7 +568,7 @@ func updateServiceTemplateByGithubPush(pushEvent *github.PushEvent, log *zap.Sug
 		// 判断PushEvent的Diffs中是否包含该服务模板的src_path
 		affected := false
 		for _, changeFile := range changeFiles {
-			if strings.Contains(changeFile, path) {
+			if subElem(path, changeFile) {
 				affected = true
 				break
 			}

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab.go
@@ -17,11 +17,9 @@ limitations under the License.
 package webhook
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -62,7 +60,6 @@ func ProcessGitlabHook(payload []byte, req *http.Request, requestID string, log 
 	}
 
 	baseURI := config.SystemAddress()
-	var eventPush *EventPush
 	var pushEvent *gitlab.PushEvent
 	var mergeEvent *gitlab.MergeEvent
 	var tagEvent *gitlab.TagEvent
@@ -82,29 +79,24 @@ func ProcessGitlabHook(payload []byte, req *http.Request, requestID string, log 
 		}
 	}
 
-	//go collie.CallGitlabWebHook(forwardedProto, forwardedHost, payload, string(eventType), log)
-
 	switch event := event.(type) {
 	case *gitlab.PushEvent:
-		eventPush = &EventPush{
-			Before:      event.Before,
-			After:       event.After,
-			Ref:         event.Ref,
-			CheckoutSha: event.CheckoutSHA,
-			ProjectID:   event.ProjectID,
-			Body:        string(payload),
-		}
 		pushEvent = event
+		changeFiles := make([]string, 0)
+		for _, commit := range pushEvent.Commits {
+			changeFiles = append(changeFiles, commit.Added...)
+			changeFiles = append(changeFiles, commit.Removed...)
+			changeFiles = append(changeFiles, commit.Modified...)
+		}
+		pathWithNamespace := pushEvent.Project.PathWithNamespace
+		// trigger service template to re-sync from remote repo
+		if err = updateServiceTemplateByPushEvent(changeFiles, pathWithNamespace, log); err != nil {
+			errorList = multierror.Append(errorList, err)
+		}
 	case *gitlab.MergeEvent:
 		mergeEvent = event
 	case *gitlab.TagEvent:
 		tagEvent = event
-	}
-	//触发更新服务模板webhook
-	if eventPush != nil {
-		if err = updateServiceTemplateByPushEvent(eventPush, log); err != nil {
-			errorList = multierror.Append(errorList, err)
-		}
 	}
 
 	//触发工作流webhook和测试管理webhook
@@ -265,32 +257,9 @@ type RepositoryInfo struct {
 	VisibilityLevel int    `json:"visibility_level"`
 }
 
-func updateServiceTemplateByPushEvent(event *EventPush, log *zap.SugaredLogger) error {
+func updateServiceTemplateByPushEvent(diffs []string, pathWithNamespace string, log *zap.SugaredLogger) error {
 	log.Infof("EVENT: GITLAB WEBHOOK UPDATING SERVICE TEMPLATE")
-	gitlabEvent := &GitlabEvent{}
 
-	err := json.Unmarshal([]byte(event.Body), gitlabEvent)
-	if err != nil {
-		log.Errorf("Get Project ID failed, error: %v", err)
-		return err
-	}
-
-	address, err := GetAddress(gitlabEvent.Project.WebURL)
-	if err != nil {
-		log.Errorf("GetGitlabAddress failed, error: %v", err)
-		return err
-	}
-
-	client, err := getGitlabClientByAddress(address)
-	if err != nil {
-		return err
-	}
-
-	diffs, err := client.Compare(event.ProjectID, event.Before, event.After)
-	if err != nil {
-		log.Errorf("Failed to get push event diffs, error: %v", err)
-		return err
-	}
 	serviceTmpls, err := GetGitlabServiceTemplates()
 	if err != nil {
 		log.Errorf("Failed to get gitlab service templates, error: %v", err)
@@ -300,6 +269,11 @@ func updateServiceTemplateByPushEvent(event *EventPush, log *zap.SugaredLogger) 
 	errs := &multierror.Error{}
 
 	for _, service := range serviceTmpls {
+		// TODO need optimize, use repo namespace
+		if service.RepoOwner+"/"+service.RepoName != pathWithNamespace {
+			continue
+		}
+
 		path, err := getServiceSrcPath(service)
 		if err != nil {
 			errs = multierror.Append(errs, err)
@@ -307,7 +281,7 @@ func updateServiceTemplateByPushEvent(event *EventPush, log *zap.SugaredLogger) 
 		// 判断PushEvent的Diffs中是否包含该服务模板的src_path
 		affected := false
 		for _, diff := range diffs {
-			if strings.Contains(diff.OldPath, path) || strings.Contains(diff.NewPath, path) {
+			if subElem(path, diff) {
 				affected = true
 				break
 			}

--- a/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -192,12 +194,12 @@ func syncLatestCommit(service *commonmodels.Service) error {
 		return fmt.Errorf("url不能是空的")
 	}
 
-	address, owner, repo, branch, path, _, err := GetOwnerRepoBranchPath(service.SrcPath)
+	_, owner, repo, branch, path, _, err := GetOwnerRepoBranchPath(service.SrcPath)
 	if err != nil {
 		return fmt.Errorf("url 必须包含 owner/repo/tree/branch/path，具体请参考 Placeholder 提示")
 	}
 
-	client, err := getGitlabClientByAddress(address)
+	client, err := getGitlabClientByCodehostId(service.CodehostID)
 	if err != nil {
 		return err
 	}
@@ -261,6 +263,21 @@ func getCodehubClientByAddress(address string) (*codehub.Client, error) {
 		return nil, e.ErrCodehostListProjects.AddDesc("git client is nil")
 	}
 	client := codehub.NewClient(codehost.AccessKey, codehost.SecretKey, codehost.Region, config.ProxyHTTPSAddr(), codehost.EnableProxy)
+
+	return client, nil
+}
+
+func getGitlabClientByCodehostId(codehostId int) (*gitlabtool.Client, error) {
+	codehost, err := systemconfig.New().GetCodeHost(codehostId)
+	if err != nil {
+		log.Error(err)
+		return nil, e.ErrCodehostListProjects.AddDesc("git client is nil")
+	}
+	client, err := gitlabtool.NewClient(codehost.Address, codehost.AccessToken, config.ProxyHTTPSAddr(), codehost.EnableProxy)
+	if err != nil {
+		log.Error(err)
+		return nil, e.ErrCodehostListProjects.AddDesc(err.Error())
+	}
 
 	return client, nil
 }
@@ -350,12 +367,12 @@ func syncContentFromGitlab(userName string, args *commonmodels.Service) error {
 		return nil
 	}
 
-	address, owner, repo, branch, path, pathType, err := GetOwnerRepoBranchPath(args.SrcPath)
+	_, owner, repo, branch, path, pathType, err := GetOwnerRepoBranchPath(args.SrcPath)
 	if err != nil {
 		return fmt.Errorf("url format failed")
 	}
 
-	client, err := getGitlabClientByAddress(address)
+	client, err := getGitlabClientByCodehostId(args.CodehostID)
 	if err != nil {
 		return err
 	}
@@ -704,4 +721,17 @@ func getServiceSrcPath(service *commonmodels.Service) (string, error) {
 	}
 	_, _, _, _, p, _, err := GetOwnerRepoBranchPath(service.SrcPath)
 	return p, err
+}
+
+// check if sub path is a part of parent path
+func subElem(parent, sub string) bool {
+	up := ".." + string(os.PathSeparator)
+	rel, err := filepath.Rel(parent, sub)
+	if err != nil {
+		return false
+	}
+	if !strings.HasPrefix(rel, up) && rel != ".." {
+		return true
+	}
+	return false
 }

--- a/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
@@ -271,7 +271,7 @@ func getGitlabClientByCodehostId(codehostId int) (*gitlabtool.Client, error) {
 	codehost, err := systemconfig.New().GetCodeHost(codehostId)
 	if err != nil {
 		log.Error(err)
-		return nil, e.ErrCodehostListProjects.AddDesc("git client is nil")
+		return nil, e.ErrCodehostListProjects.AddDesc(fmt.Sprintf("failed to get codehost:%d, err: %s", codehost, err))
 	}
 	client, err := gitlabtool.NewClient(codehost.Address, codehost.AccessToken, config.ProxyHTTPSAddr(), codehost.EnableProxy)
 	if err != nil {
@@ -724,10 +724,13 @@ func getServiceSrcPath(service *commonmodels.Service) (string, error) {
 }
 
 // check if sub path is a part of parent path
+// eg: parent: k1/k2   sub: k1/k2/k3  return true
+// parent k1/k2-2  sub: k1/k2/k3 return false
 func subElem(parent, sub string) bool {
 	up := ".." + string(os.PathSeparator)
 	rel, err := filepath.Rel(parent, sub)
 	if err != nil {
+		log.Errorf("failed to check path is relative, parent: %s, sub: %s", parent, sub)
 		return false
 	}
 	if !strings.HasPrefix(rel, up) && rel != ".." {

--- a/pkg/shared/client/systemconfig/codehost.go
+++ b/pkg/shared/client/systemconfig/codehost.go
@@ -49,7 +49,6 @@ type Option struct {
 	CodeHostType string
 	Address      string
 	Namespace    string
-	CodeHostID   int
 }
 
 func GetCodeHostInfo(opt *Option) (*CodeHost, error) {


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
the webhook auto created for services imported from gitlab can't work as expected if multiple gitlab accounts with same address are integrated, because zaidg can't init the correct gitlab client.

### What is changed and how it works?
use the data from webhook request instead of fetching from gitlab server again

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
