### PR TITLE
keep build running task when wd restarts

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskcontroller/interface.go
+++ b/pkg/microservice/warpdrive/core/service/taskcontroller/interface.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskcontroller
+
+import "context"
+
+type ControllerI interface {
+	// Init initializes the controller.
+	Init(ctx context.Context) error
+
+	// Stop stops process logics.
+	Stop(ctx context.Context) error
+}

--- a/pkg/microservice/warpdrive/core/service/taskplugin/build.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/build.go
@@ -19,6 +19,7 @@ package taskplugin
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"os"
 	"strconv"
@@ -27,6 +28,7 @@ import (
 
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -92,7 +94,11 @@ func (p *BuildTaskPlugin) SetStatus(status config.Status) {
 	p.Task.TaskStatus = status
 }
 
+// Note: Unit of input `p.Task.Timeout` is `minutes` and convert it to `seconds` internally.
+// TODO: Using time implicitly is easy to generate bugs. We need use `time.Duration` instead.
 func (p *BuildTaskPlugin) TaskTimeout() int {
+	p.Log.Infof("IsRestart: %t. TaskTimeout: %d", p.Task.IsRestart, p.Task.Timeout)
+
 	if p.Task.Timeout == 0 {
 		p.Task.Timeout = BuildTaskV2Timeout
 	} else {
@@ -101,6 +107,13 @@ func (p *BuildTaskPlugin) TaskTimeout() int {
 		}
 	}
 	return p.Task.Timeout
+}
+
+// Note: This is a temporary function to be compatible with the `TaskTimeout()` method's process of time.
+// TODO: Remove this function after `TaskTimeout` uses `time.Duration`.
+func (p *BuildTaskPlugin) tmpSetTaskTimeout(durationInSeconds int) {
+	p.Task.Timeout = int(math.Ceil(float64(durationInSeconds) / 60.0))
+	p.Task.IsRestart = false
 }
 
 func (p *BuildTaskPlugin) SetBuildStatusCompleted(status config.Status) {
@@ -295,68 +308,103 @@ func (p *BuildTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipe
 		PipelineType: string(pipelineTask.Type),
 	}
 
-	if err := ensureDeleteConfigMap(p.KubeNamespace, jobLabel, p.kubeClient); err != nil {
-		p.Log.Error(err)
-		p.Task.TaskStatus = config.StatusFailed
-		p.Task.Error = err.Error()
-		p.SetBuildStatusCompleted(config.StatusFailed)
-		return
-	}
-
-	if err := createJobConfigMap(
-		p.KubeNamespace, p.JobName, jobLabel, string(jobCtxBytes), p.kubeClient); err != nil {
-		msg := fmt.Sprintf("createJobConfigMap error: %v", err)
+	jobObj, jobExist, err := checkJobExists(ctx, p.KubeNamespace, jobLabel, p.kubeClient)
+	if err != nil {
+		msg := fmt.Sprintf("failed to check whether Job exist for %s:%d: %s", pipelineTask.PipelineName, pipelineTask.TaskID, err)
 		p.Log.Error(msg)
 		p.Task.TaskStatus = config.StatusFailed
 		p.Task.Error = msg
 		p.SetBuildStatusCompleted(config.StatusFailed)
 		return
+	}
+	if jobExist {
+		p.Log.Infof("Job %s:%d eixsts.", pipelineTask.PipelineName, pipelineTask.TaskID)
+
+		p.JobName = jobObj.Name
+
+		// If the code is executed at this point, it indicates that the `wd` instance that executed the Job has been restarted and the
+		// Job timeout period needs to be corrected.
+		//
+		// Rule of reseting timeout: `timeout - (now - start_time_of_job) + compensate_duration`
+		// For now, `compensate_duration` is 2min.
+		taskTimeout := p.TaskTimeout()
+		elaspedTime := time.Now().Unix() - jobObj.Status.StartTime.Time.Unix()
+		timeout := taskTimeout + 120 - int(elaspedTime)
+		p.Log.Infof("Timeout before normalization: %d seconds", timeout)
+		if timeout < 0 {
+			// That shouldn't happen in theory, but a protection is needed.
+			timeout = 0
+		}
+
+		p.Log.Infof("Timeout after normalization: %d seconds", timeout)
+		p.tmpSetTaskTimeout(timeout)
+	}
+
+	_, cmExist, err := checkConfigMapExists(ctx, p.KubeNamespace, jobLabel, p.kubeClient)
+	if err != nil {
+		msg := fmt.Sprintf("failed to check whether ConfigMap exist for %s:%d: %s", pipelineTask.PipelineName, pipelineTask.TaskID, err)
+		p.Log.Error(msg)
+		p.Task.TaskStatus = config.StatusFailed
+		p.Task.Error = msg
+		p.SetBuildStatusCompleted(config.StatusFailed)
+		return
+	}
+
+	if !cmExist {
+		p.Log.Infof("ConfigMap for Job %s:%d does not exist. Create.", pipelineTask.PipelineName, pipelineTask.TaskID)
+
+		err = createJobConfigMap(p.KubeNamespace, p.JobName, jobLabel, string(jobCtxBytes), p.kubeClient)
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			msg := fmt.Sprintf("createJobConfigMap error: %v", err)
+			p.Log.Error(msg)
+			p.Task.TaskStatus = config.StatusFailed
+			p.Task.Error = msg
+			p.SetBuildStatusCompleted(config.StatusFailed)
+			return
+		}
 	}
 	p.Log.Infof("succeed to create cm for build job %s", p.JobName)
 
-	jobImage := fmt.Sprintf("%s-%s", pipelineTask.ConfigPayload.Release.ReaperImage, p.Task.BuildOS)
-	if p.Task.ImageFrom == setting.ImageFromCustom {
-		jobImage = p.Task.BuildOS
-	}
+	if !jobExist {
+		p.Log.Infof("Job %s:%d does not exist. Create.", pipelineTask.PipelineName, pipelineTask.TaskID)
 
-	//Resource request default value is LOW
-	job, err := buildJob(p.Type(), jobImage, p.JobName, serviceName, p.Task.ClusterID, pipelineTask.ConfigPayload.Build.KubeNamespace, p.Task.ResReq, p.Task.ResReqSpec, pipelineCtx, pipelineTask, p.Task.Registries)
-	if err != nil {
-		msg := fmt.Sprintf("create build job context error: %v", err)
-		p.Log.Error(msg)
-		p.Task.TaskStatus = config.StatusFailed
-		p.Task.Error = msg
-		p.SetBuildStatusCompleted(config.StatusFailed)
-		return
-	}
+		jobImage := fmt.Sprintf("%s-%s", pipelineTask.ConfigPayload.Release.ReaperImage, p.Task.BuildOS)
+		if p.Task.ImageFrom == setting.ImageFromCustom {
+			jobImage = p.Task.BuildOS
+		}
 
-	job.Namespace = p.KubeNamespace
+		//Resource request default value is LOW
+		job, err := buildJob(p.Type(), jobImage, p.JobName, serviceName, p.Task.ClusterID, pipelineTask.ConfigPayload.Build.KubeNamespace, p.Task.ResReq, p.Task.ResReqSpec, pipelineCtx, pipelineTask, p.Task.Registries)
+		if err != nil {
+			msg := fmt.Sprintf("create build job context error: %v", err)
+			p.Log.Error(msg)
+			p.Task.TaskStatus = config.StatusFailed
+			p.Task.Error = msg
+			p.SetBuildStatusCompleted(config.StatusFailed)
+			return
+		}
 
-	if err := ensureDeleteJob(p.KubeNamespace, jobLabel, p.kubeClient); err != nil {
-		msg := fmt.Sprintf("delete build job error: %v", err)
-		p.Log.Error(msg)
-		p.Task.TaskStatus = config.StatusFailed
-		p.Task.Error = msg
-		p.SetBuildStatusCompleted(config.StatusFailed)
-		return
-	}
+		job.Namespace = p.KubeNamespace
 
-	// 将集成到KodeRover的私有镜像仓库的访问权限设置到namespace中
-	if err := createOrUpdateRegistrySecrets(p.KubeNamespace, pipelineTask.ConfigPayload.RegistryID, p.Task.Registries, p.kubeClient); err != nil {
-		msg := fmt.Sprintf("create secret error: %v", err)
-		p.Log.Error(msg)
-		p.Task.TaskStatus = config.StatusFailed
-		p.Task.Error = msg
-		p.SetBuildStatusCompleted(config.StatusFailed)
-		return
-	}
-	if err := updater.CreateJob(job, p.kubeClient); err != nil {
-		msg := fmt.Sprintf("create build job error: %v", err)
-		p.Log.Error(msg)
-		p.Task.TaskStatus = config.StatusFailed
-		p.Task.Error = msg
-		p.SetBuildStatusCompleted(config.StatusFailed)
-		return
+		// Set imagePullSecrets of the private image registry integrated with KodeRover into the namespace.
+		if err := createOrUpdateRegistrySecrets(p.KubeNamespace, pipelineTask.ConfigPayload.RegistryID, p.Task.Registries, p.kubeClient); err != nil {
+			msg := fmt.Sprintf("create secret error: %v", err)
+			p.Log.Error(msg)
+			p.Task.TaskStatus = config.StatusFailed
+			p.Task.Error = msg
+			p.SetBuildStatusCompleted(config.StatusFailed)
+			return
+		}
+
+		err = updater.CreateJob(job, p.kubeClient)
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			msg := fmt.Sprintf("create build job error: %v", err)
+			p.Log.Error(msg)
+			p.Task.TaskStatus = config.StatusFailed
+			p.Task.Error = msg
+			p.SetBuildStatusCompleted(config.StatusFailed)
+			return
+		}
 	}
 	p.Log.Infof("succeed to create build job %s", p.JobName)
 

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -52,6 +52,7 @@ import (
 	"github.com/koderover/zadig/pkg/tool/kube/getter"
 	"github.com/koderover/zadig/pkg/tool/kube/podexec"
 	"github.com/koderover/zadig/pkg/tool/kube/updater"
+	kubeutil "github.com/koderover/zadig/pkg/tool/kube/util"
 	"github.com/koderover/zadig/pkg/tool/log"
 	s3tool "github.com/koderover/zadig/pkg/tool/s3"
 	commontypes "github.com/koderover/zadig/pkg/types"
@@ -854,7 +855,8 @@ func waitJobEndWithFile(ctx context.Context, taskTimeout int, namespace, jobName
 	xl.Infof("wait job to start: %s/%s", namespace, jobName)
 	timeout := time.After(time.Duration(taskTimeout) * time.Second)
 	podTimeout := time.After(120 * time.Second)
-	// 等待job运行
+
+	xl.Infof("Timeout of preparing Pod: %s. Timeout of running task: %s.", 120*time.Second, time.Duration(taskTimeout)*time.Second)
 
 	var started bool
 	for {
@@ -1069,4 +1071,44 @@ func replaceEnvWithValue(str string, envs map[string]string) string {
 		ret = strings.ReplaceAll(ret, strKey, value)
 	}
 	return ret
+}
+
+func checkJobExists(ctx context.Context, ns string, jobLabels *JobLabel, kclient client.Client) (jobObj *batchv1.Job, exist bool, err error) {
+	labelsMap := getJobLabels(jobLabels)
+	labelSelector := labels.SelectorFromSet(labels.Set(labelsMap))
+
+	jobList := &batchv1.JobList{}
+	err = kclient.List(ctx, jobList, &client.ListOptions{
+		Namespace:     ns,
+		LabelSelector: labelSelector,
+	})
+	if err != nil || len(jobList.Items) == 0 {
+		return nil, false, kubeutil.IgnoreNotFoundError(err)
+	}
+
+	if len(jobList.Items) != 1 {
+		return nil, true, fmt.Errorf("more than 1 job with labels: %v", labelsMap)
+	}
+
+	return &(jobList.Items[0]), true, nil
+}
+
+func checkConfigMapExists(ctx context.Context, ns string, jobLabels *JobLabel, kclient client.Client) (cmObj *corev1.ConfigMap, exist bool, err error) {
+	labelsMap := getJobLabels(jobLabels)
+	labelSelector := labels.SelectorFromSet(labels.Set(labelsMap))
+
+	cmList := &corev1.ConfigMapList{}
+	err = kclient.List(ctx, cmList, &client.ListOptions{
+		Namespace:     ns,
+		LabelSelector: labelSelector,
+	})
+	if err != nil || len(cmList.Items) == 0 {
+		return nil, false, kubeutil.IgnoreNotFoundError(err)
+	}
+
+	if len(cmList.Items) != 1 {
+		return nil, true, fmt.Errorf("more than 1 ConfigMap with labels: %v", labelsMap)
+	}
+
+	return &(cmList.Items[0]), true, nil
 }

--- a/pkg/microservice/warpdrive/server/server.go
+++ b/pkg/microservice/warpdrive/server/server.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -37,8 +38,10 @@ func Serve(ctx context.Context) error {
 
 	log.Info("Warpdrive service start ... ")
 
-	if err := taskcontroller.InitTaskController(ctx); err != nil {
-		log.Fatalf("NewTaskController error: %v", err)
+	controller := taskcontroller.NewController()
+	err := controller.Init(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to init controller: %s", err)
 	}
 
 	http.HandleFunc("/ping", ping)
@@ -65,7 +68,7 @@ func Serve(ctx context.Context) error {
 
 	<-stopChan
 
-	return nil
+	return controller.Stop(ctx)
 }
 
 func ping(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

After `wd` has restarted, the running build jobs are not processed correctly. As a result, the status of the running build jobs cannot be showed correctly on the product.
In addition, tasks configured by users, such as `timeout`, cannot be used accurately.

### What is changed and how it works?

- improve the use of `nsq` to explicitly stop consumers and producers when `wd` exits
- consumers sets the message processing timeout to `1min` and performs the `TOUCH` cmd every `5s` to inform the producer that the message is still being processed
- after `wd` has restarted, check whether the build task is running. If yes, continue to run the task and correct the timeout period. Otherwise, create a new task

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
