### PR TITLE
add urls that only admin user  has permission to operate

### DIFF
--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -175,4 +175,5 @@ func (*Router) Inject(router *gin.RouterGroup) {
 	{
 		bundles.GET("", GetBundleResources)
 	}
+
 }

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -175,5 +175,4 @@ func (*Router) Inject(router *gin.RouterGroup) {
 	{
 		bundles.GET("", GetBundleResources)
 	}
-
 }

--- a/pkg/microservice/policy/core/service/bundle/exemption_urls.go
+++ b/pkg/microservice/policy/core/service/bundle/exemption_urls.go
@@ -121,6 +121,14 @@ var systemAdminURLs = []*policyRule{
 		Endpoints: []string{"api/aslan/project/products"},
 	},
 	{
+		Methods:   []string{"GET"},
+		Endpoints: []string{"api/aslan/system/rsaKey/publicKey"},
+	},
+	{
+		Methods:   []string{"POST"},
+		Endpoints: []string{"api/aslan/system/cleanCache/cron"},
+	},
+	{
 		Methods:   []string{"POST"},
 		Endpoints: []string{"api/v1/picket/projects"},
 	},


### PR DESCRIPTION
Signed-off-by: mouuii <zhouchengbin@koderover.com>

### What this PR does / Why we need it:
urls that only system admin can visit
### What is changed and how it works?
change the policy privilige urls 

### Does this PR introduce a user-facing change?
no
- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
