### PR TITLE
change the implementation of servicelist in workflow

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/service.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/service.go
@@ -142,6 +142,8 @@ type serviceID struct {
 	ProductName string `bson:"product_name"`
 }
 
+func (c *ServiceColl) ListMaxRe
+
 func (c *ServiceColl) ListMaxRevisionsForServices(services []*templatemodels.ServiceInfo, serviceType string) ([]*models.Service, error) {
 	var srs []bson.D
 	for _, s := range services {

--- a/pkg/microservice/aslan/core/common/repository/mongodb/service.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/service.go
@@ -142,8 +142,6 @@ type serviceID struct {
 	ProductName string `bson:"product_name"`
 }
 
-func (c *ServiceColl) ListMaxRe
-
 func (c *ServiceColl) ListMaxRevisionsForServices(services []*templatemodels.ServiceInfo, serviceType string) ([]*models.Service, error) {
 	var srs []bson.D
 	for _, s := range services {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
@@ -304,12 +304,12 @@ type DeployEnv struct {
 func PreSetWorkflow(productName string, log *zap.SugaredLogger) ([]*PreSetResp, error) {
 	resp := make([]*PreSetResp, 0)
 	targets := make(map[string][]DeployEnv)
-	//productTmpl, err := template.NewProductColl().Find(productName)
-	//if err != nil {
-	//	log.Errorf("[%s] ProductTmpl.Find error: %v", productName, err)
-	//	return resp, e.ErrGetTemplate.AddDesc(err.Error())
-	//}
-	services, err := commonrepo.NewServiceColl().ListMaxRevisionsByProduct("")
+	productTmpl, err := template.NewProductColl().Find(productName)
+	if err != nil {
+		log.Errorf("[%s] ProductTmpl.Find error: %v", productName, err)
+		return resp, e.ErrGetTemplate.AddDesc(err.Error())
+	}
+	services, err := commonrepo.NewServiceColl().ListMaxRevisionsByProduct(productTmpl.ProductName)
 	if err != nil {
 		log.Errorf("ServiceTmpl.ListMaxRevisions error: %v", err)
 		return resp, e.ErrListTemplate.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
@@ -304,12 +304,12 @@ type DeployEnv struct {
 func PreSetWorkflow(productName string, log *zap.SugaredLogger) ([]*PreSetResp, error) {
 	resp := make([]*PreSetResp, 0)
 	targets := make(map[string][]DeployEnv)
-	productTmpl, err := template.NewProductColl().Find(productName)
-	if err != nil {
-		log.Errorf("[%s] ProductTmpl.Find error: %v", productName, err)
-		return resp, e.ErrGetTemplate.AddDesc(err.Error())
-	}
-	services, err := commonrepo.NewServiceColl().ListMaxRevisionsForServices(productTmpl.AllServiceInfos(), "")
+	//productTmpl, err := template.NewProductColl().Find(productName)
+	//if err != nil {
+	//	log.Errorf("[%s] ProductTmpl.Find error: %v", productName, err)
+	//	return resp, e.ErrGetTemplate.AddDesc(err.Error())
+	//}
+	services, err := commonrepo.NewServiceColl().ListMaxRevisionsByProduct("")
 	if err != nil {
 		log.Errorf("ServiceTmpl.ListMaxRevisions error: %v", err)
 		return resp, e.ErrListTemplate.AddDesc(err.Error())


### PR DESCRIPTION
### What this PR does / Why we need it:
The service list in the workflow setting page used to be unable to update itself when a new service is added to the product. We need to make it happen.

### What is changed and how it works?
In the /api/aslan/workflow/workflow/find API, we now scan all of the service to find if there is a missing service module in the old service list. If there is one, we add it to the list.


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
