### PR TITLE
gerrit: support search with multiple keywords

### DIFF
--- a/pkg/tool/gerrit/client_test.go
+++ b/pkg/tool/gerrit/client_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gerrit
+
+import "testing"
+
+func TestKeywordToRegexp(t *testing.T) {
+	type testcase struct {
+		keyword string
+		result  string
+	}
+	testcases := []testcase{
+		{"", ".*"},
+		{" ", ".*"},
+		{"  ", ".*"},
+		{"ab", ".*ab.*"},
+		{"   a     b  ", ".*a.*b.*"},
+		{"   a b  c  d   ", ".*a.*b.*c.*d.*"},
+		{"   a/b c-d", ".*a/b.*c-d.*"},
+	}
+
+	for _, ts := range testcases {
+		regstr := keywordToRegexp(ts.keyword)
+		if regstr != ts.result {
+			t.Errorf("Expected result for keyword <%s> to be <%s> but got <%s>", ts.keyword, ts.result, regstr)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Xudong Zhang <felixmelon@gmail.com>

### What this PR does / Why we need it:
Fix #1236

### What is changed and how it works?
Search gerrit projects using regexp while multiple keywords were provided.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
