### PR TITLE
fix wrong image name

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
@@ -598,8 +598,6 @@ func releaseCandidate(b *task.Build, taskID int64, productName, envName, imageNa
 		}
 		return newTarRule
 	default:
-		// If image, replace service name with imageName
-		candidate.ServiceName = imageName
 		return replaceVariable(customImageRule, candidate)
 	}
 }
@@ -646,8 +644,16 @@ func replaceVariable(customRule *template.CustomRule, candidate *candidate) stri
 	}
 
 	currentRule = commonservice.ReplaceRuleVariable(currentRule, &commonservice.Variable{
-		candidate.ServiceName, candidate.ServiceName, candidate.Timestamp, strconv.FormatInt(candidate.TaskID, 10), candidate.CommitID, candidate.ProductName, candidate.EnvName,
-		candidate.Tag, candidate.Branch, strconv.Itoa(candidate.PR),
+		SERVICE:        candidate.ServiceName,
+		IMAGE_NAME:     candidate.ServiceName,
+		TIMESTAMP:      candidate.Timestamp,
+		TASK_ID:        strconv.FormatInt(candidate.TaskID, 10),
+		REPO_COMMIT_ID: candidate.CommitID,
+		PROJECT:        candidate.ProductName,
+		ENV_NAME:       candidate.EnvName,
+		REPO_TAG:       candidate.Tag,
+		REPO_BRANCH:    candidate.Branch,
+		REPO_PR:        strconv.Itoa(candidate.PR),
 	})
 	return currentRule
 }

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
@@ -589,6 +589,7 @@ func releaseCandidate(b *task.Build, taskID int64, productName, envName, imageNa
 		TaskID:      taskID,
 		ProductName: productName,
 		ServiceName: b.ServiceName,
+		ImageName:   imageName,
 	}
 	switch deliveryType {
 	case config.TarResourceType:
@@ -611,6 +612,7 @@ type candidate struct {
 	Timestamp   string
 	ProductName string
 	ServiceName string
+	ImageName   string
 	EnvName     string
 }
 
@@ -645,7 +647,7 @@ func replaceVariable(customRule *template.CustomRule, candidate *candidate) stri
 
 	currentRule = commonservice.ReplaceRuleVariable(currentRule, &commonservice.Variable{
 		SERVICE:        candidate.ServiceName,
-		IMAGE_NAME:     candidate.ServiceName,
+		IMAGE_NAME:     candidate.ImageName,
 		TIMESTAMP:      candidate.Timestamp,
 		TASK_ID:        strconv.FormatInt(candidate.TaskID, 10),
 		REPO_COMMIT_ID: candidate.CommitID,


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
the variable `{{.SERVICE}}` used in custom image rule will be replaced by image name, which shoule be service name

### What is changed and how it works?
fix bug

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
