### PR TITLE
cherry-pick #1176 and #1180

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflow_task.go
@@ -432,7 +432,7 @@ func UpdateWorkflowTaskArgs(triggerYaml *TriggerYaml, workflow *commonmodels.Wor
 		if test.Repo.Strategy == TestRepoStrategyCurrentRepo {
 			for _, repo := range moduleTest.Repos {
 				if repo.RepoName == item.MainRepo.RepoName && repo.RepoOwner == item.MainRepo.RepoOwner {
-					repo.Branch = item.MainRepo.Branch
+					repo.Branch = branref
 					repo.PR = prId
 				}
 			}

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflow_task.go
@@ -553,7 +553,6 @@ func TriggerWorkflowByGitlabEvent(event interface{}, baseURI, requestID string, 
 					branref = mergeEvent.ObjectAttributes.SourceBranch
 				}
 				prID = evt.ObjectAttributes.IID
-				item.MainRepo.Branch = getBranchFromRef(mergeEvent.ObjectAttributes.TargetBranch)
 			case *gitlab.TagEvent:
 				tagEvent = evt
 				if (item.MainRepo.RepoOwner + "/" + item.MainRepo.RepoName) != tagEvent.Project.PathWithNamespace {


### PR DESCRIPTION
### What this PR does / Why we need it:

Fixed webhook branch being replaced.
Fixed a problem with the test task code strategy in YamL Webhook.

### What is changed and how it works?

Cherry-pick https://github.com/koderover/zadig/pull/1176 and https://github.com/koderover/zadig/pull/1180


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
