### PR TITLE
fix typo

### DIFF
--- a/pkg/microservice/aslan/core/environment/handler/policy.yaml
+++ b/pkg/microservice/aslan/core/environment/handler/policy.yaml
@@ -342,7 +342,7 @@ rules:
           - key: "production"
             value: "false"
   - action: ssh_pm
-    alias: "主机登陆"
+    alias: "主机登录"
     description: ""
     rules:
       - method: GET

--- a/pkg/tool/errors/http_errors.go
+++ b/pkg/tool/errors/http_errors.go
@@ -200,7 +200,7 @@ var (
 	//ErrDeleteResource ...
 	ErrDeleteResource = NewHTTPError(6096, "删除对象资源失败")
 	// ErrLoginPm ...
-	ErrLoginPm = NewHTTPError(6099, "登陆主机失败")
+	ErrLoginPm = NewHTTPError(6099, "登录主机失败")
 
 	ErrDeleteSvcHasSvcsInSubEnv = NewHTTPError(6094, "删除服务失败，待删除服务存在于子环境中")
 


### PR DESCRIPTION
Signed-off-by: fansiqiong [fansiqiong@koderover.com](mailto:fansiqiong@koderover.com)

### What this PR does / Why we need it:
more than one typo styles exist in system, such as 「登录」、「登陆」
the style in frontend repo has unified,ref PR: https://github.com/koderover/zadig-portal/pull/128

### What is changed and how it works?
alter the typo of 「登陆」to 「登录」, make style consistent

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
