### PR TITLE
Bugfix for panic in wd when a scanning is triggered by gitlab

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_scanning_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_scanning_task.go
@@ -64,7 +64,6 @@ func TriggerScanningByGitlabEvent(event interface{}, baseURI, requestID string, 
 
 					triggerRepoInfo := make([]*scanningservice.ScanningRepoInfo, 0)
 					// for now only one repo is supported
-					log.Infof("codehostID is: %d", item.CodehostID)
 					repoInfo := &scanningservice.ScanningRepoInfo{
 						CodehostID: item.CodehostID,
 						Source:     item.Source,
@@ -72,6 +71,7 @@ func TriggerScanningByGitlabEvent(event interface{}, baseURI, requestID string, 
 						RepoName:   item.RepoName,
 						Branch:     item.Branch,
 					}
+					triggerRepoInfo = append(triggerRepoInfo, repoInfo)
 
 					repoInfo.PR = mergeRequestID
 

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_scanning_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_scanning_task.go
@@ -64,6 +64,7 @@ func TriggerScanningByGitlabEvent(event interface{}, baseURI, requestID string, 
 
 					triggerRepoInfo := make([]*scanningservice.ScanningRepoInfo, 0)
 					// for now only one repo is supported
+					log.Infof("codehostID is: %d", item.CodehostID)
 					repoInfo := &scanningservice.ScanningRepoInfo{
 						CodehostID: item.CodehostID,
 						Source:     item.Source,

--- a/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
@@ -200,6 +200,7 @@ func CreateScanningTask(id string, req []*ScanningRepoInfo, username string, log
 			log.Errorf("failed to get codehost info from mongodb, the error is: %s", err)
 			return 0, err
 		}
+		log.Infof("the response we got is: %+v", rep)
 		repos = append(repos, &types.Repository{
 			Source:      rep.Type,
 			RepoOwner:   arg.RepoOwner,

--- a/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
@@ -200,7 +200,6 @@ func CreateScanningTask(id string, req []*ScanningRepoInfo, username string, log
 			log.Errorf("failed to get codehost info from mongodb, the error is: %s", err)
 			return 0, err
 		}
-		log.Infof("the response we got is: %+v", rep)
 		repos = append(repos, &types.Repository{
 			Source:      rep.Type,
 			RepoOwner:   arg.RepoOwner,


### PR DESCRIPTION
Signed-off-by: Min Min <jamsman94@gmail.com>

### What this PR does / Why we need it:
Bugfix for panic in wd when a scanning is triggered by gitlab

### What is changed and how it works?
Bugfix for panic in wd when a scanning is triggered by gitlab

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
