### PR TITLE
load template service bug

### DIFF
--- a/pkg/microservice/aslan/core/project/handler/service_policy.yaml
+++ b/pkg/microservice/aslan/core/project/handler/service_policy.yaml
@@ -55,6 +55,8 @@ rules:
       - method: POST
         endpoint: "/api/aslan/service/loader/load/?*/?*"
       - method: POST
+        endpoint: "api/aslan/service/template/load"
+      - method: POST
         endpoint: "/api/aslan/service/helm/services"
       - method: POST
         endpoint: "/api/aslan/service/helm/services/bulk"


### PR DESCRIPTION
Signed-off-by: mouuii <zhouchengbin@koderover.com>

### What this PR does / Why we need it:
user can load  template into service while  having not permission to create service 

### What is changed and how it works?
add the url to create service , it is not controlled by auth system

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
