### PR TITLE
change env SERVICE to SERVICE_MODULE in testing

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskplugin/testing.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/testing.go
@@ -183,7 +183,7 @@ func (p *TestPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipelineC
 	p.Task.JobCtx.EnvVars = append(p.Task.JobCtx.EnvVars, namespaceEnvVar)
 	p.Task.JobCtx.EnvVars = append(p.Task.JobCtx.EnvVars, linkedNamespaceEnvVar)
 	p.Task.JobCtx.EnvVars = append(p.Task.JobCtx.EnvVars, envNameEnvVar)
-	p.Task.JobCtx.EnvVars = append(p.Task.JobCtx.EnvVars, &task.KeyVal{Key: "SERVICE", Value: pipelineTask.ServiceName})
+	p.Task.JobCtx.EnvVars = append(p.Task.JobCtx.EnvVars, &task.KeyVal{Key: "SERVICE_MODULE", Value: pipelineTask.ServiceName})
 	p.Task.JobCtx.EnvVars = append(p.Task.JobCtx.EnvVars, &task.KeyVal{Key: "PROJECT", Value: pipelineTask.ProductName})
 
 	var testReportFile string // html 测试报告

--- a/pkg/types/cache.go
+++ b/pkg/types/cache.go
@@ -59,5 +59,3 @@ const (
 	WorkspaceCacheDir   CacheDirType = "workspace"
 	UserDefinedCacheDir CacheDirType = "user_defined"
 )
-
-const DefaultSubpath = "$PROJECT/$WORKFLOW/$SERVICE"


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

`$PROJECT` / `$WORKFLOW` / `$SERVICE_MODULE` is currently supported in `subpath`. Fix variable names in testing tasks.


### What is changed and how it works?

Change `$SERVICE` to `$SERVICE_MODULE` for testing task.


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
