### PR TITLE
fix bug of selecting dind for attached cluster & use consistent hashing for selecting dind

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,9 @@ require (
 	github.com/bradleyfalzon/ghinstallation v1.1.1
 	github.com/bugsnag/bugsnag-go v2.1.0+incompatible // indirect
 	github.com/bugsnag/panicwrap v1.3.1 // indirect
+	github.com/buraksezer/consistent v0.9.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.1
+	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/chartmuseum/helm-push v0.10.1
 	github.com/containers/image v3.0.2+incompatible
 	github.com/coocood/freecache v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -276,6 +276,8 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0Bsq
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/bugsnag/panicwrap v1.3.1 h1:pmuhHlhbUV4OOrGDvoiMjHSZzwRcL+I9cIzYKiW4lII=
 github.com/bugsnag/panicwrap v1.3.1/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/buraksezer/consistent v0.9.0 h1:Zfs6bX62wbP3QlbPGKUhqDw7SmNkOzY5bHZIYXYpR5g=
+github.com/buraksezer/consistent v0.9.0/go.mod h1:6BrVajWq7wbKZlTOUPs/XVfR8c0maujuPowduSpZqmw=
 github.com/caarlos0/ctrlc v1.0.0/go.mod h1:CdXpj4rmq0q/1Eb44M9zi2nKB0QraNKuRGYGrrHhcQw=
 github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMSc6E5ydlp5NIonxObaeu/Iub/X03EKPVYo=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=

--- a/pkg/microservice/warpdrive/core/service/common/dockerhosts.go
+++ b/pkg/microservice/warpdrive/core/service/common/dockerhosts.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2022 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/buraksezer/consistent"
+	"github.com/cespare/xxhash"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/koderover/zadig/pkg/config"
+	"github.com/koderover/zadig/pkg/setting"
+	kubeclient "github.com/koderover/zadig/pkg/shared/kube/client"
+)
+
+var once sync.Once
+
+type Member string
+
+func (m Member) String() string {
+	return string(m)
+}
+
+type hasher struct{}
+
+func (h hasher) Sum64(data []byte) uint64 {
+	return xxhash.Sum64(data)
+}
+
+type ClusterID string
+
+type DockerHostsI interface {
+	GetBestHost(ClusterID, string) string
+
+	Sync()
+}
+
+type dockerhosts struct {
+	rwLock        *sync.RWMutex
+	store         map[ClusterID]*consistent.Consistent
+	hubServerAddr string
+	syncInterval  time.Duration
+
+	logger *zap.SugaredLogger
+}
+
+var dockerHosts DockerHostsI
+
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}
+
+func NewDockerHosts(hubServerAddr string, logger *zap.SugaredLogger) DockerHostsI {
+	once.Do(func() {
+		dockerHosts = &dockerhosts{
+			rwLock:        &sync.RWMutex{},
+			store:         map[ClusterID]*consistent.Consistent{},
+			hubServerAddr: hubServerAddr,
+			logger:        logger,
+		}
+
+		go dockerHosts.Sync()
+	})
+
+	return dockerHosts
+}
+
+func (d *dockerhosts) GetBestHost(clusterID ClusterID, key string) string {
+	if d.store[clusterID] == nil {
+		d.initClusterInfo(clusterID)
+	}
+
+	member := d.store[clusterID].LocateKey([]byte(key))
+
+	return member.String()
+}
+
+func (d *dockerhosts) initClusterInfo(clusterID ClusterID) {
+	d.rwLock.Lock()
+	defer d.rwLock.Unlock()
+
+	members := d.getDockerHostsSvc(clusterID)
+
+	cfg := consistent.Config{
+		PartitionCount:    271,
+		ReplicationFactor: 20,
+		Load:              1.25,
+		Hasher:            hasher{},
+	}
+
+	d.store[clusterID] = consistent.New(members, cfg)
+}
+
+func (d *dockerhosts) getDockerHostsSvc(clusterID ClusterID) []consistent.Member {
+	ns := config.Namespace()
+	if string(clusterID) != setting.LocalClusterID {
+		ns = setting.AttachedClusterNamespace
+	}
+
+	kclient, err := kubeclient.GetKubeClient(d.hubServerAddr, string(clusterID))
+	if err != nil {
+		d.logger.Warnf("Failed to get kubeclient for cluster %q: %s. Try to use default dockerhosts.", clusterID, err)
+		return d.getDefaultDockerHosts()
+	}
+
+	dindSts := &appsv1.StatefulSet{}
+	err = kclient.Get(context.TODO(), client.ObjectKey{
+		Name:      "dind",
+		Namespace: ns,
+	}, dindSts)
+	if err != nil {
+		d.logger.Warnf("Failed to get dind statefuleset in namespace %q of cluster %q: %s", ns, clusterID, err)
+		return d.getDefaultDockerHosts()
+	}
+
+	members := []consistent.Member{}
+	for i := 0; i < int(*dindSts.Spec.Replicas); i++ {
+		members = append(members, d.genDindAddr(i))
+	}
+
+	return members
+}
+
+func (d *dockerhosts) getDefaultDockerHosts() []consistent.Member {
+	return []consistent.Member{d.genDindAddr(0)}
+}
+
+func (d *dockerhosts) genDindAddr(idx int) Member {
+	return Member(fmt.Sprintf("tcp://dind-%d.dind:2375", idx))
+}
+
+func (d *dockerhosts) Sync() {
+	d.logger.Info("Begin to sync")
+
+	wait.Forever(func() {
+		d.rwLock.Lock()
+		defer d.rwLock.Unlock()
+
+		for clusterID, consistentHash := range d.store {
+			currentMembers := d.getDockerHostsSvc(clusterID)
+			oldMembers := consistentHash.GetMembers()
+
+			d.logger.Infof("Cluster: %q. Current Members: %d. Old Members: %d", clusterID, len(currentMembers), len(oldMembers))
+
+			addedMembers, deletedMembers := d.diffMembers(oldMembers, currentMembers)
+			for _, member := range addedMembers {
+				consistentHash.Add(member)
+			}
+			for _, member := range deletedMembers {
+				consistentHash.Remove(member.String())
+			}
+		}
+	}, 3*time.Minute)
+}
+
+func (d *dockerhosts) diffMembers(old, current []consistent.Member) (added, deleted []consistent.Member) {
+	curMap := make(map[consistent.Member]struct{}, len(current))
+	for _, member := range current {
+		curMap[member] = struct{}{}
+	}
+
+	oldMap := make(map[consistent.Member]struct{}, len(old))
+	for _, member := range old {
+		oldMap[member] = struct{}{}
+	}
+
+	for _, member := range old {
+		if _, found := curMap[member]; !found {
+			deleted = append(deleted, member)
+		}
+	}
+	for _, member := range current {
+		if _, found := oldMap[member]; !found {
+			added = append(added, member)
+		}
+	}
+
+	return added, deleted
+}

