### PR TITLE
cherry_pick:fix delete collaboration instance by mistake when exec workflow

### DIFF
--- a/pkg/microservice/aslan/core/collaboration/repository/mongodb/collaboration_instance.go
+++ b/pkg/microservice/aslan/core/collaboration/repository/mongodb/collaboration_instance.go
@@ -33,7 +33,7 @@ import (
 type CollaborationInstanceFindOptions struct {
 	ProjectName string
 	Name        string
-	UserUID     string
+	UserUID     []string
 }
 
 type CollaborationInstanceListOptions struct {
@@ -74,8 +74,8 @@ func (c *CollaborationInstanceColl) EnsureIndex(ctx context.Context) error {
 func (c *CollaborationInstanceColl) Find(opt *CollaborationInstanceFindOptions) (*models.CollaborationInstance, error) {
 	res := &models.CollaborationInstance{}
 	query := bson.M{}
-	if opt.UserUID != "" {
-		query["user_uid"] = opt.UserUID
+	if len(opt.UserUID) > 0 {
+		query["user_uid"] = bson.M{"$in": opt.UserUID}
 	}
 	if opt.ProjectName != "" {
 		query["project_name"] = opt.ProjectName
@@ -163,8 +163,8 @@ func (c *CollaborationInstanceColl) DeleteByProject(projectName string) error {
 func (c *CollaborationInstanceColl) List(opt *CollaborationInstanceFindOptions) ([]*models.CollaborationInstance, error) {
 	var ret []*models.CollaborationInstance
 	query := bson.M{}
-	if opt.UserUID != "" {
-		query["user_uid"] = opt.UserUID
+	if len(opt.UserUID) > 0 {
+		query["user_uid"] = bson.M{"$in": opt.UserUID}
 	}
 	if opt.ProjectName != "" {
 		query["project_name"] = opt.ProjectName

--- a/pkg/microservice/aslan/core/collaboration/service/collaboration_instance.go
+++ b/pkg/microservice/aslan/core/collaboration/service/collaboration_instance.go
@@ -304,7 +304,7 @@ func GetCollaborationUpdate(projectName, uid, identityType, userName string, log
 	}
 	collaborationInstances, err := mongodb.NewCollaborationInstanceColl().List(&mongodb.CollaborationInstanceFindOptions{
 		ProjectName: projectName,
-		UserUID:     uid,
+		UserUID:     []string{uid},
 	})
 	if err != nil {
 		logger.Errorf("GetCollaborationInstance error, err msg:%s", err)
@@ -359,7 +359,7 @@ func syncInstance(updateResp *GetCollaborationUpdateResp, projectName, identityT
 		findOpts = append(findOpts, mongodb.CollaborationInstanceFindOptions{
 			Name:        instance.CollaborationName,
 			ProjectName: instance.ProjectName,
-			UserUID:     instance.UserUID,
+			UserUID:     []string{instance.UserUID},
 		})
 	}
 	return mongodb.NewCollaborationInstanceColl().BulkDelete(mongodb.CollaborationInstanceListOptions{
@@ -1227,7 +1227,7 @@ func DeleteCIResources(userName, requestID string, cis []*models.CollaborationIn
 		findOpts = append(findOpts, mongodb.CollaborationInstanceFindOptions{
 			ProjectName: ci.ProjectName,
 			Name:        ci.CollaborationName,
-			UserUID:     ci.UserUID,
+			UserUID:     []string{ci.UserUID},
 		})
 		policyNames = append(policyNames, ci.PolicyName)
 	}


### PR DESCRIPTION
Signed-off-by: panxunying <panxunying@koderover.com>

### What this PR does / Why we need it:
cherry_pick:fix delete collaboration instance by mistake when exec workflow

