### PR TITLE
fix bug of not clearing resources due to job startup timeout

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskcontroller/task_handler.go
+++ b/pkg/microservice/warpdrive/core/service/taskcontroller/task_handler.go
@@ -500,6 +500,9 @@ func (h *ExecHandler) executeTask(taskCtx context.Context, plugin plugins.TaskPl
 	// 如果 SubTask 执行失败, 则不继续执行, 发送 Task 失败执行结果
 	// Failed, Timeout, Cancelled
 	if plugin.IsTaskFailed() {
+		plugin.Complete(ctx, pipelineTask, servicename)
+		xl.Infof("task status: %s", plugin.Status())
+
 		plugin.SetEndTime()
 		updatePipelineSubTask(plugin.GetTask(), pipelineTask, pos, servicename, xl)
 		return plugin.Status(), fmt.Errorf("pipeline task failed: task_handler:308")

--- a/pkg/tool/kube/containerlog/log.go
+++ b/pkg/tool/kube/containerlog/log.go
@@ -40,8 +40,11 @@ func GetContainerLogs(namespace, podName, containerName string, follow bool, tai
 			return fmt.Errorf("failed to get pod %s in %s: %s", podName, namespace, err)
 		}
 
-		_, err = out.Write([]byte(pod.Status.ContainerStatuses[0].State.Terminated.Message))
+		if pod.Status.Phase == corev1.PodPending || pod.Status.Phase == corev1.PodUnknown {
+			return fmt.Errorf("phase of Pod %s in ns %s is %s", pod.Name, pod.Namespace, pod.Status.Phase)
+		}
 
+		_, err = out.Write([]byte(pod.Status.ContainerStatuses[0].State.Terminated.Message))
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

When the current plugin fails to execute `Run()`, the `Complete()` operation is not called which causes that the created resource will not be deleted in time.

### What is changed and how it works?

When the current plugin fails to execute `Run()`, call `Complete()` to clean up the mess.


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
