### PR TITLE
fix bug of download chart from harbor repo chart

### DIFF
--- a/pkg/tool/helmclient/chartclient.go
+++ b/pkg/tool/helmclient/chartclient.go
@@ -187,14 +187,18 @@ func (client *ChartRepoClient) GetChartFromIndex(chartName, chartVersion string)
 	return nil, fmt.Errorf("failed to find chart [%s]-[%s]", chartName, chartVersion)
 }
 
+// TODO this function should be deprecated
+// we should use standard `helm pull` to provide better compatibility
 func (client *ChartRepoClient) downloadFileWithURL(chartUrl string) (*http.Response, error) {
 	u, _ := url.Parse(chartUrl)
-	// chart url is absolute path
+	// chart url is absolute path in index.yaml, set url of option to full chart url and download directly
+	// eg: chart repo hosted by gitee
 	if u.Scheme == "http" || u.Scheme == "https" {
 		client.Option(cm.URL(chartUrl))
 		defer client.Option(cm.URL(client.RepoURL))
 		return client.DownloadFile("")
-	} else {
-		return client.DownloadFile(chartUrl)
 	}
+	// chart url in index.yaml is relative path, set url of option to the repoUrl and download by fileName
+	// eg: chart repo hosted by harbor
+	return client.DownloadFile(chartUrl)
 }


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
It will fail when downloading helm charts from helm chart repo hosted by harbor

### What is changed and how it works?
fix bug

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
