### PR TITLE
Remove the limit on the number of service replicas

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -69,11 +69,6 @@ func ScaleService(envName, productName, serviceName string, number int, log *zap
 		return e.ErrScaleService.AddErr(err)
 	}
 
-	// TODO: At present, the number of replicas is forced to be 0-1000, which can be changed to configuration in the future
-	if number > 1000 || number < 0 {
-		return e.ErrInvalidParam.AddDesc("伸缩数量范围[0..1000]")
-	}
-
 	selector := labels.Set{setting.ProductLabel: productName, setting.ServiceLabel: serviceName}.AsSelector()
 	ds, err := getter.ListDeployments(prod.Namespace, selector, kubeClient)
 	if err != nil {
@@ -105,11 +100,6 @@ func ScaleService(envName, productName, serviceName string, number int, log *zap
 }
 
 func Scale(args *ScaleArgs, logger *zap.SugaredLogger) error {
-	// TODO: At present, the number of replicas is forced to be 0-1000, which can be changed to configuration in the future
-	if args.Number > 1000 || args.Number < 0 {
-		return e.ErrInvalidParam.AddDesc("伸缩数量范围[0..1000]")
-	}
-
 	opt := &commonrepo.ProductFindOptions{Name: args.ProductName, EnvName: args.EnvName}
 	prod, err := commonrepo.NewProductColl().Find(opt)
 	if err != nil {

--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -69,9 +69,9 @@ func ScaleService(envName, productName, serviceName string, number int, log *zap
 		return e.ErrScaleService.AddErr(err)
 	}
 
-	// TODO: 目前强制定死扩容数量为0-20, 以后可以改成配置
-	if number > 20 || number < 0 {
-		return e.ErrInvalidParam.AddDesc("伸缩数量范围[0..20]")
+	// TODO: At present, the number of replicas is forced to be 0-1000, which can be changed to configuration in the future
+	if number > 1000 || number < 0 {
+		return e.ErrInvalidParam.AddDesc("伸缩数量范围[0..1000]")
 	}
 
 	selector := labels.Set{setting.ProductLabel: productName, setting.ServiceLabel: serviceName}.AsSelector()
@@ -105,8 +105,9 @@ func ScaleService(envName, productName, serviceName string, number int, log *zap
 }
 
 func Scale(args *ScaleArgs, logger *zap.SugaredLogger) error {
-	if args.Number > 20 || args.Number < 0 {
-		return e.ErrInvalidParam.AddDesc("伸缩数量范围[0..20]")
+	// TODO: At present, the number of replicas is forced to be 0-1000, which can be changed to configuration in the future
+	if args.Number > 1000 || args.Number < 0 {
+		return e.ErrInvalidParam.AddDesc("伸缩数量范围[0..1000]")
 	}
 
 	opt := &commonrepo.ProductFindOptions{Name: args.ProductName, EnvName: args.EnvName}


### PR DESCRIPTION
Signed-off-by: liu deyi <andrew@koderover.com>

### What this PR does / Why we need it:
Remove the limit on the number of service replicas

### What is changed and how it works?
The number of replicas of the original service is 0-20

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
