### PR TITLE
fix bug of querying subenvs which are not related projects

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/share_env.go
+++ b/pkg/microservice/aslan/core/environment/service/share_env.go
@@ -162,7 +162,7 @@ func DisableBaseEnv(ctx context.Context, envName, productName string) error {
 	}
 
 	// 1. Delete all associated subenvironments.
-	err = ensureDeleteAssociatedEnvs(ctx, prod.EnvName)
+	err = ensureDeleteAssociatedEnvs(ctx, prod)
 	if err != nil {
 		return fmt.Errorf("failed to delete associated subenvironments of base ns `%s`: %s", ns, err)
 	}
@@ -460,6 +460,7 @@ func ensureVirtualService(ctx context.Context, kclient client.Client, istioClien
 	matchedEnvs := []MatchedEnv{}
 	if env.ShareEnv.Enable && env.ShareEnv.IsBase {
 		subEnvs, err := commonrepo.NewProductColl().List(&commonrepo.ProductListOptions{
+			Name:            env.ProductName,
 			ShareEnvEnable:  zadigutil.GetBoolPointer(true),
 			ShareEnvIsBase:  zadigutil.GetBoolPointer(false),
 			ShareEnvBaseEnv: zadigutil.GetStrPointer(env.EnvName),
@@ -1168,7 +1169,7 @@ func EnsureDeleteShareEnvConfig(ctx context.Context, env *commonmodels.Product, 
 
 	if env.ShareEnv.IsBase {
 		// 1. Delete all associated subenvironments.
-		err := ensureDeleteAssociatedEnvs(ctx, env.EnvName)
+		err := ensureDeleteAssociatedEnvs(ctx, env)
 		if err != nil {
 			return err
 		}

--- a/pkg/microservice/aslan/core/environment/service/share_env_utils.go
+++ b/pkg/microservice/aslan/core/environment/service/share_env_utils.go
@@ -63,11 +63,12 @@ func ensureDisableBaseEnvConfig(ctx context.Context, baseEnv *commonmodels.Produ
 	return commonrepo.NewProductColl().Update(baseEnv)
 }
 
-func ensureDeleteAssociatedEnvs(ctx context.Context, baseEnvName string) error {
+func ensureDeleteAssociatedEnvs(ctx context.Context, baseProduct *commonmodels.Product) error {
 	envs, err := commonrepo.NewProductColl().List(&commonrepo.ProductListOptions{
+		Name:            baseProduct.ProductName,
 		ShareEnvEnable:  zadigutil.GetBoolPointer(true),
 		ShareEnvIsBase:  zadigutil.GetBoolPointer(false),
-		ShareEnvBaseEnv: zadigutil.GetStrPointer(baseEnvName),
+		ShareEnvBaseEnv: zadigutil.GetStrPointer(baseProduct.EnvName),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

Currently, when deleting a subenvironment associated with the base environment, subenvironments which does not belong to the project are mistakenly selected. As a result, deleting a subenvironment does not meet the expectation.

### What is changed and how it works?

When deleting subenvironments associated with the base environment, add an project name as a filter.


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
