### PR TITLE
fix error return deleting all svcs from environment

### DIFF
--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -569,7 +569,7 @@ func GetProductUsedTemplateSvcs(prod *models.Product) ([]*models.Service, error)
 	}
 	templateServices, err := commonrepo.NewServiceColl().ListServicesWithSRevision(listOpt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list template services for pruduct: %s:%s, er: %s", productName, envName, err)
+		return nil, fmt.Errorf("failed to list template services for pruduct: %s:%s, err: %s", productName, envName, err)
 	}
 	return templateServices, err
 }

--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -554,6 +554,9 @@ func findServiceFromIngress(hostInfos []resource.HostInfo, currentWorkload *Work
 func GetProductUsedTemplateSvcs(prod *models.Product) ([]*models.Service, error) {
 	// filter releases, only list releases deployed by zadig
 	productName, envName, serviceMap := prod.ProductName, prod.EnvName, prod.GetServiceMap()
+	if len(serviceMap) == 0 {
+		return nil, nil
+	}
 	listOpt := &commonrepo.SvcRevisionListOption{
 		ProductName:      prod.ProductName,
 		ServiceRevisions: make([]*commonrepo.ServiceRevision, 0),
@@ -566,7 +569,7 @@ func GetProductUsedTemplateSvcs(prod *models.Product) ([]*models.Service, error)
 	}
 	templateServices, err := commonrepo.NewServiceColl().ListServicesWithSRevision(listOpt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list template services for pruduct: %s:%s", productName, envName)
+		return nil, fmt.Errorf("failed to list template services for pruduct: %s:%s, er: %s", productName, envName, err)
 	}
 	return templateServices, err
 }


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when all services in some environment are deleted, an unexpected error will be returned due to 'failed to query services deployed in environment'

### What is changed and how it works?
fix bug

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
