### PR TITLE
added dind custom image support for external clusters

### DIFF
--- a/pkg/microservice/aslan/config/config.go
+++ b/pkg/microservice/aslan/config/config.go
@@ -249,3 +249,7 @@ func ServiceNameWithRevision(serviceName string, revision int64) string {
 func ServiceAccountNameForUser(userID string) string {
 	return fmt.Sprintf("%s-sa", userID)
 }
+
+func DindImage() string {
+	return viper.GetString(setting.DindImage)
+}

--- a/pkg/microservice/aslan/core/common/service/kube/service.go
+++ b/pkg/microservice/aslan/core/common/service/kube/service.go
@@ -280,6 +280,7 @@ func (s *Service) GetYaml(id, agentImage, rsImage, aslanURL, hubURI string, useD
 			DindReplicas:        dindReplicas,
 			DindLimitsCPU:       dindLimitsCPU,
 			DindLimitsMemory:    dindLimitsMemory,
+			DindImage:           config.DindImage(),
 		})
 	} else {
 		err = YamlTemplateForNamespace.Execute(buffer, TemplateSchema{
@@ -293,6 +294,7 @@ func (s *Service) GetYaml(id, agentImage, rsImage, aslanURL, hubURI string, useD
 			DindReplicas:        dindReplicas,
 			DindLimitsCPU:       dindLimitsCPU,
 			DindLimitsMemory:    dindLimitsMemory,
+			DindImage:           config.DindImage(),
 		})
 	}
 
@@ -345,6 +347,7 @@ type TemplateSchema struct {
 	DindReplicas        int
 	DindLimitsCPU       string
 	DindLimitsMemory    string
+	DindImage           string
 }
 
 const (
@@ -573,7 +576,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
       containers:
         - name: dind
-          image: ccr.ccs.tencentyun.com/koderover-public/docker:20.10.14-dind
+          image: {{.DindImage}}
           args:
             - --mtu=1376
           env:
@@ -825,7 +828,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
       containers:
         - name: dind
-          image: ccr.ccs.tencentyun.com/koderover-public/docker:20.10.14-dind
+          image: {{.DindImage}}
           args:
             - --mtu=1376
           env:

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -104,6 +104,9 @@ const (
 	// jenkins
 	JenkinsBuildImage = "JENKINS_BUILD_IMAGE"
 
+	// dind
+	DindImage = "DIND_IMAGE"
+
 	DebugMode   = "debug"
 	ReleaseMode = "release"
 	TestMode    = "test"


### PR DESCRIPTION
Signed-off-by: Min Min <minmin@koderover.com>

### What this PR does / Why we need it:
added dind custom image support for external clusters

### What is changed and how it works?
- Now the agent.yaml generation process will get the customized dind image instead of using a static value.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
