### PR TITLE
support for multiple notifications

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/1120.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/1120.go
@@ -77,6 +77,10 @@ func moduleTestingAddNotifyCtls() error {
 
 	var ms []mongo.WriteModel
 	for _, testing := range testings {
+		// 如果已经执行过数据迁移，不要重复迁移
+		if testing.NotifyCtls != nil {
+			continue
+		}
 		if testing.NotifyCtl != nil {
 			testing.NotifyCtls = []*models.NotifyCtl{testing.NotifyCtl}
 		}
@@ -146,6 +150,10 @@ func workflowAddNotifyCtls() error {
 
 	var ms []mongo.WriteModel
 	for _, workflow := range workflows {
+		// 如果已经执行过数据迁移，不要重复迁移
+		if workflow.NotifyCtls != nil {
+			continue
+		}
 		if workflow.NotifyCtl != nil {
 			workflow.NotifyCtls = []*models.NotifyCtl{workflow.NotifyCtl}
 		}

--- a/pkg/cli/upgradeassistant/cmd/migrate/1120.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/1120.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2022 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrate
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+
+	"github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/repository/models"
+	internalmongodb "github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/repository/mongodb"
+	"github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/upgradepath"
+	"github.com/koderover/zadig/pkg/tool/log"
+)
+
+func init() {
+	upgradepath.RegisterHandler("1.11.0", "1.12.0", V1110ToV1120)
+	upgradepath.RegisterHandler("1.12.0", "1.11.0", V1120ToV1110)
+}
+
+func V1110ToV1120() error {
+	// iterate all testings , if contains notifyctl , add notifyctls
+	if err := moduleTestingAddNotifyCtls(); err != nil {
+		log.Errorf("moduleTestingAddNotifyCtls err:%s", err)
+		return err
+	}
+	// iterate all workflows , if contains notifyctl , add notifyctls
+	if err := workflowAddNotifyCtls(); err != nil {
+		log.Errorf("workflowAddNotifyCtls err:%s", err)
+		return err
+	}
+
+	return nil
+}
+
+func V1120ToV1110() error {
+	// iterate all testings , if contains notifyctl , add notifyctls
+	if err := moduleTestingRollBackNotifyCtls(); err != nil {
+		log.Errorf("moduleTestingRollBackNotifyCtls err:%s", err)
+		return err
+	}
+	// iterate all workflows , if contains notifyctl , add notifyctls
+	if err := workflowRollBackNotifyCtls(); err != nil {
+		log.Errorf("workflowRollBackNotifyCtls err:%s", err)
+		return err
+	}
+	return nil
+}
+
+func moduleTestingAddNotifyCtls() error {
+	testingCol := internalmongodb.NewTestingColl()
+
+	testings, err := testingCol.List(&internalmongodb.ListTestOption{})
+	if err != nil {
+		return fmt.Errorf("failed to list all data in `zadig.module_testing`: %s", err)
+	}
+
+	if len(testings) == 0 {
+		return nil
+	}
+
+	var ms []mongo.WriteModel
+	for _, testing := range testings {
+		if testing.NotifyCtl != nil {
+			testing.NotifyCtls = []*models.NotifyCtl{testing.NotifyCtl}
+		}
+
+		ms = append(ms,
+			mongo.NewUpdateOneModel().
+				SetFilter(bson.D{{"_id", testing.ID}}).
+				SetUpdate(bson.D{{"$set",
+					bson.D{
+						{"notify_ctls", testing.NotifyCtls},
+					}},
+				}),
+		)
+	}
+	_, err = testingCol.BulkWrite(context.TODO(), ms)
+
+	return err
+}
+
+func moduleTestingRollBackNotifyCtls() error {
+	testingCol := internalmongodb.NewTestingColl()
+
+	testings, err := testingCol.List(&internalmongodb.ListTestOption{})
+	if err != nil {
+		return fmt.Errorf("failed to list all data in `zadig.module_testing`: %s", err)
+	}
+
+	if len(testings) == 0 {
+		return nil
+	}
+
+	var ms []mongo.WriteModel
+	for _, testing := range testings {
+		for _, notifyctl := range testing.NotifyCtls {
+			if notifyctl != nil && notifyctl.Enabled {
+				testing.NotifyCtl = notifyctl
+				break
+			}
+		}
+
+		ms = append(ms,
+			mongo.NewUpdateOneModel().
+				SetFilter(bson.D{{"_id", testing.ID}}).
+				SetUpdate(bson.D{{"$set",
+					bson.D{
+						{"notify_ctl", testing.NotifyCtl},
+					}},
+				}),
+		)
+	}
+	_, err = testingCol.BulkWrite(context.TODO(), ms)
+
+	return err
+}
+
+func workflowAddNotifyCtls() error {
+	workflowColl := internalmongodb.NewWorkflowColl()
+
+	workflows, err := workflowColl.List(&internalmongodb.ListWorkflowOption{})
+	if err != nil {
+		return fmt.Errorf("failed to list all data in `zadig.workflow`: %s", err)
+	}
+
+	if len(workflows) == 0 {
+		return nil
+	}
+
+	var ms []mongo.WriteModel
+	for _, workflow := range workflows {
+		if workflow.NotifyCtl != nil {
+			workflow.NotifyCtls = []*models.NotifyCtl{workflow.NotifyCtl}
+		}
+
+		ms = append(ms,
+			mongo.NewUpdateOneModel().
+				SetFilter(bson.D{{"_id", workflow.ID}}).
+				SetUpdate(bson.D{{"$set",
+					bson.D{
+						{"notify_ctls", workflow.NotifyCtls},
+					}},
+				}),
+		)
+	}
+	_, err = workflowColl.BulkWrite(context.TODO(), ms)
+
+	return err
+}
+
+func workflowRollBackNotifyCtls() error {
+	workflowColl := internalmongodb.NewWorkflowColl()
+
+	workflows, err := workflowColl.List(&internalmongodb.ListWorkflowOption{})
+	if err != nil {
+		return fmt.Errorf("failed to list all data in `zadig.workflow`: %s", err)
+	}
+
+	if len(workflows) == 0 {
+		return nil
+	}
+
+	var ms []mongo.WriteModel
+	for _, workflow := range workflows {
+		for _, notifyctl := range workflow.NotifyCtls {
+			if notifyctl != nil && notifyctl.Enabled {
+				workflow.NotifyCtl = notifyctl
+				break
+			}
+		}
+
+		ms = append(ms,
+			mongo.NewUpdateOneModel().
+				SetFilter(bson.D{{"_id", workflow.ID}}).
+				SetUpdate(bson.D{{"$set",
+					bson.D{
+						{"notify_ctl", workflow.NotifyCtl},
+					}},
+				}),
+		)
+	}
+	_, err = workflowColl.BulkWrite(context.TODO(), ms)
+
+	return err
+}

--- a/pkg/cli/upgradeassistant/cmd/migrate/1120.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/1120.go
@@ -68,7 +68,7 @@ func moduleTestingAddNotifyCtls() error {
 
 	testings, err := testingCol.List(&internalmongodb.ListTestOption{})
 	if err != nil {
-		return fmt.Errorf("failed to list all data in `zadig.module_testing`: %s", err)
+		return fmt.Errorf("failed to list all data in `zadig.module_testing`,err: %s", err)
 	}
 
 	if len(testings) == 0 {
@@ -178,7 +178,7 @@ func workflowRollBackNotifyCtls() error {
 
 	workflows, err := workflowColl.List(&internalmongodb.ListWorkflowOption{})
 	if err != nil {
-		return fmt.Errorf("failed to list all data in `zadig.workflow`: %s", err)
+		return fmt.Errorf("failed to list all data in `zadig.workflow`,err: %s", err)
 	}
 
 	if len(workflows) == 0 {

--- a/pkg/cli/upgradeassistant/cmd/migrate/1120.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/1120.go
@@ -105,7 +105,7 @@ func moduleTestingRollBackNotifyCtls() error {
 
 	testings, err := testingCol.List(&internalmongodb.ListTestOption{})
 	if err != nil {
-		return fmt.Errorf("failed to list all data in `zadig.module_testing`: %s", err)
+		return fmt.Errorf("failed to list all data in `zadig.module_testing`,err: %s", err)
 	}
 
 	if len(testings) == 0 {
@@ -141,7 +141,7 @@ func workflowAddNotifyCtls() error {
 
 	workflows, err := workflowColl.List(&internalmongodb.ListWorkflowOption{})
 	if err != nil {
-		return fmt.Errorf("failed to list all data in `zadig.workflow`: %s", err)
+		return fmt.Errorf("failed to list all data in `zadig.workflow`,err: %s", err)
 	}
 
 	if len(workflows) == 0 {

--- a/pkg/cli/upgradeassistant/internal/repository/models/testing.go
+++ b/pkg/cli/upgradeassistant/internal/repository/models/testing.go
@@ -25,12 +25,14 @@ import (
 )
 
 type Testing struct {
-	ID        primitive.ObjectID `bson:"_id,omitempty"            json:"id,omitempty"`
-	PreTest   *PreTest           `bson:"pre_test"                 json:"pre_test"`
-	Timeout   int                `bson:"timeout"                  json:"timeout"`
-	HookCtl   *TestingHookCtrl   `bson:"hook_ctl"                 json:"hook_ctl"`
-	NotifyCtl *NotifyCtl         `bson:"notify_ctl,omitempty"     json:"notify_ctl,omitempty"`
-	Schedules *ScheduleCtrl      `bson:"schedules,omitempty"      json:"schedules,omitempty"`
+	ID         primitive.ObjectID `bson:"_id,omitempty"            json:"id,omitempty"`
+	PreTest    *PreTest           `bson:"pre_test"                 json:"pre_test"`
+	Timeout    int                `bson:"timeout"                  json:"timeout"`
+	HookCtl    *TestingHookCtrl   `bson:"hook_ctl"                 json:"hook_ctl"`
+	NotifyCtl  *NotifyCtl         `bson:"notify_ctl,omitempty"     json:"notify_ctl,omitempty"`
+	NotifyCtls []*NotifyCtl       `bson:"notify_ctls,omitempty"    json:"notify_ctls,omitempty"`
+
+	Schedules *ScheduleCtrl `bson:"schedules,omitempty"      json:"schedules,omitempty"`
 
 	ArtifactPaths []string `bson:"artifact_paths,omitempty" json:"artifact_paths,omitempty"`
 

--- a/pkg/cli/upgradeassistant/internal/repository/models/workflow.go
+++ b/pkg/cli/upgradeassistant/internal/repository/models/workflow.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type Workflow struct {
+	ID              primitive.ObjectID `bson:"_id,omitempty"                json:"id,omitempty"`
+	Name            string             `bson:"name"                         json:"name"`
+	Enabled         bool               `bson:"enabled"                      json:"enabled"`
+	ProductTmplName string             `bson:"product_tmpl_name"            json:"product_tmpl_name"`
+	Team            string             `bson:"team,omitempty"               json:"team,omitempty"`
+	EnvName         string             `bson:"env_name"                     json:"env_name,omitempty"`
+	Description     string             `bson:"description,omitempty"        json:"description,omitempty"`
+	UpdateBy        string             `bson:"update_by"                    json:"update_by,omitempty"`
+	CreateBy        string             `bson:"create_by"                    json:"create_by,omitempty"`
+	UpdateTime      int64              `bson:"update_time"                  json:"update_time"`
+	CreateTime      int64              `bson:"create_time"                  json:"create_time"`
+	Schedules       *ScheduleCtrl      `bson:"schedules,omitempty"          json:"schedules,omitempty"`
+	ScheduleEnabled bool               `bson:"schedule_enabled"             json:"schedule_enabled"`
+	// TODO: Deprecated.
+	NotifyCtl *NotifyCtl `bson:"notify_ctl,omitempty"         json:"notify_ctl,omitempty"`
+	// New since V1.12.0.
+	NotifyCtls []*NotifyCtl `bson:"notify_ctls,omitempty"        json:"notify_ctls,omitempty"`
+	BaseName   string       `bson:"base_name" json:"base_name"`
+
+	// ResetImage indicate whether reset image to original version after completion
+	ResetImage bool `bson:"reset_image"                  json:"reset_image"`
+	// IsParallel 控制单一工作流的任务是否支持并行处理
+	IsParallel bool `json:"is_parallel" bson:"is_parallel"`
+}
+
+func (Workflow) TableName() string {
+	return "workflow"
+}

--- a/pkg/cli/upgradeassistant/internal/repository/mongodb/workflow.go
+++ b/pkg/cli/upgradeassistant/internal/repository/mongodb/workflow.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2021 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mongodb
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/repository/models"
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
+)
+
+type ListWorkflowOption struct {
+	IsSort   bool
+	Projects []string
+	Names    []string
+	Ids      []string
+}
+
+type WorkflowColl struct {
+	*mongo.Collection
+
+	coll string
+}
+
+func NewWorkflowColl() *WorkflowColl {
+	name := models.Workflow{}.TableName()
+	return &WorkflowColl{Collection: mongotool.Database(config.MongoDatabase()).Collection(name), coll: name}
+}
+
+func (c *WorkflowColl) GetCollectionName() string {
+	return c.coll
+}
+
+func (c *WorkflowColl) List(opt *ListWorkflowOption) ([]*models.Workflow, error) {
+	query := bson.M{}
+	if len(opt.Projects) > 0 {
+		query["product_tmpl_name"] = bson.M{"$in": opt.Projects}
+	}
+	if len(opt.Names) > 0 {
+		query["name"] = bson.M{"$in": opt.Names}
+	}
+	if len(opt.Ids) > 0 {
+		var oids []primitive.ObjectID
+		for _, id := range opt.Ids {
+			oid, err := primitive.ObjectIDFromHex(id)
+			if err != nil {
+				return nil, err
+			}
+			oids = append(oids, oid)
+		}
+		query["_id"] = bson.M{"$in": oids}
+	}
+
+	resp := make([]*models.Workflow, 0)
+	ctx := context.Background()
+	opts := options.Find()
+	if opt.IsSort {
+		opts.SetSort(bson.D{{"update_time", -1}})
+	}
+	cursor, err := c.Collection.Find(ctx, query, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	err = cursor.All(ctx, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/pkg/microservice/aslan/core/common/repository/models/pipeline.go
+++ b/pkg/microservice/aslan/core/common/repository/models/pipeline.go
@@ -51,9 +51,11 @@ type Pipeline struct {
 	PassRate       float32                  `bson:"pass_rate,omitempty"          json:"pass_rate,omitempty"`
 	IsDeleted      bool                     `bson:"is_deleted"                   json:"is_deleted"`
 	Slack          *Slack                   `bson:"slack"                        json:"slack"`
-	NotifyCtl      *NotifyCtl               `bson:"notify_ctl"                   json:"notify_ctl"`
-	NotifyCtls     []*NotifyCtl             `bson:"notify_ctls"                  json:"notify_ctls"`
-	IsFavorite     bool                     `bson:"-"                            json:"is_favorite"`
+	// TODO: Deprecated.
+	NotifyCtl *NotifyCtl `bson:"notify_ctl"                   json:"notify_ctl"`
+	// New since V1.12.0.
+	NotifyCtls []*NotifyCtl `bson:"notify_ctls"                  json:"notify_ctls"`
+	IsFavorite bool         `bson:"-"                            json:"is_favorite"`
 	// 是否允许同时运行多次
 	MultiRun bool `bson:"multi_run"                    json:"multi_run"`
 }

--- a/pkg/microservice/aslan/core/common/repository/models/pipeline.go
+++ b/pkg/microservice/aslan/core/common/repository/models/pipeline.go
@@ -52,6 +52,7 @@ type Pipeline struct {
 	IsDeleted      bool                     `bson:"is_deleted"                   json:"is_deleted"`
 	Slack          *Slack                   `bson:"slack"                        json:"slack"`
 	NotifyCtl      *NotifyCtl               `bson:"notify_ctl"                   json:"notify_ctl"`
+	NotifyCtls     []*NotifyCtl             `bson:"notify_ctls"                  json:"notify_ctls"`
 	IsFavorite     bool                     `bson:"-"                            json:"is_favorite"`
 	// 是否允许同时运行多次
 	MultiRun bool `bson:"multi_run"                    json:"multi_run"`

--- a/pkg/microservice/aslan/core/common/repository/models/testing.go
+++ b/pkg/microservice/aslan/core/common/repository/models/testing.go
@@ -45,17 +45,19 @@ type Testing struct {
 	// TODO: Deprecated.
 	Caches []string `bson:"caches"                   json:"caches"`
 
-	ArtifactPaths   []string         `bson:"artifact_paths,omitempty" json:"artifact_paths,omitempty"`
-	TestCaseNum     int              `bson:"-"                        json:"test_case_num,omitempty"`
-	ExecuteNum      int              `bson:"-"                        json:"execute_num,omitempty"`
-	PassRate        float64          `bson:"-"                        json:"pass_rate,omitempty"`
-	AvgDuration     float64          `bson:"-"                        json:"avg_duration,omitempty"`
-	Workflows       []*Workflow      `bson:"-"                        json:"workflows,omitempty"`
-	Schedules       *ScheduleCtrl    `bson:"schedules,omitempty"      json:"schedules,omitempty"`
-	HookCtl         *TestingHookCtrl `bson:"hook_ctl"                 json:"hook_ctl"`
-	NotifyCtl       *NotifyCtl       `bson:"notify_ctl,omitempty"     json:"notify_ctl,omitempty"`
-	NotifyCtls      []*NotifyCtl     `bson:"notify_ctls,omitempty"     json:"notify_ctls,omitempty"`
-	ScheduleEnabled bool             `bson:"schedule_enabled"         json:"-"`
+	ArtifactPaths []string         `bson:"artifact_paths,omitempty" json:"artifact_paths,omitempty"`
+	TestCaseNum   int              `bson:"-"                        json:"test_case_num,omitempty"`
+	ExecuteNum    int              `bson:"-"                        json:"execute_num,omitempty"`
+	PassRate      float64          `bson:"-"                        json:"pass_rate,omitempty"`
+	AvgDuration   float64          `bson:"-"                        json:"avg_duration,omitempty"`
+	Workflows     []*Workflow      `bson:"-"                        json:"workflows,omitempty"`
+	Schedules     *ScheduleCtrl    `bson:"schedules,omitempty"      json:"schedules,omitempty"`
+	HookCtl       *TestingHookCtrl `bson:"hook_ctl"                 json:"hook_ctl"`
+	// TODO: Deprecated.
+	NotifyCtl *NotifyCtl `bson:"notify_ctl,omitempty"     json:"notify_ctl,omitempty"`
+	// New since V1.12.0.
+	NotifyCtls      []*NotifyCtl `bson:"notify_ctls,omitempty"     json:"notify_ctls,omitempty"`
+	ScheduleEnabled bool         `bson:"schedule_enabled"         json:"-"`
 
 	// New since V1.10.0.
 	CacheEnable  bool               `bson:"cache_enable"              json:"cache_enable"`

--- a/pkg/microservice/aslan/core/common/repository/models/testing.go
+++ b/pkg/microservice/aslan/core/common/repository/models/testing.go
@@ -54,6 +54,7 @@ type Testing struct {
 	Schedules       *ScheduleCtrl    `bson:"schedules,omitempty"      json:"schedules,omitempty"`
 	HookCtl         *TestingHookCtrl `bson:"hook_ctl"                 json:"hook_ctl"`
 	NotifyCtl       *NotifyCtl       `bson:"notify_ctl,omitempty"     json:"notify_ctl,omitempty"`
+	NotifyCtls      []*NotifyCtl     `bson:"notify_ctls,omitempty"     json:"notify_ctls,omitempty"`
 	ScheduleEnabled bool             `bson:"schedule_enabled"         json:"-"`
 
 	// New since V1.10.0.

--- a/pkg/microservice/aslan/core/common/repository/models/workflow.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow.go
@@ -49,6 +49,7 @@ type Workflow struct {
 	DistributeStage *DistributeStage   `bson:"distribute_stage"             json:"distribute_stage"`
 	ExtensionStage  *ExtensionStage    `bson:"extension_stage"              json:"extension_stage"`
 	NotifyCtl       *NotifyCtl         `bson:"notify_ctl,omitempty"         json:"notify_ctl,omitempty"`
+	NotifyCtls      []*NotifyCtl       `bson:"notify_ctls,omitempty"        json:"notify_ctls,omitempty"`
 	HookCtl         *WorkflowHookCtrl  `bson:"hook_ctl"                     json:"hook_ctl"`
 	BaseName        string             `bson:"base_name" json:"base_name"`
 

--- a/pkg/microservice/aslan/core/common/repository/models/workflow.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow.go
@@ -48,7 +48,9 @@ type Workflow struct {
 	SecurityStage   *SecurityStage     `bson:"security_stage"               json:"security_stage"`
 	DistributeStage *DistributeStage   `bson:"distribute_stage"             json:"distribute_stage"`
 	ExtensionStage  *ExtensionStage    `bson:"extension_stage"              json:"extension_stage"`
+	// TODO: Deprecated.
 	NotifyCtl       *NotifyCtl         `bson:"notify_ctl,omitempty"         json:"notify_ctl,omitempty"`
+	// New since V1.12.0.
 	NotifyCtls      []*NotifyCtl       `bson:"notify_ctls,omitempty"        json:"notify_ctls,omitempty"`
 	HookCtl         *WorkflowHookCtrl  `bson:"hook_ctl"                     json:"hook_ctl"`
 	BaseName        string             `bson:"base_name" json:"base_name"`

--- a/pkg/microservice/aslan/core/common/service/instantmessage/service.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/service.go
@@ -104,7 +104,7 @@ func (w *Service) SendInstantMessage(task *task.Task, testTaskStatusChanged bool
 	case config.SingleType:
 		resp, err := w.pipelineColl.Find(&mongodb.PipelineFindOption{Name: task.PipelineName})
 		if err != nil {
-			log.Errorf("Pipeline find err :%s", err)
+			log.Errorf("failed to find Pipeline,err: %s", err)
 			return err
 		}
 		notifyCtls = resp.NotifyCtls
@@ -112,7 +112,7 @@ func (w *Service) SendInstantMessage(task *task.Task, testTaskStatusChanged bool
 	case config.WorkflowType:
 		resp, err := w.workflowColl.Find(task.PipelineName)
 		if err != nil {
-			log.Errorf("Workflow find err :%s", err)
+			log.Errorf("failed to find Workflow,err: %s", err)
 			return err
 		}
 		notifyCtls = resp.NotifyCtls
@@ -120,7 +120,7 @@ func (w *Service) SendInstantMessage(task *task.Task, testTaskStatusChanged bool
 	case config.TestType:
 		resp, err := w.testingColl.Find(strings.TrimSuffix(task.PipelineName, "-job"), task.ProductName)
 		if err != nil {
-			log.Errorf("testing find err :%s", err)
+			log.Errorf("failed to find Testing,err: %s", err)
 			return err
 		}
 		notifyCtls = resp.NotifyCtls

--- a/pkg/microservice/aslan/core/common/service/instantmessage/service.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/service.go
@@ -347,7 +347,7 @@ func (w *Service) createNotifyBodyOfWorkflowIM(weChatNotification *wechatNotific
 				if buildSt.BuildStatus.Status == "" {
 					buildSt.BuildStatus.Status = config.StatusNotRun
 				}
-				buildElemTemp += fmt.Sprintf("\n\n{{if eq .WebHookType \"dingding\"}}\n\n##### {{end}}**服务名称**：%s \n", buildSt.Service)
+				buildElemTemp += fmt.Sprintf("\n\n{{if eq .WebHookType \"dingding\"}}---\n\n##### {{end}}**服务名称**：%s \n", buildSt.Service)
 				if !(buildSt.ServiceType == setting.PMDeployType &&
 					(buildSt.JobCtx.FileArchiveCtx != nil || buildSt.JobCtx.DockerBuildCtx != nil)) {
 					buildElemTemp += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**镜像信息**：%s \n", buildSt.JobCtx.Image)

--- a/pkg/microservice/aslan/core/common/service/instantmessage/service.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/service.go
@@ -347,7 +347,7 @@ func (w *Service) createNotifyBodyOfWorkflowIM(weChatNotification *wechatNotific
 				if buildSt.BuildStatus.Status == "" {
 					buildSt.BuildStatus.Status = config.StatusNotRun
 				}
-				buildElemTemp += fmt.Sprintf("\n{{if eq .WebHookType \"dingding\"}}##### {{end}}**服务名称**：%s \n", buildSt.Service)
+				buildElemTemp += fmt.Sprintf("\n\n{{if eq .WebHookType \"dingding\"}}\n\n##### {{end}}**服务名称**：%s \n", buildSt.Service)
 				if !(buildSt.ServiceType == setting.PMDeployType &&
 					(buildSt.JobCtx.FileArchiveCtx != nil || buildSt.JobCtx.DockerBuildCtx != nil)) {
 					buildElemTemp += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**镜像信息**：%s \n", buildSt.JobCtx.Image)

--- a/pkg/microservice/aslan/core/common/service/instantmessage/service.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/service.go
@@ -28,6 +28,7 @@ import (
 
 	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/task"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/base"
@@ -97,6 +98,51 @@ func (w *Service) SendMessageRequest(uri string, message interface{}) ([]byte, e
 }
 
 func (w *Service) SendInstantMessage(task *task.Task, testTaskStatusChanged bool) error {
+	var notifyCtls []*models.NotifyCtl
+	var desc string
+	switch task.Type {
+	case config.SingleType:
+		resp, err := w.pipelineColl.Find(&mongodb.PipelineFindOption{Name: task.PipelineName})
+		if err != nil {
+			log.Errorf("Pipeline find err :%s", err)
+			return err
+		}
+		notifyCtls = resp.NotifyCtls
+
+	case config.WorkflowType:
+		resp, err := w.workflowColl.Find(task.PipelineName)
+		if err != nil {
+			log.Errorf("Workflow find err :%s", err)
+			return err
+		}
+		notifyCtls = resp.NotifyCtls
+
+	case config.TestType:
+		resp, err := w.testingColl.Find(strings.TrimSuffix(task.PipelineName, "-job"), task.ProductName)
+		if err != nil {
+			log.Errorf("testing find err :%s", err)
+			return err
+		}
+		notifyCtls = resp.NotifyCtls
+
+	default:
+		log.Errorf("task type is not supported!")
+		return nil
+	}
+
+	for _, notifyCtl := range notifyCtls {
+		if err := w.sendMessage(task, notifyCtl, testTaskStatusChanged, desc); err != nil {
+			log.Errorf("send %s message err: %s", notifyCtl.WebHookType, err)
+			continue
+		}
+	}
+	return nil
+}
+
+func (w *Service) sendMessage(task *task.Task, notifyCtl *models.NotifyCtl, testTaskStatusChanged bool, desc string) error {
+	if notifyCtl == nil {
+		return nil
+	}
 	var (
 		uri         = ""
 		content     = ""
@@ -105,27 +151,19 @@ func (w *Service) SendInstantMessage(task *task.Task, testTaskStatusChanged bool
 		isAtAll     bool
 		title       = ""
 		larkCard    *LarkCard
+		err         error
 	)
 	if task.Type == config.SingleType {
-		resp, err := w.pipelineColl.Find(&mongodb.PipelineFindOption{Name: task.PipelineName})
-		if err != nil {
-			log.Errorf("Pipeline find err :%s", err)
-			return err
-		}
-		if resp.NotifyCtl == nil {
-			log.Infof("pipeline notifyCtl is not set!")
-			return nil
-		}
-		if resp.NotifyCtl.Enabled && sets.NewString(resp.NotifyCtl.NotifyTypes...).Has(string(task.Status)) {
-			webHookType = resp.NotifyCtl.WebHookType
+		if notifyCtl.Enabled && sets.NewString(notifyCtl.NotifyTypes...).Has(string(task.Status)) {
+			webHookType = notifyCtl.WebHookType
 			if webHookType == dingDingType {
-				uri = resp.NotifyCtl.DingDingWebHook
-				atMobiles = resp.NotifyCtl.AtMobiles
-				isAtAll = resp.NotifyCtl.IsAtAll
+				uri = notifyCtl.DingDingWebHook
+				atMobiles = notifyCtl.AtMobiles
+				isAtAll = notifyCtl.IsAtAll
 			} else if webHookType == feiShuType {
-				uri = resp.NotifyCtl.FeiShuWebHook
+				uri = notifyCtl.FeiShuWebHook
 			} else {
-				uri = resp.NotifyCtl.WeChatWebHook
+				uri = notifyCtl.WeChatWebHook
 			}
 			content, err = w.createNotifyBody(&wechatNotification{
 				Task:        task,
@@ -142,25 +180,16 @@ func (w *Service) SendInstantMessage(task *task.Task, testTaskStatusChanged bool
 			}
 		}
 	} else if task.Type == config.WorkflowType {
-		resp, err := w.workflowColl.Find(task.PipelineName)
-		if err != nil {
-			log.Errorf("Workflow find err :%s", err)
-			return err
-		}
-		if resp.NotifyCtl == nil {
-			log.Infof("Workflow notifyCtl is not set!")
-			return nil
-		}
-		if resp.NotifyCtl.Enabled && sets.NewString(resp.NotifyCtl.NotifyTypes...).Has(string(task.Status)) {
-			webHookType = resp.NotifyCtl.WebHookType
+		if notifyCtl.Enabled && sets.NewString(notifyCtl.NotifyTypes...).Has(string(task.Status)) {
+			webHookType = notifyCtl.WebHookType
 			if webHookType == dingDingType {
-				uri = resp.NotifyCtl.DingDingWebHook
-				atMobiles = resp.NotifyCtl.AtMobiles
-				isAtAll = resp.NotifyCtl.IsAtAll
+				uri = notifyCtl.DingDingWebHook
+				atMobiles = notifyCtl.AtMobiles
+				isAtAll = notifyCtl.IsAtAll
 			} else if webHookType == feiShuType {
-				uri = resp.NotifyCtl.FeiShuWebHook
+				uri = notifyCtl.FeiShuWebHook
 			} else {
-				uri = resp.NotifyCtl.WeChatWebHook
+				uri = notifyCtl.WeChatWebHook
 			}
 			title, content, larkCard, err = w.createNotifyBodyOfWorkflowIM(&wechatNotification{
 				Task:        task,
@@ -177,28 +206,19 @@ func (w *Service) SendInstantMessage(task *task.Task, testTaskStatusChanged bool
 			}
 		}
 	} else if task.Type == config.TestType {
-		resp, err := w.testingColl.Find(strings.TrimSuffix(task.PipelineName, "-job"), task.ProductName)
-		if err != nil {
-			log.Errorf("testing find err :%s", err)
-			return err
-		}
-		if resp.NotifyCtl == nil {
-			log.Infof("testing notifyCtl is not set!")
-			return nil
-		}
-		statusSets := sets.NewString(resp.NotifyCtl.NotifyTypes...)
-		if resp.NotifyCtl.Enabled && (statusSets.Has(string(task.Status)) || (testTaskStatusChanged && statusSets.Has(string(config.StatusChanged)))) {
-			webHookType = resp.NotifyCtl.WebHookType
+		statusSets := sets.NewString(notifyCtl.NotifyTypes...)
+		if notifyCtl.Enabled && (statusSets.Has(string(task.Status)) || (testTaskStatusChanged && statusSets.Has(string(config.StatusChanged)))) {
+			webHookType = notifyCtl.WebHookType
 			if webHookType == dingDingType {
-				uri = resp.NotifyCtl.DingDingWebHook
-				atMobiles = resp.NotifyCtl.AtMobiles
-				isAtAll = resp.NotifyCtl.IsAtAll
+				uri = notifyCtl.DingDingWebHook
+				atMobiles = notifyCtl.AtMobiles
+				isAtAll = notifyCtl.IsAtAll
 			} else if webHookType == feiShuType {
-				uri = resp.NotifyCtl.FeiShuWebHook
+				uri = notifyCtl.FeiShuWebHook
 			} else {
-				uri = resp.NotifyCtl.WeChatWebHook
+				uri = notifyCtl.WeChatWebHook
 			}
-			title, content, larkCard, err = w.createNotifyBodyOfTestIM(resp.Desc, &wechatNotification{
+			title, content, larkCard, err = w.createNotifyBodyOfTestIM(desc, &wechatNotification{
 				Task:        task,
 				BaseURI:     configbase.SystemAddress(),
 				IsSingle:    false,
@@ -327,7 +347,7 @@ func (w *Service) createNotifyBodyOfWorkflowIM(weChatNotification *wechatNotific
 				if buildSt.BuildStatus.Status == "" {
 					buildSt.BuildStatus.Status = config.StatusNotRun
 				}
-				buildElemTemp += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**服务名称**：%s \n", buildSt.Service)
+				buildElemTemp += fmt.Sprintf("\n{{if eq .WebHookType \"dingding\"}}##### {{end}}**服务名称**：%s \n", buildSt.Service)
 				if !(buildSt.ServiceType == setting.PMDeployType &&
 					(buildSt.JobCtx.FileArchiveCtx != nil || buildSt.JobCtx.DockerBuildCtx != nil)) {
 					buildElemTemp += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**镜像信息**：%s \n", buildSt.JobCtx.Image)


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
support multiple notifications

### What is changed and how it works?
user can set multiple notification controllers  to send  notification to lark/wechat/dingding


### Does this PR introduce a user-facing change?

- [x] API change
- [x] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
