### PR TITLE
support validating ephemeralcontainers in podexec

### DIFF
--- a/pkg/shared/kube/wrapper/pod.go
+++ b/pkg/shared/kube/wrapper/pod.go
@@ -135,7 +135,7 @@ func (w *pod) Resource() *resource.Pod {
 
 	containersStatus := []corev1.ContainerStatus{}
 	containersStatus = append(containersStatus, w.Status.ContainerStatuses...)
-	if checkEphemeralContainerStatusFieldExist(&w.Status) {
+	if CheckEphemeralContainerStatusFieldExist(&w.Status) {
 		containersStatus = append(containersStatus, w.Status.EphemeralContainerStatuses...)
 	}
 
@@ -183,8 +183,8 @@ func (w *pod) Resource() *resource.Pod {
 
 	// Note: Seems that in K8s versions [v1.16, v1.22], EphemeralContainerStatuses exist but are empty while in K8s versions
 	// [v1.23, ], EphemeralContainerStatuses exist and are not empty.
-	if checkEphemeralContainerStatusFieldExist(&w.Status) && len(w.Status.EphemeralContainerStatuses) == 0 &&
-		checkEphemeralContainerFieldExist(&w.Spec) {
+	if CheckEphemeralContainerStatusFieldExist(&w.Status) && len(w.Status.EphemeralContainerStatuses) == 0 &&
+		CheckEphemeralContainerFieldExist(&w.Spec) {
 		for _, container := range w.Spec.EphemeralContainers {
 			cs := resource.Container{
 				Name:         container.Name,

--- a/pkg/shared/kube/wrapper/utils.go
+++ b/pkg/shared/kube/wrapper/utils.go
@@ -22,12 +22,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func checkEphemeralContainerFieldExist(podSpec *corev1.PodSpec) bool {
+func CheckEphemeralContainerFieldExist(podSpec *corev1.PodSpec) bool {
 	metaValue := reflect.ValueOf(podSpec).Elem()
 	return metaValue.FieldByName("EphemeralContainers") != (reflect.Value{})
 }
 
-func checkEphemeralContainerStatusFieldExist(podStatus *corev1.PodStatus) bool {
+func CheckEphemeralContainerStatusFieldExist(podStatus *corev1.PodStatus) bool {
 	metaValue := reflect.ValueOf(podStatus).Elem()
 	return metaValue.FieldByName("EphemeralContainerStatuses") != (reflect.Value{})
 }


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

`EphemeralContainers` are not validated for the existence of the container when users debug through Portal.

### What is changed and how it works?

When users debug through Portal, validate existence of the container against `.spec.conainers` and `.spec.ephemeralContainers` of Pod.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
