### PR TITLE
fix bug of executing in pod

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -1540,6 +1540,7 @@ func testArgsToSubtask(args *commonmodels.WorkflowTaskArgs, pt *taskmodels.Task,
 			}
 			envs = append(envs, &commonmodels.KeyVal{Key: "TEST_URL", Value: GetLink(pt, configbase.SystemAddress(), config.WorkflowType)})
 			envs = append(envs, &commonmodels.KeyVal{Key: "SERVICES", Value: services})
+			envs = append(envs, &commonmodels.KeyVal{Key: "WORKSPACE", Value: "/workspace"})
 
 			testTask.JobCtx.EnvVars = envs
 			testTask.ImageID = testModule.PreTest.ImageID

--- a/pkg/microservice/warpdrive/core/service/taskplugin/artifact_deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/artifact_deploy.go
@@ -35,7 +35,6 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/config"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/types/task"
 	"github.com/koderover/zadig/pkg/setting"
-	kubeclient "github.com/koderover/zadig/pkg/shared/kube/client"
 	krkubeclient "github.com/koderover/zadig/pkg/tool/kube/client"
 	"github.com/koderover/zadig/pkg/tool/kube/updater"
 )
@@ -119,37 +118,17 @@ func (p *ArtifactDeployTaskPlugin) Run(ctx context.Context, pipelineTask *task.T
 	default:
 		p.KubeNamespace = setting.AttachedClusterNamespace
 
-		kubeClient, err := kubeclient.GetKubeClient(pipelineTask.ConfigPayload.HubServerAddr, p.Task.ClusterID)
+		crClient, clientset, restConfig, err := GetK8sClients(pipelineTask.ConfigPayload.HubServerAddr, p.Task.ClusterID)
 		if err != nil {
-			msg := fmt.Sprintf("failed to get kube client: %s", err)
-			p.Log.Error(msg)
+			p.Log.Error(err)
 			p.Task.TaskStatus = config.StatusFailed
-			p.Task.Error = msg
+			p.Task.Error = err.Error()
 			p.SetBuildStatusCompleted(config.StatusFailed)
 			return
 		}
-		p.kubeClient = kubeClient
 
-		clientset, err := kubeclient.GetClientset(pipelineTask.ConfigPayload.HubServerAddr, p.Task.ClusterID)
-		if err != nil {
-			msg := fmt.Sprintf("failed to get clientset: %s", err)
-			p.Log.Error(msg)
-			p.Task.TaskStatus = config.StatusFailed
-			p.Task.Error = msg
-			p.SetBuildStatusCompleted(config.StatusFailed)
-			return
-		}
+		p.kubeClient = crClient
 		p.clientset = clientset
-
-		restConfig, err := kubeclient.GetRESTConfig(pipelineTask.ConfigPayload.HubServerAddr, p.Task.ClusterID)
-		if err != nil {
-			msg := fmt.Sprintf("failed to get clientset: %s", err)
-			p.Log.Error(msg)
-			p.Task.TaskStatus = config.StatusFailed
-			p.Task.Error = msg
-			p.SetBuildStatusCompleted(config.StatusFailed)
-			return
-		}
 		p.restConfig = restConfig
 	}
 

--- a/pkg/microservice/warpdrive/core/service/taskplugin/build.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/build.go
@@ -36,7 +36,6 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/config"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/types/task"
 	"github.com/koderover/zadig/pkg/setting"
-	kubeclient "github.com/koderover/zadig/pkg/shared/kube/client"
 	krkubeclient "github.com/koderover/zadig/pkg/tool/kube/client"
 	"github.com/koderover/zadig/pkg/tool/kube/updater"
 	"github.com/koderover/zadig/pkg/types"
