### PR TITLE
remove authorization requirement for get sonar integration

### DIFF
--- a/pkg/microservice/policy/core/service/bundle/exemption_urls.go
+++ b/pkg/microservice/policy/core/service/bundle/exemption_urls.go
@@ -129,7 +129,7 @@ var systemAdminURLs = []*policyRule{
 		Endpoints: []string{"api/aslan/system/cleanCache/cron"},
 	},
 	{
-		Methods:   []string{"GET", "POST", "PUT", "DELETE"},
+		Methods:   []string{"POST", "PUT", "DELETE"},
 		Endpoints: []string{"api/aslan/system/sonar/?*"},
 	},
 	{


### PR DESCRIPTION
Signed-off-by: Min Min <jamsman94@gmail.com>

### What this PR does / Why we need it:
remove authorization requirement for get sonar integration

### What is changed and how it works?
remove authorization requirement for get sonar integration

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
