### PR TITLE
fix panic when job not found

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -825,9 +825,13 @@ func waitJobReady(ctx context.Context, namespace, jobName string, kubeClient cli
 		default:
 			time.Sleep(time.Second)
 
-			job, _, err := getter.GetJob(namespace, jobName, kubeClient)
+			job, found, err := getter.GetJob(namespace, jobName, kubeClient)
 			if err != nil {
 				xl.Errorf("Failed to get job `%s` in namespace `%s`: %s", jobName, namespace, err)
+				continue
+			}
+			if !found {
+				xl.Errorf("Job `%s` not found in namespace `%s`, retry in a second", jobName, namespace)
 				continue
 			}
 


### PR DESCRIPTION
Signed-off-by: dianqihanwangzi <dianqihanwangzi@gmail.com>

### What this PR does / Why we need it:
Check if job were nil to avoid panic.

### What is changed and how it works?
When create  job at very beginning, the job may not found in cache, to aviod  get a nil job.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
