### PR TITLE
Fixed failure to get service instance details due to RenderSet version error

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -283,7 +283,7 @@ func GetService(envName, productName, serviceName string, workLoadType string, l
 			)
 		}
 
-		renderSetFindOpt := &commonrepo.RenderSetFindOption{Name: env.Render.Name, Revision: env.Render.Revision}
+		renderSetFindOpt := &commonrepo.RenderSetFindOption{Name: env.Render.Name, Revision: service.Render.Revision}
 		rs, err := commonrepo.NewRenderSetColl().Find(renderSetFindOpt)
 		if err != nil {
 			log.Errorf("find renderset[%s] error: %v", service.Render.Name, err)


### PR DESCRIPTION
Signed-off-by: ddh27 <duandehua@koderover.com>

### What this PR does / Why we need it:
Fixed failure to get service instance details due to RenderSet version error

### What is changed and how it works?
Fixed failure to get service instance details due to RenderSet version error

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
