### PR TITLE
rego logic correct

### DIFF
--- a/pkg/microservice/policy/core/service/bundle/rego/authz.rego
+++ b/pkg/microservice/policy/core/service/bundle/rego/authz.rego
@@ -114,7 +114,7 @@ access_is_granted {
     rule.method == http_request.method
     glob.match(trim(rule.endpoint, "/"), ["/"], concat("/", input.parsed_path))
 
-    all_attributes_match(rule.matchAttributes, rule.resourceType, get_resource_id(rule.idRegex))
+    any_attribute_match(rule.matchAttributes, rule.resourceType, get_resource_id(rule.idRegex))
 }
 
 access_is_granted {
@@ -124,7 +124,7 @@ access_is_granted {
     rule.method == http_request.method
     glob.match(trim(rule.endpoint, "/"), ["/"], concat("/", input.parsed_path))
 
-    all_attributes_match(rule.matchAttributes, rule.resourceType, get_resource_id(rule.idRegex))
+    any_attribute_match(rule.matchAttributes, rule.resourceType, get_resource_id(rule.idRegex))
 }
 
 rule_is_matched_for_filtering {
@@ -215,7 +215,7 @@ user_matched_role_rule_for_filtering[rule] {
 }
 
 
-all_attributes_match(attributes, resourceType, resourceID) {
+any_attribute_match(attributes, resourceType, resourceID) {
     res := data.resources[resourceType][_]
     res.resourceID == resourceID
     project_name_is_match(res)
@@ -226,19 +226,6 @@ all_attributes_match(attributes, resourceType, resourceID) {
 attributes_match(attributes, res) {
     attribute := attributes[_]
     attribute_match(attribute, res)
-}
-
-attributes_mismatch(attributes, res) {
-    attribute := attributes[_]
-    attribute_mismatch(attribute, res)
-}
-
-attribute_mismatch(attribute, res) {
-    res.spec[attribute.key] != attribute.value
-}
-
-attribute_mismatch(attribute, res) {
-    not res.spec[attribute.key]
 }
 
 get_resource_id(idRegex) = id {


### PR DESCRIPTION
### What this PR does / Why we need it:
1.any attribute match is ok , the name is mismatch
2.mismatch is not need 

### What is changed and how it works?
1.correct the all_attributes match
2.remove mismatch
