### PR TITLE
Service module can be associated with multiple builds

### DIFF
--- a/pkg/microservice/aslan/core/build/handler/build.go
+++ b/pkg/microservice/aslan/core/build/handler/build.go
@@ -44,6 +44,13 @@ func ListBuildModules(c *gin.Context) {
 	ctx.Resp, ctx.Err = buildservice.ListBuild(c.Query("name"), c.Query("targets"), c.Query("projectName"), ctx.Logger)
 }
 
+func ListBuildModulesByServiceModule(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	ctx.Resp, ctx.Err = buildservice.ListBuildModulesByServiceModule(c.Query("productName"), c.Param("serviceName"), c.Param("serviceModule"), ctx.Logger)
+}
+
 func CreateBuildModule(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()

--- a/pkg/microservice/aslan/core/build/handler/build.go
+++ b/pkg/microservice/aslan/core/build/handler/build.go
@@ -48,7 +48,7 @@ func ListBuildModulesByServiceModule(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
-	ctx.Resp, ctx.Err = buildservice.ListBuildModulesByServiceModule(c.Query("productName"), ctx.Logger)
+	ctx.Resp, ctx.Err = buildservice.ListBuildModulesByServiceModule(c.Query("projectName"), ctx.Logger)
 }
 
 func CreateBuildModule(c *gin.Context) {

--- a/pkg/microservice/aslan/core/build/handler/build.go
+++ b/pkg/microservice/aslan/core/build/handler/build.go
@@ -48,7 +48,7 @@ func ListBuildModulesByServiceModule(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
-	ctx.Resp, ctx.Err = buildservice.ListBuildModulesByServiceModule(c.Query("productName"), c.Param("serviceName"), c.Param("serviceModule"), ctx.Logger)
+	ctx.Resp, ctx.Err = buildservice.ListBuildModulesByServiceModule(c.Query("productName"), ctx.Logger)
 }
 
 func CreateBuildModule(c *gin.Context) {

--- a/pkg/microservice/aslan/core/build/handler/router.go
+++ b/pkg/microservice/aslan/core/build/handler/router.go
@@ -29,7 +29,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 	{
 		build.GET("/:name", FindBuildModule)
 		build.GET("", ListBuildModules)
-		build.GET("/:serviceName/:serviceModule", ListBuildModulesByServiceModule)
+		build.GET("/serviceName/:serviceName/serviceModule/:serviceModule", ListBuildModulesByServiceModule)
 		build.POST("", gin2.UpdateOperationLogStatus, CreateBuildModule)
 		build.PUT("", gin2.UpdateOperationLogStatus, UpdateBuildModule)
 		build.DELETE("", gin2.UpdateOperationLogStatus, DeleteBuildModule)

--- a/pkg/microservice/aslan/core/build/handler/router.go
+++ b/pkg/microservice/aslan/core/build/handler/router.go
@@ -29,7 +29,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 	{
 		build.GET("/:name", FindBuildModule)
 		build.GET("", ListBuildModules)
-		build.GET("/serviceName/:serviceName/serviceModule/:serviceModule", ListBuildModulesByServiceModule)
+		build.GET("/serviceModule", ListBuildModulesByServiceModule)
 		build.POST("", gin2.UpdateOperationLogStatus, CreateBuildModule)
 		build.PUT("", gin2.UpdateOperationLogStatus, UpdateBuildModule)
 		build.DELETE("", gin2.UpdateOperationLogStatus, DeleteBuildModule)

--- a/pkg/microservice/aslan/core/build/handler/router.go
+++ b/pkg/microservice/aslan/core/build/handler/router.go
@@ -29,6 +29,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 	{
 		build.GET("/:name", FindBuildModule)
 		build.GET("", ListBuildModules)
+		build.GET("/:serviceName/:serviceModule", ListBuildModulesByServiceModule)
 		build.POST("", gin2.UpdateOperationLogStatus, CreateBuildModule)
 		build.PUT("", gin2.UpdateOperationLogStatus, UpdateBuildModule)
 		build.DELETE("", gin2.UpdateOperationLogStatus, DeleteBuildModule)

--- a/pkg/microservice/aslan/core/build/service/build.go
+++ b/pkg/microservice/aslan/core/build/service/build.go
@@ -119,6 +119,7 @@ func ListBuildModulesByServiceModule(productName string, log *zap.SugaredLogger)
 	if err != nil {
 		return nil, e.ErrListBuildModule.AddErr(err)
 	}
+
 	serviceModuleAndBuildResp := make([]*ServiceModuleAndBuildResp, 0)
 	for _, serviceTmpl := range services {
 		for _, container := range serviceTmpl.Containers {

--- a/pkg/microservice/aslan/core/build/service/build.go
+++ b/pkg/microservice/aslan/core/build/service/build.go
@@ -108,6 +108,43 @@ func ListBuild(name, targets, productName string, log *zap.SugaredLogger) ([]*Bu
 	return resp, nil
 }
 
+func ListBuildModulesByServiceModule(productName, serviceName, serviceModule string, log *zap.SugaredLogger) ([]*BuildResp, error) {
+	resp := make([]*BuildResp, 0)
+	opt := &commonrepo.BuildListOption{
+		ProductName: productName,
+		ServiceName: serviceName,
+		Targets:     []string{serviceModule},
+	}
+
+	buildModules, err := commonrepo.NewBuildColl().List(opt)
+	if err != nil {
+		return nil, e.ErrListBuildModule.AddErr(err)
+	}
+	if len(buildModules) > 0 {
+		for _, build := range buildModules {
+			resp = append(resp, &BuildResp{
+				ID:   build.ID.Hex(),
+				Name: build.Name,
+			})
+		}
+		return resp, nil
+	}
+
+	// When the service is a shared service
+	opt.ProductName = ""
+	buildModules, err = commonrepo.NewBuildColl().List(opt)
+	if err != nil {
+		return nil, e.ErrListBuildModule.AddErr(err)
+	}
+	for _, build := range buildModules {
+		resp = append(resp, &BuildResp{
+			ID:   build.ID.Hex(),
+			Name: build.Name,
+		})
+	}
+	return resp, nil
+}
+
 func CreateBuild(username string, build *commonmodels.Build, log *zap.SugaredLogger) error {
 	if len(build.Name) == 0 {
 		return e.ErrCreateBuildModule.AddDesc("empty name")

--- a/pkg/microservice/aslan/core/build/service/build.go
+++ b/pkg/microservice/aslan/core/build/service/build.go
@@ -43,6 +43,12 @@ type BuildResp struct {
 	ProductName string                              `json:"productName"`
 }
 
+type ServiceModuleAndBuildResp struct {
+	ServiceName   string       `json:"service_name"`
+	ServiceModule string       `json:"service_module"`
+	ModuleBuilds  []*BuildResp `json:"module_builds"`
+}
+
 func FindBuild(name, productName string, log *zap.SugaredLogger) (*commonmodels.Build, error) {
 	opt := &commonrepo.BuildFindOption{
 		Name:        name,
@@ -108,41 +114,41 @@ func ListBuild(name, targets, productName string, log *zap.SugaredLogger) ([]*Bu
 	return resp, nil
 }
 
-func ListBuildModulesByServiceModule(productName, serviceName, serviceModule string, log *zap.SugaredLogger) ([]*BuildResp, error) {
-	resp := make([]*BuildResp, 0)
-	opt := &commonrepo.BuildListOption{
-		ProductName: productName,
-		ServiceName: serviceName,
-		Targets:     []string{serviceModule},
-	}
-
-	buildModules, err := commonrepo.NewBuildColl().List(opt)
+func ListBuildModulesByServiceModule(productName string, log *zap.SugaredLogger) ([]*ServiceModuleAndBuildResp, error) {
+	services, err := commonrepo.NewServiceColl().ListMaxRevisionsByProduct(productName)
 	if err != nil {
 		return nil, e.ErrListBuildModule.AddErr(err)
 	}
-	if len(buildModules) > 0 {
-		for _, build := range buildModules {
-			resp = append(resp, &BuildResp{
-				ID:   build.ID.Hex(),
-				Name: build.Name,
+	serviceModuleAndBuildResp := make([]*ServiceModuleAndBuildResp, 0)
+	for _, serviceTmpl := range services {
+		for _, container := range serviceTmpl.Containers {
+			opt := &commonrepo.BuildListOption{
+				ServiceName: serviceTmpl.ServiceName,
+				Targets:     []string{container.Name},
+			}
+			if serviceTmpl.Visibility != setting.PublicService {
+				opt.ProductName = productName
+			}
+
+			buildModules, err := commonrepo.NewBuildColl().List(opt)
+			if err != nil {
+				return nil, e.ErrListBuildModule.AddErr(err)
+			}
+			var resp []*BuildResp
+			for _, build := range buildModules {
+				resp = append(resp, &BuildResp{
+					ID:   build.ID.Hex(),
+					Name: build.Name,
+				})
+			}
+			serviceModuleAndBuildResp = append(serviceModuleAndBuildResp, &ServiceModuleAndBuildResp{
+				ServiceName:   serviceTmpl.ServiceName,
+				ServiceModule: container.Name,
+				ModuleBuilds:  resp,
 			})
 		}
-		return resp, nil
 	}
-
-	// When the service is a shared service
-	opt.ProductName = ""
-	buildModules, err = commonrepo.NewBuildColl().List(opt)
-	if err != nil {
-		return nil, e.ErrListBuildModule.AddErr(err)
-	}
-	for _, build := range buildModules {
-		resp = append(resp, &BuildResp{
-			ID:   build.ID.Hex(),
-			Name: build.Name,
-		})
-	}
-	return resp, nil
+	return serviceModuleAndBuildResp, nil
 }
 
 func fillBuildRepoData(build *commonmodels.Build) {

--- a/pkg/microservice/aslan/core/build/service/target.go
+++ b/pkg/microservice/aslan/core/build/service/target.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
@@ -38,38 +37,38 @@ func ListDeployTarget(productName string, log *zap.SugaredLogger) ([]*commonmode
 	}
 
 	//获取该项目下的的build的targets
-	buildTargets := sets.NewString()
-	builds, err := commonrepo.NewBuildColl().List(&commonrepo.BuildListOption{ProductName: productName})
-	if err != nil {
-		log.Errorf("[Build.List] %s error: %v", productName, err)
-		return nil, e.ErrListBuildModule.AddErr(err)
-	}
-	for _, build := range builds {
-		for _, serviceModuleTarget := range build.Targets {
-			buildTargets.Insert(fmt.Sprintf("%s-%s", serviceModuleTarget.ServiceName, serviceModuleTarget.ServiceModule))
-		}
-	}
+	//buildTargets := sets.NewString()
+	//builds, err := commonrepo.NewBuildColl().List(&commonrepo.BuildListOption{ProductName: productName})
+	//if err != nil {
+	//	log.Errorf("[Build.List] %s error: %v", productName, err)
+	//	return nil, e.ErrListBuildModule.AddErr(err)
+	//}
+	//for _, build := range builds {
+	//	for _, serviceModuleTarget := range build.Targets {
+	//		buildTargets.Insert(fmt.Sprintf("%s-%s", serviceModuleTarget.ServiceName, serviceModuleTarget.ServiceModule))
+	//	}
+	//}
 
 	for _, svc := range services {
 		switch svc.Type {
 		case setting.K8SDeployType, setting.HelmDeployType:
 			for _, container := range svc.Containers {
-				if !buildTargets.Has(fmt.Sprintf("%s-%s", svc.ServiceName, container.Name)) {
-					serviceObjects = append(serviceObjects, &commonmodels.ServiceModuleTarget{
-						ProductName:   svc.ProductName,
-						ServiceName:   svc.ServiceName,
-						ServiceModule: container.Name,
-					})
-				}
-			}
-		case setting.PMDeployType:
-			if !buildTargets.Has(fmt.Sprintf("%s-%s", svc.ServiceName, svc.ServiceName)) {
+				//if !buildTargets.Has(fmt.Sprintf("%s-%s", svc.ServiceName, container.Name)) {
 				serviceObjects = append(serviceObjects, &commonmodels.ServiceModuleTarget{
 					ProductName:   svc.ProductName,
 					ServiceName:   svc.ServiceName,
-					ServiceModule: svc.ServiceName,
+					ServiceModule: container.Name,
 				})
+				//}
 			}
+		case setting.PMDeployType:
+			//if !buildTargets.Has(fmt.Sprintf("%s-%s", svc.ServiceName, svc.ServiceName)) {
+			serviceObjects = append(serviceObjects, &commonmodels.ServiceModuleTarget{
+				ProductName:   svc.ProductName,
+				ServiceName:   svc.ServiceName,
+				ServiceModule: svc.ServiceName,
+			})
+			//}
 		}
 	}
 

--- a/pkg/microservice/aslan/core/build/service/target.go
+++ b/pkg/microservice/aslan/core/build/service/target.go
@@ -36,39 +36,22 @@ func ListDeployTarget(productName string, log *zap.SugaredLogger) ([]*commonmode
 		return serviceObjects, e.ErrListTemplate.AddDesc(errMsg)
 	}
 
-	//获取该项目下的的build的targets
-	//buildTargets := sets.NewString()
-	//builds, err := commonrepo.NewBuildColl().List(&commonrepo.BuildListOption{ProductName: productName})
-	//if err != nil {
-	//	log.Errorf("[Build.List] %s error: %v", productName, err)
-	//	return nil, e.ErrListBuildModule.AddErr(err)
-	//}
-	//for _, build := range builds {
-	//	for _, serviceModuleTarget := range build.Targets {
-	//		buildTargets.Insert(fmt.Sprintf("%s-%s", serviceModuleTarget.ServiceName, serviceModuleTarget.ServiceModule))
-	//	}
-	//}
-
 	for _, svc := range services {
 		switch svc.Type {
 		case setting.K8SDeployType, setting.HelmDeployType:
 			for _, container := range svc.Containers {
-				//if !buildTargets.Has(fmt.Sprintf("%s-%s", svc.ServiceName, container.Name)) {
 				serviceObjects = append(serviceObjects, &commonmodels.ServiceModuleTarget{
 					ProductName:   svc.ProductName,
 					ServiceName:   svc.ServiceName,
 					ServiceModule: container.Name,
 				})
-				//}
 			}
 		case setting.PMDeployType:
-			//if !buildTargets.Has(fmt.Sprintf("%s-%s", svc.ServiceName, svc.ServiceName)) {
 			serviceObjects = append(serviceObjects, &commonmodels.ServiceModuleTarget{
 				ProductName:   svc.ProductName,
 				ServiceName:   svc.ServiceName,
 				ServiceModule: svc.ServiceName,
 			})
-			//}
 		}
 	}
 

--- a/pkg/microservice/aslan/core/common/repository/models/build.go
+++ b/pkg/microservice/aslan/core/common/repository/models/build.go
@@ -147,6 +147,7 @@ type ServiceModuleTarget struct {
 	ProductName   string `bson:"product_name"                  json:"product_name"`
 	ServiceName   string `bson:"service_name"                  json:"service_name"`
 	ServiceModule string `bson:"service_module"                json:"service_module"`
+	BuildName     string `bson:"build_name"                    json:"build_name"`
 }
 
 type KeyVal struct {

--- a/pkg/microservice/aslan/core/common/repository/models/workflow.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow.go
@@ -353,6 +353,7 @@ type TargetArgs struct {
 	Envs             []*KeyVal         `bson:"envs"                          json:"envs"`
 	HasBuild         bool              `bson:"has_build"                     json:"has_build"`
 	JenkinsBuildArgs *JenkinsBuildArgs `bson:"jenkins_build_args,omitempty"  json:"jenkins_build_args,omitempty"`
+	BuildName        string            `bson:"build_name,omitempty"          json:"build_name"`
 }
 
 type JenkinsBuildArgs struct {

--- a/pkg/microservice/aslan/core/service/service/helm.go
+++ b/pkg/microservice/aslan/core/service/service/helm.go
@@ -177,10 +177,6 @@ func GetHelmServiceModule(serviceName, productName string, revision int64, log *
 	for _, container := range serviceTemplate.Containers {
 		serviceModule := new(ServiceModule)
 		serviceModule.Container = container
-		//buildObj, _ := commonrepo.NewBuildColl().Find(&commonrepo.BuildFindOption{ProductName: productName, ServiceName: serviceName, Targets: []string{container.Name}})
-		//if buildObj != nil {
-		//	serviceModule.BuildName = buildObj.Name
-		//}
 
 		buildObjs, _ := commonrepo.NewBuildColl().List(&commonrepo.BuildListOption{ProductName: productName, ServiceName: serviceName, Targets: []string{container.Name}})
 		buildNames := sets.NewString()

--- a/pkg/microservice/aslan/core/service/service/helm.go
+++ b/pkg/microservice/aslan/core/service/service/helm.go
@@ -178,7 +178,10 @@ func GetHelmServiceModule(serviceName, productName string, revision int64, log *
 		serviceModule := new(ServiceModule)
 		serviceModule.Container = container
 
-		buildObjs, _ := commonrepo.NewBuildColl().List(&commonrepo.BuildListOption{ProductName: productName, ServiceName: serviceName, Targets: []string{container.Name}})
+		buildObjs, err := commonrepo.NewBuildColl().List(&commonrepo.BuildListOption{ProductName: productName, ServiceName: serviceName, Targets: []string{container.Name}})
+		if err != nil {
+			return nil, err
+		}
 		buildNames := sets.NewString()
 		for _, buildObj := range buildObjs {
 			buildNames.Insert(buildObj.Name)

--- a/pkg/microservice/aslan/core/service/service/helm.go
+++ b/pkg/microservice/aslan/core/service/service/helm.go
@@ -33,6 +33,7 @@ import (
 	"github.com/otiai10/copy"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/yaml"
 
@@ -176,10 +177,17 @@ func GetHelmServiceModule(serviceName, productName string, revision int64, log *
 	for _, container := range serviceTemplate.Containers {
 		serviceModule := new(ServiceModule)
 		serviceModule.Container = container
-		buildObj, _ := commonrepo.NewBuildColl().Find(&commonrepo.BuildFindOption{ProductName: productName, ServiceName: serviceName, Targets: []string{container.Name}})
-		if buildObj != nil {
-			serviceModule.BuildName = buildObj.Name
+		//buildObj, _ := commonrepo.NewBuildColl().Find(&commonrepo.BuildFindOption{ProductName: productName, ServiceName: serviceName, Targets: []string{container.Name}})
+		//if buildObj != nil {
+		//	serviceModule.BuildName = buildObj.Name
+		//}
+
+		buildObjs, _ := commonrepo.NewBuildColl().List(&commonrepo.BuildListOption{ProductName: productName, ServiceName: serviceName, Targets: []string{container.Name}})
+		buildNames := sets.NewString()
+		for _, buildObj := range buildObjs {
+			buildNames.Insert(buildObj.Name)
 		}
+		serviceModule.BuildNames = buildNames.List()
 		serviceModules = append(serviceModules, serviceModule)
 	}
 	helmServiceModule.Service = serviceTemplate

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -64,7 +64,8 @@ type ServiceOption struct {
 
 type ServiceModule struct {
 	*commonmodels.Container
-	BuildName string `json:"build_name"`
+	//BuildName  string   `json:"build_name"`
+	BuildNames []string `json:"build_names"`
 }
 
 type Variable struct {
@@ -189,10 +190,15 @@ func GetServiceOption(args *commonmodels.Service, log *zap.SugaredLogger) (*Serv
 		serviceModule := new(ServiceModule)
 		serviceModule.Container = container
 		serviceModule.ImageName = util.GetImageNameFromContainerInfo(container.ImageName, container.Name)
-		buildObj, _ := commonrepo.NewBuildColl().Find(&commonrepo.BuildFindOption{ProductName: args.ProductName, ServiceName: args.ServiceName, Targets: []string{container.Name}})
-		if buildObj != nil {
-			serviceModule.BuildName = buildObj.Name
+		buildObjs, _ := commonrepo.NewBuildColl().List(&commonrepo.BuildListOption{ProductName: args.ProductName, ServiceName: args.ServiceName, Targets: []string{container.Name}})
+		//if buildObj != nil {
+		//	serviceModule.BuildName = buildObj.Name
+		//}
+		buildNames := sets.NewString()
+		for _, buildObj := range buildObjs {
+			buildNames.Insert(buildObj.Name)
 		}
+		serviceModule.BuildNames = buildNames.List()
 		serviceModules = append(serviceModules, serviceModule)
 	}
 	serviceOption.ServiceModules = serviceModules

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -189,7 +189,10 @@ func GetServiceOption(args *commonmodels.Service, log *zap.SugaredLogger) (*Serv
 		serviceModule := new(ServiceModule)
 		serviceModule.Container = container
 		serviceModule.ImageName = util.GetImageNameFromContainerInfo(container.ImageName, container.Name)
-		buildObjs, _ := commonrepo.NewBuildColl().List(&commonrepo.BuildListOption{ProductName: args.ProductName, ServiceName: args.ServiceName, Targets: []string{container.Name}})
+		buildObjs, err := commonrepo.NewBuildColl().List(&commonrepo.BuildListOption{ProductName: args.ProductName, ServiceName: args.ServiceName, Targets: []string{container.Name}})
+		if err != nil {
+			return nil, err
+		}
 
 		buildNames := sets.NewString()
 		for _, buildObj := range buildObjs {

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -64,7 +64,6 @@ type ServiceOption struct {
 
 type ServiceModule struct {
 	*commonmodels.Container
-	//BuildName  string   `json:"build_name"`
 	BuildNames []string `json:"build_names"`
 }
 
@@ -191,9 +190,7 @@ func GetServiceOption(args *commonmodels.Service, log *zap.SugaredLogger) (*Serv
 		serviceModule.Container = container
 		serviceModule.ImageName = util.GetImageNameFromContainerInfo(container.ImageName, container.Name)
 		buildObjs, _ := commonrepo.NewBuildColl().List(&commonrepo.BuildListOption{ProductName: args.ProductName, ServiceName: args.ServiceName, Targets: []string{container.Name}})
-		//if buildObj != nil {
-		//	serviceModule.BuildName = buildObj.Name
-		//}
+
 		buildNames := sets.NewString()
 		for _, buildObj := range buildObjs {
 			buildNames.Insert(buildObj.Name)

--- a/pkg/microservice/aslan/core/workflow/service/workflow/convert.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/convert.go
@@ -126,6 +126,7 @@ func ConvertTaskToQueue(task *task.Task) *commonmodels.Queue {
 }
 
 type JenkinsBuildOption struct {
+	BuildName        string
 	Version          string
 	Target           string
 	ServiceName      string
@@ -139,6 +140,7 @@ func JenkinsBuildModuleToSubTasks(jenkinsBuildOption *JenkinsBuildOption, log *z
 	)
 
 	opt := &commonrepo.BuildListOption{
+		Name:        jenkinsBuildOption.BuildName,
 		ServiceName: jenkinsBuildOption.ServiceName,
 		ProductName: jenkinsBuildOption.ProductName,
 	}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
@@ -441,6 +441,10 @@ func CreateWorkflow(workflow *commonmodels.Workflow, log *zap.SugaredLogger) err
 		return e.ErrUpsertWorkflow.AddDesc(err.Error())
 	}
 
+	if err := checkWorkflowBuildStage(workflow); err != nil {
+		return e.ErrUpsertWorkflow.AddDesc(err.Error())
+	}
+
 	if err := commonrepo.NewWorkflowColl().Create(workflow); err != nil {
 		log.Errorf("Workflow.Create error: %v", err)
 		return e.ErrUpsertWorkflow.AddDesc(err.Error())
@@ -483,6 +487,22 @@ func checkWorkflowSubModule(workflow *commonmodels.Workflow) bool {
 	return false
 }
 
+func checkWorkflowBuildStage(workflow *commonmodels.Workflow) error {
+	if workflow.BuildStage != nil && workflow.BuildStage.Enabled {
+		// find all of builds in this project
+		builds, err := commonrepo.NewBuildColl().List(&commonrepo.BuildListOption{ProductName: workflow.ProductTmplName})
+		if err != nil {
+			return err
+		}
+		for _, serviceModule := range workflow.BuildStage.Modules {
+			if serviceModule.Target != nil && serviceModule.Target.BuildName == "" && len(builds) > 0 {
+				serviceModule.Target.BuildName = builds[0].Name
+			}
+		}
+	}
+	return nil
+}
+
 func UpdateWorkflow(workflow *commonmodels.Workflow, log *zap.SugaredLogger) error {
 	if !checkWorkflowSubModule(workflow) {
 		return e.ErrUpsertWorkflow.AddDesc("未检测到构建部署或交付物部署，请配置一项")
@@ -519,6 +539,10 @@ func UpdateWorkflow(workflow *commonmodels.Workflow, log *zap.SugaredLogger) err
 				test.Envs = make([]*commonmodels.KeyVal, 0)
 			}
 		}
+	}
+
+	if err := checkWorkflowBuildStage(workflow); err != nil {
+		return e.ErrUpsertWorkflow.AddDesc(err.Error())
 	}
 
 	if err = commonrepo.NewWorkflowColl().Replace(workflow); err != nil {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
@@ -324,6 +324,7 @@ func FindWorkflow(workflowName string, log *zap.SugaredLogger) (*commonmodels.Wo
 								ProductName:   serviceTmpl.ProductName,
 								ServiceName:   serviceTmpl.ServiceName,
 								ServiceModule: container.Name,
+								BuildName: findBuildName(key, moList),
 							},
 						})
 					}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
@@ -298,6 +298,7 @@ func FindWorkflow(workflowName string, log *zap.SugaredLogger) (*commonmodels.Wo
 			buildName := build.Target.BuildName
 			if buildName == "" {
 				buildName = findBuildName(key, moList)
+				log.Infof("buildName:%s", buildName)
 			}
 			buildMap[key] = buildName
 		}
@@ -338,13 +339,14 @@ func FindWorkflow(workflowName string, log *zap.SugaredLogger) (*commonmodels.Wo
 	return resp, nil
 }
 
-func findBuildName(container string, moList []*commonmodels.Build) string {
-	fmt.Println("container: ", container)
+func findBuildName(key string, moList []*commonmodels.Build) string {
+	fmt.Println("key: ", key)
 	for _, mo := range moList {
 		for _, moTarget := range mo.Targets {
 			moduleTargetStr := fmt.Sprintf("%s-%s-%s", moTarget.ProductName, moTarget.ServiceName, moTarget.ServiceModule)
 			fmt.Println("moduleTargetStr: ", moduleTargetStr)
-			if container == moduleTargetStr {
+			if key == moduleTargetStr {
+				fmt.Println("find it key: ", moduleTargetStr)
 				return mo.Name
 			}
 		}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
@@ -315,6 +315,7 @@ func FindWorkflow(workflowName string, log *zap.SugaredLogger) (*commonmodels.Wo
 					// if no target info is found for this container, meaning that this is a new service for that workflow
 					// then we need to add it to the response
 					if _, ok := buildMap[key]; !ok {
+						log.Infof("key:%s", key)
 						resp.BuildStage.Modules = append(resp.BuildStage.Modules, &commonmodels.BuildModule{
 							HideServiceModule: false,
 							BuildModuleVer:    "stable",
@@ -339,6 +340,7 @@ func findBuildName(key string, moList []*commonmodels.Build) string {
 		for _, moTarget := range mo.Targets {
 			moduleTargetStr := fmt.Sprintf("%s-%s-%s", moTarget.ProductName, moTarget.ServiceName, moTarget.ServiceModule)
 			if key == moduleTargetStr {
+				fmt.Println("key:", moduleTargetStr)
 				return mo.Name
 			}
 		}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
@@ -441,9 +441,9 @@ func CreateWorkflow(workflow *commonmodels.Workflow, log *zap.SugaredLogger) err
 		return e.ErrUpsertWorkflow.AddDesc(err.Error())
 	}
 
-	if err := checkWorkflowBuildStage(workflow); err != nil {
-		return e.ErrUpsertWorkflow.AddDesc(err.Error())
-	}
+	//if err := checkWorkflowBuildStage(workflow); err != nil {
+	//	return e.ErrUpsertWorkflow.AddDesc(err.Error())
+	//}
 
 	if err := commonrepo.NewWorkflowColl().Create(workflow); err != nil {
 		log.Errorf("Workflow.Create error: %v", err)
@@ -487,21 +487,21 @@ func checkWorkflowSubModule(workflow *commonmodels.Workflow) bool {
 	return false
 }
 
-func checkWorkflowBuildStage(workflow *commonmodels.Workflow) error {
-	if workflow.BuildStage != nil && workflow.BuildStage.Enabled {
-		// find all of builds in this project
-		builds, err := commonrepo.NewBuildColl().List(&commonrepo.BuildListOption{ProductName: workflow.ProductTmplName})
-		if err != nil {
-			return err
-		}
-		for _, serviceModule := range workflow.BuildStage.Modules {
-			if serviceModule.Target != nil && serviceModule.Target.BuildName == "" && len(builds) > 0 {
-				serviceModule.Target.BuildName = builds[0].Name
-			}
-		}
-	}
-	return nil
-}
+//func checkWorkflowBuildStage(workflow *commonmodels.Workflow) error {
+//	if workflow.BuildStage != nil && workflow.BuildStage.Enabled {
+//		// find all of builds in this project
+//		builds, err := commonrepo.NewBuildColl().List(&commonrepo.BuildListOption{ProductName: workflow.ProductTmplName})
+//		if err != nil {
+//			return err
+//		}
+//		for _, serviceModule := range workflow.BuildStage.Modules {
+//			if serviceModule.Target != nil && serviceModule.Target.BuildName == "" && len(builds) > 0 {
+//				serviceModule.Target.BuildName = builds[0].Name
+//			}
+//		}
+//	}
+//	return nil
+//}
 
 func UpdateWorkflow(workflow *commonmodels.Workflow, log *zap.SugaredLogger) error {
 	if !checkWorkflowSubModule(workflow) {
@@ -541,9 +541,9 @@ func UpdateWorkflow(workflow *commonmodels.Workflow, log *zap.SugaredLogger) err
 		}
 	}
 
-	if err := checkWorkflowBuildStage(workflow); err != nil {
-		return e.ErrUpsertWorkflow.AddDesc(err.Error())
-	}
+	//if err := checkWorkflowBuildStage(workflow); err != nil {
+	//	return e.ErrUpsertWorkflow.AddDesc(err.Error())
+	//}
 
 	if err = commonrepo.NewWorkflowColl().Replace(workflow); err != nil {
 		log.Errorf("Workflow.Update error: %v", err)

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
@@ -462,10 +462,6 @@ func CreateWorkflow(workflow *commonmodels.Workflow, log *zap.SugaredLogger) err
 		return e.ErrUpsertWorkflow.AddDesc(err.Error())
 	}
 
-	//if err := checkWorkflowBuildStage(workflow); err != nil {
-	//	return e.ErrUpsertWorkflow.AddDesc(err.Error())
-	//}
-
 	if err := commonrepo.NewWorkflowColl().Create(workflow); err != nil {
 		log.Errorf("Workflow.Create error: %v", err)
 		return e.ErrUpsertWorkflow.AddDesc(err.Error())
@@ -508,22 +504,6 @@ func checkWorkflowSubModule(workflow *commonmodels.Workflow) bool {
 	return false
 }
 
-//func checkWorkflowBuildStage(workflow *commonmodels.Workflow) error {
-//	if workflow.BuildStage != nil && workflow.BuildStage.Enabled {
-//		// find all of builds in this project
-//		builds, err := commonrepo.NewBuildColl().List(&commonrepo.BuildListOption{ProductName: workflow.ProductTmplName})
-//		if err != nil {
-//			return err
-//		}
-//		for _, serviceModule := range workflow.BuildStage.Modules {
-//			if serviceModule.Target != nil && serviceModule.Target.BuildName == "" && len(builds) > 0 {
-//				serviceModule.Target.BuildName = builds[0].Name
-//			}
-//		}
-//	}
-//	return nil
-//}
-
 func UpdateWorkflow(workflow *commonmodels.Workflow, log *zap.SugaredLogger) error {
 	if !checkWorkflowSubModule(workflow) {
 		return e.ErrUpsertWorkflow.AddDesc("未检测到构建部署或交付物部署，请配置一项")
@@ -561,10 +541,6 @@ func UpdateWorkflow(workflow *commonmodels.Workflow, log *zap.SugaredLogger) err
 			}
 		}
 	}
-
-	//if err := checkWorkflowBuildStage(workflow); err != nil {
-	//	return e.ErrUpsertWorkflow.AddDesc(err.Error())
-	//}
 
 	if err = commonrepo.NewWorkflowColl().Replace(workflow); err != nil {
 		log.Errorf("Workflow.Update error: %v", err)

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
@@ -340,7 +340,6 @@ func findBuildName(key string, moList []*commonmodels.Build) string {
 		for _, moTarget := range mo.Targets {
 			moduleTargetStr := fmt.Sprintf("%s-%s-%s", moTarget.ProductName, moTarget.ServiceName, moTarget.ServiceModule)
 			if key == moduleTargetStr {
-				fmt.Println("key:", moduleTargetStr)
 				return mo.Name
 			}
 		}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
@@ -341,7 +341,7 @@ func FindWorkflow(workflowName string, log *zap.SugaredLogger) (*commonmodels.Wo
 func findBuildName(container string, moList []*commonmodels.Build) string {
 	for _, mo := range moList {
 		for _, moTarget := range mo.Targets {
-			moduleTargetStr := fmt.Sprintf("%s%s%s%s%s", moTarget.ProductName, SplitSymbol, moTarget.ServiceName, SplitSymbol, moTarget.ServiceModule)
+			moduleTargetStr := fmt.Sprintf("%s-%s-%s", moTarget.ProductName, moTarget.ServiceName, moTarget.ServiceModule)
 			if container == moduleTargetStr {
 				return mo.Name
 			}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
@@ -368,7 +368,7 @@ func PreSetWorkflow(productName string, log *zap.SugaredLogger) ([]*PreSetResp, 
 		log.Errorf("[%s] ProductTmpl.Find error: %v", productName, err)
 		return resp, e.ErrGetTemplate.AddDesc(err.Error())
 	}
-	services, err := commonrepo.NewServiceColl().ListMaxRevisionsByProduct(productTmpl.ProductName)
+	services, err := commonrepo.NewServiceColl().ListMaxRevisionsForServices(productTmpl.AllServiceInfos(), "")
 	if err != nil {
 		log.Errorf("ServiceTmpl.ListMaxRevisions error: %v", err)
 		return resp, e.ErrListTemplate.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
@@ -296,7 +296,9 @@ func FindWorkflow(workflowName string, log *zap.SugaredLogger) (*commonmodels.Wo
 		for _, build := range resp.BuildStage.Modules {
 			key := fmt.Sprintf("%s-%s-%s", build.Target.ProductName, build.Target.ServiceName, build.Target.ServiceModule)
 			buildMap[key] = true
-			build.Target.BuildName = findBuildName(key, moList)
+			if build.Target.BuildName == "" {
+				build.Target.BuildName = findBuildName(key, moList)
+			}
 		}
 
 		services, err := commonrepo.NewServiceColl().ListMaxRevisionsByProduct(resp.ProductTmplName)
@@ -324,7 +326,7 @@ func FindWorkflow(workflowName string, log *zap.SugaredLogger) (*commonmodels.Wo
 								ProductName:   serviceTmpl.ProductName,
 								ServiceName:   serviceTmpl.ServiceName,
 								ServiceModule: container.Name,
-								BuildName: findBuildName(key, moList),
+								BuildName:     findBuildName(key, moList),
 							},
 						})
 					}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
@@ -339,9 +339,11 @@ func FindWorkflow(workflowName string, log *zap.SugaredLogger) (*commonmodels.Wo
 }
 
 func findBuildName(container string, moList []*commonmodels.Build) string {
+	fmt.Println("container: ", container)
 	for _, mo := range moList {
 		for _, moTarget := range mo.Targets {
 			moduleTargetStr := fmt.Sprintf("%s-%s-%s", moTarget.ProductName, moTarget.ServiceName, moTarget.ServiceModule)
+			fmt.Println("moduleTargetStr: ", moduleTargetStr)
 			if container == moduleTargetStr {
 				return mo.Name
 			}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -321,7 +321,7 @@ func findBuildNameByContainerName(containerName string, serviceTmpl *commonmodel
 	}
 
 	buildModules, err := commonrepo.NewBuildColl().List(opt)
-	if err != nil {
+	if err != nil || len(buildModules) == 0 {
 		return ""
 	}
 	buildName := buildModules[0].Name

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -253,6 +253,29 @@ func getProjectTargets(productName string) []string {
 	return targets
 }
 
+func findModuleByContainer(serviceModuleTarget string, buildStageModules []*commonmodels.BuildModule, allModules []*commonmodels.Build) *commonmodels.Build {
+	// find build name
+	var buildName string
+	for _, buildStageModule := range buildStageModules {
+		if buildStageModule.Target == nil {
+			return nil
+		}
+		targetStr := fmt.Sprintf("%s%s%s%s%s", buildStageModule.Target.ProductName, SplitSymbol, buildStageModule.Target.ServiceName, SplitSymbol, buildStageModule.Target.ServiceModule)
+		if serviceModuleTarget == targetStr {
+			buildName = buildStageModule.Target.BuildName
+			break
+		}
+	}
+	if buildName != "" {
+		for _, module := range allModules {
+			if module.Name == buildName {
+				return module
+			}
+		}
+	}
+	return nil
+}
+
 func findModuleByTargetAndVersion(allModules []*commonmodels.Build, serviceModuleTarget string) *commonmodels.Build {
 	containerArr := strings.Split(serviceModuleTarget, SplitSymbol)
 	if len(containerArr) != 3 {
@@ -385,7 +408,8 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 				Build:       &commonmodels.BuildArgs{},
 				HasBuild:    true,
 			}
-			moBuild := findModuleByTargetAndVersion(allModules, container)
+			//moBuild := findModuleByTargetAndVersion(allModules, container)
+			moBuild := findModuleByContainer(container, workflow.BuildStage.Modules, allModules)
 			if moBuild == nil {
 				moBuild = &commonmodels.Build{}
 				target.HasBuild = false

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -414,6 +414,7 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 				moBuild = &commonmodels.Build{}
 				target.HasBuild = false
 			}
+			target.BuildName = moBuild.Name
 
 			if moBuild.TemplateID != "" {
 				target.Build.Repos = targetInfo.Repos

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -642,6 +642,7 @@ func CreateWorkflowTask(args *commonmodels.WorkflowTaskArgs, taskCreator string,
 				ProductName: args.ProductTmplName,
 				Variables:   target.Envs,
 				Env:         env,
+				BuildName:   target.BuildName,
 			}
 			subTasks, err = BuildModuleToSubTasks(buildModuleArgs, log)
 		} else {
@@ -650,6 +651,7 @@ func CreateWorkflowTask(args *commonmodels.WorkflowTaskArgs, taskCreator string,
 				ServiceName:      target.ServiceName,
 				ProductName:      args.ProductTmplName,
 				JenkinsBuildArgs: target.JenkinsBuildArgs,
+				BuildName:        target.BuildName,
 			}, log)
 		}
 		if err != nil {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -253,7 +253,7 @@ func getProjectTargets(productName string) []string {
 	return targets
 }
 
-func findModuleByContainer(productName, serviceModuleTarget string, buildStageModules []*commonmodels.BuildModule, allModules []*commonmodels.Build) (*commonmodels.Build, *commonmodels.ServiceModuleTarget) {
+func findModuleByContainer(productName, serviceModuleTarget string, buildStageModules []*commonmodels.BuildModule, allModules []*commonmodels.Build, log *zap.SugaredLogger) (*commonmodels.Build, *commonmodels.ServiceModuleTarget) {
 	// find build name
 	var buildName string
 	for _, buildStageModule := range buildStageModules {
@@ -270,10 +270,12 @@ func findModuleByContainer(productName, serviceModuleTarget string, buildStageMo
 		// Compatible with old data if buildName is empty
 		productTmpl, err := template.NewProductColl().Find(productName)
 		if err != nil {
+			log.Errorf("failed to find project,err:%s", err)
 			return nil, nil
 		}
 		services, err := commonrepo.NewServiceColl().ListMaxRevisionsForServices(productTmpl.AllServiceInfos(), "")
 		if err != nil {
+			log.Errorf("failed to list services,err:%s", err)
 			return nil, nil
 		}
 
@@ -457,7 +459,7 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 				HasBuild:    true,
 			}
 
-			moBuild, targetInfo := findModuleByContainer(workflow.ProductTmplName, container, workflow.BuildStage.Modules, allModules)
+			moBuild, targetInfo := findModuleByContainer(workflow.ProductTmplName, container, workflow.BuildStage.Modules, allModules, log)
 			if moBuild == nil {
 				moBuild = &commonmodels.Build{}
 				target.HasBuild = false

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -278,13 +278,13 @@ func findModuleByContainer(productName, serviceModuleTarget string, buildStageMo
 				for _, container := range serviceTmpl.Containers {
 					targetStr := fmt.Sprintf("%s%s%s%s%s", serviceTmpl.ProductName, SplitSymbol, serviceTmpl.ServiceName, SplitSymbol, container.Name)
 					if serviceModuleTarget == targetStr {
-						buildName = findBuildName(container.Name, serviceTmpl)
+						buildName = findBuildNameByContainerName(container.Name, serviceTmpl)
 					}
 				}
 			} else if serviceTmpl.Type == setting.PMDeployType {
 				targetStr := fmt.Sprintf("%s%s%s%s%s", serviceTmpl.ProductName, SplitSymbol, serviceTmpl.ServiceName, SplitSymbol, serviceTmpl.ServiceName)
 				if serviceModuleTarget == targetStr {
-					buildName = findBuildName(serviceTmpl.ServiceName, serviceTmpl)
+					buildName = findBuildNameByContainerName(serviceTmpl.ServiceName, serviceTmpl)
 				}
 			}
 		}
@@ -305,7 +305,7 @@ func findModuleByContainer(productName, serviceModuleTarget string, buildStageMo
 	return nil, nil
 }
 
-func findBuildName(containerName string, serviceTmpl *commonmodels.Service) string {
+func findBuildNameByContainerName(containerName string, serviceTmpl *commonmodels.Service) string {
 	opt := &commonrepo.BuildListOption{
 		ServiceName: serviceTmpl.ServiceName,
 		Targets:     []string{containerName},

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -268,7 +268,11 @@ func findModuleByContainer(productName, serviceModuleTarget string, buildStageMo
 	}
 	if buildName == "" {
 		// Compatible with old data if buildName is empty
-		services, err := commonrepo.NewServiceColl().ListMaxRevisionsByProduct(productName)
+		productTmpl, err := template.NewProductColl().Find(productName)
+		if err != nil {
+			return nil, nil
+		}
+		services, err := commonrepo.NewServiceColl().ListMaxRevisionsForServices(productTmpl.AllServiceInfos(), "")
 		if err != nil {
 			return nil, nil
 		}


### PR DESCRIPTION
Signed-off-by: liu deyi <andrew@koderover.com>

### What this PR does / Why we need it:
Service module can be associated with multiple builds

### What is changed and how it works?
Previously a service module could only choose one build

### Does this PR introduce a user-facing change?

- [x] API change
- [x] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
