### PR TITLE
check length of .status.containerStatuses to avoid panic

### DIFF
--- a/pkg/tool/kube/containerlog/log.go
+++ b/pkg/tool/kube/containerlog/log.go
@@ -40,8 +40,12 @@ func GetContainerLogs(namespace, podName, containerName string, follow bool, tai
 			return fmt.Errorf("failed to get pod %s in %s: %s", podName, namespace, err)
 		}
 
+		// Note: Do two protections to avoid panic.
 		if pod.Status.Phase == corev1.PodPending || pod.Status.Phase == corev1.PodUnknown {
 			return fmt.Errorf("phase of Pod %s in ns %s is %s", pod.Name, pod.Namespace, pod.Status.Phase)
+		}
+		if len(pod.Status.ContainerStatuses) == 0 {
+			return fmt.Errorf("length of container statuses is 0 for pod %s in ns %s", podName, namespace)
 		}
 
 		_, err = out.Write([]byte(pod.Status.ContainerStatuses[0].State.Terminated.Message))


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

If we don't check pod's `.status.containerStatuses`, it may lead to the following statement panic.

### What is changed and how it works?

Check pod's `.status.containerStatuses` before trying to read message.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
