### PR TITLE
dont copy .nodePort in port item to avoid exception when update NodePort Service

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/share_env.go
+++ b/pkg/microservice/aslan/core/environment/service/share_env.go
@@ -899,7 +899,17 @@ func ensureDefaultK8sServiceInGray(ctx context.Context, baseSvc *corev1.Service,
 	svcInGray.Labels = baseSvc.Labels
 	svcInGray.Annotations = baseSvc.Annotations
 	svcInGray.Spec.Selector = baseSvc.Spec.Selector
-	svcInGray.Spec.Ports = baseSvc.Spec.Ports
+
+	ports := make([]corev1.ServicePort, len(baseSvc.Spec.Ports))
+	for i, port := range baseSvc.Spec.Ports {
+		ports[i] = corev1.ServicePort{
+			Name:       port.Name,
+			Protocol:   port.Protocol,
+			Port:       port.Port,
+			TargetPort: port.TargetPort,
+		}
+	}
+	svcInGray.Spec.Ports = ports
 
 	if svcInGray.Labels != nil {
 		svcInGray.Labels[zadigtypes.ZadigLabelKeyGlobalOwner] = zadigtypes.Zadig


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

`NodePort` Service has a `nodePort` field in items of`.spec.ports`. This field must be deleted when updating the Service  to avoid failure.

### What is changed and how it works?

Don't copy `.nodePort` in `port` item to avoid exception when update `NodePort` Service.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
