### PR TITLE
fix helm workload change image tag fail bug

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/image.go
+++ b/pkg/microservice/aslan/core/environment/service/image.go
@@ -63,8 +63,10 @@ func getValidMatchData(spec *models.ImagePathSpec) map[string]string {
 }
 
 // prepare necessary data from db
-func prepareData(namespace, serviceName string, containerName string, product *models.Product) (targetContainer *models.Container,
+func prepareData(namespace, serviceName, containerName, image string, product *models.Product) (targetContainer *models.Container,
 	targetChart *templatemodels.RenderChart, renderSet *models.RenderSet, serviceObj *models.Service, err error) {
+
+	imageName := commonservice.ExtractImageName(image)
 
 	var targetProductService *models.ProductService
 	for _, productService := range product.GetServiceMap() {
@@ -73,16 +75,15 @@ func prepareData(namespace, serviceName string, containerName string, product *m
 		}
 		targetProductService = productService
 		for _, container := range productService.Containers {
-			if container.Name != containerName {
-				continue
+			if container.ImageName == imageName {
+				targetContainer = container
+				break
 			}
-			targetContainer = container
-			break
 		}
 		break
 	}
 	if targetContainer == nil {
-		err = fmt.Errorf("failed to find container %s", containerName)
+		err = fmt.Errorf("failed to find image config: %s for container %s", imageName, containerName)
 		return
 	}
 
@@ -130,7 +131,7 @@ func updateContainerForHelmChart(serviceName, resType, image, containerName stri
 		namespace                string = product.Namespace
 	)
 
-	targetContainer, targetChart, renderSet, serviceObj, err := prepareData(namespace, serviceName, containerName, product)
+	targetContainer, targetChart, renderSet, serviceObj, err := prepareData(namespace, serviceName, containerName, image, product)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when changing image tag directly from workload detail page for helm projects, error occurs when container name and image name of depolyment/sts are different

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
