### PR TITLE
add image filter logic when creating versions

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/helm.go
+++ b/pkg/microservice/aslan/core/environment/service/helm.go
@@ -24,8 +24,6 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"github.com/hashicorp/go-multierror"
 	"github.com/otiai10/copy"
 	"github.com/pkg/errors"
@@ -34,6 +32,7 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
@@ -140,7 +139,7 @@ func getReleaseStatus(re *release.Release) ReleaseStatus {
 type ImageData struct {
 	ImageName string `json:"imageName"`
 	ImageTag  string `json:"imageTag"`
-	HasBuild  bool   `json:"hasBuild"`
+	Selected  bool   `json:"selected"`
 }
 
 type ServiceImages struct {


### PR DESCRIPTION
### What this PR does / Why we need it:
add ability to select images since some images may not need to be retaged and pushed when creating delivery version for helm services

### Does this PR introduce a user-facing change?
yes

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
