### PR TITLE
remove scripts that are added for node project

### DIFF
--- a/pkg/microservice/reaper/core/service/reaper/script.go
+++ b/pkg/microservice/reaper/core/service/reaper/script.go
@@ -206,11 +206,6 @@ func (r *Reaper) runScripts() error {
 	// avoid non-blocking IO for stdout to workaround "stdout: write error"
 	for _, script := range r.Ctx.Scripts {
 		scripts = append(scripts, script)
-		// TODO: This may cause nodejs compilation problems, but it is not completely determined, so keep it for now.
-		if strings.Contains(script, "yarn ") || strings.Contains(script, "npm ") || strings.Contains(script, "bower ") {
-			scripts = append(scripts, "echo 'turn off O_NONBLOCK after using node'")
-			scripts = append(scripts, "python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'")
-		}
 	}
 
 	userScriptFile := "user_script.sh"


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

For the `nodejs` project, statements were automatically added to the user's script to prevent the runtime from hanging at first.
The root cause of this problem probably has nothing to do with `nodejs`, but rather `reaper` itself. At the same time, these added statements may bring users trouble, so remove them.

### What is changed and how it works?

Remove scripts that were added when building `nodejs` project.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
