### PR TITLE
 cherry pick fix overview bug

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/delivery_artifact.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/delivery_artifact.go
@@ -45,6 +45,7 @@ type DeliveryArtifactArgs struct {
 	PerPage           int    `json:"per_page"`
 	Page              int    `json:"page"`
 	IsFuzzyQuery      bool   `json:"is_fuzzy_query"`
+	OnlyCount         bool   `json:"only_count"`
 	PackageStorageURI string `json:"package_storage_uri"`
 }
 
@@ -120,6 +121,11 @@ func (c *DeliveryArtifactColl) List(args *DeliveryArtifactArgs) ([]*models.Deliv
 	if err != nil {
 		return nil, 0, fmt.Errorf("find artifact err:%v", err)
 	}
+
+	if args.OnlyCount {
+		return nil, int(count), nil
+	}
+
 	opt := options.Find().
 		SetSort(bson.D{{"created_time", -1}}).
 		SetSkip(int64(args.PerPage * (args.Page - 1))).

--- a/pkg/microservice/aslan/core/stat/service/overview.go
+++ b/pkg/microservice/aslan/core/stat/service/overview.go
@@ -62,7 +62,7 @@ func GetOverviewStat(log *zap.SugaredLogger) (*Overview, error) {
 	}
 	overview.EnvCount = int(envCount)
 
-	_, artifactCount, err := commonrepo.NewDeliveryArtifactColl().List(&commonrepo.DeliveryArtifactArgs{})
+	_, artifactCount, err := commonrepo.NewDeliveryArtifactColl().List(&commonrepo.DeliveryArtifactArgs{OnlyCount: true})
 	if err != nil {
 		log.Errorf("Failed to get artifact count err:%s", err)
 		return nil, err


### PR DESCRIPTION
### What this PR does / Why we need it:
cherry pick fix overview bug
pr url : https://github.com/koderover/zadig/pull/1241


### What is changed and how it works?
Sort operation used more than the maximum 33554432 bytes of RAM.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
