### PR TITLE
update public login url

### DIFF
--- a/pkg/microservice/policy/core/service/bundle/exemption_urls.go
+++ b/pkg/microservice/policy/core/service/bundle/exemption_urls.go
@@ -62,7 +62,7 @@ var publicURLs = []*policyRule{
 	},
 	{
 		Methods:   []string{"GET", "POST"},
-		Endpoints: []string{"api/v1/login", "api/v1/signup", "api/v1/retrieve", "api/v1/login-enabled", "login/pure"},
+		Endpoints: []string{"api/v1/login", "api/v1/signup", "api/v1/retrieve", "api/v1/login-enabled", "login/password"},
 	},
 	{
 		Methods:   []string{"GET"},


### PR DESCRIPTION
Signed-off-by: fansi <fansiqiong@koderover.com>

### What this PR does / Why we need it:

the public login url has changed from `login/prue` to `login/password`


### What is changed and how it works?

update the public login url

### Does this PR introduce a user-facing change?

- [x] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
