### PR TITLE
add resource limit for multi-service demo template

### DIFF
--- a/examples/multi-service-demo/k8s-yaml/template.yaml
+++ b/examples/multi-service-demo/k8s-yaml/template.yaml
@@ -26,6 +26,10 @@ spec:
           ports:
             - protocol: TCP
               containerPort: {{.port}}
+          resources:
+            limits:
+              memory: {{.memoryLimit}}
+              cpu: {{.cpuLimit}}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Signed-off-by: fansi <fansiqiong@koderover.com>

### What this PR does / Why we need it:

missing the resource limit config for multi-service-demo template

ref PR: https://github.com/koderover/zadig/pull/1662


### What is changed and how it works?

add resource limit for multi-service-demo template

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
