### PR TITLE
save values yaml source data

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/render_set.go
+++ b/pkg/microservice/aslan/core/common/repository/models/render_set.go
@@ -33,8 +33,9 @@ type RenderSet struct {
 	Team          string                        `bson:"team,omitempty"           json:"team,omitempty"`
 	UpdateTime    int64                         `bson:"update_time"              json:"update_time"`
 	UpdateBy      string                        `bson:"update_by"                json:"update_by"`
-	IsDefault     bool                          `bson:"is_default"               json:"is_default"`                          // 是否是默认配置
-	DefaultValues string                        `bson:"default_values,omitempty"            json:"default_values,omitempty"` //环境默认变量 yaml content
+	IsDefault     bool                          `bson:"is_default"               json:"is_default"`                     // 是否是默认配置
+	DefaultValues string                        `bson:"default_values,omitempty"       json:"default_values,omitempty"` //环境默认变量 yaml content
+	YamlData      *templatemodels.CustomYaml    `bson:"yaml_data,omitempty"            json:"yaml_data,omitempty"`
 	KVs           []*templatemodels.RenderKV    `bson:"kvs,omitempty"            json:"kvs,omitempty"`
 	ChartInfos    []*templatemodels.RenderChart `bson:"chart_infos,omitempty"    json:"chart_infos,omitempty"`
 	Description   string                        `bson:"description,omitempty"    json:"description,omitempty"`

--- a/pkg/microservice/aslan/core/common/repository/models/render_set.go
+++ b/pkg/microservice/aslan/core/common/repository/models/render_set.go
@@ -33,8 +33,8 @@ type RenderSet struct {
 	Team          string                        `bson:"team,omitempty"           json:"team,omitempty"`
 	UpdateTime    int64                         `bson:"update_time"              json:"update_time"`
 	UpdateBy      string                        `bson:"update_by"                json:"update_by"`
-	IsDefault     bool                          `bson:"is_default"               json:"is_default"`                     // 是否是默认配置
-	DefaultValues string                        `bson:"default_values,omitempty"       json:"default_values,omitempty"` //环境默认变量 yaml content
+	IsDefault     bool                          `bson:"is_default"               json:"is_default"`
+	DefaultValues string                        `bson:"default_values,omitempty"       json:"default_values,omitempty"`
 	YamlData      *templatemodels.CustomYaml    `bson:"yaml_data,omitempty"            json:"yaml_data,omitempty"`
 	KVs           []*templatemodels.RenderKV    `bson:"kvs,omitempty"            json:"kvs,omitempty"`
 	ChartInfos    []*templatemodels.RenderChart `bson:"chart_infos,omitempty"    json:"chart_infos,omitempty"`

--- a/pkg/microservice/aslan/core/common/repository/models/template/product.go
+++ b/pkg/microservice/aslan/core/common/repository/models/template/product.go
@@ -105,6 +105,7 @@ type GitRepoConfig struct {
 type CustomYaml struct {
 	YamlContent  string      `bson:"yaml_content,omitempty"    json:"yaml_content,omitempty"`
 	Source       string      `bson:"source" json:"source"`
+	AutoSync     bool        `bson:"auto_sync" json:"auto_sync"`
 	SourceDetail interface{} `bson:"source_detail" json:"source_detail"`
 }
 

--- a/pkg/microservice/aslan/core/common/repository/models/template/product.go
+++ b/pkg/microservice/aslan/core/common/repository/models/template/product.go
@@ -103,7 +103,9 @@ type GitRepoConfig struct {
 }
 
 type CustomYaml struct {
-	YamlContent string `bson:"yaml_content,omitempty"    json:"yaml_content,omitempty"`
+	YamlContent  string      `bson:"yaml_content,omitempty"    json:"yaml_content,omitempty"`
+	Source       string      `bson:"source" json:"source"`
+	SourceDetail interface{} `bson:"source_detail" json:"source_detail"`
 }
 
 // RenderChart ...

--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -133,6 +133,7 @@ func GetRenderCharts(productName, envName, serviceName string, log *zap.SugaredL
 		rcaObj := new(RenderChartArg)
 		rcaObj.LoadFromRenderChartModel(singleChart)
 		rcaObj.EnvName = envName
+		rcaObj.YamlData = singleChart.OverrideYaml
 		ret = append(ret, rcaObj)
 	}
 	return ret, nil

--- a/pkg/microservice/aslan/core/common/service/render.go
+++ b/pkg/microservice/aslan/core/common/service/render.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	templatemodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/template"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
@@ -48,12 +49,19 @@ type KVPair struct {
 	Value interface{} `json:"value"`
 }
 
+type ValuesDataArgs struct {
+	YamlSource    string      `json:"yamlSource,omitempty"`
+	GitRepoConfig *RepoConfig `json:"gitRepoConfig,omitempty"`
+}
+
 type RenderChartArg struct {
-	EnvName        string    `json:"envName,omitempty"`
-	ServiceName    string    `json:"serviceName,omitempty"`
-	ChartVersion   string    `json:"chartVersion,omitempty"`
-	OverrideValues []*KVPair `json:"overrideValues,omitempty"`
-	OverrideYaml   string    `json:"overrideYaml,omitempty"`
+	EnvName        string                     `json:"envName,omitempty"`
+	ServiceName    string                     `json:"serviceName,omitempty"`
+	ChartVersion   string                     `json:"chartVersion,omitempty"`
+	OverrideValues []*KVPair                  `json:"overrideValues,omitempty"`
+	OverrideYaml   string                     `json:"overrideYaml,omitempty"`
+	ValuesData     *ValuesDataArgs            `json:"valuesData,omitempty"`
+	YamlData       *templatemodels.CustomYaml `bson:"yaml_data,omitempty"            json:"yaml_data,omitempty"`
 }
 
 func (args *RenderChartArg) ToOverrideValueString() string {
@@ -83,9 +91,27 @@ func (args *RenderChartArg) fromOverrideValueString(valueStr string) {
 
 func (args *RenderChartArg) toCustomValuesYaml() *templatemodels.CustomYaml {
 	if len(args.OverrideYaml) > 0 {
-		return &templatemodels.CustomYaml{
+		ret := &templatemodels.CustomYaml{
 			YamlContent: args.OverrideYaml,
 		}
+		if args.ValuesData != nil {
+			ret.Source = args.ValuesData.YamlSource
+			if args.ValuesData.GitRepoConfig != nil {
+				repoData := &models.CreateFromRepo{
+					GitRepoConfig: &templatemodels.GitRepoConfig{
+						CodehostID: args.ValuesData.GitRepoConfig.CodehostID,
+						Owner:      args.ValuesData.GitRepoConfig.Owner,
+						Repo:       args.ValuesData.GitRepoConfig.Repo,
+						Branch:     args.ValuesData.GitRepoConfig.Branch,
+					},
+				}
+				if len(args.ValuesData.GitRepoConfig.ValuesPaths) > 0 {
+					repoData.LoadPath = args.ValuesData.GitRepoConfig.ValuesPaths[0]
+				}
+				ret.SourceDetail = repoData
+			}
+		}
+		return ret
 	}
 	return nil
 }

--- a/pkg/microservice/aslan/core/common/service/render.go
+++ b/pkg/microservice/aslan/core/common/service/render.go
@@ -51,6 +51,7 @@ type KVPair struct {
 
 type ValuesDataArgs struct {
 	YamlSource    string      `json:"yamlSource,omitempty"`
+	AutoSync      bool        `json:"autoSync,omitempty"`
 	GitRepoConfig *RepoConfig `json:"gitRepoConfig,omitempty"`
 }
 
@@ -96,6 +97,7 @@ func (args *RenderChartArg) toCustomValuesYaml() *templatemodels.CustomYaml {
 		}
 		if args.ValuesData != nil {
 			ret.Source = args.ValuesData.YamlSource
+			ret.AutoSync = args.ValuesData.AutoSync
 			if args.ValuesData.GitRepoConfig != nil {
 				repoData := &models.CreateFromRepo{
 					GitRepoConfig: &templatemodels.GitRepoConfig{

--- a/pkg/microservice/aslan/core/common/service/render.go
+++ b/pkg/microservice/aslan/core/common/service/render.go
@@ -61,7 +61,7 @@ type RenderChartArg struct {
 	OverrideValues []*KVPair                  `json:"overrideValues,omitempty"`
 	OverrideYaml   string                     `json:"overrideYaml,omitempty"`
 	ValuesData     *ValuesDataArgs            `json:"valuesData,omitempty"`
-	YamlData       *templatemodels.CustomYaml `bson:"yaml_data,omitempty"            json:"yaml_data,omitempty"`
+	YamlData       *templatemodels.CustomYaml `json:"yaml_data,omitempty"`
 }
 
 func (args *RenderChartArg) ToOverrideValueString() string {

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -1381,6 +1381,7 @@ func geneYamlData(args *commonservice.ValuesDataArgs) *templatemodels.CustomYaml
 	}
 	ret := &templatemodels.CustomYaml{
 		Source:       args.YamlSource,
+		AutoSync:     args.AutoSync,
 		SourceDetail: repoData,
 	}
 	return ret
@@ -2937,6 +2938,7 @@ func diffRenderSet(username, productName, envName, updateType string, productRes
 
 	newChartInfos := make([]*templatemodels.RenderChart, 0)
 	defaultValues := ""
+	var yamlData *templatemodels.CustomYaml
 	switch updateType {
 	case UpdateTypeSystem:
 		for _, serviceNameGroup := range productTemp.Services {
@@ -2954,6 +2956,7 @@ func diffRenderSet(username, productName, envName, updateType string, productRes
 			return nil, err
 		}
 		defaultValues = currentEnvRenderSet.DefaultValues
+		yamlData = currentEnvRenderSet.YamlData
 
 		// 环境里面的变量
 		currentEnvRenderSetMap := make(map[string]*templatemodels.RenderChart)
@@ -3039,6 +3042,7 @@ func diffRenderSet(username, productName, envName, updateType string, productRes
 			ProductTmpl:   productName,
 			ChartInfos:    newChartInfos,
 			DefaultValues: defaultValues,
+			YamlData:      yamlData,
 			UpdateBy:      username,
 		},
 		log,

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -1115,6 +1115,7 @@ func copySingleHelmProduct(productName, requestID, userName string, arg *CreateH
 			UpdateBy:      userName,
 			IsDefault:     false,
 			DefaultValues: defaultValuesYaml,
+			YamlData:      geneYamlData(arg.ValuesData),
 			ChartInfos:    productInfo.ChartInfos,
 		}, log)
 		if err != nil {

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -46,11 +46,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
-	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/template"
-
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/template"
 	templatemodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/template"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	templaterepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb/template"

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -1114,9 +1114,6 @@ func copySingleHelmProduct(productName, requestID, userName string, arg *CreateH
 		}
 	}
 
-	// default values
-	defaultValuesYaml := arg.DefaultValues
-
 	// insert renderset info into db
 	if len(productInfo.ChartInfos) > 0 {
 		err := commonservice.CreateHelmRenderSet(&commonmodels.RenderSet{
@@ -1125,7 +1122,7 @@ func copySingleHelmProduct(productName, requestID, userName string, arg *CreateH
 			ProductTmpl:   arg.ProductName,
 			UpdateBy:      userName,
 			IsDefault:     false,
-			DefaultValues: defaultValuesYaml,
+			DefaultValues: arg.DefaultValues,
 			YamlData:      geneYamlData(arg.ValuesData),
 			ChartInfos:    productInfo.ChartInfos,
 		}, log)
@@ -2672,11 +2669,10 @@ func installProductHelmCharts(user, envName, requestID string, args *commonmodel
 
 			// 获取服务详情
 			opt := &commonrepo.ServiceFindOption{
-				ServiceName:   svc.ServiceName,
-				Type:          svc.Type,
-				Revision:      svc.Revision,
-				ProductName:   args.ProductName,
-				ExcludeStatus: setting.ProductStatusDeleting,
+				ServiceName: svc.ServiceName,
+				Type:        svc.Type,
+				Revision:    svc.Revision,
+				ProductName: args.ProductName,
 			}
 			serviceObj, err := commonrepo.NewServiceColl().Find(opt)
 			if err != nil {

--- a/pkg/microservice/aslan/core/environment/service/renderset.go
+++ b/pkg/microservice/aslan/core/environment/service/renderset.go
@@ -32,7 +32,7 @@ import (
 
 type DefaultValuesResp struct {
 	DefaultValues string                     `json:"defaultValues"`
-	YamlData      *templatemodels.CustomYaml `bson:"yaml_data,omitempty"            json:"yaml_data,omitempty"`
+	YamlData      *templatemodels.CustomYaml `json:"yaml_data,omitempty"`
 }
 
 type YamlContentRequestArg struct {

--- a/pkg/microservice/aslan/core/environment/service/renderset.go
+++ b/pkg/microservice/aslan/core/environment/service/renderset.go
@@ -24,13 +24,15 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.uber.org/zap"
 
+	templatemodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/template"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	fsservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/fs"
 	yamlutil "github.com/koderover/zadig/pkg/util/yaml"
 )
 
 type DefaultValuesResp struct {
-	DefaultValues string `json:"defaultValues"`
+	DefaultValues string                     `json:"defaultValues"`
+	YamlData      *templatemodels.CustomYaml `bson:"yaml_data,omitempty"            json:"yaml_data,omitempty"`
 }
 
 type YamlContentRequestArg struct {
@@ -74,6 +76,7 @@ func GetDefaultValues(productName, envName string, log *zap.SugaredLogger) (*Def
 		return ret, nil
 	}
 	ret.DefaultValues = rendersetObj.DefaultValues
+	ret.YamlData = rendersetObj.YamlData
 	return ret, nil
 }
 

--- a/pkg/microservice/aslan/core/service/service/helm.go
+++ b/pkg/microservice/aslan/core/service/service/helm.go
@@ -111,6 +111,7 @@ type helmServiceCreationArgs struct {
 	GerritPath       string
 	GerritCodeHostID int
 	ChartRepoName    string
+	ValuesSource     *commonservice.ValuesDataArgs
 }
 
 type ChartTemplateData struct {
@@ -539,6 +540,7 @@ func CreateOrUpdateHelmServiceFromChartTemplate(projectName string, args *HelmSe
 			HelmTemplateName: templateArgs.TemplateName,
 			ValuesYaml:       templateArgs.ValuesYAML,
 			Variables:        templateArgs.Variables,
+			ValuesSource:     args.ValuesData,
 		},
 		logger,
 	)
@@ -550,7 +552,8 @@ func CreateOrUpdateHelmServiceFromChartTemplate(projectName string, args *HelmSe
 	}
 
 	compareHelmVariable([]*templatemodels.RenderChart{
-		{ServiceName: args.Name,
+		{
+			ServiceName:  args.Name,
 			ChartVersion: svc.HelmChart.Version,
 			ValuesYaml:   svc.HelmChart.ValuesYaml,
 		},
@@ -886,7 +889,7 @@ func CreateOrUpdateBulkHelmServiceFromTemplate(projectName string, args *BulkHel
 		wg.Add(1)
 		go func(repoConfig *commonservice.RepoConfig, path string) {
 			defer wg.Done()
-			renderChart, err := handleSingleService(projectName, repoConfig, path, from, args.CreatedBy, templateChartData, logger)
+			renderChart, err := handleSingleService(projectName, repoConfig, path, from, args.CreatedBy, templateChartData, args.ValuesData, logger)
 			if err != nil {
 				failedServiceMap.Store(path, err.Error())
 			} else {
@@ -924,7 +927,7 @@ func CreateOrUpdateBulkHelmServiceFromTemplate(projectName string, args *BulkHel
 }
 
 func handleSingleService(projectName string, repoConfig *commonservice.RepoConfig, path, fromPath, createBy string,
-	templateChartData *ChartTemplateData, logger *zap.SugaredLogger) (*templatemodels.RenderChart, error) {
+	templateChartData *ChartTemplateData, valuesData *commonservice.ValuesDataArgs, logger *zap.SugaredLogger) (*templatemodels.RenderChart, error) {
 
 	valuesYAML, err := fsservice.DownloadFileFromSource(&fsservice.DownloadFromSourceArgs{
 		CodehostID: repoConfig.CodehostID,
@@ -1011,6 +1014,7 @@ func handleSingleService(projectName string, repoConfig *commonservice.RepoConfi
 			HelmTemplateName: templateChartData.TemplateName,
 			ValuePaths:       []string{path},
 			ValuesYaml:       string(valuesYAML),
+			ValuesSource:     valuesData,
 		},
 		logger,
 	)
@@ -1104,6 +1108,21 @@ func geneCreationDetail(args *helmServiceCreationArgs) interface{} {
 				Key:   variable.Key,
 				Value: variable.Value,
 			})
+		}
+		if args.ValuesSource != nil && args.ValuesSource.GitRepoConfig != nil {
+			yamlData.Source = args.ValuesSource.YamlSource
+			repoData := &models.CreateFromRepo{
+				GitRepoConfig: &templatemodels.GitRepoConfig{
+					CodehostID: args.ValuesSource.GitRepoConfig.CodehostID,
+					Owner:      args.ValuesSource.GitRepoConfig.Owner,
+					Repo:       args.ValuesSource.GitRepoConfig.Repo,
+					Branch:     args.ValuesSource.GitRepoConfig.Branch,
+				},
+			}
+			if len(args.ValuesSource.GitRepoConfig.ValuesPaths) > 0 {
+				repoData.LoadPath = args.ValuesSource.GitRepoConfig.ValuesPaths[0]
+			}
+			yamlData.SourceDetail = repoData
 		}
 		return &models.CreateFromChartTemplate{
 			YamlData:     yamlData,

--- a/pkg/microservice/aslan/core/service/service/types.go
+++ b/pkg/microservice/aslan/core/service/service/types.go
@@ -40,21 +40,17 @@ type HelmLoadSource struct {
 
 type HelmServiceCreationArgs struct {
 	HelmLoadSource
-	Name       string      `json:"name"`
-	CreatedBy  string      `json:"createdBy"`
-	CreateFrom interface{} `json:"createFrom"`
-}
-
-type ValuesDataArgs struct {
-	YamlSource    string              `json:"yamlSource,omitempty"`
-	GitRepoConfig *service.RepoConfig `json:"gitRepoConfig,omitempty"`
+	Name       string                  `json:"name"`
+	CreatedBy  string                  `json:"createdBy"`
+	CreateFrom interface{}             `json:"createFrom"`
+	ValuesData *service.ValuesDataArgs `json:"valuesData"`
 }
 
 type BulkHelmServiceCreationArgs struct {
 	HelmLoadSource
-	CreateFrom interface{}     `json:"createFrom"`
-	CreatedBy  string          `json:"createdBy"`
-	ValuesData *ValuesDataArgs `json:"valuesData"`
+	CreateFrom interface{}             `json:"createFrom"`
+	CreatedBy  string                  `json:"createdBy"`
+	ValuesData *service.ValuesDataArgs `json:"valuesData"`
 }
 
 type FailedService struct {

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -508,9 +508,6 @@ const (
 
 // helm related
 const (
-	ValuesYamlSourceFreeEdit = "freeEdit"
-	ValuesYamlSourceGitRepo  = "gitRepo"
-
 	// components used to search image paths from yaml
 	PathSearchComponentRepo  = "repo"
 	PathSearchComponentImage = "image"


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when creating helm services from chart repo, the source info of values.yaml imported from git repository is not saved. We need to go through all the processes to select the file when we just need to reload values.yaml. This inconvenience also happens when creating environments or updating environment variables. 
 
### What is changed and how it works?
save the import detail data and fill the git options to improve convenience

### Does this PR introduce a user-facing change?
yes

- [x] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
