### PR TITLE
fix Clusters can be connected to HubAgent

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/service.go
+++ b/pkg/microservice/aslan/core/common/service/kube/service.go
@@ -240,7 +240,7 @@ func (s *Service) ListConnectedClusters(logger *zap.SugaredLogger) ([]*models.K8
 	return clusters, nil
 }
 
-func (s *Service) GetYaml(id, agentImage, rsImage, aslanURL, hubURI string, useDeployment, upgradeAgent bool, logger *zap.SugaredLogger) ([]byte, error) {
+func (s *Service) GetYaml(id, agentImage, rsImage, aslanURL, hubURI string, useDeployment bool, logger *zap.SugaredLogger) ([]byte, error) {
 	var (
 		cluster *models.K8SCluster
 		err     error
@@ -267,7 +267,7 @@ func (s *Service) GetYaml(id, agentImage, rsImage, aslanURL, hubURI string, useD
 		return nil, err
 	}
 
-	dindReplicas, dindLimitsCPU, dindLimitsMemory := setDindCfg(upgradeAgent, cluster)
+	dindReplicas, dindLimitsCPU, dindLimitsMemory := setDindCfg(cluster)
 
 	if cluster.Namespace == "" {
 		err = YamlTemplate.Execute(buffer, TemplateSchema{
@@ -312,12 +312,12 @@ func (s *Service) UpdateUpgradeAgentInfo(id, updateHubagentErrorMsg string) erro
 	return err
 }
 
-func setDindCfg(upgradeAgent bool, cluster *models.K8SCluster) (int, string, string) {
+func setDindCfg(cluster *models.K8SCluster) (int, string, string) {
 	var dindReplicas int = DefaultDindReplicas
 	var dindLimitsCPU string = strconv.Itoa(DefaultDindLimitsCPU) + setting.CpuUintM
 	var dindLimitsMemory string = strconv.Itoa(DefaultDindLimitsMemory) + setting.MemoryUintMi
 
-	if upgradeAgent && cluster.DindCfg != nil {
+	if cluster.DindCfg != nil {
 		if cluster.DindCfg.Replicas > 0 {
 			dindReplicas = cluster.DindCfg.Replicas
 		}

--- a/pkg/microservice/aslan/core/multicluster/service/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/service/clusters.go
@@ -390,7 +390,7 @@ func ProxyAgent(writer gin.ResponseWriter, request *http.Request) {
 func GetYaml(id, hubURI string, useDeployment bool, logger *zap.SugaredLogger) ([]byte, error) {
 	s, _ := kube.NewService("")
 
-	return s.GetYaml(id, config.HubAgentImage(), config.ResourceServerImage(), configbase.SystemAddress(), hubURI, useDeployment, false, logger)
+	return s.GetYaml(id, config.HubAgentImage(), config.ResourceServerImage(), configbase.SystemAddress(), hubURI, useDeployment, logger)
 }
 
 func UpgradeAgent(id string, logger *zap.SugaredLogger) error {
@@ -411,7 +411,7 @@ func UpgradeAgent(id string, logger *zap.SugaredLogger) error {
 		return fmt.Errorf(" failed to get kube client: %s cluster: %s", err, clusterInfo.Name)
 	}
 
-	yamls, err := s.GetYaml(id, config.HubAgentImage(), config.ResourceServerImage(), configbase.SystemAddress(), "/api/hub", true, true, logger)
+	yamls, err := s.GetYaml(id, config.HubAgentImage(), config.ResourceServerImage(), configbase.SystemAddress(), "/api/hub", true, logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/microservice/hubserver/core/service/service.go
+++ b/pkg/microservice/hubserver/core/service/service.go
@@ -83,14 +83,12 @@ func Authorize(req *http.Request) (clientKey string, authed bool, err error) {
 
 	clusters.Store(cluster.ID.Hex(), input.Cluster)
 
-	if cluster.Status != "normal" {
-		cluster.Status = "normal"
-		cluster.LastConnectionTime = time.Now().Unix()
-		err = mongodb.NewK8sClusterColl().UpdateStatus(cluster)
-		if err != nil {
-			log.Errorf("failed to update clusters status %s %v", cluster.Name, err)
-			return
-		}
+	cluster.Status = "normal"
+	cluster.LastConnectionTime = time.Now().Unix()
+	err = mongodb.NewK8sClusterColl().UpdateStatus(cluster)
+	if err != nil {
+		log.Errorf("failed to update clusters status %s %v", cluster.Name, err)
+		return
 	}
 
 	log.Infof("cluster %s connected", cluster.Name)


### PR DESCRIPTION
Signed-off-by: ddh27 <duandehua@koderover.com>

### What this PR does / Why we need it:
fix Clusters can be connected to HubAgent

### What is changed and how it works?
Keep dind configured by manual apply and auto Apply

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
