### PR TITLE
log not panic

### DIFF
--- a/pkg/tool/log/log.go
+++ b/pkg/tool/log/log.go
@@ -137,7 +137,10 @@ func SugaredLogger() *zap.SugaredLogger {
 
 func getLogger() *zap.Logger {
 	if logger == nil {
-		panic("Logger is not initialized yet!")
+		Init(&Config{
+			Level:    "debug",
+			NoCaller: true,
+		})
 	}
 
 	return logger
@@ -149,7 +152,10 @@ func getSugaredLogger() *zap.SugaredLogger {
 
 func getSimpleLogger() *zap.SugaredLogger {
 	if simpleLogger == nil {
-		panic("Logger is not initialized yet!")
+		Init(&Config{
+			Level:    "debug",
+			NoCaller: true,
+		})
 	}
 
 	return simpleLogger


### PR DESCRIPTION
Signed-off-by: mouuii <zhouchengbin@koderover.com>

### What this PR does / Why we need it:
when a service module forget to call log.Init , the service will panic at runtime when use log.Info

### What is changed and how it works?
remove panic , add default init if the global var log is ni

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
