### PR TITLE
reaper: upload dir to s3 recursively

### DIFF
--- a/pkg/microservice/reaper/core/service/reaper/reaper.go
+++ b/pkg/microservice/reaper/core/service/reaper/reaper.go
@@ -462,26 +462,17 @@ func (r *Reaper) AfterExec() error {
 			}
 			// if the given path is a directory
 			if info.IsDir() {
-				// we get ALL files in this directory and upload it to the object storage
-				files, err := ioutil.ReadDir(upload.FilePath)
+				err := client.UploadDir(r.Ctx.UploadStorageInfo.Bucket, upload.FilePath, upload.DestinationPath)
 				if err != nil {
-					return fmt.Errorf("failed to read file information in directory: [%s], the error is: %s", upload.FilePath, err)
-				}
-				for _, file := range files {
-					if !file.IsDir() {
-						key := filepath.Join(upload.DestinationPath, file.Name())
-						originalFilePath := filepath.Join(upload.FilePath, file.Name())
-						err := client.Upload(r.Ctx.UploadStorageInfo.Bucket, originalFilePath, key)
-						if err != nil {
-							fmt.Printf("Failed to upload [%s] to key [%s] on s3, the error is: %s", originalFilePath, key, err)
-						}
-					}
+					log.Errorf("Failed to upload dir [%s] to path [%s] on s3, the error is: %s", upload.FilePath, upload.DestinationPath, err)
+					return err
 				}
 			} else {
 				key := filepath.Join(upload.DestinationPath, info.Name())
 				err := client.Upload(r.Ctx.UploadStorageInfo.Bucket, upload.FilePath, key)
 				if err != nil {
-					fmt.Printf("Failed to upload [%s] to key [%s] on s3, the error is: %s", upload.FilePath, key, err)
+					log.Errorf("Failed to upload [%s] to key [%s] on s3, the error is: %s", upload.FilePath, key, err)
+					return err
 				}
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Xudong Zhang <felixmelon@gmail.com>

### What this PR does / Why we need it:
Support upload all files in a directory to S3.

zadig only uploads all files in a directory to S3, this didn't includes files in sub-directories.
Then we have to add a lot of sub-directories in build config, like `a, a/b, a/b/c1, a/b/c2`.

### What is changed and how it works?
Upload all files in a directory recursively.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
