### PR TITLE
support trace id of SkyWalking, Jaeger and Zipkin

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/share_env.go
+++ b/pkg/microservice/aslan/core/environment/service/share_env.go
@@ -663,13 +663,32 @@ func ensureEnvoyFilter(ctx context.Context, istioClient versionedclient.Interfac
 
 func buildEnvoyStoreCacheOperation() (*types.Struct, error) {
 	inlineCode := `function envoy_on_request(request_handle)
-  local requestID = request_handle:headers():get("x-request-id")
+  function split_str(s, delimiter)
+    res = {}
+    for match in (s..delimiter):gmatch("(.-)"..delimiter) do
+      table.insert(res, match)
+    end
+
+    return res
+  end
+
+  local traceid = request_handle:headers():get("sw8")
+  if traceid then
+    arr = split_str(traceid, "-")
+    traceid = arr[2]
+  else
+    traceid = request_handle:headers():get("x-request-id")
+    if not traceid then
+      traceid = request_handle:headers():get("x-b3-traceid")
+    end
+  end
+
   local env = request_handle:headers():get("x-env")
   local headers, body = request_handle:httpCall(
     "cache",
     {
       [":method"] = "POST",
-      [":path"] = string.format("/api/cache/%s/%s", requestID, env),
+      [":path"] = string.format("/api/cache/%s/%s", traceid, env),
       [":authority"] = "cache",
     },
     "",
@@ -690,12 +709,32 @@ end
 
 func buildEnvoyGetCacheOperation() (*types.Struct, error) {
 	inlineCode := `function envoy_on_request(request_handle)
-  local requestID = request_handle:headers():get("x-request-id")
+  function split_str(s, delimiter)
+    res = {}
+    for match in (s..delimiter):gmatch("(.-)"..delimiter) do
+      table.insert(res, match)
+    end
+
+    return res
+  end
+
+  local traceid = request_handle:headers():get("sw8")
+  request_handle:logWarn(string.format("[inbound]sw8: %s", traceid))
+  if traceid then
+    arr = split_str(traceid, "-")
+    traceid = arr[2]
+  else
+    traceid = request_handle:headers():get("x-request-id")
+    if not traceid then
+      traceid = request_handle:headers():get("x-b3-traceid")
+    end
+  end
+
   local headers, body = request_handle:httpCall(
     "cache",
     {
       [":method"] = "GET",
-      [":path"] = string.format("/api/cache/%s", requestID),
+      [":path"] = string.format("/api/cache/%s", traceid),
       [":authority"] = "cache",
     },
     "",


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

SkyWalking, Jaeger and Zikpin use different trace ids as keys for tracing info, which needs support.

### What is changed and how it works?

Support different trace id in EnvoyFilter.

Priority: `sw8` > `x-request-id` > `x-b3-traceid`

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
