### PR TITLE
fix k8s yaml reload from template bug

### DIFF
--- a/pkg/microservice/aslan/core/service/handler/yaml_template.go
+++ b/pkg/microservice/aslan/core/service/handler/yaml_template.go
@@ -54,5 +54,5 @@ func ReloadServiceFromYamlTemplate(c *gin.Context) {
 		return
 	}
 
-	ctx.Err = svcservice.ReloadServiceFromYamlTemplate(ctx.UserName, req.ProjectName, req.ServiceName, req.Variables, ctx.Logger)
+	ctx.Err = svcservice.ReloadServiceFromYamlTemplate(ctx.UserName, req.ProjectName, req.ServiceName, req.TemplateID, req.Variables, ctx.Logger)
 }

--- a/pkg/microservice/aslan/core/service/service/yaml_template.go
+++ b/pkg/microservice/aslan/core/service/service/yaml_template.go
@@ -51,7 +51,7 @@ func LoadServiceFromYamlTemplate(username, projectName, serviceName, templateID 
 	return err
 }
 
-func ReloadServiceFromYamlTemplate(username, projectName, serviceName string, variables []*Variable, logger *zap.SugaredLogger) error {
+func ReloadServiceFromYamlTemplate(username, projectName, serviceName, templateID string, variables []*Variable, logger *zap.SugaredLogger) error {
 	service, err := commonrepo.NewServiceColl().Find(&commonrepo.ServiceFindOption{
 		ServiceName: serviceName,
 		ProductName: projectName,
@@ -63,12 +63,12 @@ func ReloadServiceFromYamlTemplate(username, projectName, serviceName string, va
 	if service.Source != setting.ServiceSourceTemplate {
 		return errors.New("service is not created from template")
 	}
-	if service.TemplateID == "" {
-		return errors.New("failed to find template id for service:" + serviceName)
+	if templateID == "" {
+		return errors.New("template id can't be nil")
 	}
-	template, err := commonrepo.NewYamlTemplateColl().GetById(service.TemplateID)
+	template, err := commonrepo.NewYamlTemplateColl().GetById(templateID)
 	if err != nil {
-		logger.Errorf("Failed to find template of ID: %s, the error is: %s", service.TemplateID, err)
+		logger.Errorf("Failed to find template of ID: %s, the error is: %s", templateID, err)
 		return err
 	}
 	renderedYaml := renderYamlFromTemplate(template.Content, projectName, serviceName, variables)
@@ -79,11 +79,11 @@ func ReloadServiceFromYamlTemplate(username, projectName, serviceName string, va
 		Source:      setting.ServiceSourceTemplate,
 		Yaml:        renderedYaml,
 		Visibility:  setting.PrivateVisibility,
-		TemplateID:  service.TemplateID,
+		TemplateID:  templateID,
 	}
 	_, err = CreateServiceTemplate(username, svc, logger)
 	if err != nil {
-		logger.Errorf("Failed to create service template from template ID: %s, the error is: %s", service.TemplateID, err)
+		logger.Errorf("Failed to create service template from template ID: %s, the error is: %s", templateID, err)
 	}
 	return err
 }


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when reloading service created from k8s yaml template, the new selected template is not used as expected

### What is changed and how it works?
fix bug

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