@@ -128,37 +127,17 @@ func (p *BuildTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipe
 	default:
 		p.KubeNamespace = setting.AttachedClusterNamespace
 
-		kubeClient, err := kubeclient.GetKubeClient(pipelineTask.ConfigPayload.HubServerAddr, p.Task.ClusterID)
+		crClient, clientset, restConfig, err := GetK8sClients(pipelineTask.ConfigPayload.HubServerAddr, p.Task.ClusterID)
 		if err != nil {
-			msg := fmt.Sprintf("failed to get kube client: %s", err)
-			p.Log.Error(msg)
+			p.Log.Error(err)
 			p.Task.TaskStatus = config.StatusFailed
-			p.Task.Error = msg
+			p.Task.Error = err.Error()
 			p.SetBuildStatusCompleted(config.StatusFailed)
 			return
 		}
-		p.kubeClient = kubeClient
 
-		clientset, err := kubeclient.GetClientset(pipelineTask.ConfigPayload.HubServerAddr, p.Task.ClusterID)
-		if err != nil {
-			msg := fmt.Sprintf("failed to get clientset: %s", err)
-			p.Log.Error(msg)
-			p.Task.TaskStatus = config.StatusFailed
-			p.Task.Error = msg
-			p.SetBuildStatusCompleted(config.StatusFailed)
-			return
-		}
+		p.kubeClient = crClient
 		p.clientset = clientset
-
-		restConfig, err := kubeclient.GetRESTConfig(pipelineTask.ConfigPayload.HubServerAddr, p.Task.ClusterID)
-		if err != nil {
-			msg := fmt.Sprintf("failed to get clientset: %s", err)
-			p.Log.Error(msg)
-			p.Task.TaskStatus = config.StatusFailed
-			p.Task.Error = msg
-			p.SetBuildStatusCompleted(config.StatusFailed)
-			return
-		}
 		p.restConfig = restConfig
 	}
 

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -37,6 +37,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/config"
@@ -559,29 +561,47 @@ func buildJobWithLinkedNs(taskType config.TaskType, jobImage, jobName, serviceNa
 		job.Spec.Template.Spec.Affinity = affinity
 	}
 
-	if linkedNs != "" && execNs != "" && pipelineTask.ConfigPayload.CustomDNSSupported {
-		job.Spec.Template.Spec.DNSConfig = &corev1.PodDNSConfig{
-			Searches: []string{
-				linkedNs + ".svc.cluster.local",
-				execNs + ".svc.cluster.local",
-				"svc.cluster.local",
-				"cluster.local",
-			},
-		}
+	// Note:
+	// The following logic is valid for the testing task and configures dNSconfig as follows:
+	// ```
+	// dnsConfig:
+	//   nameservers:
+	//   - 192.168.0.157
+	//   options:
+	//   - name: ndots
+	//     value: "5"
+	//   searches:
+	//   - piggymetrics-env-dev.svc.cluster.local
+	//   - koderover-agent.svc.cluster.local
+	//   - svc.cluster.local
+	//   - cluster.local
+	// ```
+	//
+	// These are intra-cluster domain names that can be satisfied by default `ClusterFirst` DNSPolicy.
+	// No one knows why there is such logic, comment it out, run it for a while and then delete it.
+	//
+	// if linkedNs != "" && execNs != "" && pipelineTask.ConfigPayload.CustomDNSSupported {
+	// 	job.Spec.Template.Spec.DNSConfig = &corev1.PodDNSConfig{
+	// 		Searches: []string{
+	// 			linkedNs + ".svc.cluster.local",
+	// 			execNs + ".svc.cluster.local",
+	// 			"svc.cluster.local",
+	// 			"cluster.local",
+	// 		},
 
-		if addresses, lookupErr := lookupKubeDNSServerHost(); lookupErr == nil {
-			job.Spec.Template.Spec.DNSPolicy = corev1.DNSNone
-			// https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-config
-			// There can be at most 3 IP addresses specified
-			job.Spec.Template.Spec.DNSConfig.Nameservers = addresses[:Min(3, len(addresses))]
-			value := "5"
-			job.Spec.Template.Spec.DNSConfig.Options = []corev1.PodDNSConfigOption{
-				{Name: "ndots", Value: &value},
-			}
-		} else {
-			log.SugaredLogger().Errorf("failed to find ip of kube dns %v", lookupErr)
-		}
-	}
+	// 	if addresses, lookupErr := lookupKubeDNSServerHost(); lookupErr == nil {
+	// 		job.Spec.Template.Spec.DNSPolicy = corev1.DNSNone
+	// 		// https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-config
+	// 		// There can be at most 3 IP addresses specified
+	// 		job.Spec.Template.Spec.DNSConfig.Nameservers = addresses[:Min(3, len(addresses))]
+	// 		value := "5"
+	// 		job.Spec.Template.Spec.DNSConfig.Options = []corev1.PodDNSConfigOption{
+	// 			{Name: "ndots", Value: &value},
+	// 		}
+	// 	} else {
+	// 		log.SugaredLogger().Errorf("failed to find ip of kube dns %v", lookupErr)
+	// 	}
+	// }
 
 	return job, nil
 }
