### PR TITLE
add logic to ensure helm chart upgrade

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2575,7 +2575,7 @@ func installOrUpgradeHelmChartWithValues(namespace, valuesYaml string, renderCha
 	return err
 }
 
-func installProductHelmCharts(user, envName, requestID string, args *commonmodels.Product, renderset *commonmodels.RenderSet, eventStart int64, helmClient helmclient.Client, kubecli client.Client, log *zap.SugaredLogger) {
+func installProductHelmCharts(user, envName, requestID string, args *commonmodels.Product, renderset *commonmodels.RenderSet, eventStart int64, helmClient helmclient.Client, log *zap.SugaredLogger) {
 	var (
 		err     error
 		errList = &multierror.Error{}
@@ -2755,12 +2755,8 @@ func updateProductGroup(username, productName, envName, updateType string, produ
 		productServiceMap      = make(map[string]*commonmodels.ProductService)
 		productTemplServiceMap = make(map[string]*commonmodels.ProductService)
 	)
-	restConfig, err := kube.GetRESTConfig(productResp.ClusterID)
-	if err != nil {
-		return e.ErrUpdateEnv.AddErr(err)
-	}
 
-	helmClient, err := helmtool.NewClientFromRestConf(restConfig, productResp.Namespace)
+	helmClient, err := helmtool.NewClientFromNamespace(productResp.ClusterID, productResp.Namespace)
 	if err != nil {
 		return e.ErrUpdateEnv.AddErr(err)
 	}
@@ -3078,12 +3074,7 @@ func overrideValues(currentValuesYaml, latestValuesYaml []byte, imageRelatedKey 
 }
 
 func updateProductVariable(productName, envName string, productResp *commonmodels.Product, renderset *commonmodels.RenderSet, log *zap.SugaredLogger) error {
-	restConfig, err := kube.GetRESTConfig(productResp.ClusterID)
-	if err != nil {
-		return e.ErrUpdateEnv.AddErr(err)
-	}
-
-	helmClient, err := helmtool.NewClientFromRestConf(restConfig, productResp.Namespace)
+	helmClient, err := helmtool.NewClientFromNamespace(productResp.ClusterID, productResp.Namespace)
 	if err != nil {
 		return e.ErrUpdateEnv.AddErr(err)
 	}

--- a/pkg/microservice/aslan/core/environment/service/environment_creator.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_creator.go
@@ -27,11 +27,10 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/template"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	commonservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service"
-	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/kube"
 	"github.com/koderover/zadig/pkg/setting"
 	kubeclient "github.com/koderover/zadig/pkg/shared/kube/client"
 	e "github.com/koderover/zadig/pkg/tool/errors"
-	"github.com/koderover/zadig/pkg/tool/helmclient"
+	helmtool "github.com/koderover/zadig/pkg/tool/helmclient"
 	"github.com/koderover/zadig/pkg/tool/kube/informer"
 )
 
@@ -147,14 +146,8 @@ func (creator *HelmProductCreator) Create(user, requestID string, args *models.P
 		args.Namespace = namespace
 	}
 
-	restConfig, err := kube.GetRESTConfig(args.ClusterID)
+	helmClient, err := helmtool.NewClientFromNamespace(args.ClusterID, args.Namespace)
 	if err != nil {
-		log.Errorf("GetRESTConfig error: %v", err)
-		return e.ErrCreateEnv.AddDesc(err.Error())
-	}
-	helmClient, err := helmclient.NewClientFromRestConf(restConfig, args.Namespace)
-	if err != nil {
-		log.Errorf("[%s][%s] NewClientFromRestConf error: %v", args.EnvName, args.ProductName, err)
 		return e.ErrCreateEnv.AddErr(err)
 	}
 
@@ -224,7 +217,7 @@ func (creator *HelmProductCreator) Create(user, requestID string, args *models.P
 
 	eventStart := time.Now().Unix()
 
-	go installProductHelmCharts(user, args.EnvName, requestID, args, renderSet, eventStart, helmClient, kubeClient, log)
+	go installProductHelmCharts(user, args.EnvName, requestID, args, renderSet, eventStart, helmClient, log)
 	return nil
 }
 

--- a/pkg/microservice/aslan/core/environment/service/image.go
+++ b/pkg/microservice/aslan/core/environment/service/image.go
@@ -22,7 +22,6 @@ import (
 
 	helmclient "github.com/mittwald/go-helm-client"
 	"go.uber.org/zap"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
@@ -127,7 +126,6 @@ func updateContainerForHelmChart(serviceName, resType, image, containerName stri
 		replacedValuesYaml       string
 		mergedValuesYaml         string
 		replacedMergedValuesYaml string
-		restConfig               *rest.Config
 		helmClient               helmclient.Client
 		namespace                string = product.Namespace
 	)
@@ -171,11 +169,7 @@ func updateContainerForHelmChart(serviceName, resType, image, containerName stri
 		return err
 	}
 
-	restConfig, err = kube.GetRESTConfig(product.ClusterID)
-	if err != nil {
-		return err
-	}
-	helmClient, err = helmtool.NewClientFromRestConf(restConfig, namespace)
+	helmClient, err = helmtool.NewClientFromNamespace(product.ClusterID, namespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
@@ -507,7 +507,7 @@ func (p *DeployTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, _ *
 
 		p.Log.Infof("final replaced merged values: \n%s", replacedMergedValuesYaml)
 
-		helmClient, err = helmtool.NewClientFromRestConf(p.restConfig, p.Task.Namespace)
+		helmClient, err = helmtool.NewClientFromNamespace(pipelineTask.ConfigPayload.DeployClusterID, p.Task.Namespace)
 		if err != nil {
 			err = errors.WithMessagef(
 				err,

--- a/pkg/tool/helmclient/helmclient.go
+++ b/pkg/tool/helmclient/helmclient.go
@@ -354,11 +354,6 @@ func (hClient *HelmClient) ensureUpgrade(maxHistoryCount int, releaseName string
 	if maxHistoryCount <= 0 || len(releases) < maxHistoryCount {
 		return nil
 	}
-	for _, re := range releases {
-		if re.Info.Status == release.StatusDeployed {
-			return nil
-		}
-	}
 	if hClient.kubeClient == nil {
 		return errors.New("kubeClient is nil")
 	}

--- a/pkg/tool/helmclient/helmclient.go
+++ b/pkg/tool/helmclient/helmclient.go
@@ -43,7 +43,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
-	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/kube"
 	kubeclient "github.com/koderover/zadig/pkg/shared/kube/client"
 	"github.com/koderover/zadig/pkg/tool/kube/updater"
 	"github.com/koderover/zadig/pkg/tool/log"
@@ -56,8 +55,10 @@ type HelmClient struct {
 	Namespace  string
 }
 
+// NewClientFromNamespace returns a new Helm client constructed with the provided clusterID and namespace
+// a kubeClient will be initialized to support necessary k8s operations when install/upgrade helm charts
 func NewClientFromNamespace(clusterID, namespace string) (hc.Client, error) {
-	restConfig, err := kube.GetRESTConfig(clusterID)
+	restConfig, err := kubeclient.GetRESTConfig(config.HubServerAddress(), clusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -87,6 +88,7 @@ func NewClientFromNamespace(clusterID, namespace string) (hc.Client, error) {
 }
 
 // NewClientFromRestConf returns a new Helm client constructed with the provided REST config options
+// used to list/uninstall helm release
 func NewClientFromRestConf(restConfig *rest.Config, ns string) (hc.Client, error) {
 	hcClient, err := hc.NewClientFromRestConf(&hc.RestConfClientOptions{
 		Options: &hc.Options{


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when upgrading helm charts, a new revision of helm release will be saved as secret, helm will delete a revison marked as status `deployed` when the amount of releases reachs the limit specified by parameter history-max(default 10). It will cause error `has no deployed releases` to occur when the following conditions are met:
* the amount of releases reachs the limit(history-max)
* no revisions with status `deployed` found in current history revisions

### What is changed and how it works?
try to find release with status `deployed` when the count of releases reaches the limit, delete the oldest revision if no release with status deployed found. 

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
