### PR TITLE
fix resource restart fail error

### DIFF
--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -171,7 +171,7 @@ func ListWorkloadsInEnv(envName, productName, filter string, perPage, page int, 
 
 	filterArray := []FilterFunc{
 		func(workloads []*Workload) []*Workload {
-			if projectInfo.ProductFeature == nil || projectInfo.ProductFeature.CreateEnvType != setting.SourceFromExternal {
+			if projectInfo.ProductFeature == nil || projectInfo.ProductFeature.DeployType != setting.SourceFromExternal {
 				return workloads
 			}
 
@@ -202,6 +202,31 @@ func ListWorkloadsInEnv(envName, productName, filter string, perPage, page int, 
 			return res
 		},
 	}
+
+	// for helm service, only show deploys/stss created by zadig
+	if projectInfo.ProductFeature != nil && projectInfo.ProductFeature.DeployType == setting.SourceFromHelm {
+		filterArray = append(filterArray, func(workloads []*Workload) []*Workload {
+			releaseNameMap, err := GetReleaseNameToServiceNameMap(productInfo)
+			if err != nil {
+				log.Errorf("failed to generate relase map for product: %s:%s", productInfo.ProductName, productInfo.EnvName)
+				return workloads
+			}
+
+			var res []*Workload
+			for _, workload := range workloads {
+				if len(workload.Annotation) == 0 {
+					continue
+				}
+				releaseName := workload.Annotation[setting.HelmReleaseNameAnnotation]
+				log.Infof("###### the relaseName is %s", releaseName)
+				if _, ok := releaseNameMap[releaseName]; ok {
+					res = append(res, workload)
+				}
+			}
+			return res
+		})
+	}
+
 	if filter != "" {
 		filterArray = append(filterArray, func(workloads []*Workload) []*Workload {
 			data, err := jsonutil.ToJSON(filter)
@@ -254,6 +279,7 @@ type Workload struct {
 	Images      []string               `json:"-"`
 	Ready       bool                   `json:"ready"`
 	ServiceName string                 `json:"service_name"`
+	Annotation  map[string]string      `json:"-"`
 }
 
 func ListWorkloads(envName, clusterID, namespace, productName string, perPage, page int, log *zap.SugaredLogger, filter ...FilterFunc) (int, []*ServiceResp, error) {
@@ -277,7 +303,14 @@ func ListWorkloads(envName, clusterID, namespace, productName string, perPage, p
 		return 0, resp, e.ErrListGroups.AddDesc(err.Error())
 	}
 	for _, v := range listDeployments {
-		workLoads = append(workLoads, &Workload{Name: v.Name, Spec: v.Spec.Template, Type: setting.Deployment, Images: wrapper.Deployment(v).ImageInfos(), Ready: wrapper.Deployment(v).Ready()})
+		workLoads = append(workLoads, &Workload{
+			Name:       v.Name,
+			Spec:       v.Spec.Template,
+			Type:       setting.Deployment,
+			Images:     wrapper.Deployment(v).ImageInfos(),
+			Ready:      wrapper.Deployment(v).Ready(),
+			Annotation: v.Annotations,
+		})
 	}
 	statefulSets, err := getter.ListStatefulSetsWithCache(nil, informer)
 	if err != nil {
@@ -285,7 +318,14 @@ func ListWorkloads(envName, clusterID, namespace, productName string, perPage, p
 		return 0, resp, e.ErrListGroups.AddDesc(err.Error())
 	}
 	for _, v := range statefulSets {
-		workLoads = append(workLoads, &Workload{Name: v.Name, Spec: v.Spec.Template, Type: setting.StatefulSet, Images: wrapper.StatefulSet(v).ImageInfos(), Ready: wrapper.StatefulSet(v).Ready()})
+		workLoads = append(workLoads, &Workload{
+			Name:       v.Name,
+			Spec:       v.Spec.Template,
+			Type:       setting.StatefulSet,
+			Images:     wrapper.StatefulSet(v).ImageInfos(),
+			Ready:      wrapper.StatefulSet(v).Ready(),
+			Annotation: v.Annotations,
+		})
 	}
 
 	log.Debugf("Found %d workloads in total", len(workLoads))

--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -218,7 +218,6 @@ func ListWorkloadsInEnv(envName, productName, filter string, perPage, page int, 
 					continue
 				}
 				releaseName := workload.Annotation[setting.HelmReleaseNameAnnotation]
-				log.Infof("###### the relaseName is %s", releaseName)
 				if _, ok := releaseNameMap[releaseName]; ok {
 					res = append(res, workload)
 				}

--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -171,7 +171,7 @@ func ListWorkloadsInEnv(envName, productName, filter string, perPage, page int, 
 
 	filterArray := []FilterFunc{
 		func(workloads []*Workload) []*Workload {
-			if projectInfo.ProductFeature == nil || projectInfo.ProductFeature.DeployType != setting.SourceFromExternal {
+			if projectInfo.ProductFeature == nil || projectInfo.ProductFeature.CreateEnvType != setting.SourceFromExternal {
 				return workloads
 			}
 


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
fix bug:
1. restarting deployment/statefulset from workloads list on environment page may fail
2. workloads displayed on the environment page are not filtered for helm services

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
