### PR TITLE
Fix a bug where UploadStorageInfo may be nil for stages other than build

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -227,15 +227,19 @@ func (b *JobCtxBuilder) BuildReaperContext(pipelineTask *task.Task, serviceName 
 		StorageEndpoint: pipelineTask.StorageEndpoint,
 		AesKey:          pipelineTask.ConfigPayload.AesKey,
 		UploadEnabled:   b.JobCtx.UploadEnabled,
-		UploadStorageInfo: &commontypes.ObjectStorageInfo{
+		UploadInfo:      b.JobCtx.UploadInfo,
+	}
+
+	// Currently only the build stage will have this info. For the rest we will skip this context
+	if b.JobCtx.UploadStorageInfo != nil {
+		ctx.UploadStorageInfo = &commontypes.ObjectStorageInfo{
 			Endpoint: b.JobCtx.UploadStorageInfo.Endpoint,
 			AK:       b.JobCtx.UploadStorageInfo.AK,
 			SK:       b.JobCtx.UploadStorageInfo.SK,
 			Bucket:   b.JobCtx.UploadStorageInfo.Bucket,
 			Insecure: b.JobCtx.UploadStorageInfo.Insecure,
 			Provider: b.JobCtx.UploadStorageInfo.Provider,
-		},
-		UploadInfo: b.JobCtx.UploadInfo,
+		}
 	}
 
 	if b.PipelineCtx.CacheEnable && !pipelineTask.ConfigPayload.ResetCache {


### PR DESCRIPTION
Signed-off-by: Min Min <jamsman94@gmail.com>

### What this PR does / Why we need it:
As the title stated.

### What is changed and how it works?
For stages other than build, I simply ignores the UploadStorageInfo  structure

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
