### PR TITLE
restrict deletion of registry, if used in the environment

### DIFF
--- a/pkg/microservice/aslan/core/system/service/registry.go
+++ b/pkg/microservice/aslan/core/system/service/registry.go
@@ -146,7 +146,7 @@ func DeleteRegistryNamespace(id string, log *zap.SugaredLogger) error {
 
 	for _, env := range envs {
 		if env.RegistryID == id {
-			return fmt.Errorf("The registry cannot be deleted, the environment [%s] in project [%s] is in use", env.EnvName, env.ProductName)
+			return fmt.Errorf("The registry cannot be deleted, it's being used by environment [%s] of project [%s]", env.EnvName, env.ProductName)
 		}
 	}
 

--- a/pkg/microservice/aslan/core/system/service/registry.go
+++ b/pkg/microservice/aslan/core/system/service/registry.go
@@ -26,6 +26,7 @@ import (
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	commonservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/registry"
+	"github.com/koderover/zadig/pkg/setting"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 	"github.com/koderover/zadig/pkg/util"
 )
@@ -139,6 +140,16 @@ func DeleteRegistryNamespace(id string, log *zap.SugaredLogger) error {
 		isDefault          = false
 		registryNamespaces []*commonmodels.RegistryNamespace
 	)
+	envs, err := commonrepo.NewProductColl().List(&commonrepo.ProductListOptions{
+		ExcludeStatus: []string{setting.ProductStatusDeleting},
+	})
+
+	for _, env := range envs {
+		if env.RegistryID == id {
+			return fmt.Errorf("The registry cannot be deleted, the environment [%s] in project [%s] is in use", env.EnvName, env.ProductName)
+		}
+	}
+
 	// whether it is the default registry
 	for _, registry := range registries {
 		if registry.ID.Hex() == id && registry.IsDefault {


### PR DESCRIPTION
Signed-off-by: liu deyi <andrew@koderover.com>

### What this PR does / Why we need it:
restrict deletion of registry, if used in the environment

### What is changed and how it works?
When deleting the registry, restrict deletion if it is used in the environment

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
