### PR TITLE
fixed updating aws secret will accidently update default registry secret

### DIFF
--- a/pkg/microservice/aslan/core/common/service/registry.go
+++ b/pkg/microservice/aslan/core/common/service/registry.go
@@ -174,7 +174,7 @@ func EnsureDefaultRegistrySecret(namespace string, registryId string, kubeClient
 		}
 	}
 
-	err = kube.CreateOrUpdateRegistrySecret(namespace, reg, kubeClient)
+	err = kube.CreateOrUpdateDefaultRegistrySecret(namespace, reg, kubeClient)
 	if err != nil {
 		log.Errorf("[%s] CreateDockerSecret error: %s", namespace, err)
 		return e.ErrUpdateSecret.AddDesc(e.CreateDefaultRegistryErrMsg)

--- a/pkg/microservice/aslan/core/environment/service/image.go
+++ b/pkg/microservice/aslan/core/environment/service/image.go
@@ -222,7 +222,7 @@ func UpdateContainerImage(requestID string, args *UpdateContainerImageArgs, log 
 	}
 	for _, reg := range regs {
 		if reg.RegProvider == config.RegistryTypeAWS {
-			if err := kube.CreateOrUpdateRegistrySecret(namespace, reg, kubeClient); err != nil {
+			if err := kube.CreateOrUpdateRegistrySecret(namespace, reg, false, kubeClient); err != nil {
 				retErr := fmt.Errorf("failed to update pull secret for registry: %s, the error is: %s", reg.ID.Hex(), err)
 				log.Errorf("%s\n", retErr.Error())
 				return retErr

--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -150,7 +150,7 @@ func RestartScale(args *RestartScaleArgs, _ *zap.SugaredLogger) error {
 	}
 	for _, reg := range regs {
 		if reg.RegProvider == config.RegistryTypeAWS {
-			if err := kube.CreateOrUpdateRegistrySecret(prod.Namespace, reg, kubeClient); err != nil {
+			if err := kube.CreateOrUpdateRegistrySecret(prod.Namespace, reg, false, kubeClient); err != nil {
 				retErr := fmt.Errorf("failed to update pull secret for registry: %s, the error is: %s", reg.ID.Hex(), err)
 				log.Errorf("%s\n", retErr.Error())
 				return retErr
@@ -411,7 +411,7 @@ func RestartService(envName string, args *SvcOptArgs, log *zap.SugaredLogger) (e
 	}
 	for _, reg := range regs {
 		if reg.RegProvider == config.RegistryTypeAWS {
-			if err := kube.CreateOrUpdateRegistrySecret(productObj.Namespace, reg, kubeClient); err != nil {
+			if err := kube.CreateOrUpdateRegistrySecret(productObj.Namespace, reg, false, kubeClient); err != nil {
 				retErr := fmt.Errorf("failed to update pull secret for registry: %s, the error is: %s", reg.ID.Hex(), err)
 				log.Errorf("%s\n", retErr.Error())
 				return retErr


### PR DESCRIPTION

Signed-off-by: Min Min <jamsman94@gmail.com>

### What this PR does / Why we need it:
fixed updating aws secret will accidently update default registry secret

### What is changed and how it works?
Changed CreateOrUpdateRegistry function to make it work like its name

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