@@ -758,8 +778,8 @@ func generateResourceRequirements(req setting.Request, reqSpec setting.RequestSp
 
 //waitJobEnd
 //Returns job status
-func waitJobEnd(ctx context.Context, taskTimeout int, namspace, jobName string, kubeClient client.Client, xl *zap.SugaredLogger) (status config.Status) {
-	return waitJobEndWithFile(ctx, taskTimeout, namspace, jobName, false, kubeClient, xl)
+func waitJobEnd(ctx context.Context, taskTimeout int, namspace, jobName string, kubeClient client.Client, clientset kubernetes.Interface, restConfig *rest.Config, xl *zap.SugaredLogger) (status config.Status) {
+	return waitJobEndWithFile(ctx, taskTimeout, namspace, jobName, false, kubeClient, clientset, restConfig, xl)
 }
 
 func waitJobReady(ctx context.Context, namespace, jobName string, kubeClient client.Client, xl *zap.SugaredLogger) (status config.Status) {
@@ -808,7 +828,7 @@ func waitJobReady(ctx context.Context, namespace, jobName string, kubeClient cli
 	return config.StatusRunning
 }
 
-func waitJobEndWithFile(ctx context.Context, taskTimeout int, namespace, jobName string, checkFile bool, kubeClient client.Client, xl *zap.SugaredLogger) (status config.Status) {
+func waitJobEndWithFile(ctx context.Context, taskTimeout int, namespace, jobName string, checkFile bool, kubeClient client.Client, clientset kubernetes.Interface, restConfig *rest.Config, xl *zap.SugaredLogger) (status config.Status) {
 	xl.Infof("wait job to start: %s/%s", namespace, jobName)
 	timeout := time.After(time.Duration(taskTimeout) * time.Second)
 	podTimeout := time.After(120 * time.Second)
@@ -876,7 +896,7 @@ func waitJobEndWithFile(ctx context.Context, taskTimeout int, namespace, jobName
 					}
 
 					if !ipod.Finished() {
-						jobStatus, exists, err = checkDogFoodExistsInContainer(namespace, ipod.Name, ipod.ContainerNames()[0])
+						jobStatus, exists, err = checkDogFoodExistsInContainer(clientset, restConfig, namespace, ipod.Name, ipod.ContainerNames()[0])
 						if err != nil {
 							xl.Errorf("Failed to check dog food file %s: %s.", pods[0].Name, err)
 							break
@@ -907,11 +927,10 @@ func waitJobEndWithFile(ctx context.Context, taskTimeout int, namespace, jobName
 
 		time.Sleep(time.Second * 1)
 	}
-
 }
 
-func checkDogFoodExistsInContainer(namespace string, pod string, container string) (commontypes.JobStatus, bool, error) {
-	stdout, _, success, err := podexec.ExecWithOptions(podexec.ExecOptions{
+func checkDogFoodExistsInContainer(clientset kubernetes.Interface, restConfig *rest.Config, namespace, pod, container string) (commontypes.JobStatus, bool, error) {
+	stdout, _, success, err := podexec.KubeExec(clientset, restConfig, podexec.ExecOptions{
 		Command:       []string{"/bin/sh", "-c", fmt.Sprintf("test -f %[1]s && cat %[1]s", setting.DogFood)},
 		Namespace:     namespace,
 		PodName:       pod,

--- a/pkg/microservice/warpdrive/core/service/taskplugin/release_image.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/release_image.go
@@ -24,6 +24,8 @@ import (
 
 	"go.uber.org/zap"
 	yaml "gopkg.in/yaml.v3"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/config"
@@ -39,6 +41,8 @@ func InitializeReleaseImagePlugin(taskType config.TaskType) TaskPlugin {
 	return &ReleaseImagePlugin{
 		Name:       taskType,
 		kubeClient: krkubeclient.Client(),
+		clientset:  krkubeclient.Clientset(),
+		restConfig: krkubeclient.RESTConfig(),
 	}
 }
 
@@ -49,6 +53,8 @@ type ReleaseImagePlugin struct {
 	JobName       string
 	FileName      string
 	kubeClient    client.Client
+	clientset     kubernetes.Interface
+	restConfig    *rest.Config
 	Task          *task.ReleaseImage
 	Log           *zap.SugaredLogger
 }
@@ -206,7 +212,7 @@ func (p *ReleaseImagePlugin) Run(ctx context.Context, pipelineTask *task.Task, p
 
 // Wait ...
 func (p *ReleaseImagePlugin) Wait(ctx context.Context) {
-	status := waitJobEnd(ctx, p.TaskTimeout(), p.KubeNamespace, p.JobName, p.kubeClient, p.Log)
+	status := waitJobEnd(ctx, p.TaskTimeout(), p.KubeNamespace, p.JobName, p.kubeClient, p.clientset, p.restConfig, p.Log)
 	p.SetStatus(status)
 }
 

--- a/pkg/microservice/warpdrive/core/service/taskplugin/utils.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/utils.go
@@ -27,9 +27,13 @@ import (
 	t "github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	crClient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/config"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/types/task"
+	kubeclient "github.com/koderover/zadig/pkg/shared/kube/client"
 	"github.com/koderover/zadig/pkg/tool/kodo"
 )
 
@@ -218,4 +222,23 @@ func ToExtensionTask(sb map[string]interface{}) (*task.Extension, error) {
 		return nil, fmt.Errorf("convert interface to extensionTask error: %s", err)
 	}
 	return extension, nil
+}
+
+func GetK8sClients(hubServerAddr, clusterID string) (crClient.Client, kubernetes.Interface, *rest.Config, error) {
+	controllerRuntimeClient, err := kubeclient.GetKubeClient(hubServerAddr, clusterID)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to get controller runtime client: %s", err)
+	}
+
+	clientset, err := kubeclient.GetKubeClientSet(hubServerAddr, clusterID)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to get clientset: %s", err)
+	}
+
+	restConfig, err := kubeclient.GetRESTConfig(hubServerAddr, clusterID)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to get rest config: %s", err)
+	}
+
+	return controllerRuntimeClient, clientset, restConfig, nil
 }


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

Zadig supports attached cluster. However, `wd` still uses the client of the local cluster when detecting `dogfood` file of Pod in the attched cluster. As a result, Pod in the attached cluster cannot be found.
Besides, `controller-runtime` does not support `exec` operations and must be implemented through `client-go`: https://github.com/kubernetes-sigs/controller-runtime/issues/1229

For executing testing task in workflow, the custom DNS config will affect the testing Workflow execution in the attached cluster, and the `resource-server` cannot be accessed to pull the `reaper`.

### What is changed and how it works?

- For the `exec` method, add support for attached clusters and modify the use of `wd` plugins for this.
- For testing Jobs, use the default DNS policy.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
