### PR TITLE
add EphemeralContainer image info when listing workloads

### DIFF
--- a/pkg/shared/kube/wrapper/pod.go
+++ b/pkg/shared/kube/wrapper/pod.go
@@ -178,6 +178,16 @@ func (w *pod) Resource() *resource.Pod {
 				break
 			}
 		}
+
+		if CheckEphemeralContainerFieldExist(&w.Spec) {
+			for _, specContainer := range w.Spec.EphemeralContainers {
+				if specContainer.Name == container.Name {
+					cs.Image = specContainer.Image
+					break
+				}
+			}
+		}
+
 		p.ContainerStatuses = append(p.ContainerStatuses, cs)
 	}
 


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

When listing workloads, images of EphemeralContainers have not been returned.

### What is changed and how it works?

Return images of EphemeralContainers when listing workloads.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
