### PR TITLE
add enable_debug_container field when listing workload info

### DIFF
--- a/pkg/shared/kube/resource/pod.go
+++ b/pkg/shared/kube/resource/pod.go
@@ -17,16 +17,17 @@ limitations under the License.
 package resource
 
 type Pod struct {
-	Kind              string            `json:"kind"`
-	Name              string            `json:"name"`
-	Status            string            `json:"status"`
-	Age               string            `json:"age"`
-	CreateTime        int64             `json:"createtime"`
-	IP                string            `json:"ip"`
-	Labels            map[string]string `json:"labels"`
-	ContainerStatuses []Container       `json:"containers"`
-	NodeName          string            `json:"node_name"`
-	HostIP            string            `json:"host_ip"`
+	Kind                 string            `json:"kind"`
+	Name                 string            `json:"name"`
+	Status               string            `json:"status"`
+	Age                  string            `json:"age"`
+	CreateTime           int64             `json:"createtime"`
+	IP                   string            `json:"ip"`
+	Labels               map[string]string `json:"labels"`
+	ContainerStatuses    []Container       `json:"containers"`
+	NodeName             string            `json:"node_name"`
+	HostIP               string            `json:"host_ip"`
+	EnableDebugContainer bool              `json:"enable_debug_container"`
 }
 
 type Container struct {

--- a/pkg/shared/kube/wrapper/pod.go
+++ b/pkg/shared/kube/wrapper/pod.go
@@ -210,5 +210,9 @@ func (w *pod) Resource() *resource.Pod {
 		}
 	}
 
+	if CheckEphemeralContainerFieldExist(&w.Spec) && len(w.Spec.EphemeralContainers) > 0 {
+		p.EnableDebugContainer = true
+	}
+
 	return p
 }


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

To provide a better user experience, we need to specify in the API whether the Pod should be injected with debug container.

### What is changed and how it works?

Add `enable_debug_container` field when listing workload info.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
