### PR TITLE
support subpath

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -1516,6 +1516,21 @@ func testArgsToSubtask(args *commonmodels.WorkflowTaskArgs, pt *taskmodels.Task,
 		testTask.JobCtx.TestResultPath = testModule.TestResultPath
 		testTask.JobCtx.TestReportPath = testModule.TestReportPath
 
+		clusterInfo, err := commonrepo.NewK8SClusterColl().Get(testModule.PreTest.ClusterID)
+		if err != nil {
+			return nil, err
+		}
+		testTask.Cache = clusterInfo.Cache
+
+		// If the cluster is not configured with a cache medium, the cache cannot be used, so don't enable cache explicitly.
+		if testTask.Cache.MediumType == "" {
+			testTask.CacheEnable = false
+		} else {
+			testTask.CacheEnable = testModule.CacheEnable
+			testTask.CacheDirType = testModule.CacheDirType
+			testTask.CacheUserDir = testModule.CacheUserDir
+		}
+
 		if testTask.Registries == nil {
 			testTask.Registries = registries
 		}

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -549,6 +549,7 @@ func buildJobWithLinkedNs(taskType config.TaskType, jobImage, jobName, serviceNa
 		job.Spec.Template.Spec.Containers[0].VolumeMounts = append(job.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 			Name:      volumeName,
 			MountPath: mountPath,
+			SubPath:   ctx.Cache.NFSProperties.Subpath,
 		})
 	}
 
@@ -898,7 +899,10 @@ func waitJobEndWithFile(ctx context.Context, taskTimeout int, namespace, jobName
 					if !ipod.Finished() {
 						jobStatus, exists, err = checkDogFoodExistsInContainer(clientset, restConfig, namespace, ipod.Name, ipod.ContainerNames()[0])
 						if err != nil {
-							xl.Errorf("Failed to check dog food file %s: %s.", pods[0].Name, err)
+							// Note:
+							// Currently, this error indicates "the target Pod cannot be accessed" or "the target Pod can be accessed, but the dog food file does not exist".
+							// In these two scenarios, `Info` is used to print logs because they are not business semantic exceptions.
+							xl.Infof("Result of checking dog food file %s: %s", pods[0].Name, err)
 							break
 						}
 						if !exists {

--- a/pkg/types/cache.go
+++ b/pkg/types/cache.go
@@ -44,6 +44,7 @@ type NFSProperties struct {
 	StorageClass     string        `json:"storage_class"       bson:"storage_class"`
 	StorageSizeInGiB int64         `json:"storage_size_in_gib" bson:"storage_size_in_gib"`
 	PVC              string        `json:"pvc"                 bson:"pvc"`
+	Subpath          string        `json:"subpath"             bson:"subpath"`
 }
 
 type Cache struct {
@@ -58,3 +59,5 @@ const (
 	WorkspaceCacheDir   CacheDirType = "workspace"
 	UserDefinedCacheDir CacheDirType = "user_defined"
 )
+
+const DefaultSubpath = "$PROJECT/$WORKFLOW/$SERVICE"


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

- When PVC is used in a cluster, all data is placed under `/`, which may cause cache data conflicts. `subpath` needs to be supported so that users can configure PVC subdirectories for different scenarios.
- The cache was not handled correctly when the workflow ran the test task.

### What is changed and how it works?

- Support `subpath`
- Fixed bug where workflows did not handle cache correctly when running test tasks.

### Does this PR introduce a user-facing change?

- [ ] API change
- [x] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
