### PR TITLE
bugfix for hubagent connection problem

### DIFF
--- a/pkg/microservice/hubagent/server/server.go
+++ b/pkg/microservice/hubagent/server/server.go
@@ -76,7 +76,7 @@ func Serve(ctx context.Context) error {
 }
 
 func initDinD() {
-	client := aslan.New(config2.AslanBaseAddr())
+	client := aslan.NewExternal(config2.AslanBaseAddr(), "")
 
 	ls, err := client.ListRegistries()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Min Min <jamsman94@gmail.com>

### What this PR does / Why we need it:
fixed a bug which can cause hubagent to panic when trying to connect to zadig system

### What is changed and how it works?
used a different client to make sure the api call goes through

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
