### PR TITLE
Handle the problem that the service module name is too long and the job creation fails

### DIFF
--- a/pkg/microservice/aslan/core/log/service/sse.go
+++ b/pkg/microservice/aslan/core/log/service/sse.go
@@ -266,7 +266,10 @@ func getPipelineSelector(options *GetContainerOptions) labels.Selector {
 	ret[setting.TypeLabel] = options.SubTask
 
 	if options.ServiceName != "" {
-		serviceKey := strings.TrimRight(options.ServiceName[:63], "_")
+		serviceKey := options.ServiceName
+		if len(serviceKey) > 63 {
+			serviceKey = serviceKey[:63]
+		}
 		ret[setting.ServiceLabel] = strings.ToLower(serviceKey)
 	}
 

--- a/pkg/microservice/aslan/core/log/service/sse.go
+++ b/pkg/microservice/aslan/core/log/service/sse.go
@@ -266,7 +266,8 @@ func getPipelineSelector(options *GetContainerOptions) labels.Selector {
 	ret[setting.TypeLabel] = options.SubTask
 
 	if options.ServiceName != "" {
-		ret[setting.ServiceLabel] = strings.ToLower(options.ServiceName)
+		serviceKey := strings.TrimRight(options.ServiceName[:63], "_")
+		ret[setting.ServiceLabel] = strings.ToLower(serviceKey)
 	}
 
 	if options.PipelineType != "" {

--- a/pkg/microservice/warpdrive/core/service/common/types.go
+++ b/pkg/microservice/warpdrive/core/service/common/types.go
@@ -25,5 +25,5 @@ type Stage struct {
 	RunParallel bool                              `bson:"run_parallel"       json:"run_parallel"`
 	Desc        string                            `bson:"desc,omitempty"     json:"desc,omitempty"`
 	SubTasks    map[string]map[string]interface{} `bson:"sub_tasks"          json:"sub_tasks"`
-	AfterAll    bool                              `json:"after_all" bson:"after_all"`
+	AfterAll    bool                              `bson:"after_all"          json:"after_all"`
 }

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -376,9 +376,10 @@ const (
 
 // getJobLabels get labels k-v map from JobLabel struct
 func getJobLabels(jobLabel *JobLabel) map[string]string {
+	serviceKey := strings.TrimRight(jobLabel.ServiceName[:63], "_")
 	retMap := map[string]string{
 		jobLabelTaskKey:    fmt.Sprintf("%s-%d", strings.ToLower(jobLabel.PipelineName), jobLabel.TaskID),
-		jobLabelServiceKey: strings.ToLower(jobLabel.ServiceName),
+		jobLabelServiceKey: strings.ToLower(serviceKey),
 		jobLabelSTypeKey:   strings.Replace(jobLabel.TaskType, "_", "-", -1),
 		jobLabelPTypeKey:   jobLabel.PipelineType,
 	}

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -376,7 +376,11 @@ const (
 
 // getJobLabels get labels k-v map from JobLabel struct
 func getJobLabels(jobLabel *JobLabel) map[string]string {
-	serviceKey := strings.TrimRight(jobLabel.ServiceName[:63], "_")
+	serviceKey := jobLabel.ServiceName
+	if len(serviceKey) > 63 {
+		serviceKey = serviceKey[:63]
+	}
+
 	retMap := map[string]string{
 		jobLabelTaskKey:    fmt.Sprintf("%s-%d", strings.ToLower(jobLabel.PipelineName), jobLabel.TaskID),
 		jobLabelServiceKey: strings.ToLower(serviceKey),


### PR DESCRIPTION
Signed-off-by: liu deyi <andrew@koderover.com>

### What this PR does / Why we need it:
Handle the problem that the service module name is too long and the job creation fails

### What is changed and how it works?
Cut after the length is exceeded

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
