### PR TITLE
fix can't delete no use params when update product template

### DIFF
--- a/pkg/microservice/aslan/core/common/service/render.go
+++ b/pkg/microservice/aslan/core/common/service/render.go
@@ -248,8 +248,6 @@ func CreateRenderSetByMerge(args *commonmodels.RenderSet, log *zap.SugaredLogger
 	opt := &commonrepo.RenderSetFindOption{Name: args.Name, ProductTmpl: args.ProductTmpl}
 	rs, err := commonrepo.NewRenderSetColl().Find(opt)
 	if rs != nil && err == nil {
-		// 已经存在渲染配置集
-		// 判断是否有修改
 		if rs.Diff(args) {
 			args.IsDefault = rs.IsDefault
 		} else {
@@ -274,8 +272,6 @@ func CreateRenderSet(args *commonmodels.RenderSet, log *zap.SugaredLogger) error
 	opt := &commonrepo.RenderSetFindOption{Name: args.Name, ProductTmpl: args.ProductTmpl}
 	rs, err := commonrepo.NewRenderSetColl().Find(opt)
 	if rs != nil && err == nil {
-		// 已经存在渲染配置集
-		// 判断是否有修改
 		if rs.Diff(args) {
 			args.IsDefault = rs.IsDefault
 		} else {

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -767,7 +767,7 @@ func UpdateProductV2(envName, productName, user, requestID string, serviceNames 
 			return err
 		}
 
-		err = commonservice.CreateRenderSet(
+		err = commonservice.CreateRenderSetByMerge(
 			&commonmodels.RenderSet{
 				Name:        exitedProd.Namespace,
 				EnvName:     envName,


### PR DESCRIPTION
Signed-off-by: panxunying <panxunying@koderover.com>

### What this PR does / Why we need it:
fix can't delete no use params when update product template

### What is changed and how it works?
don't merge args when update product template

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
