### PR TITLE
fix bug of creating env based on existed namespace

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/render_set.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/render_set.go
@@ -42,8 +42,9 @@ type RenderSetListOption struct {
 // RenderSetFindOption ...
 type RenderSetFindOption struct {
 	// if Revision == 0 then search max revision of RenderSet
-	Revision int64
-	Name     string
+	ProductTmpl string
+	Revision    int64
+	Name        string
 }
 
 type RenderSetPipeResp struct {
@@ -168,8 +169,9 @@ func (c *RenderSetColl) List(opt *RenderSetListOption) ([]*models.RenderSet, err
 	var resp []*models.RenderSet
 	for _, pipe := range pipeResp {
 		optRender := &RenderSetFindOption{
-			Revision: pipe.Revision,
-			Name:     pipe.RenderSet.Name,
+			Revision:    pipe.Revision,
+			Name:        pipe.RenderSet.Name,
+			ProductTmpl: pipe.RenderSet.ProductTmpl,
 		}
 		if pipe.Revision == 0 && pipe.RenderSet.Name == "" {
 			continue
@@ -206,6 +208,10 @@ func (c *RenderSetColl) Find(opt *RenderSetFindOption) (*models.RenderSet, error
 		query["revision"] = opt.Revision
 	} else {
 		opts.SetSort(bson.D{{"revision", -1}})
+	}
+
+	if len(opt.ProductTmpl) > 0 {
+		query["product_tmpl"] = opt.ProductTmpl
 	}
 
 	rs := &models.RenderSet{}

--- a/pkg/microservice/aslan/core/common/service/render.go
+++ b/pkg/microservice/aslan/core/common/service/render.go
@@ -153,7 +153,6 @@ func GetRenderSet(renderName string, revision int64, log *zap.SugaredLogger) (*c
 	return resp, nil
 }
 
-// GetRenderSetInfo
 func GetRenderSetInfo(renderName string, revision int64) (*commonmodels.RenderSet, error) {
 	opt := &commonrepo.RenderSetFindOption{
 		Name:     renderName,

--- a/pkg/microservice/aslan/core/common/service/render.go
+++ b/pkg/microservice/aslan/core/common/service/render.go
@@ -153,6 +153,7 @@ func GetRenderSet(renderName string, revision int64, log *zap.SugaredLogger) (*c
 	return resp, nil
 }
 
+// GetRenderSetInfo
 func GetRenderSetInfo(renderName string, revision int64) (*commonmodels.RenderSet, error) {
 	opt := &commonrepo.RenderSetFindOption{
 		Name:     renderName,
@@ -171,16 +172,12 @@ func ValidateRenderSet(productName, renderName string, serviceInfo *templatemode
 	resp := &commonmodels.RenderSet{ProductTmpl: productName}
 	var err error
 	if renderName != "" {
-		opt := &commonrepo.RenderSetFindOption{Name: renderName}
+		opt := &commonrepo.RenderSetFindOption{Name: renderName, ProductTmpl: productName}
 		resp, err = commonrepo.NewRenderSetColl().Find(opt)
 		if err != nil {
 			log.Errorf("find renderset[%s] error: %v", renderName, err)
 			return resp, err
 		}
-	}
-	if renderName != "" && resp.ProductTmpl != productName {
-		log.Errorf("renderset[%s] not match product[%s]", renderName, productName)
-		return resp, fmt.Errorf("renderset[%s] not match product[%s]", renderName, productName)
 	}
 	if serviceInfo == nil {
 		//if err := IsAllKeyCovered(resp, log); err != nil {
@@ -221,7 +218,7 @@ func mergeKVs(newKVs []*templatemodels.RenderKV, oldKVs []*templatemodels.Render
 }
 
 func CreateRenderSet(args *commonmodels.RenderSet, log *zap.SugaredLogger) error {
-	opt := &commonrepo.RenderSetFindOption{Name: args.Name}
+	opt := &commonrepo.RenderSetFindOption{Name: args.Name, ProductTmpl: args.ProductTmpl}
 	rs, err := commonrepo.NewRenderSetColl().Find(opt)
 	if rs != nil && err == nil {
 		// 已经存在渲染配置集
@@ -248,7 +245,7 @@ func CreateRenderSet(args *commonmodels.RenderSet, log *zap.SugaredLogger) error
 
 // CreateHelmRenderSet 添加renderSet
 func CreateHelmRenderSet(args *commonmodels.RenderSet, log *zap.SugaredLogger) error {
-	opt := &commonrepo.RenderSetFindOption{Name: args.Name}
+	opt := &commonrepo.RenderSetFindOption{Name: args.Name, ProductTmpl: args.ProductTmpl}
 	rs, err := commonrepo.NewRenderSetColl().Find(opt)
 	if rs != nil && err == nil {
 		// 已经存在渲染配置集

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -1737,7 +1737,8 @@ func DeleteProductServices(envName, productName string, serviceNames []string, l
 		}
 	}
 	rs, err := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{
-		Name: productInfo.Namespace,
+		Name:        productInfo.Namespace,
+		ProductTmpl: productName,
 	})
 	if err != nil {
 		log.Errorf("get renderSet error: %v", err)
@@ -2509,16 +2510,12 @@ func FindHelmRenderSet(productName, renderName string, log *zap.SugaredLogger) (
 	resp := &commonmodels.RenderSet{ProductTmpl: productName}
 	var err error
 	if renderName != "" {
-		opt := &commonrepo.RenderSetFindOption{Name: renderName}
+		opt := &commonrepo.RenderSetFindOption{Name: renderName, ProductTmpl: productName}
 		resp, err = commonrepo.NewRenderSetColl().Find(opt)
 		if err != nil {
 			log.Errorf("find helm renderset[%s] error: %v", renderName, err)
 			return resp, err
 		}
-	}
-	if renderName != "" && resp.ProductTmpl != productName {
-		log.Errorf("helm renderset[%s] not match product[%s]", renderName, productName)
-		return resp, fmt.Errorf("helm renderset[%s] not match product[%s]", renderName, productName)
 	}
 	return resp, nil
 }
@@ -2875,7 +2872,7 @@ func diffRenderSet(username, productName, envName, updateType string, productRes
 		return nil, err
 	}
 	// 系统默认的变量
-	latestRenderSet, err := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{Name: productName})
+	latestRenderSet, err := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{Name: productName, ProductTmpl: productName})
 	if err != nil {
 		log.Errorf("[RenderSet.find] err: %v", err)
 		return nil, err

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2872,7 +2872,7 @@ func diffRenderSet(username, productName, envName, updateType string, productRes
 		return nil, err
 	}
 	// 系统默认的变量
-	latestRenderSet, err := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{Name: productName, ProductTmpl: productName})
+	latestRenderSet, err := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{Name: productName})
 	if err != nil {
 		log.Errorf("[RenderSet.find] err: %v", err)
 		return nil, err

--- a/pkg/microservice/aslan/core/service/service/helm.go
+++ b/pkg/microservice/aslan/core/service/service/helm.go
@@ -1444,7 +1444,7 @@ func UpdateHelmService(args *HelmServiceArgs, log *zap.SugaredLogger) error {
 func compareHelmVariable(chartInfos []*templatemodels.RenderChart, productName, createdBy string, log *zap.SugaredLogger) {
 	// 对比上个版本的renderset，新增一个版本
 	latestChartInfos := make([]*templatemodels.RenderChart, 0)
-	renderOpt := &commonrepo.RenderSetFindOption{Name: productName}
+	renderOpt := &commonrepo.RenderSetFindOption{Name: productName, ProductTmpl: productName}
 	if latestDefaultRenderSet, err := commonrepo.NewRenderSetColl().Find(renderOpt); err == nil {
 		latestChartInfos = latestDefaultRenderSet.ChartInfos
 	}

--- a/pkg/microservice/aslan/core/service/service/helm.go
+++ b/pkg/microservice/aslan/core/service/service/helm.go
@@ -1444,7 +1444,7 @@ func UpdateHelmService(args *HelmServiceArgs, log *zap.SugaredLogger) error {
 func compareHelmVariable(chartInfos []*templatemodels.RenderChart, productName, createdBy string, log *zap.SugaredLogger) {
 	// 对比上个版本的renderset，新增一个版本
 	latestChartInfos := make([]*templatemodels.RenderChart, 0)
-	renderOpt := &commonrepo.RenderSetFindOption{Name: productName, ProductTmpl: productName}
+	renderOpt := &commonrepo.RenderSetFindOption{Name: productName}
 	if latestDefaultRenderSet, err := commonrepo.NewRenderSetColl().Find(renderOpt); err == nil {
 		latestChartInfos = latestDefaultRenderSet.ChartInfos
 	}

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -1036,7 +1036,7 @@ func DeleteServiceTemplate(serviceName, serviceType, productName, isEnvTemplate,
 
 // remove specific services from rendersets.chartinfos
 func removeServiceFromRenderset(productName, renderName, serviceName string) error {
-	renderOpt := &commonrepo.RenderSetFindOption{Name: renderName}
+	renderOpt := &commonrepo.RenderSetFindOption{Name: renderName, ProductTmpl: productName}
 	if rs, err := commonrepo.NewRenderSetColl().Find(renderOpt); err == nil {
 		chartInfos := make([]*templatemodels.RenderChart, 0)
 		for _, chartInfo := range rs.ChartInfos {


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when creating new environment based on an existed namespace, errors will occur when a namespace is used by multiple environments while there should be no such limitation

### What is changed and how it works?
fix bug

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
