### PR TITLE
use buildkit by default when docker build

### DIFF
--- a/pkg/microservice/reaper/core/service/reaper/reaper.go
+++ b/pkg/microservice/reaper/core/service/reaper/reaper.go
@@ -543,6 +543,7 @@ func (r *Reaper) getUserEnvs() []string {
 		fmt.Sprintf("WORKSPACE=%s", r.ActiveWorkspace),
 		// TODO: readme文件可以使用别的方式代替
 		fmt.Sprintf("README=%s", ReadmeFile),
+		"DOCKER_BUILDKIT=1",
 	}
 
 	r.Ctx.Paths = strings.Replace(r.Ctx.Paths, "$HOME", config.Home(), -1)


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

Use `buildkit` engine when executing `docker build` to improve image building efficiency.

### What is changed and how it works?

Enable `buildkit` by setting environment `DOCKER_BUILDKIT=1` when running `docker build`.


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
