### PR TITLE
fix ua execute error bug

### DIFF
--- a/pkg/cli/upgradeassistant/internal/upgradepath/versions.go
+++ b/pkg/cli/upgradeassistant/internal/upgradepath/versions.go
@@ -23,16 +23,11 @@ import (
 
 var VersionDatas versionList
 
-type versionList []string
+type versionList semver.Versions
 
 func (v versionList) VersionIndex(version string) int {
-	t, err := semver.Make(version)
-	if err != nil {
-		return 0
-	}
-
 	for index, _version := range VersionDatas {
-		if _version == t.FinalizeVersion() {
+		if _version.String() == version {
 			return index
 		}
 	}


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when upgrading zadig from community version to latest version (1.13.0-20220616), the execution of the ua component will not work as expected

### What is changed and how it works?
fix bug

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
