### PR TITLE
restrict deletion of registry, if used in the environment

### DIFF
--- a/pkg/microservice/aslan/core/system/service/registry.go
+++ b/pkg/microservice/aslan/core/system/service/registry.go
@@ -17,6 +17,7 @@ limitations under the License.
 package service
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -146,7 +147,7 @@ func DeleteRegistryNamespace(id string, log *zap.SugaredLogger) error {
 
 	for _, env := range envs {
 		if env.RegistryID == id {
-			return fmt.Errorf("The registry cannot be deleted, it's being used by environment")
+			return errors.New("The registry cannot be deleted, it's being used by environment")
 		}
 	}
 

--- a/pkg/microservice/aslan/core/system/service/registry.go
+++ b/pkg/microservice/aslan/core/system/service/registry.go
@@ -146,7 +146,7 @@ func DeleteRegistryNamespace(id string, log *zap.SugaredLogger) error {
 
 	for _, env := range envs {
 		if env.RegistryID == id {
-			return fmt.Errorf("The registry cannot be deleted, it's being used by environment [%s] of project [%s]", env.EnvName, env.ProductName)
+			return fmt.Errorf("The registry cannot be deleted, it's being used by environment")
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: liu deyi <andrew@koderover.com>

### What this PR does / Why we need it:
restrict deletion of registry, if used in the environment

### What is changed and how it works?
just edit the text

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
