### PR TITLE
fixed get scanning task info error

### DIFF
--- a/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
@@ -406,10 +406,15 @@ func GetScanningTaskInfo(scanningID string, taskID int64, log *zap.SugaredLogger
 		return nil, err
 	}
 
-	sonarInfo, err := commonrepo.NewSonarIntegrationColl().GetByID(context.TODO(), scanningInfo.SonarID)
-	if err != nil {
-		log.Errorf("failed to get sonar integration info, error: %s", err)
-		return nil, err
+	resultAddr := ""
+
+	if scanningInfo.ScannerType == "sonarQube" {
+		sonarInfo, err := commonrepo.NewSonarIntegrationColl().GetByID(context.TODO(), scanningInfo.SonarID)
+		if err != nil {
+			log.Errorf("failed to get sonar integration info, error: %s", err)
+			return nil, err
+		}
+		resultAddr = sonarInfo.ServerAddress
 	}
 
 	repoInfo := resp.Stages[0].SubTasks[scanningInfo.Name]
@@ -432,7 +437,7 @@ func GetScanningTaskInfo(scanningID string, taskID int64, log *zap.SugaredLogger
 		CreateTime: resp.CreateTime,
 		EndTime:    resp.EndTime,
 		RepoInfo:   scanningTaskInfo.Repos,
-		ResultLink: sonarInfo.ServerAddress,
+		ResultLink: resultAddr,
 	}, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Min Min <jamsman94@gmail.com>

### What this PR does / Why we need it:
fixed get scanning task info error

### What is changed and how it works?
scanner of type other does not have sonar info , removing it from the main logic


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
