### PR TITLE
optimize information indicating that a namespace may be in the terminating state during environment creation

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/actions.go
+++ b/pkg/microservice/aslan/core/common/service/kube/actions.go
@@ -17,7 +17,9 @@ limitations under the License.
 package kube
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,6 +40,27 @@ func CreateNamespace(namespace string, kubeClient client.Client) error {
 	err := updater.CreateNamespaceByName(namespace, map[string]string{setting.EnvCreatedBy: setting.EnvCreator}, kubeClient)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
+	}
+
+	nsObj := &corev1.Namespace{}
+	// It may fail to obtain the namespace immediately after it is created due to synchronization delay.
+	// Try twice.
+	for i := 0; i < 2; i++ {
+		err = kubeClient.Get(context.TODO(), client.ObjectKey{
+			Name: namespace,
+		}, nsObj)
+		if err == nil {
+			break
+		}
+
+		time.Sleep(time.Second)
+	}
+	if err != nil {
+		return err
+	}
+
+	if nsObj.Status.Phase == corev1.NamespaceTerminating {
+		return fmt.Errorf("namespace `%s` is in terminating state, please wait for a whilie and try again.", namespace)
 	}
 
 	return nil

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2506,7 +2506,7 @@ func ensureKubeEnv(namespace string, registryId string, kubeClient client.Client
 	err := kube.CreateNamespace(namespace, kubeClient)
 	if err != nil {
 		log.Errorf("[%s] get or create namespace error: %v", namespace, err)
-		return e.ErrCreateNamspace.AddDesc(e.SetNamespaceErrMsg)
+		return e.ErrCreateNamspace.AddDesc(err.Error())
 	}
 
 	// 创建默认的镜像仓库secret


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

Currently, it returns immediately after deleting the environment. If the user creates an environment with the same name at this time, it may fail because the original namespace may still be in the `Terminating` state. Optimize the error message prompt to give accurate information. 

### What is changed and how it works?

When creating the environment, check whether the namespace is in `Terminating` state and provide accurate information.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
