### PR TITLE
fix bug: should only get pr for github repo

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskplugin/jira.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/jira.go
@@ -175,7 +175,7 @@ func (p *JiraPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipelineC
 					}
 				}
 			}
-		} else {
+		} else if build.Source == setting.SourceFromGithub {
 			httpsAddr := ""
 			if pipelineTask.ConfigPayload.Proxy.EnableRepoProxy && pipelineTask.ConfigPayload.Proxy.Type == "http" {
 				httpsAddr = pipelineTask.ConfigPayload.Proxy.GetProxyURL()


### PR DESCRIPTION
Signed-off-by: Xudong Zhang <felixmelon@gmail.com>

### What this PR does / Why we need it:
Fix bug. Currently zadig request **github** PR for all kinds of repo except gitlab.

### What is changed and how it works?
Fix bug.

### Does this PR introduce a user-facing change?
No.
- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
