### PR TITLE
fix the cache address in the local cluster

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/share_env.go
+++ b/pkg/microservice/aslan/core/environment/service/share_env.go
@@ -580,7 +580,7 @@ func ensureEnvoyFilter(ctx context.Context, istioClient versionedclient.Interfac
 
 	switch clusterID {
 	case setting.LocalClusterID:
-		cacheServerAddr = "aslan.zadig.svc.cluster.local"
+		cacheServerAddr = fmt.Sprintf("aslan.%s.svc.cluster.local", config.Namespace())
 		cacheServerPort = 25000
 	default:
 		cacheServerAddr = "hub-agent.koderover-agent.svc.cluster.local"


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

Zadig may be deployed in a non-`zadig` namespace. In this case, the cache address must be set correctly.

### What is changed and how it works?

When configuring the cache address, obtain the namespace installed by Zadig from the environment variable.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
