### PR TITLE
dont enable buildkit feature by default

### DIFF
--- a/pkg/microservice/reaper/core/service/reaper/reaper.go
+++ b/pkg/microservice/reaper/core/service/reaper/reaper.go
@@ -543,7 +543,6 @@ func (r *Reaper) getUserEnvs() []string {
 		fmt.Sprintf("WORKSPACE=%s", r.ActiveWorkspace),
 		// TODO: readme文件可以使用别的方式代替
 		fmt.Sprintf("README=%s", ReadmeFile),
-		"DOCKER_BUILDKIT=1",
 	}
 
 	r.Ctx.Paths = strings.Replace(r.Ctx.Paths, "$HOME", config.Home(), -1)


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

One user has problems with multi-stage builds and we have not analyzed the root cause for now. Try to remove the default buildKit feature.

### What is changed and how it works?

Don't enable buildkit feature by default.

In addition, if users want to enable the buildkit feature, users can add the custom build variable `DOCKER_BUILDKIT=1` to their build configuration.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
