### PR TITLE
Modify the parameters for refreshing the access token

### DIFF
--- a/pkg/tool/git/gitlab/client.go
+++ b/pkg/tool/git/gitlab/client.go
@@ -65,7 +65,7 @@ func NewClient(id int, address, accessToken, proxyAddr string, enableProxy bool)
 		ch, err := systemconfig.New().GetCodeHost(id)
 		// The normal expiration time is 7200
 		if err == nil && (time.Now().Unix()-ch.UpdatedAt) >= 7000 {
-			token, err := refreshAccessToken(ch.Address, ch.AccessKey, ch.RefreshToken)
+			token, err := refreshAccessToken(ch.Address, ch.AccessKey, ch.SecretKey, ch.RefreshToken)
 			if err == nil {
 				accessToken = token.AccessToken
 				ch.AccessToken = token.AccessToken
@@ -154,16 +154,16 @@ type AccessToken struct {
 	CreatedAt    int    `json:"created_at"`
 }
 
-func refreshAccessToken(address, clientID, refreshToken string) (*AccessToken, error) {
+func refreshAccessToken(address, clientID, clientSecret, refreshToken string) (*AccessToken, error) {
 	httpClient := httpclient.New(
 		httpclient.SetHostURL(address),
 	)
 	url := "/oauth/token"
 	queryParams := make(map[string]string)
 	queryParams["grant_type"] = "refresh_token"
-	queryParams["code_verifier"] = "CODE_VERIFIER"
 	queryParams["refresh_token"] = refreshToken
 	queryParams["client_id"] = clientID
+	queryParams["client_secret"] = clientSecret
 
 	var accessToken *AccessToken
 	_, err := httpClient.Post(url, httpclient.SetQueryParams(queryParams), httpclient.SetResult(&accessToken))


### PR DESCRIPTION
Signed-off-by: liu deyi <andrew@koderover.com>

### What this PR does / Why we need it:
cherry pick from url : https://github.com/koderover/zadig/pull/1637

### What is changed and how it works?
Modify the parameters for refreshing the token

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