--- a/pkg/microservice/warpdrive/core/service/common/dockerhosts_test.go
+++ b/pkg/microservice/warpdrive/core/service/common/dockerhosts_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}
+
+func TestNewDockerHosts(t *testing.T) {
+	hubServerAddr := "hub-server.zadig"
+	logger, _ := zap.NewProduction()
+	dockerhosts := NewDockerHosts(hubServerAddr, logger.Sugar())
+
+	clusters := []ClusterID{ClusterID("local"), ClusterID("worker0"), ClusterID("worker1")}
+	svcs := []string{"svc0", "svc1", "svc2", "svc3", "svc4"}
+
+	for i := 0; i < len(clusters); i++ {
+		t.Logf("In Cluster %q\n", clusters[i])
+
+		for j := 0; j < 10; j++ {
+			svc := svcs[rand.Intn(len(svcs))]
+			host := dockerhosts.GetBestHost(clusters[i], svc)
+			t.Logf("\tHost for svc %q: %q\n", svc, host)
+		}
+
+		t.Log("\n")
+	}
+}

--- a/pkg/microservice/warpdrive/core/service/taskcontroller/task_handler.go
+++ b/pkg/microservice/warpdrive/core/service/taskcontroller/task_handler.go
@@ -138,7 +138,9 @@ func (h *ExecHandler) runPipelineTask(ctx context.Context, cancel context.Cancel
 		return
 	}
 
-	// 选取当前最空闲的dockerhost
+	// Deprecated.
+	// Note: This logic is reserved for compatibility with plugins other than build. This logic can be removed if we have understood all of the plugins.
+	//       For attached clusters, this logic is wrong because it still deals with dind in the local cluster.
 	dockerHost, err := plugins.GetBestDockerHost(pipelineTask.ConfigPayload.Docker.HostList, string(pipelineTask.Type), pipelineTask.ConfigPayload.Build.KubeNamespace, xl)
 	if err != nil {
 		errMsg := fmt.Sprintf("[%s]Cannot find docker host: %v", pipelineTask.PipelineName, err)

--- a/pkg/microservice/warpdrive/core/service/taskplugin/build.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/build.go
@@ -36,6 +36,7 @@ import (
 
 	zadigconfig "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/config"
+	"github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/common"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/types/task"
 	"github.com/koderover/zadig/pkg/setting"
 	krkubeclient "github.com/koderover/zadig/pkg/tool/kube/client"
@@ -153,6 +154,9 @@ func (p *BuildTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipe
 		p.clientset = clientset
 		p.restConfig = restConfig
 	}
+
+	dockerhosts := common.NewDockerHosts(pipelineTask.ConfigPayload.HubServerAddr, p.Log)
+	pipelineTask.DockerHost = dockerhosts.GetBestHost(common.ClusterID(p.Task.ClusterID), serviceName)
 
 	// not local cluster
 	var (


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

For the attached cluster, the current selection of DockerHost is still based on the `dind` of the local cluster, which needs to be corrected. 
Besides, considering the build efficiency, the same service should be scheduled to the same `dind` instance for building as quickly as possible.

### What is changed and how it works?

For building tasks:
- fix bug of selecting wrong DockerHost for attached clusters
- get the `dind` instances' address of the target cluster dynamically
- use consistent hashing to ensure that the same service uses the same `dind` instance

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
