### PR TITLE
cron status always cleaning

### DIFF
--- a/pkg/microservice/aslan/core/system/service/system_cache.go
+++ b/pkg/microservice/aslan/core/system/service/system_cache.go
@@ -78,7 +78,6 @@ func SetCron(cron string, cronEnabled bool, logger *zap.SugaredLogger) error {
 // CleanImageCache 清理镜像缓存
 func CleanImageCache(logger *zap.SugaredLogger) error {
 	//Get pod list by label and namespace
-	//判断当前的状态，cleaning状态下不做清理
 	var mu sync.Mutex
 	mu.Lock()
 	defer func() {
@@ -98,9 +97,6 @@ func CleanImageCache(logger *zap.SugaredLogger) error {
 		}
 	case 1:
 		dindClean := dindCleans[0]
-		if dindClean.Status == CleanStatusCleaning {
-			return e.ErrDindClean.AddDesc("")
-		}
 		dindClean.Status = CleanStatusCleaning
 		dindClean.DindCleanInfos = []*commonmodels.DindCleanInfo{}
 		dindClean.Cron = dindCleans[0].Cron


### PR DESCRIPTION
Signed-off-by: mouuii <zhouchengbin@koderover.com>

### What this PR does / Why we need it:
status can be pending cleaning

### What is changed and how it works?
remove the cleaning check logic

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
