### PR TITLE
fix filter problem for multiple service modules

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/build.go
+++ b/pkg/microservice/aslan/core/common/repository/models/build.go
@@ -185,6 +185,18 @@ func (build *Build) SafeRepos() []*types.Repository {
 	return build.Repos
 }
 
+func (build *Build) SafeReposDeepCopy() []*types.Repository {
+	if len(build.Repos) == 0 {
+		return []*types.Repository{}
+	}
+	resp := make([]*types.Repository, 0)
+	for _, repo := range build.Repos {
+		tmpRepo := *repo
+		resp = append(resp, &tmpRepo)
+	}
+	return build.Repos
+}
+
 func (Build) TableName() string {
 	return "module_build"
 }

--- a/pkg/microservice/aslan/core/common/repository/models/build.go
+++ b/pkg/microservice/aslan/core/common/repository/models/build.go
@@ -194,7 +194,7 @@ func (build *Build) SafeReposDeepCopy() []*types.Repository {
 		tmpRepo := *repo
 		resp = append(resp, &tmpRepo)
 	}
-	return build.Repos
+	return resp
 }
 
 func (Build) TableName() string {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -491,6 +491,7 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 						log.Infof("finding filter info for key: [%s], filterInfo is: [%+v]", key, *filter)
 						// make sure they are the same repository
 						if filter.CodehostID == repoInfo.CodehostID && filter.RepoOwner == repoInfo.RepoOwner && filter.RepoName == repoInfo.RepoName {
+							log.Infof("changing filterRegExp for repo: [%s/%s] from [%s] to [%s]", repoInfo.RepoOwner, repoInfo.RepoName, repoInfo.FilterRegexp, filter.FilterRegExp)
 							repoInfo.FilterRegexp = filter.FilterRegExp
 							log.Infof("the search for key [%s] has ended, the filter regExp is : [%s]", key, filter.FilterRegExp)
 							break

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -484,23 +484,6 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 				target.Build.Repos = moBuild.SafeRepos()
 			}
 
-			key := fmt.Sprintf("%s/%s", containerArr[2], containerArr[1])
-			for _, repoInfo := range target.Build.Repos {
-				if filterList, ok := filtermap[key]; ok {
-					for _, filter := range filterList {
-						log.Infof("finding filter info for key: [%s], filterInfo is: [%+v]", key, *filter)
-						// make sure they are the same repository
-						if filter.CodehostID == repoInfo.CodehostID && filter.RepoOwner == repoInfo.RepoOwner && filter.RepoName == repoInfo.RepoName {
-							log.Infof("changing filterRegExp for repo: [%s/%s] from [%s] to [%s]", repoInfo.RepoOwner, repoInfo.RepoName, repoInfo.FilterRegexp, filter.FilterRegExp)
-							repoInfo.FilterRegexp = filter.FilterRegExp
-							log.Infof("the search for key [%s] has ended, the filter regExp is : [%s]", key, filter.FilterRegExp)
-							break
-						}
-					}
-				}
-			}
-			log.Infof("replace filterRegExp done for target %s", key)
-
 			if moBuild.PreBuild != nil {
 				EnsureBuildResp(moBuild)
 				target.Envs = moBuild.PreBuild.Envs
@@ -526,6 +509,26 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 
 			targets = append(targets, target)
 		}
+	}
+
+	for _, target := range targets {
+		key := fmt.Sprintf("%s/%s", target.Name, target.ServiceName)
+		for _, repoInfo := range target.Build.Repos {
+			if filterList, ok := filtermap[key]; ok {
+				for _, filter := range filterList {
+					log.Infof("finding filter info for key: [%s], filterInfo is: [%+v]", key, *filter)
+					// make sure they are the same repository
+					if filter.CodehostID == repoInfo.CodehostID && filter.RepoOwner == repoInfo.RepoOwner && filter.RepoName == repoInfo.RepoName {
+						log.Infof("changing filterRegExp for repo: [%s/%s] from [%s] to [%s]", repoInfo.RepoOwner, repoInfo.RepoName, repoInfo.FilterRegexp, filter.FilterRegExp)
+						repoInfo.FilterRegexp = filter.FilterRegExp
+						log.Infof("the search for key [%s] has ended, the filter regExp is : [%s]", key, filter.FilterRegExp)
+						break
+					}
+				}
+			}
+		}
+
+		log.Infof("replace filterRegExp done for target %s", key)
 	}
 
 	resp.Target = targets

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -513,6 +513,7 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 
 	for _, target := range targets {
 		key := fmt.Sprintf("%s/%s", target.Name, target.ServiceName)
+		log.Infof("the build list is: %v", target.Build.Repos)
 		for i, repoInfo := range target.Build.Repos {
 			if filterList, ok := filtermap[key]; ok {
 				for _, filter := range filterList {
@@ -535,6 +536,7 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 				}
 			}
 		}
+		log.Infof("the build list after is: %v", target.Build.Repos)
 	}
 
 	resp.Target = targets

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -492,6 +492,7 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 						// make sure they are the same repository
 						if filter.CodehostID == repoInfo.CodehostID && filter.RepoOwner == repoInfo.RepoOwner && filter.RepoName == repoInfo.RepoName {
 							repoInfo.FilterRegexp = filter.FilterRegExp
+							log.Infof("the search for key [%s] has ended, the filter regExp is : [%s]", key, filter.FilterRegExp)
 							break
 						}
 					}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -481,7 +481,7 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 			if moBuild.TemplateID != "" {
 				target.Build.Repos = targetInfo.Repos
 			} else {
-				target.Build.Repos = moBuild.SafeRepos()
+				target.Build.Repos = append([]*types.Repository{}, moBuild.SafeRepos()...)
 			}
 
 			if moBuild.PreBuild != nil {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -413,6 +413,7 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 	if workflow.BuildStage.Enabled {
 		for _, buildModule := range workflow.BuildStage.Modules {
 			buildKey := fmt.Sprintf("%s/%s", buildModule.Target.ServiceModule, buildModule.Target.ServiceName)
+			log.Infof("adding filterInfo for service module of: %s", buildKey)
 			filtermap[buildKey] = buildModule.BranchFilter
 		}
 	}
@@ -487,6 +488,7 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 			for _, repoInfo := range target.Build.Repos {
 				if filterList, ok := filtermap[key]; ok {
 					for _, filter := range filterList {
+						log.Infof("finding filter info for key: [%s], filterInfo is: [%+v]", key, *filter)
 						// make sure they are the same repository
 						if filter.CodehostID == repoInfo.CodehostID && filter.RepoOwner == repoInfo.RepoOwner && filter.RepoName == repoInfo.RepoName {
 							repoInfo.FilterRegexp = filter.FilterRegExp

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -499,6 +499,7 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 					}
 				}
 			}
+			log.Infof("replace filterRegExp done for target %s", key)
 
 			if moBuild.PreBuild != nil {
 				EnsureBuildResp(moBuild)

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -413,7 +413,6 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 	if workflow.BuildStage.Enabled {
 		for _, buildModule := range workflow.BuildStage.Modules {
 			buildKey := fmt.Sprintf("%s/%s", buildModule.Target.ServiceModule, buildModule.Target.ServiceName)
-			log.Infof("adding filterInfo for service module of: %s", buildKey)
 			filtermap[buildKey] = buildModule.BranchFilter
 		}
 	}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -481,7 +481,7 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 			if moBuild.TemplateID != "" {
 				target.Build.Repos = targetInfo.Repos
 			} else {
-				target.Build.Repos = append([]*types.Repository{}, moBuild.SafeRepos()...)
+				target.Build.Repos = moBuild.SafeReposDeepCopy()
 			}
 
 			if moBuild.PreBuild != nil {
@@ -514,23 +514,12 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 	for _, target := range targets {
 		key := fmt.Sprintf("%s/%s", target.Name, target.ServiceName)
 		log.Infof("the build list is: %v", target.Build.Repos)
-		for i, repoInfo := range target.Build.Repos {
+		for _, repoInfo := range target.Build.Repos {
 			if filterList, ok := filtermap[key]; ok {
 				for _, filter := range filterList {
 					// make sure they are the same repository
 					if filter.CodehostID == repoInfo.CodehostID && filter.RepoOwner == repoInfo.RepoOwner && filter.RepoName == repoInfo.RepoName {
-						target.Build.Repos[i] = &types.Repository{
-							Address:      repoInfo.Address,
-							Branch:       repoInfo.Branch,
-							CodehostID:   repoInfo.CodehostID,
-							FilterRegexp: filter.FilterRegExp,
-							IsPrimary:    repoInfo.IsPrimary,
-							OauthToken:   repoInfo.OauthToken,
-							RemoteName:   repoInfo.RemoteName,
-							RepoName:     repoInfo.RemoteName,
-							RepoOwner:    repoInfo.RepoOwner,
-							Source:       repoInfo.Source,
-						}
+						repoInfo.FilterRegexp = filter.FilterRegExp
 						break
 					}
 				}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -513,7 +513,6 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 
 	for _, target := range targets {
 		key := fmt.Sprintf("%s/%s", target.Name, target.ServiceName)
-		log.Infof("the build list is: %v", target.Build.Repos)
 		for _, repoInfo := range target.Build.Repos {
 			if filterList, ok := filtermap[key]; ok {
 				for _, filter := range filterList {
@@ -525,7 +524,6 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 				}
 			}
 		}
-		log.Infof("the build list after is: %v", target.Build.Repos)
 	}
 
 	resp.Target = targets

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -518,9 +518,18 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 				for _, filter := range filterList {
 					// make sure they are the same repository
 					if filter.CodehostID == repoInfo.CodehostID && filter.RepoOwner == repoInfo.RepoOwner && filter.RepoName == repoInfo.RepoName {
-						tmpVar := *repoInfo
-						target.Build.Repos[i] = &(tmpVar)
-						target.Build.Repos[i].FilterRegexp = filter.FilterRegExp
+						target.Build.Repos[i] = &types.Repository{
+							Address:      repoInfo.Address,
+							Branch:       repoInfo.Branch,
+							CodehostID:   repoInfo.CodehostID,
+							FilterRegexp: filter.FilterRegExp,
+							IsPrimary:    repoInfo.IsPrimary,
+							OauthToken:   repoInfo.OauthToken,
+							RemoteName:   repoInfo.RemoteName,
+							RepoName:     repoInfo.RemoteName,
+							RepoOwner:    repoInfo.RepoOwner,
+							Source:       repoInfo.Source,
+						}
 						break
 					}
 				}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -513,22 +513,19 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 
 	for _, target := range targets {
 		key := fmt.Sprintf("%s/%s", target.Name, target.ServiceName)
-		for _, repoInfo := range target.Build.Repos {
+		for i, repoInfo := range target.Build.Repos {
 			if filterList, ok := filtermap[key]; ok {
 				for _, filter := range filterList {
-					log.Infof("finding filter info for key: [%s], filterInfo is: [%+v]", key, *filter)
 					// make sure they are the same repository
 					if filter.CodehostID == repoInfo.CodehostID && filter.RepoOwner == repoInfo.RepoOwner && filter.RepoName == repoInfo.RepoName {
-						log.Infof("changing filterRegExp for repo: [%s/%s] from [%s] to [%s]", repoInfo.RepoOwner, repoInfo.RepoName, repoInfo.FilterRegexp, filter.FilterRegExp)
-						repoInfo.FilterRegexp = filter.FilterRegExp
-						log.Infof("the search for key [%s] has ended, the filter regExp is : [%s]", key, filter.FilterRegExp)
+						tmpVar := *repoInfo
+						target.Build.Repos[i] = &(tmpVar)
+						target.Build.Repos[i].FilterRegexp = filter.FilterRegExp
 						break
 					}
 				}
 			}
 		}
-
-		log.Infof("replace filterRegExp done for target %s", key)
 	}
 
 	resp.Target = targets


### PR DESCRIPTION
Signed-off-by: Min Min <jamsman94@gmail.com>

### What this PR does / Why we need it:
The SafeRepo function is returning the same build repo info making it hard to alter each one.

### What is changed and how it works?
Add a new function named SafeRepoDeepCopy to make a deep copy of a slice to make altering single repo easier.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
