### PR TITLE
add env setting ability

### DIFF
--- a/pkg/microservice/aslan/core/build/service/build.go
+++ b/pkg/microservice/aslan/core/build/service/build.go
@@ -155,7 +155,7 @@ func ListBuildModulesByServiceModule(productName string, log *zap.SugaredLogger)
 	return serviceModuleAndBuildResp, nil
 }
 
-func fillBuildRepoData(build *commonmodels.Build) {
+func fillBuildTargetData(build *commonmodels.Build) {
 	if build.TemplateID == "" {
 		return
 	}
@@ -166,6 +166,7 @@ func fillBuildRepoData(build *commonmodels.Build) {
 			ServiceName:   target.Service.ServiceName,
 			ServiceModule: target.Service.ServiceModule,
 			Repos:         target.Repos,
+			Envs:          target.Envs,
 		})
 	}
 }
@@ -381,7 +382,7 @@ func UpdateBuildTargets(name, productName string, targets []*commonmodels.Servic
 }
 
 func correctFields(build *commonmodels.Build) {
-	fillBuildRepoData(build)
+	fillBuildTargetData(build)
 	// make sure cache has no empty field
 	caches := make([]string, 0)
 	for _, cache := range build.Caches {

--- a/pkg/microservice/aslan/core/common/repository/models/build.go
+++ b/pkg/microservice/aslan/core/common/repository/models/build.go
@@ -151,7 +151,8 @@ type ServiceModuleTarget struct {
 	ServiceName   string              `bson:"service_name"                  json:"service_name"`
 	ServiceModule string              `bson:"service_module"                json:"service_module"`
 	BuildName     string              `bson:"build_name"                    json:"build_name"`
-	Repos         []*types.Repository `bson:"repos,omitempty"  json:"repos,omitempty"`
+	Repos         []*types.Repository `bson:"repos,omitempty"               json:"repos,omitempty"`
+	Envs          []*KeyVal           `bson:"envs,omitempty"                json:"envs"`
 }
 
 type ServiceModuleTargetBase struct {
@@ -163,6 +164,7 @@ type ServiceModuleTargetBase struct {
 type TargetRepo struct {
 	Service *ServiceModuleTargetBase `json:"service"`
 	Repos   []*types.Repository      `json:"repos"`
+	Envs    []*KeyVal                `json:"envs"`
 }
 
 type KeyVal struct {

--- a/pkg/microservice/aslan/core/common/repository/mongodb/build.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/build.go
@@ -41,6 +41,7 @@ type BuildListOption struct {
 	BuildOS      string
 	BasicImageID string
 	PrivateKeyID string
+	TemplateID   string
 }
 
 // FindOption ...
@@ -141,6 +142,9 @@ func (c *BuildColl) List(opt *BuildListOption) ([]*models.Build, error) {
 	}
 	if len(opt.PrivateKeyID) != 0 {
 		query["ssh.id"] = opt.PrivateKeyID
+	}
+	if len(opt.TemplateID) != 0 {
+		query["template_id"] = opt.TemplateID
 	}
 
 	var resp []*models.Build

--- a/pkg/microservice/aslan/core/common/service/build.go
+++ b/pkg/microservice/aslan/core/common/service/build.go
@@ -156,6 +156,12 @@ func EnsureResp(build *commonmodels.Build) {
 					ServiceModule: target.ServiceModule,
 				},
 				Repos: target.Repos,
+				Envs:  target.Envs,
+			}
+			for _, v := range targetRepo.Envs {
+				if v.IsCredential {
+					v.Value = setting.MaskValue
+				}
 			}
 			build.TargetRepos = append(build.TargetRepos, targetRepo)
 		}

--- a/pkg/microservice/aslan/core/common/service/build.go
+++ b/pkg/microservice/aslan/core/common/service/build.go
@@ -20,8 +20,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/koderover/zadig/pkg/tool/log"
-
 	"go.uber.org/zap"
 
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
@@ -29,6 +27,7 @@ import (
 	commonutil "github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/pkg/setting"
 	e "github.com/koderover/zadig/pkg/tool/errors"
+	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/koderover/zadig/pkg/types"
 )
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -2080,6 +2080,10 @@ func fillBuildDetail(moduleBuild *commonmodels.Build, serviceName, serviceModule
 	for _, serviceConfig := range moduleBuild.Targets {
 		if serviceConfig.ServiceName == serviceName && serviceConfig.ServiceModule == serviceModule {
 			moduleBuild.Repos = serviceConfig.Repos
+			if moduleBuild.PreBuild == nil {
+				moduleBuild.PreBuild = &commonmodels.PreBuild{}
+			}
+			moduleBuild.PreBuild.Envs = serviceConfig.Envs
 			break
 		}
 	}
@@ -2285,7 +2289,7 @@ func BuildModuleToSubTasks(args *commonmodels.BuildModuleArgs, log *zap.SugaredL
 
 		build.JobCtx.EnvVars = module.PreBuild.Envs
 
-		if len(module.PreBuild.Envs) == 0 {
+		if len(build.JobCtx.EnvVars) == 0 {
 			build.JobCtx.EnvVars = make([]*commonmodels.KeyVal, 0)
 		}
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -2083,7 +2083,7 @@ func fillBuildDetail(moduleBuild *commonmodels.Build, serviceName, serviceModule
 			if moduleBuild.PreBuild == nil {
 				moduleBuild.PreBuild = &commonmodels.PreBuild{}
 			}
-			moduleBuild.PreBuild.Envs = serviceConfig.Envs
+			moduleBuild.PreBuild.Envs = commonservice.MergeBuildEnvs(moduleBuild.PreBuild.Envs, serviceConfig.Envs)
 			break
 		}
 	}


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
add env setting ability for single service in the build modules which are created from global build template

### Does this PR introduce a user-facing change?
yes

- [x] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
