### PR TITLE
added filter for default branch

### DIFF
--- a/pkg/microservice/aslan/core/code/service/repo.go
+++ b/pkg/microservice/aslan/core/code/service/repo.go
@@ -133,7 +133,7 @@ func ListRepoInfos(infos []*GitRepoInfo, log *zap.SugaredLogger) ([]*GitRepoInfo
 				match, err := regexp.MatchString(info.FilterRegexp, branch.Name)
 				if err != nil {
 					log.Errorf("failed to match regular expression: %s on branch name :%s, error: %s", info.FilterRegexp, branch.Name, err)
-					continue
+					return nil, err
 				}
 				if match {
 					newBranchList = append(newBranchList, branch)
@@ -144,7 +144,7 @@ func ListRepoInfos(infos []*GitRepoInfo, log *zap.SugaredLogger) ([]*GitRepoInfo
 				match, err := regexp.MatchString(info.FilterRegexp, tag.Name)
 				if err != nil {
 					log.Errorf("failed to match regular expression: %s on tag name :%s, error: %s", info.FilterRegexp, tag.Name, err)
-					continue
+					return nil, err
 				}
 				if match {
 					newTagList = append(newTagList, tag)

--- a/pkg/microservice/aslan/core/code/service/repo.go
+++ b/pkg/microservice/aslan/core/code/service/repo.go
@@ -154,7 +154,11 @@ func ListRepoInfos(infos []*GitRepoInfo, log *zap.SugaredLogger) ([]*GitRepoInfo
 			info.Tags = newTagList
 
 			match, err := regexp.MatchString(info.FilterRegexp, info.DefaultBranch)
-			if err == nil && !match {
+			if err != nil {
+				log.Errorf("failed to compile regular expression: %s, the error is: %s", info.FilterRegexp, err)
+				return nil, err
+			}
+			if !match {
 				info.DefaultBranch = ""
 			}
 		}

--- a/pkg/microservice/aslan/core/code/service/repo.go
+++ b/pkg/microservice/aslan/core/code/service/repo.go
@@ -165,6 +165,7 @@ func ListRepoInfos(infos []*GitRepoInfo, log *zap.SugaredLogger) ([]*GitRepoInfo
 	}
 	if err := errList.ErrorOrNil(); err != nil {
 		log.Errorf("list repo info error: %v", err)
+		return nil, err
 	}
 	return infos, nil
 }

--- a/pkg/microservice/aslan/core/code/service/repo.go
+++ b/pkg/microservice/aslan/core/code/service/repo.go
@@ -152,6 +152,11 @@ func ListRepoInfos(infos []*GitRepoInfo, log *zap.SugaredLogger) ([]*GitRepoInfo
 			}
 			info.Branches = newBranchList
 			info.Tags = newTagList
+
+			match, err := regexp.MatchString(info.FilterRegexp, info.DefaultBranch)
+			if err == nil && !match {
+				info.DefaultBranch = ""
+			}
 		}
 	}
 	if err := errList.ErrorOrNil(); err != nil {


### PR DESCRIPTION
Signed-off-by: Min Min <jamsman94@gmail.com>

### What this PR does / Why we need it:
Improve branch/tag filter by filtering default branches.

### What is changed and how it works?
now if the default branch in build does not match the given regexp, it will be filtered

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
