### PR TITLE
fix configMap change occasional label value invalid

### DIFF
--- a/pkg/microservice/aslan/core/environment/handler/configmap.go
+++ b/pkg/microservice/aslan/core/environment/handler/configmap.go
@@ -55,7 +55,7 @@ func UpdateConfigMap(c *gin.Context) {
 	if err = json.Unmarshal(data, args); err != nil {
 		log.Errorf("UpdateConfigMap json.Unmarshal err : %v", err)
 	}
-	internalhandler.InsertOperationLog(c, ctx.UserName, args.ProductName, "更新", "环境-服务-configMap", fmt.Sprintf("环境名称:%s,服务名称:%s", args.EnvName, args.ServiceName), string(data), ctx.Logger)
+	internalhandler.InsertOperationLog(c, ctx.Account, args.ProductName, "更新", "环境-服务-configMap", fmt.Sprintf("环境名称:%s,服务名称:%s", args.EnvName, args.ServiceName), string(data), ctx.Logger)
 	c.Request.Body = ioutil.NopCloser(bytes.NewBuffer(data))
 
 	if err := c.BindJSON(args); err != nil {
@@ -74,7 +74,7 @@ func UpdateConfigMap(c *gin.Context) {
 	//	return
 	//}
 
-	ctx.Err = service.UpdateConfigMap(args.EnvName, args, ctx.UserName, ctx.UserID, ctx.Logger)
+	ctx.Err = service.UpdateConfigMap(args.EnvName, args, ctx.Account, ctx.UserID, ctx.Logger)
 }
 
 func RollBackConfigMap(c *gin.Context) {
@@ -89,7 +89,7 @@ func RollBackConfigMap(c *gin.Context) {
 	if err = json.Unmarshal(data, args); err != nil {
 		log.Errorf("RollBackConfigMap json.Unmarshal err : %v", err)
 	}
-	internalhandler.InsertOperationLog(c, ctx.UserName, args.ProductName, "回滚", "环境-服务-configMap", fmt.Sprintf("环境名称:%s,服务名称:%s", args.EnvName, args.ServiceName), string(data), ctx.Logger)
+	internalhandler.InsertOperationLog(c, ctx.Account, args.ProductName, "回滚", "环境-服务-configMap", fmt.Sprintf("环境名称:%s,服务名称:%s", args.EnvName, args.ServiceName), string(data), ctx.Logger)
 	c.Request.Body = ioutil.NopCloser(bytes.NewBuffer(data))
 
 	if err := c.BindJSON(args); err != nil {
@@ -102,5 +102,5 @@ func RollBackConfigMap(c *gin.Context) {
 		return
 	}
 
-	ctx.Err = service.RollBackConfigMap(args.EnvName, args, ctx.UserName, ctx.UserID, ctx.Logger)
+	ctx.Err = service.RollBackConfigMap(args.EnvName, args, ctx.Account, ctx.UserID, ctx.Logger)
 }


### PR DESCRIPTION
Signed-off-by: ddh27 <duandehua@koderover.com>

### What this PR does / Why we need it:
During configMap modification, the user name is used as the label value, and the value does not comply with the label rules

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
