### PR TITLE
fix helm dev delete ns bug

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2134,22 +2134,24 @@ func DeleteProduct(username, envName, productName, requestID string, isDelete bo
 				}
 			}()
 
-			if hc, err := helmtool.NewClientFromRestConf(restConfig, productInfo.Namespace); err == nil {
-				for _, services := range productInfo.Services {
-					for _, service := range services {
-						if err = UninstallServiceByName(hc, service.ServiceName, productInfo, service.Revision, true); err != nil {
-							log.Errorf("UninstallRelease err:%v", err)
+			if isDelete {
+				if hc, err := helmtool.NewClientFromRestConf(restConfig, productInfo.Namespace); err == nil {
+					for _, services := range productInfo.Services {
+						for _, service := range services {
+							if err = UninstallServiceByName(hc, service.ServiceName, productInfo, service.Revision, true); err != nil {
+								log.Errorf("UninstallRelease err:%v", err)
+							}
 						}
 					}
+				} else {
+					log.Errorf("获取helmClient err:%v", err)
 				}
-			} else {
-				log.Errorf("获取helmClient err:%v", err)
-			}
 
-			s := labels.Set{setting.EnvCreatedBy: setting.EnvCreator}.AsSelector()
-			if err1 := commonservice.DeleteNamespaceIfMatch(productInfo.Namespace, s, productInfo.ClusterID, log); err1 != nil {
-				err = e.ErrDeleteEnv.AddDesc(e.DeleteNamespaceErrMsg + ": " + err1.Error())
-				return
+				s := labels.Set{setting.EnvCreatedBy: setting.EnvCreator}.AsSelector()
+				if err1 := commonservice.DeleteNamespaceIfMatch(productInfo.Namespace, s, productInfo.ClusterID, log); err1 != nil {
+					err = e.ErrDeleteEnv.AddDesc(e.DeleteNamespaceErrMsg + ": " + err1.Error())
+					return
+				}
 			}
 		}()
 	case setting.SourceFromExternal:

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2135,7 +2135,7 @@ func DeleteProduct(username, envName, productName, requestID string, isDelete bo
 			}()
 
 			if isDelete {
-				if hc, err := helmtool.NewClientFromRestConf(restConfig, productInfo.Namespace); err == nil {
+				if hc, errHelmClient := helmtool.NewClientFromRestConf(restConfig, productInfo.Namespace); errHelmClient == nil {
 					for _, services := range productInfo.Services {
 						for _, service := range services {
 							if err = UninstallServiceByName(hc, service.ServiceName, productInfo, service.Revision, true); err != nil {
@@ -2144,7 +2144,9 @@ func DeleteProduct(username, envName, productName, requestID string, isDelete bo
 						}
 					}
 				} else {
-					log.Errorf("获取helmClient err:%v", err)
+					log.Errorf("failed to get helmClient, err:%v", errHelmClient)
+					err = e.ErrDeleteEnv.AddErr(errHelmClient)
+					return
 				}
 
 				s := labels.Set{setting.EnvCreatedBy: setting.EnvCreator}.AsSelector()


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when deleting environmet for helm projects, namespace created by zadig will always be deleted even if users choose to keep the releated resources

### What is changed and how it works?
fix bug

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
