### PR TITLE
policyMeta interface miss `Service` meta

### DIFF
--- a/pkg/microservice/policy/core/service/policy_meta_registration.go
+++ b/pkg/microservice/policy/core/service/policy_meta_registration.go
@@ -104,7 +104,7 @@ func GetPolicyRegistrationDefinitions(scope string, _ *zap.SugaredLogger) ([]*Po
 		return nil, err
 	}
 	systemScopeSet := sets.NewString("TestCenter", "DataCenter", "Template", "DeliveryCenter")
-	projectScopeSet := sets.NewString("Workflow", "Environment", "ProductionEnvironment", "Test", "Delivery", "Build")
+	projectScopeSet := sets.NewString("Workflow", "Environment", "ProductionEnvironment", "Test", "Delivery", "Build", "Service")
 	systemPolicyMetas, projectPolicyMetas, filteredPolicyMetas := []*models.PolicyMeta{}, []*models.PolicyMeta{}, []*models.PolicyMeta{}
 	for _, v := range policieMetas {
 		if systemScopeSet.Has(v.Resource) {


### PR DESCRIPTION
Signed-off-by: mouuii <zhouchengbin@koderover.com>

### What this PR does / Why we need it:
get role  permission meta interface miss service meta , user can not config service permission

### What is changed and how it works?
add service meta

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
