### PR TITLE
Adding Deploy after distribute feature

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/task/release_image.go
+++ b/pkg/microservice/aslan/core/common/repository/models/task/release_image.go
@@ -44,12 +44,32 @@ type ReleaseImage struct {
 
 	// destinations to distribute images
 	Releases []models.RepoImage `bson:"releases"                 json:"releases"`
+
+	// New Version field
+	ProductName    string            `bson:"product_name"    json:"product_name"`
+	SourceImage    string            `bson:"source_image"    json:"source_image"`
+	DistributeInfo []*DistributeInfo `bson:"distribute_info" json:"distribute_info"`
+}
+
+type DistributeInfo struct {
+	Image               string `bson:"image" json:"image"`
+	DistributeStartTime int64  `bson:"distribute_start_time" json:"distribute_start_time"`
+	DistributeEndTime   int64  `bson:"distribute_end_time"   json:"distribute_end_time"`
+	DistributeStatus    string `bson:"distribute_status"     json:"distribute_status"`
+	DeployEnabled       bool   `bson:"deploy_enabled"        json:"deploy_enabled"`
+	DeployEnv           string `bson:"deploy_env"            json:"deploy_env"`
+	DeployNamespace     string `bson:"deploy_namespace"      json:"deploy_namespace"`
+	DeployStartTime     int64  `bson:"deploy_start_time"     json:"deploy_start_time"`
+	DeployEndTime       int64  `bson:"deploy_end_time"       json:"deploy_end_time"`
+	DeployStatus        string `bson:"deploy_status"         json:"deploy_status"`
+	RepoID              string `bson:"repo_id"               json:"repo_id"`
 }
 
 // SetImage ...
 func (ri *ReleaseImage) SetImage(image string) {
 	if image != "" {
 		ri.ImageTest = image
+		ri.SourceImage = image
 	}
 }
 

--- a/pkg/microservice/aslan/core/common/repository/models/task/release_image.go
+++ b/pkg/microservice/aslan/core/common/repository/models/task/release_image.go
@@ -58,6 +58,10 @@ type DistributeInfo struct {
 	DistributeStatus    string `bson:"distribute_status"     json:"distribute_status"`
 	DeployEnabled       bool   `bson:"deploy_enabled"        json:"deploy_enabled"`
 	DeployEnv           string `bson:"deploy_env"            json:"deploy_env"`
+	DeployServiceType   string `json:"deploy_service_type"   yaml:"deploy_service_type"`
+	DeployContainerName string `json:"deploy_container_name" yaml:"deploy_container_name"`
+	DeployServiceName   string `json:"deploy_service_name"   yaml:"deploy_service_name"`
+	DeployClusterID     string `json:"deploy_cluster_id"     yaml:"deploy_cluster_id"`
 	DeployNamespace     string `bson:"deploy_namespace"      json:"deploy_namespace"`
 	DeployStartTime     int64  `bson:"deploy_start_time"     json:"deploy_start_time"`
 	DeployEndTime       int64  `bson:"deploy_end_time"       json:"deploy_end_time"`

--- a/pkg/microservice/aslan/core/common/repository/models/workflow.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow.go
@@ -274,12 +274,14 @@ type ExtensionStage struct {
 }
 
 type RepoImage struct {
-	RepoID    string `json:"repo_id" bson:"repo_id"`
-	Name      string `json:"name" bson:"name" yaml:"name"`
-	Username  string `json:"-" yaml:"username"`
-	Password  string `json:"-" yaml:"password"`
-	Host      string `json:"host" yaml:"host"`
-	Namespace string `json:"namespace" yaml:"namespace"`
+	RepoID        string `json:"repo_id" bson:"repo_id"`
+	Name          string `json:"name" bson:"name" yaml:"name"`
+	Username      string `json:"-" yaml:"username"`
+	Password      string `json:"-" yaml:"password"`
+	Host          string `json:"host" yaml:"host"`
+	Namespace     string `json:"namespace" yaml:"namespace"`
+	DeployEnabled bool   `json:"deploy_enabled" yaml:"deploy_enabled"`
+	DeployEnv     string `json:"deploy_env"   yaml:"deploy_env"`
 }
 
 type ProductDistribute struct {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -2610,6 +2610,7 @@ func ensurePipelineTask(taskOpt *taskmodels.TaskOpt, log *zap.SugaredLogger) err
 
 				taskOpt.Task.SubTasks[i], err = t.ToSubTask()
 				if err != nil {
+					log.Errorf("release task to subtask error: %s", err)
 					return err
 				}
 			}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -1391,6 +1391,7 @@ func formatDistributeSubtasks(productName string, releaseImages []commonmodels.R
 			})
 		}
 		t.DistributeInfo = distributeInfo
