### PR TITLE
bugfix for case of service with no workloadType

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
@@ -761,17 +761,17 @@ func getImageInfoFromWorkload(envName, productName, serviceName, container strin
 		if err != nil {
 			return "", err
 		}
-		var statefulSets []*appsv1.StatefulSet
-		statefulSets, err = getter.ListStatefulSets(product.Namespace, selector, kubeClient)
-		if err != nil {
-			return "", err
-		}
 		for _, deploy := range deployments {
 			for _, c := range deploy.Spec.Template.Spec.Containers {
 				if c.Name == container {
 					return c.Image, nil
 				}
 			}
+		}
+		var statefulSets []*appsv1.StatefulSet
+		statefulSets, err = getter.ListStatefulSets(product.Namespace, selector, kubeClient)
+		if err != nil {
+			return "", err
 		}
 		for _, sts := range statefulSets {
 			for _, c := range sts.Spec.Template.Spec.Containers {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/labels"
 	"regexp"
 	"sort"
 	"strconv"
@@ -31,6 +30,7 @@ import (
 	"github.com/google/go-github/v35/github"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"


### PR DESCRIPTION
Signed-off-by: Min Min <jamsman94@gmail.com>

### What this PR does / Why we need it:
There are cases in zadig services that they have no workload type registered. It will block the image reset process since the search for the image requires this field. 

### What is changed and how it works?
I changed the logic to find throught all the workloads ( deployment & statefulset ) if such field is empty.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
