### PR TITLE
fix wardrive panic issue

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskplugin/jenkins_plugin.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/jenkins_plugin.go
@@ -205,14 +205,26 @@ func (j *JenkinsBuildPlugin) Wait(ctx context.Context) {
 	jenkinsClient, err := gojenkins.CreateJenkins(nil, j.Task.JenkinsIntegration.URL, j.Task.JenkinsIntegration.Username, j.Task.JenkinsIntegration.Password).Init(ctx)
 	if err != nil {
 		j.SetStatus(config.StatusFailed)
+		msg := fmt.Sprintf("failed to create jenkins client, error: %s", err)
+		j.Log.Error(msg)
+		j.Task.Error = msg
+		return
 	}
 	job, err := jenkinsClient.GetJob(ctx, j.Task.JenkinsBuildArgs.JobName)
 	if err != nil {
 		j.SetStatus(config.StatusFailed)
+		msg := fmt.Sprintf("failed to get jenkins job, error: %s", err)
+		j.Log.Error(msg)
+		j.Task.Error = msg
+		return
 	}
 	build, err := job.GetLastCompletedBuild(ctx)
 	if err != nil {
 		j.SetStatus(config.StatusFailed)
+		msg := fmt.Sprintf("failed to get last completed build, error: %s", err)
+		j.Log.Error(msg)
+		j.Task.Error = msg
+		return
 	}
 	jenkinsBuildStatus := j.matchStatus(jobStatus, build.GetResult())
 	j.SetStatus(jenkinsBuildStatus)


### PR DESCRIPTION
Signed-off-by: liu deyi <andrew@koderover.com>

### What this PR does / Why we need it:
fix wardrive panic issue

### What is changed and how it works?
If creating jenkins client fails, warpdrive panics

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