+		t.Releases = releaseImages
 
 		// convert to subtask
 		subtask, err := t.ToSubTask()

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -640,6 +640,9 @@ func CreateWorkflowTask(args *commonmodels.WorkflowTaskArgs, taskCreator string,
 						log.Errorf("distrbiute stages to subtasks error: %v", err)
 						return nil, e.ErrCreateTask.AddErr(err)
 					}
+					for _, dtask := range distributeTasks {
+						fmt.Printf(">>>>>>>>>>>>>>>>>>>>>> task is: %+v <<<<<<<<<<<<<<<<<\n ", dtask)
+					}
 				}
 			}
 			subTasks = append(subTasks, distributeTasks...)

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -627,6 +627,8 @@ func CreateWorkflowTask(args *commonmodels.WorkflowTaskArgs, taskCreator string,
 				if distribute.Target != nil {
 					serviceModule.ProductName = distribute.Target.ProductName
 				}
+				fmt.Printf(">>>>>>>>>>>>>>>> distribute.Target is: %s <<<<<<<<<<<<<<<<<<<< \n", distribute.Target)
+				fmt.Printf(">>>>>>>>>>>>>>>> distribute.Target is: %s <<<<<<<<<<<<<<<<<<<< \n", serviceModule)
 				if reflect.DeepEqual(distribute.Target, serviceModule) {
 					distributeTasks, err = formatDistributeSubtasks(
 						args.ProductTmplName,

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -627,8 +627,6 @@ func CreateWorkflowTask(args *commonmodels.WorkflowTaskArgs, taskCreator string,
 				if distribute.Target != nil {
 					serviceModule.ProductName = distribute.Target.ProductName
 				}
-				fmt.Printf(">>>>>>>>>>>>>>>> distribute.Target is: %s <<<<<<<<<<<<<<<<<<<< \n", distribute.Target)
-				fmt.Printf(">>>>>>>>>>>>>>>> distribute.Target is: %s <<<<<<<<<<<<<<<<<<<< \n", serviceModule)
 				if reflect.DeepEqual(distribute.Target, serviceModule) {
 					distributeTasks, err = formatDistributeSubtasks(
 						args.ProductTmplName,
@@ -641,9 +639,6 @@ func CreateWorkflowTask(args *commonmodels.WorkflowTaskArgs, taskCreator string,
 					if err != nil {
 						log.Errorf("distrbiute stages to subtasks error: %v", err)
 						return nil, e.ErrCreateTask.AddErr(err)
-					}
-					for _, dtask := range distributeTasks {
-						fmt.Printf(">>>>>>>>>>>>>>>>>>>>>> task is: %+v <<<<<<<<<<<<<<<<<\n ", dtask)
 					}
 				}
 			}

--- a/pkg/microservice/predator/core/service/predator.go
+++ b/pkg/microservice/predator/core/service/predator.go
@@ -18,11 +18,12 @@ package service
 
 // Context ...
 type Context struct {
-	JobType        string          `yaml:"job_type"`
-	DockerRegistry *DockerRegistry `yaml:"docker_registry"`
-	DockerBuildCtx *DockerBuildCtx `yaml:"build_ctx"`
-	OnSetup        string          `yaml:"setup,omitempty"`
-	ReleaseImages  []RepoImage     `yaml:"release_images"`
+	JobType        string            `yaml:"job_type"`
+	DockerRegistry *DockerRegistry   `yaml:"docker_registry"`
+	DockerBuildCtx *DockerBuildCtx   `yaml:"build_ctx"`
+	OnSetup        string            `yaml:"setup,omitempty"`
+	ReleaseImages  []RepoImage       `yaml:"release_images"`
+	DistributeList []*DistributeInfo `yaml:"distribute_info"`
 }
 
 type RepoImage struct {
@@ -32,6 +33,23 @@ type RepoImage struct {
 	Password  string `yaml:"password"`
 	Host      string `yaml:"host"`
 	Namespace string `yaml:"namespace"`
+}
+
+// DistributeInfo will be convert into yaml, adding yaml
+type DistributeInfo struct {
+	Image               string `yaml:"image"`
+	DistributeStartTime int64  `yaml:"distribute_start_time"`
+	DistributeEndTime   int64  `yaml:"distribute_end_time"`
+	DistributeStatus    string `yaml:"distribute_status"`
+	DeployEnabled       bool   `yaml:"deploy_enabled"`
+	DeployEnv           string `yaml:"deploy_env"`
+	DeployNamespace     string `yaml:"deploy_namespace"`
+	DeployStartTime     int64  `yaml:"deploy_start_time"`
+	DeployEndTime       int64  `yaml:"deploy_end_time"`
+	DeployStatus        string `yaml:"deploy_status"`
+	RepoID              string `yaml:"repo_id"`
+	RepoAK              string `yaml:"repo_ak"`
+	RepoSK              string `yaml:"repo_sk"`
 }
 
 // DockerBuildCtx ...

--- a/pkg/microservice/warpdrive/core/service/taskplugin/release_image.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/release_image.go
@@ -111,6 +111,7 @@ func (p *ReleaseImagePlugin) TaskTimeout() int {
 
 // Run ...
 func (p *ReleaseImagePlugin) Run(ctx context.Context, pipelineTask *task.Task, pipelineCtx *task.PipelineCtx, serviceName string) {
+	fmt.Println("Starting to run release image plugin")
 	p.KubeNamespace = pipelineTask.ConfigPayload.Build.KubeNamespace
 	// 设置本次运行需要配置
 	//t.Workspace = fmt.Sprintf("%s/%s", pipelineTask.ConfigPayload.NFS.Path, pipelineTask.PipelineName)
@@ -132,10 +133,8 @@ func (p *ReleaseImagePlugin) Run(ctx context.Context, pipelineTask *task.Task, p
 		}
 	}
 
-	if len(releases) == 0 {
-		return
-	}
 	if len(distributes) == 0 {
+		fmt.Println("distribute is 0")
 		return
 	}
 

--- a/pkg/microservice/warpdrive/core/service/taskplugin/release_image.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/release_image.go
@@ -204,6 +204,7 @@ func (p *ReleaseImagePlugin) Run(ctx context.Context, pipelineTask *task.Task, p
 		return
 	}
 
+	fmt.Printf(">>>>>>>>>>>>>>> ensure deleteing job <<<<<<<<<<<<<<<<<\n")
 	if err := ensureDeleteJob(p.KubeNamespace, jobLabel, p.kubeClient); err != nil {
 		msg := fmt.Sprintf("delete release image job error: %v", err)
 		p.Log.Error(msg)
@@ -217,7 +218,10 @@ func (p *ReleaseImagePlugin) Run(ctx context.Context, pipelineTask *task.Task, p
 	for _, distribute := range p.Task.DistributeInfo {
 		distribute.DistributeStartTime = startTime
 	}
+
+	fmt.Printf(">>>>>>>>>>>>>>>>>>>>>>> creating job <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n")
 	if err := updater.CreateJob(job, p.kubeClient); err != nil {
+		fmt.Printf(">>>>>>>>>>>>>>>> failed to create job, the error is: %s <<<<<<<<<<<<<<<<", err)
 		msg := fmt.Sprintf("create release image job error: %v", err)
 		p.Log.Error(msg)
 		p.Task.TaskStatus = config.StatusFailed

--- a/pkg/microservice/warpdrive/core/service/taskplugin/release_image.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/release_image.go
@@ -251,6 +251,8 @@ func (p *ReleaseImagePlugin) Wait(ctx context.Context) {
 			p.Task.TaskStatus = config.StatusFailed
 			p.Task.Error = err.Error()
 			return
+		} else {
+			p.SetStatus(config.StatusPassed)
 		}
 	}()
 	status = waitJobEnd(ctx, p.TaskTimeout(), p.KubeNamespace, p.JobName, p.kubeClient, p.clientset, p.restConfig, p.Log)

--- a/pkg/microservice/warpdrive/core/service/taskplugin/release_image.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/release_image.go
@@ -816,7 +816,11 @@ func (p *ReleaseImagePlugin) IsTaskFailed() bool {
 
 // SetStartTime ...
 func (p *ReleaseImagePlugin) SetStartTime() {
-	p.Task.StartTime = time.Now().Unix()
+	startTime := time.Now().Unix()
+	p.Task.StartTime = startTime
+	for _, distribute := range p.Task.DistributeInfo {
+		distribute.DistributeStartTime = startTime
+	}
 }
 
 // SetEndTime ...

--- a/pkg/microservice/warpdrive/core/service/types/predator.go
+++ b/pkg/microservice/warpdrive/core/service/types/predator.go
@@ -19,9 +19,10 @@ package types
 import "github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/types/task"
 
 type PredatorContext struct {
-	JobType        string               `yaml:"job_type"`
-	DockerRegistry *DockerRegistry      `yaml:"docker_registry"`
-	DockerBuildCtx *task.DockerBuildCtx `yaml:"build_ctx"`
-	OnSetup        string               `yaml:"setup,omitempty"`
-	ReleaseImages  []task.RepoImage     `yaml:"release_images"`
+	JobType        string                 `yaml:"job_type"`
+	DockerRegistry *DockerRegistry        `yaml:"docker_registry"`
+	DockerBuildCtx *task.DockerBuildCtx   `yaml:"build_ctx"`
+	OnSetup        string                 `yaml:"setup,omitempty"`
+	ReleaseImages  []task.RepoImage       `yaml:"release_images"`
+	DistributeInfo []*task.DistributeInfo `yaml:"distribute_info"`
 }

--- a/pkg/microservice/warpdrive/core/service/types/task/release_image.go
+++ b/pkg/microservice/warpdrive/core/service/types/task/release_image.go
@@ -43,6 +43,30 @@ type ReleaseImage struct {
 
 	// destinations to distribute images
 	Releases []RepoImage `bson:"releases"                 json:"releases"`
+
+	// New Version field
+	ProductName    string            `json:"product_name"`
+	SourceImage    string            `json:"source_image"`
+	DistributeInfo []*DistributeInfo `json:"distribute_info"`
+}
+
+// DistributeInfo will be convert into yaml, adding yaml
+type DistributeInfo struct {
+	Image               string `json:"image"                 yaml:"image"`
+	DistributeStartTime int64  `json:"distribute_start_time" yaml:"distribute_start_time"`
+	DistributeEndTime   int64  `json:"distribute_end_time"   yaml:"distribute_end_time"`
+	DistributeStatus    string `json:"distribute_status"     yaml:"distribute_status"`
+	DeployEnabled       bool   `json:"deploy_enabled"        yaml:"deploy_enabled"`
+	DeployEnv           string `json:"deploy_env"            yaml:"deploy_env"`
+	DeployNamespace     string `json:"deploy_namespace"      yaml:"deploy_namespace"`
+	DeployStartTime     int64  `json:"deploy_start_time"     yaml:"deploy_start_time"`
+	DeployEndTime       int64  `json:"deploy_end_time"       yaml:"deploy_end_time"`
+	DeployStatus        string `json:"deploy_status"         yaml:"deploy_status"`
+	RepoID              string `json:"repo_id"               yaml:"repo_id"`
+
+	//RepoAK and RepoSK is used for docker login, it is determined runtime, not passed by message so no json is required
+	RepoAK string `json:"-"  yaml:"repo_ak"`
+	RepoSK string `json:"-"  yaml:"repo_sk"`
 }
 
 type RepoImage struct {

--- a/pkg/microservice/warpdrive/core/service/types/task/release_image.go
+++ b/pkg/microservice/warpdrive/core/service/types/task/release_image.go
@@ -58,6 +58,10 @@ type DistributeInfo struct {
 	DistributeStatus    string `json:"distribute_status"     yaml:"distribute_status"`
 	DeployEnabled       bool   `json:"deploy_enabled"        yaml:"deploy_enabled"`
 	DeployEnv           string `json:"deploy_env"            yaml:"deploy_env"`
+	DeployServiceType   string `json:"deploy_service_type"   yaml:"deploy_service_type"`
+	DeployContainerName string `json:"deploy_container_name" yaml:"deploy_container_name"`
+	DeployServiceName   string `json:"deploy_service_name"   yaml:"deploy_service_name"`
+	DeployClusterID     string `json:"deploy_cluster_id"     yaml:"deploy_cluster_id"`
 	DeployNamespace     string `json:"deploy_namespace"      yaml:"deploy_namespace"`
 	DeployStartTime     int64  `json:"deploy_start_time"     yaml:"deploy_start_time"`
 	DeployEndTime       int64  `json:"deploy_end_time"       yaml:"deploy_end_time"`


### PR DESCRIPTION
Signed-off-by: Min Min <jamsman94@gmail.com>

### What this PR does / Why we need it:
Currently Zadig does not support deploy an image after distribute it to the image repository. Now we need to deploy after distribute.

### What is changed and how it works?
In this PR, I added a subtask in distribute stage to enable deployment after distribute. And changed warpdrive (for deploy after distribute) and predator (for distribute) to make it work

### Does this PR introduce a user-facing change?

- [x] API change
- [x] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
