### PR TITLE
support debug container based on EphemeralContainers

### DIFF
--- a/pkg/microservice/aslan/core/environment/handler/debug.go
+++ b/pkg/microservice/aslan/core/environment/handler/debug.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/environment/service"
+	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
+	"github.com/koderover/zadig/pkg/types"
+)
+
+func PatchDebugContainer(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	envName := c.Param("env")
+	podName := c.Param("podName")
+	projectName := c.Query("projectName")
+	debugImage := c.Query("debugImage")
+	if debugImage == "" {
+		debugImage = types.DebugImage
+	}
+
+	ctx.Err = service.PatchDebugContainer(c, projectName, envName, podName, debugImage)
+}

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -107,6 +107,8 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		kube.GET("/pods/:podName/events", ListPodEvents)
 		kube.GET("/workloads", ListWorkloads)
 		kube.GET("/nodes", ListNodes)
+
+		kube.POST("/:env/pods/:podName/debugcontainer", PatchDebugContainer)
 	}
 
 	// ---------------------------------------------------------------------------------------

--- a/pkg/microservice/aslan/core/environment/service/debug.go
+++ b/pkg/microservice/aslan/core/environment/service/debug.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2022 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
+	kubeclient "github.com/koderover/zadig/pkg/shared/kube/client"
+)
+
+const ZadigDebugContainerName = "zadig-debug"
+const K8sBetaVersionForEphemeralContainer = "v1.23"
+
+func PatchDebugContainer(ctx context.Context, projectName, envName, podName, debugImage string) error {
+	prod, err := commonrepo.NewProductColl().Find(&commonrepo.ProductFindOptions{
+		Name:    projectName,
+		EnvName: envName,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to query env %q in project %q: %s", envName, projectName, err)
+	}
+
+	clusterID := prod.ClusterID
+	ns := prod.Namespace
+
+	kclient, err := kubeclient.GetKubeClient(config.HubServerAddress(), clusterID)
+	if err != nil {
+		return fmt.Errorf("failed to get kube client: %s", err)
+	}
+
+	clientset, err := kubeclient.GetKubeClientSet(config.HubServerAddress(), clusterID)
+	if err != nil {
+		return fmt.Errorf("failed to get kube clientset: %s", err)
+	}
+
+	restConfig, err := kubeclient.GetRESTConfig(config.HubServerAddress(), clusterID)
+	if err != nil {
+		return fmt.Errorf("failed to get rest config: %s", err)
+	}
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("failed to get discovery client: %s", err)
+	}
+
+	pod := &corev1.Pod{}
+	err = kclient.Get(ctx, client.ObjectKey{
+		Name:      podName,
+		Namespace: ns,
+	}, pod)
+	if err != nil {
+		return fmt.Errorf("failed to get pod %q in ns %q: %s", podName, ns, err)
+	}
+
+	k8sVersion, err := checkK8sVersion(discoveryClient)
+	if err != nil {
+		return fmt.Errorf("failed to check K8s version: %s", err)
+	}
+
+	debugContainer := genDebugContainer(debugImage)
+	if version.CompareKubeAwareVersionStrings(K8sBetaVersionForEphemeralContainer, k8sVersion) < 0 {
+		_, _, err = debugByEphemeralContainerLegacy(ctx, clientset.CoreV1(), pod, debugContainer)
+	} else {
+		_, _, err = debugByEphemeralContainer(ctx, clientset.CoreV1(), pod, debugContainer)
+	}
+
+	return err
+}
+
+func checkK8sVersion(client *discovery.DiscoveryClient) (string, error) {
+	serverInfo, err := client.ServerVersion()
+	if err != nil {
+		return "", err
+	}
+
+	// Examples: v1.23.3, v1.20.6-tke.16
+	items := strings.Split(serverInfo.GitVersion, ".")
+	if len(items) < 2 {
+		return "", fmt.Errorf("invalid server version format %q", serverInfo.GitVersion)
+	}
+
+	return fmt.Sprintf("%s.%s", items[0], items[1]), nil
+}
+
+func genDebugContainer(imageName string) *corev1.EphemeralContainer {
+	return &corev1.EphemeralContainer{
+		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+			Name:                     ZadigDebugContainerName,
+			Image:                    imageName,
+			Command:                  []string{"tail", "-f", "/dev/null"},
+			ImagePullPolicy:          corev1.PullAlways,
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		},
+	}
+}
+
+func debugByEphemeralContainerLegacy(ctx context.Context, podClient corev1client.CoreV1Interface, pod *corev1.Pod,
+	debugContainer *corev1.EphemeralContainer) (*corev1.Pod, string, error) {
+
+	patch, err := json.Marshal([]map[string]interface{}{{
+		"op":    "add",
+		"path":  "/ephemeralContainers/-",
+		"value": debugContainer,
+	}})
+	if err != nil {
+		return nil, "", fmt.Errorf("error creating JSON 6902 patch for old /ephemeralcontainers API: %s", err)
+	}
+
+	result := podClient.RESTClient().Patch(types.JSONPatchType).
+		Namespace(pod.Namespace).
+		Resource("pods").
+		Name(pod.Name).
+		SubResource("ephemeralcontainers").
+		Body(patch).
+		Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, "", err
+	}
+
+	newPod, err := podClient.Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, "", err
+	}
+
+	return newPod, debugContainer.Name, nil
+}
+
+func debugByEphemeralContainer(ctx context.Context, podClient corev1client.CoreV1Interface, pod *corev1.Pod,
+	debugContainer *corev1.EphemeralContainer) (*corev1.Pod, string, error) {
+	podJS, err := json.Marshal(pod)
+	if err != nil {
+		return nil, "", fmt.Errorf("error creating JSON for pod: %v", err)
+	}
+
+	debugPod := pod.DeepCopy()
+	debugPod.Spec.EphemeralContainers = append(debugPod.Spec.EphemeralContainers, *debugContainer)
+	debugJS, err := json.Marshal(debugPod)
+	if err != nil {
+		return nil, "", fmt.Errorf("error creating JSON for debug container: %v", err)
+	}
+
+	patch, err := strategicpatch.CreateTwoWayMergePatch(podJS, debugJS, pod)
+	if err != nil {
+		return nil, "", fmt.Errorf("error creating patch to add debug container: %v", err)
+	}
+
+	pods := podClient.Pods(pod.Namespace)
+	result, err := pods.Patch(ctx, pod.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "ephemeralcontainers")
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to patch: %s", err)
+	}
+
+	return result, debugContainer.Name, nil
+}

