### PR TITLE
fix dind version in attached cluster

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/service.go
+++ b/pkg/microservice/aslan/core/common/service/kube/service.go
@@ -19,7 +19,6 @@ package kube
 import (
 	"bytes"
 	"fmt"
-	config2 "github.com/koderover/zadig/pkg/config"
 	"net/url"
 	"strings"
 	"text/template"
@@ -29,6 +28,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	config2 "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
@@ -510,7 +510,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
       containers:
         - name: dind
-          image: ccr.ccs.tencentyun.com/koderover-public/library-docker:stable-dind
+          image: ccr.ccs.tencentyun.com/koderover-public/docker:20.10.14-dind
           args:
             - --mtu=1376
           env:
@@ -762,7 +762,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
       containers:
         - name: dind
-          image: ccr.ccs.tencentyun.com/koderover-public/library-docker:stable-dind
+          image: ccr.ccs.tencentyun.com/koderover-public/docker:20.10.14-dind
           args:
             - --mtu=1376
           env:


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

The version of `dind` in `http://xxx/api/aslan/cluster/agent/xxx/agent.yaml?type=deploy` for attached cluster is not correct.

### What is changed and how it works?

Fix version of `dind` for attached cluster.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
