### PR TITLE
add directory description for demo

### DIFF
--- a/examples/multi-service-demo/README.md
+++ b/examples/multi-service-demo/README.md
@@ -1,0 +1,16 @@
+`multi-service-demo` 目录结构说明：
+
+``` bash
+├── Dockerfile # Dockerfile，也可以作为 Dockerfile 模板，构建镜像时需要通过 --build-arg service=<值> 指定 service 参数的值
+├── Makefile # 构建工程文件，构建时使用 make build-service* 即可
+├── base-chart # Helm Chart 模板，可用于使用模板批量创建服务
+├── full-charts # 多个 Helm Chart，service1、service2、service3 分别有完整独立的 Helm Chart 配置
+├── general-chart # Helm Chart 模板，不可用于使用模板批量创建服务
+├── k8s-yaml # K8s YAML 配置文件，用于 K8s YAML 项目
+│   ├── service1 # service1 完整的配置
+│   ├── service2 # service2 完整的配置
+│   ├── service3 # service3 完整的配置
+│   └── template.yaml # service1/service2/service3 的 K8s YAML 服务模板
+├── src # 服务源代码
+└── values # 使用 base-chart 模板批量创建服务时，多个服务的 values 文件
+```

--- a/examples/multi-service-demo/full-charts/service3/Chart.yaml
+++ b/examples/multi-service-demo/full-charts/service3/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: service3
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/examples/multi-service-demo/full-charts/service3/templates/_helpers.tpl
+++ b/examples/multi-service-demo/full-charts/service3/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chart.labels" -}}
+helm.sh/chart: {{ include "chart.chart" . }}
+{{ include "chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/examples/multi-service-demo/full-charts/service3/templates/deployment.yaml
+++ b/examples/multi-service-demo/full-charts/service3/templates/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.fullnameOverride }}
+  labels: 
+    app.kubernetes.io/name: demo
+    app.kubernetes.io/instance: {{ .Values.fullnameOverride }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: demo
+      app.kubernetes.io/instance: {{ .Values.fullnameOverride }}
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata: 
+      labels:
+        app.kubernetes.io/name: demo
+        app.kubernetes.io/instance: {{ .Values.fullnameOverride }}
+    spec:
+      containers:
+        - name: {{ .Values.fullnameOverride }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: Always 
+          command:
+            - /workspace/{{ .Values.fullnameOverride }}
+          ports:
+            - protocol: TCP
+              containerPort: {{ .Values.port }}
+          resources:
+            limits:
+              cpu: {{ .Values.resources.limits.cpu }}
+              memory: {{ .Values.resources.limits.mem }}
+            requests:
+              cpu: {{ .Values.resources.requests.cpu }}
+              memory: {{ .Values.resources.requests.mem }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecretsName }}

--- a/examples/multi-service-demo/full-charts/service3/templates/service.yaml
+++ b/examples/multi-service-demo/full-charts/service3/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.fullnameOverride }}
+  labels:
+    app.kubernetes.io/name: demo
+    app.kubernetes.io/instance: {{ .Values.fullnameOverride }}
+spec:
+  selector:
+    app.kubernetes.io/name: demo
+    app.kubernetes.io/instance: {{ .Values.fullnameOverride }}
+  type: NodePort
+  ports:
+    - protocol: TCP
+      port: {{ .Values.port }}
+      targetPort: {{ .Values.port }}

--- a/examples/multi-service-demo/full-charts/service3/values.yaml
+++ b/examples/multi-service-demo/full-charts/service3/values.yaml
@@ -1,0 +1,18 @@
+fullnameOverride: service1
+replicaCount: 1
+port: 20223
+
+imagePullSecretsName: "default-registry-secret"
+
+image:
+  repository: "ccr.ccs.tencentyun.com/koderover-public/service3"
+  tag: "latest"
+
+resources:
+  requests:
+    cpu: 10m
+    mem: 10Mi
+
+  limits:
+    cpu: 20m
+    mem: 20Mi


### PR DESCRIPTION
### What this PR does / Why we need it:

1. missing chart for `service3` under `full-charts` directory
2. specify the function of different directories under `multi-service-demo` so that we have a reference when use it

### What is changed and how it works?

1. add chart for `service3`
2. add directory description for `multi-service-demo` demo

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
