### PR TITLE
info add  key

### DIFF
--- a/pkg/microservice/aslan/core/code/service/repo.go
+++ b/pkg/microservice/aslan/core/code/service/repo.go
@@ -45,6 +45,7 @@ type GitRepoInfo struct {
 	ProjectUUID   string                `json:"project_uuid,omitempty"`
 	RepoUUID      string                `json:"repo_uuid,omitempty"`
 	RepoID        string                `json:"repo_id,omitempty"`
+	Key           string                `json:"key"`
 }
 
 // ListRepoInfos ...
@@ -87,6 +88,7 @@ func ListRepoInfos(infos []*GitRepoInfo, log *zap.SugaredLogger) ([]*GitRepoInfo
 			info.Branches, err = codehostClient.ListBranches(client.ListOpt{
 				Namespace:   strings.Replace(info.Owner, "%2F", "/", -1),
 				ProjectName: projectName,
+				Key:         info.Key,
 			})
 			if err != nil {
 				errList = multierror.Append(errList, err)
@@ -110,6 +112,7 @@ func ListRepoInfos(infos []*GitRepoInfo, log *zap.SugaredLogger) ([]*GitRepoInfo
 			info.Tags, err = codehostClient.ListTags(client.ListOpt{
 				Namespace:   strings.Replace(info.Owner, "%2F", "/", -1),
 				ProjectName: projectName,
+				Key:         info.Key,
 			})
 			if err != nil {
 				errList = multierror.Append(errList, err)


### PR DESCRIPTION
### What this PR does / Why we need it:

when run workflow，we need to get codehost infos (br+tag+pr), br and tag are not support backend search , need to support search
