### PR TITLE
fix registry error when running workflows

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -858,12 +858,6 @@ func CreateWorkflowTask(args *commonmodels.WorkflowTaskArgs, taskCreator string,
 			return nil, e.ErrCreateTask.AddDesc(err.Error())
 		}
 
-		err = SetCandidateRegistry(configPayload, log)
-		if err != nil {
-			log.Errorf("workflow_task setCandidateRegistry configPayload:[%v] err:%v", configPayload, err)
-			return nil, err
-		}
-
 		AddSubtaskToStage(&stages, testSubTask, testTask.TestModuleName)
 	}
 
@@ -1991,13 +1985,6 @@ func CreateArtifactWorkflowTask(args *commonmodels.WorkflowTaskArgs, taskCreator
 			log.Errorf("workflow_task ToSubTask err:%v", err)
 			return nil, e.ErrCreateTask.AddDesc(err.Error())
 		}
-
-		err = SetCandidateRegistry(configPayload, log)
-		if err != nil {
-			log.Errorf("workflow_task setCandidateRegistry configPayload:[%v] err:%v", configPayload, err)
-			return nil, err
-		}
-
 		AddSubtaskToStage(&stages, testSubTask, testTask.TestModuleName)
 	}
 
@@ -2709,17 +2696,11 @@ func ensurePipelineTask(taskOpt *taskmodels.TaskOpt, log *zap.SugaredLogger) err
 					}
 				}
 
-				err = SetCandidateRegistry(taskOpt.Task.ConfigPayload, log)
-				if err != nil {
-					return err
-				}
-
 				taskOpt.Task.SubTasks[i], err = t.ToSubTask()
 				if err != nil {
 					return err
 				}
 			}
-
 		case config.TaskTestingV2:
 			t, err := base.ToTestingTask(subTask)
 			if err != nil {
@@ -2738,11 +2719,6 @@ func ensurePipelineTask(taskOpt *taskmodels.TaskOpt, log *zap.SugaredLogger) err
 					SetTriggerBuilds(t.JobCtx.Builds, taskOpt.Task.TaskArgs.Test.Builds, log)
 				} else {
 					setManunalBuilds(t.JobCtx.Builds, taskOpt.Task.TaskArgs.Test.Builds, log)
-				}
-
-				err = SetCandidateRegistry(taskOpt.Task.ConfigPayload, log)
-				if err != nil {
-					return err
 				}
 
 				//use log path

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -658,6 +658,11 @@ func CreateWorkflowTask(args *commonmodels.WorkflowTaskArgs, taskCreator string,
 		env.RegistryID = reg.ID.Hex()
 	}
 	configPayload.RegistryID = env.RegistryID
+	err = SetCandidateRegistry(configPayload, log)
+	if err != nil {
+		log.Errorf("workflow_task setCandidateRegistry configPayload:[%v] err:%v", configPayload, err)
+		return nil, err
+	}
 
 	nextTaskID, err := generateNextTaskID(args.WorkflowName)
 	if err != nil {
@@ -1816,6 +1821,12 @@ func CreateArtifactWorkflowTask(args *commonmodels.WorkflowTaskArgs, taskCreator
 		for _, repo := range repos {
 			configPayload.RepoConfigs[repo.ID.Hex()] = repo
 		}
+	}
+
+	err = SetCandidateRegistry(configPayload, log)
+	if err != nil {
+		log.Errorf("workflow_task setCandidateRegistry configPayload:[%v] err:%v", configPayload, err)
+		return nil, err
 	}
 
 	configPayload.IgnoreCache = args.IgnoreCache


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when running a workflow with testing module, the docker registry info will be set to the default values which should be the registry appointed by associated environment

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
