### PR TITLE
abac config permission bugfix

### DIFF
--- a/pkg/microservice/aslan/core/environment/handler/policy.yaml
+++ b/pkg/microservice/aslan/core/environment/handler/policy.yaml
@@ -32,22 +32,31 @@ rules:
             value: "false"
       - method: GET
         endpoint: "/api/aslan/environment/kube/workloads"
+        resourceType: "Environment"
       - method: GET
         endpoint: "/api/aslan/service/workloads"
+        resourceType: "Environment"
       - method: GET
         endpoint: "/api/aslan/environment/export/service"
+        resourceType: "Environment"
       - method: GET
         endpoint: "/api/aslan/environment/configmaps"
+        resourceType: "Environment"
       - method: GET
         endpoint: "/api/aslan/environment/kube/pods/?*/events"
+        resourceType: "Environment"
       - method: GET
         endpoint: "/api/aslan/environment/kube/events"
+        resourceType: "Environment"
       - method: GET
         endpoint: "/api/aslan/logs/sse/pods/?*/containers/?*"
+        resourceType: "Environment"
       - method: GET
         endpoint: "/api/aslan/project/products/?*/services"
+        resourceType: "Environment"
       - method: GET
         endpoint: "/api/aslan/environment/revision/products"
+        resourceType: "Environment"
       - method: GET
         endpoint: "/api/aslan/environment/environments/?*/workloads"
         resourceType: "Environment"
@@ -78,6 +87,7 @@ rules:
             value: "false"
       - method: GET
         endpoint: "/api/aslan/environment/diff/products/?*/service/?*"
+        resourceType: "Environment"
       - method: GET
         endpoint: "/api/aslan/environment/configmaps/?*"
         resourceType: "Environment"
@@ -154,6 +164,7 @@ rules:
             value: "false"
       - method: PUT
         endpoint: "/api/aslan/environment/environments"
+        resourceType: "Environment"
       - method: PUT
         endpoint: "/api/aslan/environment/environments/?*"
         resourceType: "Environment"
@@ -180,8 +191,10 @@ rules:
             value: "false"
       - method: PUT
         endpoint: "/api/aslan/service/workloads"
+        resourceType: "Environment"
       - method: GET
         endpoint: "/api/aslan/project/products/?*/services"
+        resourceType: "Environment"
       - method: PUT
         endpoint: "/api/aslan/environment/environments/?*/registry"
         resourceType: "Environment"
@@ -216,6 +229,7 @@ rules:
     rules:
       - method: PUT
         endpoint: "/api/aslan/environment/environments"
+        resourceType: "Environment"
       - method: POST
         endpoint: "/api/aslan/environment/environments/?*/services/?*/restart"
         resourceType: "Environment"
@@ -271,10 +285,13 @@ rules:
             value: "false"
       - method: PUT
         endpoint: "/api/aslan/environment/configmaps"
+        resourceType: "Environment"
       - method: POST
         endpoint: "/api/aslan/environment/configmaps"
+        resourceType: "Environment"
       - method: POST
         endpoint: "/api/aslan/workflow/servicetask"
+        resourceType: "Environment"
   - action: delete_environment
     alias: "删除"
     description: ""

--- a/pkg/microservice/aslan/core/workflow/handler/policy.yaml
+++ b/pkg/microservice/aslan/core/workflow/handler/policy.yaml
@@ -14,36 +14,52 @@ rules:
             value: "placeholder"
       - method: GET
         endpoint: "api/aslan/workflow/workflow"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/aslan/workflow/workflow/find/?*"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/aslan/workflow/workflowtask/max/?*/start/?*/pipelines/?*"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/aslan/workflow/workflowtask/id/?*/pipelines/?*"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/aslan/workflow/sse/workflows/id/?*/pipelines/?*"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/aslan/logs/sse/workflow/build/?*/?*/?*/?*"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/aslan/logs/log/workflow/?*/tasks/?*/service/?*"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/aslan/logs/sse/workflow/test/?*/?*/?*/?*/?*"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/aslan/logs/log/workflow/?*/tasks/?*/tests/test/service/?*"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/aslan/logs/log/workflow/?*/tasks/?*/tests/test/service/?*"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/aslan/testing/itreport/workflow/?*/id/?*/names/?*/service/?*"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/directory/workflowTask"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/aslan/workflow/v3"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/aslan/workflow/v3/?*"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/aslan/workflow/v3/?*/args"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/aslan/workflow/servicetask/workflows/?*/?*/?*/?*"
+        resourceType: "Workflow"
   - action: edit_workflow
     alias: "编辑"
     description: ""
@@ -60,20 +76,26 @@ rules:
             value: "placeholder"
       - method: GET
         endpoint: "/api/aslan/workflow/workflow/preset/?*"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/aslan/testing/testdetail"
+        resourceType: "Workflow"
       - method: PUT
         endpoint: "/api/aslan/workflow/v3/?*"
+        resourceType: "Workflow"
   - action: create_workflow
     alias: "新建"
     description: ""
     rules:
       - method: POST
         endpoint: "api/aslan/workflow/workflow"
+        resourceType: "Workflow"
       - method: PUT
         endpoint: "/api/aslan/workflow/workflow/old/?*/new/?*"
+        resourceType: "Workflow"
       - method: POST
         endpoint: "/api/directory/workflowTask/create"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/aslan/environment/environments"
         resourceType: "Environment"
@@ -82,16 +104,20 @@ rules:
             value: "placeholder"
       - method: GET
         endpoint: "/api/aslan/testing/testdetail"
+        resourceType: "Workflow"
       - method: POST
         endpoint: "/api/aslan/workflow/v3"
+        resourceType: "Workflow"
   - action: delete_workflow
     alias: "删除"
     description: ""
     rules:
       - method: DELETE
         endpoint: "/api/aslan/workflow/workflow/?*"
+        resourceType: "Workflow"
       - method: DELETE
         endpoint: "/api/aslan/workflow/v3/?*"
+        resourceType: "Workflow"
   - action: run_workflow
     alias: "执行"
     description: ""
@@ -114,8 +140,10 @@ rules:
         resourceType: "Workflow"
       - method: POST
         endpoint: "/api/directory/workflowTask/id/?*/pipelines/?*/restart"
+        resourceType: "Workflow"
       - method: POST
         endpoint: "/api/directory/workflowTask/id/?*/pipelines/?*/cancel"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/aslan/environment/environments"
         resourceType: "Environment"
@@ -124,11 +152,16 @@ rules:
             value: "placeholder"
       - method: GET
         endpoint: "/api/aslan/project/products/?*/services"
+        resourceType: "Workflow"
       - method: GET
         endpoint: "/api/aslan/workflow/v3/?*/args"
+        resourceType: "Workflow"
       - method: POST
         endpoint: "/api/aslan/workflow/v3/workflowtask"
+        resourceType: "Workflow"
       - method: POST
         endpoint: "/api/aslan/workflow/v3/workflowtask/id/?*/name/?*/restart"
+        resourceType: "Workflow"
       - method: DELETE
         endpoint: "/api/aslan/workflow/v3/workflowtask/id/?*/name/?*"
+        resourceType: "Workflow"


### PR DESCRIPTION
Signed-off-by: mouuii <zhouchengbin@koderover.com>

### What this PR does / Why we need it:
abac permission bug , user has permission to config service in an environment can not operate , resourceType not add

### What is changed and how it works?
add the resource type , rego filter  logic way 

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
