### PR TITLE
fix artifact image miss bug

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go
@@ -311,7 +311,7 @@ func (h *TaskAckHandler) uploadTaskData(pt *task.Task) error {
 							deliveryArtifact.Type = string(config.Image)
 							deliveryArtifact.Name = imageName
 							deliveryArtifact.ImageTag = imageTag
-							//获取镜像详细信息
+							//get image detail info
 							imageInfo, _ := getImageInfo(buildInfo.ProductName, buildInfo.EnvName, imageName, imageTag, h.log)
 							if imageInfo != nil {
 								deliveryArtifact.ImageSize = imageInfo.ImageSize

--- a/pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go
@@ -312,7 +312,7 @@ func (h *TaskAckHandler) uploadTaskData(pt *task.Task) error {
 							deliveryArtifact.Name = imageName
 							deliveryArtifact.ImageTag = imageTag
 							//获取镜像详细信息
-							imageInfo, _ := getImageInfo(imageName, imageTag, h.log)
+							imageInfo, _ := getImageInfo(buildInfo.ProductName, buildInfo.EnvName, imageName, imageTag, h.log)
 							if imageInfo != nil {
 								deliveryArtifact.ImageSize = imageInfo.ImageSize
 								deliveryArtifact.ImageDigest = imageInfo.ImageDigest
@@ -911,8 +911,15 @@ func upsertWorkflowStat(args *commonmodels.WorkflowStat, log *zap.SugaredLogger)
 	return nil
 }
 
-func getImageInfo(repoName, tag string, log *zap.SugaredLogger) (*commonmodels.DeliveryImage, error) {
-	registryInfo, _, err := commonservice.FindDefaultRegistry(false, log)
+func getImageInfo(productName, evnName, repoName, tag string, log *zap.SugaredLogger) (*commonmodels.DeliveryImage, error) {
+	productInfo, err := commonrepo.NewProductColl().Find(&commonrepo.ProductFindOptions{
+		Name:    productName,
+		EnvName: evnName,
+	})
+	if err != nil {
+		return nil, err
+	}
+	registryInfo, _, err := commonservice.FindRegistryById(productInfo.RegistryID, false, log)
 	if err != nil {
 		log.Errorf("RegistryNamespace.get error: %v", err)
 		return nil, fmt.Errorf("RegistryNamespace.get error: %v", err)


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
If the image repository used by the environment is inconsistent with the default mirror repository, images generaged from workflows won't will not be displayed in the list on `Delivery tracking` page


### What is changed and how it works?
fix bug

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
