### PR TITLE
fix host query filter

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/private_key.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/private_key.go
@@ -34,6 +34,7 @@ import (
 type PrivateKeyArgs struct {
 	Name        string
 	ProjectName string
+	SystemOnly  bool
 }
 
 type PrivateKeyColl struct {
@@ -101,7 +102,8 @@ func (c *PrivateKeyColl) List(args *PrivateKeyArgs) ([]*models.PrivateKey, error
 
 	if args.ProjectName != "" {
 		query["project_name"] = args.ProjectName
-	} else {
+	}
+	if args.SystemOnly {
 		query["project_name"] = bson.M{"$exists": false}
 	}
 

--- a/pkg/microservice/aslan/core/project/handler/host.go
+++ b/pkg/microservice/aslan/core/project/handler/host.go
@@ -46,7 +46,7 @@ func ListPMHosts(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam
 		return
 	}
-	ctx.Resp, ctx.Err = systemservice.ListPrivateKeys(encryptedKey, c.Query("projectName"), c.Query("keyword"), ctx.Logger)
+	ctx.Resp, ctx.Err = systemservice.ListPrivateKeys(encryptedKey, c.Query("projectName"), c.Query("keyword"), false, ctx.Logger)
 }
 
 func GetPMHost(c *gin.Context) {

--- a/pkg/microservice/aslan/core/system/handler/private_key.go
+++ b/pkg/microservice/aslan/core/system/handler/private_key.go
@@ -48,7 +48,7 @@ func ListPrivateKeys(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam
 		return
 	}
-	ctx.Resp, ctx.Err = service.ListPrivateKeys(encryptedKey, "", c.Query("keyword"), ctx.Logger)
+	ctx.Resp, ctx.Err = service.ListPrivateKeys(encryptedKey, "", c.Query("keyword"), true, ctx.Logger)
 }
 
 func GetPrivateKey(c *gin.Context) {

--- a/pkg/microservice/aslan/core/system/service/private_key.go
+++ b/pkg/microservice/aslan/core/system/service/private_key.go
@@ -34,10 +34,10 @@ import (
 	"github.com/koderover/zadig/pkg/types"
 )
 
-func ListPrivateKeys(encryptedKey, projectName, keyword string, log *zap.SugaredLogger) ([]*commonmodels.PrivateKey, error) {
+func ListPrivateKeys(encryptedKey, projectName, keyword string, systemOnly bool, log *zap.SugaredLogger) ([]*commonmodels.PrivateKey, error) {
 	var resp []*commonmodels.PrivateKey
 	var err error
-	privateKeys, err := commonrepo.NewPrivateKeyColl().List(&commonrepo.PrivateKeyArgs{ProjectName: projectName})
+	privateKeys, err := commonrepo.NewPrivateKeyColl().List(&commonrepo.PrivateKeyArgs{ProjectName: projectName, SystemOnly: systemOnly})
 	if err != nil {
 		log.Errorf("PrivateKey.List error: %s", err)
 		return resp, e.ErrListPrivateKeys


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when cron service queries all host information for  status updates, the host information of projects will be missed

### What is changed and how it works?
fix bug

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