--- a/pkg/microservice/aslan/core/environment/service/ide.go
+++ b/pkg/microservice/aslan/core/environment/service/ide.go
@@ -422,7 +422,6 @@ func recoverWorkload(ctx context.Context, kclient client.Client, selector labels
 			return err
 		}
 	case types.StatefulSetWorkload:
-		log.Infof("[ZADIG]Begin to recover statefulset: %s", selector.String())
 		err := recoverStatefulSet(ctx, kclient, selector, ns)
 		if err != nil {
 			return err

--- a/pkg/microservice/aslan/core/multicluster/handler/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/handler/clusters.go
@@ -150,3 +150,10 @@ func UpgradeAgent(c *gin.Context) {
 
 	ctx.Err = service.UpgradeAgent(c.Param("id"), ctx.Logger)
 }
+
+func CheckEphemeralContainers(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	ctx.Resp, ctx.Err = service.CheckEphemeralContainers(c, c.Param("id"))
+}

--- a/pkg/microservice/aslan/core/multicluster/handler/router.go
+++ b/pkg/microservice/aslan/core/multicluster/handler/router.go
@@ -54,4 +54,6 @@ func (*Router) Inject(router *gin.RouterGroup) {
 
 	router.GET("/:id/storageclasses", ListStorageClasses)
 	router.GET("/:id/:namespace/pvcs", ListPVCs)
+
+	router.GET("/:id/check/ephemeralcontainers", CheckEphemeralContainers)
 }

--- a/pkg/microservice/policy/core/yamlconfig/metas.yaml
+++ b/pkg/microservice/policy/core/yamlconfig/metas.yaml
@@ -688,6 +688,8 @@ metas:
         rules:
           - method: GET
             endpoint: '/api/podexec/?*/?*/?*/?*/podExec/:name'
+          - method: POST
+            endpoint: '/api/aslan/environment/kube/:name/pods/?*/debugcontainer'
       - action: ssh_pm
         alias: 主机登录
         description: ''

--- a/pkg/shared/kube/wrapper/deployment.go
+++ b/pkg/shared/kube/wrapper/deployment.go
@@ -57,6 +57,7 @@ func (w *deployment) WorkloadResource(pods []*corev1.Pod) *resource.Workload {
 		Pods:     make([]*resource.Pod, 0, len(pods)),
 	}
 
+	// Note: EphemeralContainers only belong to Pods and do not exist in Deployment Spec.
 	for _, c := range w.Spec.Template.Spec.Containers {
 		wl.Images = append(wl.Images, resource.ContainerImage{Name: c.Name, Image: c.Image, ImageName: util.ExtractImageName(c.Image)})
 	}

--- a/pkg/shared/kube/wrapper/pod.go
+++ b/pkg/shared/kube/wrapper/pod.go
@@ -133,7 +133,13 @@ func (w *pod) Resource() *resource.Pod {
 		p.Kind = w.OwnerReferences[0].Kind
 	}
 
-	for _, container := range w.Status.ContainerStatuses {
+	containersStatus := []corev1.ContainerStatus{}
+	containersStatus = append(containersStatus, w.Status.ContainerStatuses...)
+	if checkEphemeralContainerStatusFieldExist(&w.Status) {
+		containersStatus = append(containersStatus, w.Status.EphemeralContainerStatuses...)
+	}
+
+	for _, container := range containersStatus {
 		cs := resource.Container{
 			Name:         container.Name,
 			RestartCount: container.RestartCount,
@@ -173,6 +179,22 @@ func (w *pod) Resource() *resource.Pod {
 			}
 		}
 		p.ContainerStatuses = append(p.ContainerStatuses, cs)
+	}
+
+	// Note: Seems that in K8s versions [v1.16, v1.22], EphemeralContainerStatuses exist but are empty while in K8s versions
+	// [v1.23, ], EphemeralContainerStatuses exist and are not empty.
+	if checkEphemeralContainerStatusFieldExist(&w.Status) && len(w.Status.EphemeralContainerStatuses) == 0 &&
+		checkEphemeralContainerFieldExist(&w.Spec) {
+		for _, container := range w.Spec.EphemeralContainers {
+			cs := resource.Container{
+				Name:         container.Name,
+				Image:        container.Image,
+				RestartCount: 0,
+				Status:       "running",
+			}
+
+			p.ContainerStatuses = append(p.ContainerStatuses, cs)
+		}
 	}
 
 	if w.DeletionTimestamp != nil {

--- a/pkg/shared/kube/wrapper/statefulset.go
+++ b/pkg/shared/kube/wrapper/statefulset.go
@@ -56,6 +56,7 @@ func (w *statefulSet) WorkloadResource(pods []*corev1.Pod) *resource.Workload {
 		Pods:     make([]*resource.Pod, 0, len(pods)),
 	}
 
+	// Note: EphemeralContainers only belong to Pods and do not exist in Deployment Spec.
 	for _, c := range w.Spec.Template.Spec.Containers {
 		wl.Images = append(wl.Images, resource.ContainerImage{Name: c.Name, Image: c.Image})
 	}

--- a/pkg/shared/kube/wrapper/utils.go
+++ b/pkg/shared/kube/wrapper/utils.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,13 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package types
+package wrapper
 
-type EnvType string
+import (
+	"reflect"
 
-const (
-	GeneralEnv EnvType = "general"
-	ShareEnv   EnvType = "share"
+	corev1 "k8s.io/api/core/v1"
 )
 
-const DebugImage = "ccr.ccs.tencentyun.com/koderover-public/zadig-debug:v0.1.0"
+func checkEphemeralContainerFieldExist(podSpec *corev1.PodSpec) bool {
+	metaValue := reflect.ValueOf(podSpec).Elem()
+	return metaValue.FieldByName("EphemeralContainers") != (reflect.Value{})
+}
+
+func checkEphemeralContainerStatusFieldExist(podStatus *corev1.PodStatus) bool {
+	metaValue := reflect.ValueOf(podStatus).Elem()
+	return metaValue.FieldByName("EphemeralContainerStatuses") != (reflect.Value{})
+}


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

Provides convenient and diversified debug functions for users.

### What is changed and how it works?

Inject debug containers into pods base on `EphemeralContainers` of K8s.

### Does this PR introduce a user-facing change?

- [x] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
