### PR TITLE
check whether user has canceled task when touching msg

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskcontroller/task_handler.go
+++ b/pkg/microservice/warpdrive/core/service/taskcontroller/task_handler.go
@@ -82,18 +82,23 @@ func (h *ExecHandler) HandleMessage(message *nsq.Message) error {
 	xl = Logger(pipelineTask)
 	ctx, cancel = context.WithCancel(context.Background())
 
-	go func(taskName string) {
+	go func(ctx context.Context, taskName string) {
 		for {
-			if pipelineTask == nil {
-				xl.Infof("Pipeline task %q has completed. Exit.", taskName)
-				break
-			}
+			select {
+			case <-ctx.Done():
+				xl.Infof("Pipeline task %q has been canceled. Exit.", taskName)
+				return
+			case <-time.After(durationTouchMsg):
+				if pipelineTask == nil {
+					xl.Infof("Pipeline task %q has completed. Exit.", taskName)
+					return
+				}
 
-			<-time.After(durationTouchMsg)
-			xl.Infof("After %s, touch message %q.", durationTouchMsg.String(), taskName)
-			message.Touch()
+				xl.Infof("After %s, touch message %q.", durationTouchMsg.String(), taskName)
+				message.Touch()
+			}
 		}
-	}(taskName)
+	}(ctx, taskName)
 
 	h.runPipelineTask(ctx, cancel, xl)
 


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

When executing touching message, user may have canceled the task, and the status needs to be detected in time.

### What is changed and how it works?

Add cancellation handling to touch message and check if the task has been canceled before sending touch message.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
