### PR TITLE
cherry-pick:pr:1343

### DIFF
--- a/pkg/shared/client/systemconfig/codehost.go
+++ b/pkg/shared/client/systemconfig/codehost.go
@@ -90,7 +90,7 @@ func (c *Client) UpdateCodeHost(id int, codehost *CodeHost) error {
 }
 
 func (c *Client) GetCodeHostByAddressAndOwner(address, owner, source string) (*CodeHost, error) {
-	url := "/codehosts"
+	url := "/codehosts/internal"
 
 	res := make([]*CodeHost, 0)
 


### PR DESCRIPTION
Signed-off-by: panxunying <panxunying@koderover.com>

### What this PR does / Why we need it:
cherry-pick:pr:1343

### What is changed and how it works?
get codehosts with no encryption

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue