### PR TITLE
intercept the first eight display of the commit id

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
@@ -27,9 +27,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/go-github/v35/github"
+	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 
-	"github.com/google/go-github/v35/github"
 	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
@@ -49,12 +50,12 @@ import (
 	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/koderover/zadig/pkg/types"
 	"github.com/koderover/zadig/pkg/util"
-	"go.uber.org/zap"
 )
 
 const (
 	NameSpaceRegexString   = "[^a-z0-9.-]"
 	defaultNameRegexString = "^[a-zA-Z0-9-_]{1,50}$"
+	InterceptCommitID      = 8
 )
 
 var (
@@ -525,8 +526,8 @@ func releaseCandidate(b *task.Build, taskID int64, productName, envName, imageNa
 		customTarRule = project.CustomTarRule
 	}
 
-	if len(commitID) > 8 {
-		commitID = commitID[0:8]
+	if len(commitID) > InterceptCommitID {
+		commitID = commitID[0:InterceptCommitID]
 	}
 
 	candidate := &candidate{

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	appsv1 "k8s.io/api/apps/v1"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/google/go-github/v35/github"
 	configbase "github.com/koderover/zadig/pkg/config"
@@ -514,6 +515,7 @@ func releaseCandidate(b *task.Build, taskID int64, productName, envName, imageNa
 		reg             = regexp.MustCompile(`[^\w.-]`)
 		customImageRule *template.CustomRule
 		customTarRule   *template.CustomRule
+		commitID        = first.CommitID
 	)
 
 	if project, err := templaterepo.NewProductColl().Find(productName); err != nil {
@@ -523,9 +525,13 @@ func releaseCandidate(b *task.Build, taskID int64, productName, envName, imageNa
 		customTarRule = project.CustomTarRule
 	}
 
+	if len(commitID) > 8 {
+		commitID = commitID[0:8]
+	}
+
 	candidate := &candidate{
 		Branch:      string(reg.ReplaceAll([]byte(first.Branch), []byte("-"))),
-		CommitID:    first.CommitID,
+		CommitID:    commitID,
 		PR:          first.PR,
 		Tag:         string(reg.ReplaceAll([]byte(first.Tag), []byte("-"))),
 		EnvName:     envName,


### PR DESCRIPTION
Signed-off-by: liu deyi <andrew@koderover.com>

### What this PR does / Why we need it:
intercept the first eight display of the commit id

### What is changed and how it works?
commit id is too long in image tag

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
