### PR TITLE
fix webhook remove fail bug

### DIFF
--- a/pkg/microservice/aslan/core/common/service/webhook/controller.go
+++ b/pkg/microservice/aslan/core/common/service/webhook/controller.go
@@ -137,7 +137,7 @@ func ensureSafeDelete(ref, repoName, repoOwner, repoAddress string) (bool, error
 		if service.RepoName != repoName || service.RepoOwner != repoOwner {
 			continue
 		}
-		codeHostInfo, err := codehostdb.NewCodehostColl().GetCodeHostByID(service.CodehostID)
+		codeHostInfo, err := codehostdb.NewCodehostColl().GetCodeHostByID(service.CodehostID, false)
 		if err == nil {
 			if codeHostInfo.Address != repoAddress {
 				continue

--- a/pkg/microservice/aslan/core/common/service/workflow.go
+++ b/pkg/microservice/aslan/core/common/service/workflow.go
@@ -208,7 +208,7 @@ func ProcessWebhook(updatedHooks, currentHooks interface{}, name string, logger 
 		wg.Add(1)
 		go func(wh hookItem) {
 			defer wg.Done()
-			ch, err := systemconfig.New().GetCodeHost(wh.codeHostID)
+			ch, err := systemconfig.New().GetRawCodeHost(wh.codeHostID)
 			if err != nil {
 				logger.Errorf("Failed to get codeHost by id %d, err: %s", wh.codeHostID, err)
 				errs = multierror.Append(errs, err)

--- a/pkg/microservice/systemconfig/core/codehost/handler/codehost.go
+++ b/pkg/microservice/systemconfig/core/codehost/handler/codehost.go
@@ -17,6 +17,7 @@ limitations under the License.
 package handler
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -77,7 +78,17 @@ func GetCodeHost(c *gin.Context) {
 		ctx.Err = err
 		return
 	}
-	ctx.Resp, ctx.Err = service.GetCodeHost(id, c.Query("ignoreDelete") == "true", ctx.Logger)
+
+	ignoreDelete := false
+	if len(c.Query("ignoreDelete")) > 0 {
+		ignoreDelete, err = strconv.ParseBool(c.Query("ignoreDelete"))
+		if err != nil {
+			ctx.Err = fmt.Errorf("failed to parse param ignoreDelete, err: %s", err)
+		}
+		return
+	}
+
+	ctx.Resp, ctx.Err = service.GetCodeHost(id, ignoreDelete, ctx.Logger)
 }
 
 func AuthCodeHost(c *gin.Context) {

--- a/pkg/microservice/systemconfig/core/codehost/handler/codehost.go
+++ b/pkg/microservice/systemconfig/core/codehost/handler/codehost.go
@@ -77,7 +77,7 @@ func GetCodeHost(c *gin.Context) {
 		ctx.Err = err
 		return
 	}
-	ctx.Resp, ctx.Err = service.GetCodeHost(id, ctx.Logger)
+	ctx.Resp, ctx.Err = service.GetCodeHost(id, c.Query("ignoreDelete") == "true", ctx.Logger)
 }
 
 func AuthCodeHost(c *gin.Context) {

--- a/pkg/microservice/systemconfig/core/codehost/handler/codehost.go
+++ b/pkg/microservice/systemconfig/core/codehost/handler/codehost.go
@@ -84,8 +84,8 @@ func GetCodeHost(c *gin.Context) {
 		ignoreDelete, err = strconv.ParseBool(c.Query("ignoreDelete"))
 		if err != nil {
 			ctx.Err = fmt.Errorf("failed to parse param ignoreDelete, err: %s", err)
+			return
 		}
-		return
 	}
 
 	ctx.Resp, ctx.Err = service.GetCodeHost(id, ignoreDelete, ctx.Logger)

--- a/pkg/microservice/systemconfig/core/codehost/repository/mongodb/codehost.go
+++ b/pkg/microservice/systemconfig/core/codehost/repository/mongodb/codehost.go
@@ -80,10 +80,13 @@ func (c *CodehostColl) DeleteCodeHost() error {
 	return nil
 }
 
-func (c *CodehostColl) GetCodeHostByID(ID int) (*models.CodeHost, error) {
+func (c *CodehostColl) GetCodeHostByID(ID int, ignoreDelete bool) (*models.CodeHost, error) {
 
 	codehost := new(models.CodeHost)
-	query := bson.M{"id": ID, "deleted_at": 0}
+	query := bson.M{"id": ID}
+	if !ignoreDelete {
+		query["deleted_at"] = 0
+	}
 	if err := c.Collection.FindOne(context.TODO(), query).Decode(codehost); err != nil {
 		return nil, err
 	}

--- a/pkg/microservice/systemconfig/core/codehost/service/codehost.go
+++ b/pkg/microservice/systemconfig/core/codehost/service/codehost.go
@@ -139,8 +139,8 @@ func UpdateCodeHostByToken(host *models.CodeHost, _ *zap.SugaredLogger) (*models
 	return mongodb.NewCodehostColl().UpdateCodeHostByToken(host)
 }
 
-func GetCodeHost(id int, _ *zap.SugaredLogger) (*models.CodeHost, error) {
-	return mongodb.NewCodehostColl().GetCodeHostByID(id)
+func GetCodeHost(id int, ignoreDelete bool, _ *zap.SugaredLogger) (*models.CodeHost, error) {
+	return mongodb.NewCodehostColl().GetCodeHostByID(id, ignoreDelete)
 }
 
 type state struct {
@@ -149,7 +149,7 @@ type state struct {
 }
 
 func AuthCodeHost(redirectURI string, codeHostID int, logger *zap.SugaredLogger) (string, error) {
-	codeHost, err := GetCodeHost(codeHostID, logger)
+	codeHost, err := GetCodeHost(codeHostID, false, logger)
 	if err != nil {
 		logger.Errorf("GetCodeHost:%s err:%s", codeHostID, err)
 		return "", err
@@ -195,7 +195,7 @@ func HandleCallback(stateStr string, r *http.Request, logger *zap.SugaredLogger)
 		logger.Errorf("ParseURL:%s err:%s", sta.RedirectURL, err)
 		return "", err
 	}
-	codehost, err := GetCodeHost(sta.CodeHostID, logger)
+	codehost, err := GetCodeHost(sta.CodeHostID, false, logger)
 	if err != nil {
 		return handle(redirectParsedURL, err)
 	}

--- a/pkg/shared/client/systemconfig/codehost.go
+++ b/pkg/shared/client/systemconfig/codehost.go
@@ -76,6 +76,18 @@ func (c *Client) GetCodeHost(id int) (*CodeHost, error) {
 	return res, nil
 }
 
+func (c *Client) GetRawCodeHost(id int) (*CodeHost, error) {
+	url := fmt.Sprintf("/codehosts/%d?ignoreDelete=true", id)
+
+	res := &CodeHost{}
+	_, err := c.Get(url, httpclient.SetResult(res))
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
 func (c *Client) ListCodeHostsInternal() ([]*CodeHost, error) {
 	url := "/codehosts/internal"
 


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when codehost config is deleted, workflow/test/scanning with triggers associated with this repository will not be able to edit triggers again

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
