### PR TITLE
fix resource label miss bug

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/common_env_cfg.go
+++ b/pkg/microservice/aslan/core/environment/service/common_env_cfg.go
@@ -20,11 +20,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/microservice/aslan/core/environment/service/configmap.go
+++ b/pkg/microservice/aslan/core/environment/service/configmap.go
@@ -239,6 +239,12 @@ func UpdateConfigMap(args *UpdateCommonEnvCfgArgs, userName, userID string, log 
 		log.Errorf("failed to create kubernetes clientset for clusterID: %s, the error is: %s", product.ClusterID, err)
 		return e.ErrUpdateConfigMap.AddErr(err)
 	}
+
+	yamlData, err := ensureLabel(&cm.ObjectMeta, args.ProductName)
+	if err != nil {
+		return e.ErrUpdateResource.AddErr(err)
+	}
+
 	if err := updater.UpdateConfigMap(namespace, cm, clientset); err != nil {
 		log.Error(err)
 		return e.ErrUpdateConfigMap.AddDesc(err.Error())
@@ -248,7 +254,7 @@ func UpdateConfigMap(args *UpdateCommonEnvCfgArgs, userName, userID string, log 
 		UpdateUserName: userName,
 		EnvName:        args.EnvName,
 		Name:           cm.Name,
-		YamlData:       args.YamlData,
+		YamlData:       yamlData,
 	}
 	if err := commonrepo.NewConfigMapColl().Create(envcm, true); err != nil {
 		return e.ErrUpdateConfigMap.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/environment/service/configmap.go
+++ b/pkg/microservice/aslan/core/environment/service/configmap.go
@@ -199,6 +199,10 @@ func ListConfigMaps(args *ListConfigMapArgs, log *zap.SugaredLogger) ([]*ListCon
 		}(cmElem)
 	}
 	wg.Wait()
+
+	sort.SliceStable(res, func(i, j int) bool {
+		return res[i].CmName < res[j].CmName
+	})
 	return res, nil
 }
 
@@ -240,7 +244,7 @@ func UpdateConfigMap(args *UpdateCommonEnvCfgArgs, userName, userID string, log 
 		return e.ErrUpdateConfigMap.AddErr(err)
 	}
 
-	yamlData, err := ensureLabel(&cm.ObjectMeta, args.ProductName)
+	yamlData, err := ensureLabel(cm, args.ProductName)
 	if err != nil {
 		return e.ErrUpdateResource.AddErr(err)
 	}

--- a/pkg/microservice/aslan/core/environment/service/ingress.go
+++ b/pkg/microservice/aslan/core/environment/service/ingress.go
@@ -19,6 +19,7 @@ package service
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -170,6 +171,9 @@ func ListIngresses(envName, productName string, log *zap.SugaredLogger) ([]*List
 			res = append(res, resElem)
 		}
 	}
+	sort.SliceStable(res, func(i, j int) bool {
+		return res[i].IngressName < res[j].IngressName
+	})
 	return res, nil
 }
 

--- a/pkg/microservice/aslan/core/environment/service/pvc.go
+++ b/pkg/microservice/aslan/core/environment/service/pvc.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"encoding/json"
+	"sort"
 	"sync"
 	"time"
 
@@ -142,6 +143,9 @@ func ListPvcs(envName, productName string, log *zap.SugaredLogger) ([]*ListPvcsR
 		}(pvcElem)
 	}
 	wg.Wait()
+	sort.SliceStable(res, func(i, j int) bool {
+		return res[i].PvcName < res[j].PvcName
+	})
 	return res, nil
 }
 

--- a/pkg/microservice/aslan/core/environment/service/secret.go
+++ b/pkg/microservice/aslan/core/environment/service/secret.go
@@ -144,6 +144,12 @@ func UpdateSecret(args *UpdateCommonEnvCfgArgs, userName, userID string, log *za
 		return e.ErrUpdateResource.AddErr(err)
 	}
 	secret.Namespace = product.Namespace
+
+	yamlData, err := ensureLabel(&secret.ObjectMeta, args.ProductName)
+	if err != nil {
+		return e.ErrUpdateResource.AddErr(err)
+	}
+
 	err = updater.UpdateOrCreateSecret(secret, kubeClient)
 	if err != nil {
 		log.Error(err)
@@ -154,7 +160,7 @@ func UpdateSecret(args *UpdateCommonEnvCfgArgs, userName, userID string, log *za
 		UpdateUserName: userName,
 		EnvName:        args.EnvName,
 		Name:           secret.Name,
-		YamlData:       args.YamlData,
+		YamlData:       yamlData,
 	}
 	if commonrepo.NewSecretColl().Create(envSecret, true) != nil {
 		return e.ErrUpdateResource.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/environment/service/secret.go
+++ b/pkg/microservice/aslan/core/environment/service/secret.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"encoding/json"
+	"sort"
 	"sync"
 	"time"
 
@@ -117,6 +118,9 @@ func ListSecrets(envName, productName string, log *zap.SugaredLogger) ([]*ListSe
 		}(secret)
 	}
 	wg.Wait()
+	sort.SliceStable(res, func(i, j int) bool {
+		return res[i].SecretName < res[j].SecretName
+	})
 	return res, nil
 }
 
@@ -145,7 +149,7 @@ func UpdateSecret(args *UpdateCommonEnvCfgArgs, userName, userID string, log *za
 	}
 	secret.Namespace = product.Namespace
 
-	yamlData, err := ensureLabel(&secret.ObjectMeta, args.ProductName)
+	yamlData, err := ensureLabel(secret, args.ProductName)
 	if err != nil {
 		return e.ErrUpdateResource.AddErr(err)
 	}


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when creating secrets/configmap resources from environment manage page, the lable 's-product' may be missing in some revisions

### What is changed and how it works?
fix bug

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
