### PR TITLE
event first time can be null

### DIFF
--- a/pkg/shared/kube/wrapper/event.go
+++ b/pkg/shared/kube/wrapper/event.go
@@ -43,7 +43,7 @@ func (w *event) Unwrap() *corev1.Event {
 }
 
 func (w *event) Resource() *resource.Event {
-	return &resource.Event{
+	e := &resource.Event{
 		Reason:    w.Reason,
 		Message:   w.Message,
 		FirstSeen: w.FirstTimestamp.Unix(),
@@ -51,4 +51,9 @@ func (w *event) Resource() *resource.Event {
 		Count:     w.Count,
 		Type:      w.Type,
 	}
+	if (w.FirstTimestamp.IsZero() || w.LastTimestamp.IsZero()) && !w.EventTime.IsZero() {
+		e.FirstSeen = w.EventTime.Unix()
+		e.LastSeen = w.EventTime.Unix()
+	}
+	return e
 }


### PR DESCRIPTION
Signed-off-by: mouuii <zhouchengbin@koderover.com>

### What this PR does / Why we need it:
event schedule first time can be null ,use event time instead
ref：https://github.com/kubernetes/kubernetes/issues/90482

### What is changed and how it works?
schedule time use the event time

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
