### PR TITLE
fix List API does not return kind and apiVersion

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/common_env_cfg_informer.go
+++ b/pkg/microservice/aslan/core/environment/service/common_env_cfg_informer.go
@@ -36,7 +36,6 @@ import (
 	"github.com/koderover/zadig/pkg/setting"
 	kubeclient "github.com/koderover/zadig/pkg/shared/kube/client"
 	"github.com/koderover/zadig/pkg/tool/log"
-	"github.com/koderover/zadig/pkg/util"
 )
 
 var ClusterInformersMap sync.Map
@@ -109,19 +108,19 @@ func DeleteClusterInformer(clusterID string) {
 
 func onDeploymentAddAndUpdate(obj interface{}) {
 	deploy := obj.(*appsv1.Deployment)
-	product, continueFlag := GetProductAndFilterNs(deploy.Namespace, deploy.Name)
+	labels := deploy.GetLabels()
+	serviceName := labels[setting.ServiceLabel]
+	product, continueFlag := GetProductAndFilterNs(deploy.Namespace, deploy.Name, serviceName)
 	if !continueFlag {
 		return
 	}
-	labels := deploy.GetLabels()
-	label := labels[setting.ServiceLabel]
 
 	configMaps, secrets, pvcs := VisitDeployment(deploy)
 	envSvcDepend := &models.EnvSvcDepend{
 		ProductName:   product.ProductName,
 		EnvName:       product.EnvName,
 		Namespace:     deploy.Namespace,
-		ServiceName:   label,
+		ServiceName:   serviceName,
 		ServiceModule: deploy.Name,
 		WorkloadType:  setting.Deployment,
 		ConfigMaps:    configMaps.List(),
@@ -135,13 +134,16 @@ func onDeploymentAddAndUpdate(obj interface{}) {
 
 func onDeploymentDelete(obj interface{}) {
 	deploy := obj.(*appsv1.Deployment)
-	product, continueFlag := GetProductAndFilterNs(deploy.Namespace, deploy.Name)
+	labels := deploy.GetLabels()
+	serviceName := labels[setting.ServiceLabel]
+	product, continueFlag := GetProductAndFilterNs(deploy.Namespace, deploy.Name, serviceName)
 	if !continueFlag {
 		return
 	}
 	opts := &commonrepo.DeleteEnvSvcDependOption{
 		ProductName:   product.ProductName,
 		EnvName:       product.EnvName,
+		ServiceName:   serviceName,
 		ServiceModule: deploy.Name,
 	}
 	if err := commonrepo.NewEnvSvcDependColl().Delete(opts); err != nil {
@@ -182,18 +184,19 @@ func VisitDeployment(deployment *appsv1.Deployment) (sets.String, sets.String, s
 
 func onStatefulSetAddAndUpdate(obj interface{}) {
 	sts := obj.(*appsv1.StatefulSet)
-	product, continueFlag := GetProductAndFilterNs(sts.Namespace, sts.Name)
+	labels := sts.GetLabels()
+	serviceName := labels[setting.ServiceLabel]
+	product, continueFlag := GetProductAndFilterNs(sts.Namespace, sts.Name, serviceName)
 	if !continueFlag {
 		return
 	}
-	labels := sts.GetLabels()
-	label := labels[setting.ServiceLabel]
+
 	configMaps, secrets, pvcs := VisitStatefulSet(sts)
 	envSvcDepend := &models.EnvSvcDepend{
 		ProductName:   product.ProductName,
 		EnvName:       product.EnvName,
 		Namespace:     sts.Namespace,
-		ServiceName:   label,
+		ServiceName:   serviceName,
 		ServiceModule: sts.Name,
 		WorkloadType:  setting.StatefulSet,
 		ConfigMaps:    configMaps.List(),
@@ -208,13 +211,16 @@ func onStatefulSetAddAndUpdate(obj interface{}) {
 
 func onStatefulSetDelete(obj interface{}) {
 	sts := obj.(*appsv1.StatefulSet)
-	product, continueFlag := GetProductAndFilterNs(sts.Namespace, sts.Name)
+	labels := sts.GetLabels()
+	serviceName := labels[setting.ServiceLabel]
+	product, continueFlag := GetProductAndFilterNs(sts.Namespace, sts.Name, serviceName)
 	if !continueFlag {
 		return
 	}
 	opts := &commonrepo.DeleteEnvSvcDependOption{
 		ProductName:   product.ProductName,
 		EnvName:       product.EnvName,
+		ServiceName:   serviceName,
 		ServiceModule: sts.Name,
 	}
 	if err := commonrepo.NewEnvSvcDependColl().Delete(opts); err != nil {
@@ -253,7 +259,7 @@ func VisitStatefulSet(sts *appsv1.StatefulSet) (sets.String, sets.String, sets.S
 	return cfgSets, secretSets, pvcSets
 }
 
-func GetProductAndFilterNs(namespace, workloadName string) (*models.Product, bool) {
+func GetProductAndFilterNs(namespace, workloadName, svcName string) (*models.Product, bool) {
 	products, err := commonrepo.NewProductColl().List(&commonrepo.ProductListOptions{Namespace: namespace})
 	if err != nil {
 		if !commonrepo.IsErrNoDocuments(err) {
@@ -280,10 +286,10 @@ func GetProductAndFilterNs(namespace, workloadName string) (*models.Product, boo
 		}
 		for _, psvc := range product.GetServiceMap() {
 			//TODO: helm not support restart service
-			if psvc.Type == setting.HelmDeployType && psvc.ServiceName == util.ExtraServiceName(workloadName, namespace) {
+			if psvc.Type == setting.HelmDeployType {
 				return product, false
 			}
-			if psvc.Type == setting.K8SDeployType && psvc.ServiceName == workloadName {
+			if psvc.Type == setting.K8SDeployType && (psvc.ServiceName == workloadName || psvc.ServiceName == svcName) {
 				return product, true
 			}
 		}

--- a/pkg/tool/kube/getter/configmap.go
+++ b/pkg/tool/kube/getter/configmap.go
@@ -25,6 +25,12 @@ import (
 
 func ListConfigMaps(ns string, selector labels.Selector, cl client.Client) ([]*corev1.ConfigMap, error) {
 	l := &corev1.ConfigMapList{}
+	gvk := schema.GroupVersionKind{
+		Group:   "",
+		Kind:    "ConfigMap",
+		Version: "v1",
+	}
+	l.SetGroupVersionKind(gvk)
 	err := ListResourceInCache(ns, selector, nil, l, cl)
 	if err != nil {
 		return nil, err

--- a/pkg/tool/kube/getter/pvc.go
+++ b/pkg/tool/kube/getter/pvc.go
@@ -19,11 +19,18 @@ package getter
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func ListPvcs(ns string, selector fields.Selector, cl client.Reader) ([]*corev1.PersistentVolumeClaim, error) {
 	pvcList := &corev1.PersistentVolumeClaimList{}
+	gvk := schema.GroupVersionKind{
+		Group:   "",
+		Kind:    "PersistentVolumeClaim",
+		Version: "v1",
+	}
+	pvcList.SetGroupVersionKind(gvk)
 	err := ListResourceInCache(ns, nil, selector, pvcList, cl)
 	if err != nil {
 		return nil, err

--- a/pkg/tool/kube/getter/secrets.go
+++ b/pkg/tool/kube/getter/secrets.go
@@ -18,6 +18,7 @@ package getter
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -33,6 +34,12 @@ func GetSecret(ns, name string, cl client.Client) (*corev1.Secret, bool, error) 
 
 func ListSecrets(ns string, cl client.Client) ([]*corev1.Secret, error) {
 	l := &corev1.SecretList{}
+	gvk := schema.GroupVersionKind{
+		Group:   "",
+		Kind:    "Secret",
+		Version: "v1",
+	}
+	l.SetGroupVersionKind(gvk)
 	err := ListResourceInCache(ns, nil, nil, l, cl)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: ddh27 <duandehua@koderover.com>

### What this PR does / Why we need it:
fix List API does not return kind and apiVersion

### What is changed and how it works?
The controller-Runtime library failed to return the apiVersion and KIND fields when listing yamL from configmap/secret/ PVC. This is the expected result of K8s; In the TKE cluster it will return, but not in the ACK cluster.

https://github.com/kubernetes/kubernetes/issues/98925
https://github.com/kubernetes/kubernetes/issues/3030

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
