### PR TITLE
reaper: avoid change origin job info since it may be retried

### DIFF
--- a/pkg/microservice/reaper/core/service/reaper/reaper.go
+++ b/pkg/microservice/reaper/core/service/reaper/reaper.go
@@ -456,22 +456,22 @@ func (r *Reaper) AfterExec() error {
 			return fmt.Errorf("failed to create s3 client to upload file, err: %s", err)
 		}
 		for _, upload := range r.Ctx.UploadInfo {
-			info, err := os.Stat(upload.FilePath)
+			info, err := os.Stat(upload.AbsFilePath)
 			if err != nil {
-				return fmt.Errorf("failed to upload file path [%s] to destination [%s], the error is: %s", upload.FilePath, upload.DestinationPath, err)
+				return fmt.Errorf("failed to upload file path [%s] to destination [%s], the error is: %s", upload.AbsFilePath, upload.DestinationPath, err)
 			}
 			// if the given path is a directory
 			if info.IsDir() {
-				err := client.UploadDir(r.Ctx.UploadStorageInfo.Bucket, upload.FilePath, upload.DestinationPath)
+				err := client.UploadDir(r.Ctx.UploadStorageInfo.Bucket, upload.AbsFilePath, upload.DestinationPath)
 				if err != nil {
-					log.Errorf("Failed to upload dir [%s] to path [%s] on s3, the error is: %s", upload.FilePath, upload.DestinationPath, err)
+					log.Errorf("Failed to upload dir [%s] to path [%s] on s3, the error is: %s", upload.AbsFilePath, upload.DestinationPath, err)
 					return err
 				}
 			} else {
 				key := filepath.Join(upload.DestinationPath, info.Name())
-				err := client.Upload(r.Ctx.UploadStorageInfo.Bucket, upload.FilePath, key)
+				err := client.Upload(r.Ctx.UploadStorageInfo.Bucket, upload.AbsFilePath, key)
 				if err != nil {
-					log.Errorf("Failed to upload [%s] to key [%s] on s3, the error is: %s", upload.FilePath, key, err)
+					log.Errorf("Failed to upload [%s] to key [%s] on s3, the error is: %s", upload.AbsFilePath, key, err)
 					return err
 				}
 			}

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -305,9 +305,10 @@ func (b *JobCtxBuilder) BuildReaperContext(pipelineTask *task.Task, serviceName 
 	if b.JobCtx.UploadEnabled {
 		for _, upload := range b.JobCtx.UploadInfo {
 			// since the frontend won't change the file path, the backend will have to add it
-			upload.FilePath = fmt.Sprintf("$WORKSPACE/%s", upload.FilePath)
+			// use AbsFilePath to avoid change the original user input since a job may be retried
+			upload.AbsFilePath = fmt.Sprintf("$WORKSPACE/%s", upload.FilePath)
 			// then we replace it with our env variables
-			upload.FilePath = replaceEnvWithValue(upload.FilePath, envmaps)
+			upload.AbsFilePath = replaceEnvWithValue(upload.AbsFilePath, envmaps)
 			upload.DestinationPath = replaceEnvWithValue(upload.DestinationPath, envmaps)
 		}
 	}

--- a/pkg/types/object_storage.go
+++ b/pkg/types/object_storage.go
@@ -27,5 +27,6 @@ type ObjectStorageInfo struct {
 
 type ObjectStoragePathDetail struct {
 	FilePath        string `bson:"file_path" json:"file_path" yaml:"file_path"`
+	AbsFilePath     string `bson:"abs_file_path" json:"abs_file_path" yaml:"abs_file_path"`
 	DestinationPath string `bson:"dest_path" json:"dest_path" yaml:"dest_path"`
 }


### PR DESCRIPTION
Changing user input leads to following problem:
1. The UploadPath became sth like `/workspace/static` at first
2. Then it became `/workspace/workspace/static` if retried

Signed-off-by: Xudong Zhang <felixmelon@gmail.com>

### What this PR does / Why we need it:
Bug fix.

### What is changed and how it works?
Currently, it adds the `$WORKSPACE/` to `FilePath`. And it will add multiple
 times if the job is retried.

### Does this PR introduce a user-facing change?
No.
- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
