### PR TITLE
fix render query condition not accurate bug

### DIFF
--- a/pkg/microservice/aslan/core/collaboration/service/collaboration_instance.go
+++ b/pkg/microservice/aslan/core/collaboration/service/collaboration_instance.go
@@ -1343,8 +1343,10 @@ func getRenderSet(projectName string, envs []string) ([]models2.RenderSet, error
 			revision = productService.Render.Revision
 		}
 		findOpts = append(findOpts, commonrepo.RenderSetFindOption{
-			Revision: revision,
-			Name:     product.Namespace,
+			Revision:    revision,
+			ProductTmpl: projectName,
+			EnvName:     product.EnvName,
+			Name:        product.Namespace,
 		})
 	}
 	renderSets, err := commonrepo.NewRenderSetColl().ListByFindOpts(&commonrepo.RenderSetListOption{

--- a/pkg/microservice/aslan/core/common/repository/mongodb/render_set.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/render_set.go
@@ -43,6 +43,8 @@ type RenderSetListOption struct {
 type RenderSetFindOption struct {
 	// if Revision == 0 then search max revision of RenderSet
 	ProductTmpl string
+	EnvName     string
+	IsDefault   bool
 	Revision    int64
 	Name        string
 }
@@ -212,6 +214,12 @@ func (c *RenderSetColl) Find(opt *RenderSetFindOption) (*models.RenderSet, error
 
 	if len(opt.ProductTmpl) > 0 {
 		query["product_tmpl"] = opt.ProductTmpl
+	}
+	if len(opt.EnvName) > 0 {
+		query["env_name"] = opt.EnvName
+	}
+	if opt.IsDefault {
+		query["is_default"] = opt.IsDefault
 	}
 
 	rs := &models.RenderSet{}

--- a/pkg/microservice/aslan/core/common/service/delivery.go
+++ b/pkg/microservice/aslan/core/common/service/delivery.go
@@ -374,7 +374,7 @@ func getProductEnvInfo(pipelineTask *taskmodels.Task, log *zap.SugaredLogger) (*
 		product.Namespace = productInfo.Namespace
 	}
 
-	if renderSet, err := GetRenderSet(product.Namespace, pipelineTask.Render.Revision, log); err == nil {
+	if renderSet, err := GetRenderSet(product.Namespace, pipelineTask.Render.Revision, false, log); err == nil {
 		product.Vars = renderSet.KVs
 	} else {
 		log.Errorf("GetProductEnvInfo GetRenderSet namespace:%s pipelineTask.Render.Revision:%d err:%v", product.GetNamespace(), pipelineTask.Render.Revision, err)

--- a/pkg/microservice/aslan/core/common/service/delivery.go
+++ b/pkg/microservice/aslan/core/common/service/delivery.go
@@ -374,7 +374,7 @@ func getProductEnvInfo(pipelineTask *taskmodels.Task, log *zap.SugaredLogger) (*
 		product.Namespace = productInfo.Namespace
 	}
 
-	if renderSet, err := GetRenderSet(product.Namespace, pipelineTask.Render.Revision, false, log); err == nil {
+	if renderSet, err := GetRenderSet(product.Namespace, pipelineTask.Render.Revision, false, product.Namespace, log); err == nil {
 		product.Vars = renderSet.KVs
 	} else {
 		log.Errorf("GetProductEnvInfo GetRenderSet namespace:%s pipelineTask.Render.Revision:%d err:%v", product.GetNamespace(), pipelineTask.Render.Revision, err)
@@ -450,7 +450,12 @@ func updateServiceImage(serviceName, image, containerName string, product *commo
 
 func getServiceRenderYAML(productInfo *commonmodels.Product, containers []*commonmodels.Container, serviceName, deployType string, log *zap.SugaredLogger) (string, error) {
 	if deployType == setting.K8SDeployType {
-		opt := &commonrepo.RenderSetFindOption{Name: productInfo.Render.Name, Revision: productInfo.Render.Revision}
+		opt := &commonrepo.RenderSetFindOption{
+			Name:        productInfo.Render.Name,
+			Revision:    productInfo.Render.Revision,
+			EnvName:     productInfo.EnvName,
+			ProductTmpl: productInfo.ProductName,
+		}
 		newRender, err := commonrepo.NewRenderSetColl().Find(opt)
 		if err != nil {
 			log.Errorf("[%s][P:%s]renderset Find error: %v", productInfo.EnvName, productInfo.ProductName, err)

--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -49,7 +49,7 @@ import (
 
 // FillProductTemplateValuesYamls 返回renderSet中的renderChart信息
 func FillProductTemplateValuesYamls(tmpl *templatemodels.Product, log *zap.SugaredLogger) error {
-	renderSet, err := GetRenderSet(tmpl.ProductName, 0, log)
+	renderSet, err := GetRenderSet(tmpl.ProductName, 0, true, log)
 	if err != nil {
 		log.Errorf("Failed to find render set for product template %s", tmpl.ProductName)
 		return err
@@ -130,7 +130,9 @@ func GetRenderCharts(productName, envName, serviceName string, log *zap.SugaredL
 	renderSetName := GetProductEnvNamespace(envName, productName, "")
 
 	opt := &commonrepo.RenderSetFindOption{
-		Name: renderSetName,
+		ProductTmpl: productName,
+		EnvName:     envName,
+		Name:        renderSetName,
 	}
 	rendersetObj, existed, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
 	if err != nil {

--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -49,7 +49,7 @@ import (
 
 // FillProductTemplateValuesYamls 返回renderSet中的renderChart信息
 func FillProductTemplateValuesYamls(tmpl *templatemodels.Product, log *zap.SugaredLogger) error {
-	renderSet, err := GetRenderSet(tmpl.ProductName, 0, true, log)
+	renderSet, err := GetRenderSet(tmpl.ProductName, 0, true, "", log)
 	if err != nil {
 		log.Errorf("Failed to find render set for product template %s", tmpl.ProductName)
 		return err

--- a/pkg/microservice/aslan/core/common/service/render.go
+++ b/pkg/microservice/aslan/core/common/service/render.go
@@ -194,14 +194,15 @@ func listTmplRenderKeys(productTmplName string, log *zap.SugaredLogger) ([]*temp
 	return kvs, prodTmpl.AllServiceInfoMap(), err
 }
 
-func GetRenderSet(renderName string, revision int64, log *zap.SugaredLogger) (*commonmodels.RenderSet, error) {
+func GetRenderSet(renderName string, revision int64, isDefault bool, log *zap.SugaredLogger) (*commonmodels.RenderSet, error) {
 	// 未指定renderName返回空的renderSet
 	if renderName == "" {
 		return &commonmodels.RenderSet{KVs: []*templatemodels.RenderKV{}}, nil
 	}
 	opt := &commonrepo.RenderSetFindOption{
-		Name:     renderName,
-		Revision: revision,
+		Name:      renderName,
+		Revision:  revision,
+		IsDefault: isDefault,
 	}
 	resp, found, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
 	if err != nil {
@@ -231,11 +232,11 @@ func GetRenderSetInfo(renderName string, revision int64) (*commonmodels.RenderSe
 }
 
 // ValidateRenderSet 检查指定renderSet是否能覆盖产品所有需要渲染的值
-func ValidateRenderSet(productName, renderName string, serviceInfo *templatemodels.ServiceInfo, log *zap.SugaredLogger) (*commonmodels.RenderSet, error) {
+func ValidateRenderSet(productName, renderName, envName string, serviceInfo *templatemodels.ServiceInfo, log *zap.SugaredLogger) (*commonmodels.RenderSet, error) {
 	resp := &commonmodels.RenderSet{ProductTmpl: productName}
 	var err error
 	if renderName != "" {
-		opt := &commonrepo.RenderSetFindOption{Name: renderName, ProductTmpl: productName}
+		opt := &commonrepo.RenderSetFindOption{Name: renderName, ProductTmpl: productName, EnvName: envName}
 		resp, err = commonrepo.NewRenderSetColl().Find(opt)
 		if err != nil {
 			log.Errorf("find renderset[%s] error: %v", renderName, err)
@@ -281,7 +282,7 @@ func mergeKVs(newKVs []*templatemodels.RenderKV, oldKVs []*templatemodels.Render
 }
 
 func CreateRenderSetByMerge(args *commonmodels.RenderSet, log *zap.SugaredLogger) error {
-	opt := &commonrepo.RenderSetFindOption{Name: args.Name, ProductTmpl: args.ProductTmpl}
+	opt := &commonrepo.RenderSetFindOption{Name: args.Name, ProductTmpl: args.ProductTmpl, EnvName: args.EnvName}
 	rs, err := commonrepo.NewRenderSetColl().Find(opt)
 	if rs != nil && err == nil {
 		if rs.Diff(args) {
@@ -305,7 +306,11 @@ func CreateRenderSetByMerge(args *commonmodels.RenderSet, log *zap.SugaredLogger
 }
 
 func CreateRenderSet(args *commonmodels.RenderSet, log *zap.SugaredLogger) error {
-	opt := &commonrepo.RenderSetFindOption{Name: args.Name, ProductTmpl: args.ProductTmpl}
+	opt := &commonrepo.RenderSetFindOption{
+		Name:        args.Name,
+		ProductTmpl: args.ProductTmpl,
+		EnvName:     args.EnvName,
+	}
 	rs, err := commonrepo.NewRenderSetColl().Find(opt)
 	if rs != nil && err == nil {
 		if rs.Diff(args) {
@@ -328,7 +333,11 @@ func CreateRenderSet(args *commonmodels.RenderSet, log *zap.SugaredLogger) error
 
 // CreateHelmRenderSet 添加renderSet
 func CreateHelmRenderSet(args *commonmodels.RenderSet, log *zap.SugaredLogger) error {
-	opt := &commonrepo.RenderSetFindOption{Name: args.Name, ProductTmpl: args.ProductTmpl}
+	opt := &commonrepo.RenderSetFindOption{
+		Name:        args.Name,
+		ProductTmpl: args.ProductTmpl,
+		EnvName:     args.EnvName,
+	}
 	rs, err := commonrepo.NewRenderSetColl().Find(opt)
 	if rs != nil && err == nil {
 		// 已经存在渲染配置集
@@ -568,8 +577,9 @@ func getValueFromSharedRenderSet(kv *templatemodels.RenderKV, productName string
 	}
 
 	renderSetOpt := &commonrepo.RenderSetFindOption{
-		Name:     targetProduct,
-		Revision: 0,
+		Name:      targetProduct,
+		IsDefault: true,
+		Revision:  0,
 	}
 	renderSet, err := commonrepo.NewRenderSetColl().Find(renderSetOpt)
 	if err != nil {

--- a/pkg/microservice/aslan/core/common/service/render.go
+++ b/pkg/microservice/aslan/core/common/service/render.go
@@ -194,7 +194,7 @@ func listTmplRenderKeys(productTmplName string, log *zap.SugaredLogger) ([]*temp
 	return kvs, prodTmpl.AllServiceInfoMap(), err
 }
 
-func GetRenderSet(renderName string, revision int64, isDefault bool, log *zap.SugaredLogger) (*commonmodels.RenderSet, error) {
+func GetRenderSet(renderName string, revision int64, isDefault bool, envName string, log *zap.SugaredLogger) (*commonmodels.RenderSet, error) {
 	// 未指定renderName返回空的renderSet
 	if renderName == "" {
 		return &commonmodels.RenderSet{KVs: []*templatemodels.RenderKV{}}, nil
@@ -203,6 +203,7 @@ func GetRenderSet(renderName string, revision int64, isDefault bool, log *zap.Su
 		Name:      renderName,
 		Revision:  revision,
 		IsDefault: isDefault,
+		EnvName:   envName,
 	}
 	resp, found, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
 	if err != nil {

--- a/pkg/microservice/aslan/core/common/service/template_product.go
+++ b/pkg/microservice/aslan/core/common/service/template_product.go
@@ -188,7 +188,7 @@ func FillProductTemplateVars(productTemplates []*template.Product, log *zap.Suga
 				<-ch
 				wg.Done()
 			}()
-			renderSet, err := GetRenderSet(tmpl.ProductName, 0, true, log)
+			renderSet, err := GetRenderSet(tmpl.ProductName, 0, true, "", log)
 			if err != nil {
 				errStr += fmt.Sprintf("Failed to find render set for product template, productName:%s, err:%v\n", tmpl.ProductName, err)
 				log.Errorf("Failed to find render set for product template %s", tmpl.ProductName)

--- a/pkg/microservice/aslan/core/common/service/template_product.go
+++ b/pkg/microservice/aslan/core/common/service/template_product.go
@@ -188,7 +188,7 @@ func FillProductTemplateVars(productTemplates []*template.Product, log *zap.Suga
 				<-ch
 				wg.Done()
 			}()
-			renderSet, err := GetRenderSet(tmpl.ProductName, 0, log)
+			renderSet, err := GetRenderSet(tmpl.ProductName, 0, true, log)
 			if err != nil {
 				errStr += fmt.Sprintf("Failed to find render set for product template, productName:%s, err:%v\n", tmpl.ProductName, err)
 				log.Errorf("Failed to find render set for product template %s", tmpl.ProductName)

--- a/pkg/microservice/aslan/core/delivery/service/version.go
+++ b/pkg/microservice/aslan/core/delivery/service/version.go
@@ -793,8 +793,10 @@ func CreateHelmDeliveryVersion(args *CreateHelmDeliveryVersionArgs, logger *zap.
 func prepareChartData(chartDatas []*CreateHelmDeliveryVersionChartData, productInfo *commonmodels.Product) (map[string]*DeliveryChartData, error) {
 
 	renderSet, err := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{
-		Revision: productInfo.Render.Revision,
-		Name:     productInfo.Render.Name,
+		Revision:    productInfo.Render.Revision,
+		Name:        productInfo.Render.Name,
+		EnvName:     productInfo.EnvName,
+		ProductTmpl: productInfo.ProductName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to find renderSet: %s, revision: %d", productInfo.Render.Name, productInfo.Render.Revision)

--- a/pkg/microservice/aslan/core/environment/service/configmap.go
+++ b/pkg/microservice/aslan/core/environment/service/configmap.go
@@ -225,7 +225,7 @@ func UpdateConfigMap(args *UpdateCommonEnvCfgArgs, userName, userID string, log 
 	}
 
 	namespace := product.Namespace
-	renderSet, err := commonservice.GetRenderSet(namespace, 0, false, log)
+	renderSet, err := commonservice.GetRenderSet(namespace, 0, false, product.EnvName, log)
 	if err != nil {
 		log.Errorf("Failed to find render set for product template %s, err: %v", product.ProductName, err)
 		return err

--- a/pkg/microservice/aslan/core/environment/service/configmap.go
+++ b/pkg/microservice/aslan/core/environment/service/configmap.go
@@ -225,7 +225,7 @@ func UpdateConfigMap(args *UpdateCommonEnvCfgArgs, userName, userID string, log 
 	}
 
 	namespace := product.Namespace
-	renderSet, err := commonservice.GetRenderSet(namespace, 0, log)
+	renderSet, err := commonservice.GetRenderSet(namespace, 0, false, log)
 	if err != nil {
 		log.Errorf("Failed to find render set for product template %s, err: %v", product.ProductName, err)
 		return err

--- a/pkg/microservice/aslan/core/environment/service/diff.go
+++ b/pkg/microservice/aslan/core/environment/service/diff.go
@@ -88,11 +88,11 @@ func GetServiceDiff(envName, productName, serviceName string, log *zap.SugaredLo
 	oldRender := &commonmodels.RenderSet{}
 	newRender := &commonmodels.RenderSet{}
 	if productInfo.Render != nil {
-		oldRender, err = commonservice.GetRenderSet(productInfo.Render.Name, productInfo.Render.Revision, log)
+		oldRender, err = commonservice.GetRenderSet(productInfo.Render.Name, productInfo.Render.Revision, false, log)
 		if err != nil {
 			return resp, err
 		}
-		newRender, err = commonservice.GetRenderSet(productInfo.Render.Name, 0, log)
+		newRender, err = commonservice.GetRenderSet(productInfo.Render.Name, 0, false, log)
 		if err != nil {
 			return resp, err
 		}

--- a/pkg/microservice/aslan/core/environment/service/diff.go
+++ b/pkg/microservice/aslan/core/environment/service/diff.go
@@ -88,11 +88,11 @@ func GetServiceDiff(envName, productName, serviceName string, log *zap.SugaredLo
 	oldRender := &commonmodels.RenderSet{}
 	newRender := &commonmodels.RenderSet{}
 	if productInfo.Render != nil {
-		oldRender, err = commonservice.GetRenderSet(productInfo.Render.Name, productInfo.Render.Revision, false, log)
+		oldRender, err = commonservice.GetRenderSet(productInfo.Render.Name, productInfo.Render.Revision, false, envName, log)
 		if err != nil {
 			return resp, err
 		}
-		newRender, err = commonservice.GetRenderSet(productInfo.Render.Name, 0, false, log)
+		newRender, err = commonservice.GetRenderSet(productInfo.Render.Name, 0, false, envName, log)
 		if err != nil {
 			return resp, err
 		}

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -1197,7 +1197,7 @@ func copySingleHelmProduct(templateProduct *templatemodels.Product, productName,
 	// merge chart infos, use chart info in product to override charts in template_project
 	sourceRenderSet, _, err := commonrepo.NewRenderSetColl().FindRenderSet(&commonrepo.RenderSetFindOption{
 		Name:        sourceRendersetName,
-		EnvName:     arg.EnvName,
+		EnvName:     arg.BaseName,
 		ProductTmpl: arg.ProductName,
 	})
 	if err != nil {

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -291,7 +291,7 @@ func FillProductVars(products []*commonmodels.Product, log *zap.SugaredLogger) e
 			renderName = product.Render.Name
 			revision = product.Render.Revision
 		}
-		renderSet, err := commonservice.GetRenderSet(renderName, revision, log)
+		renderSet, err := commonservice.GetRenderSet(renderName, revision, false, log)
 		if err != nil {
 			log.Errorf("Failed to find render set, productName: %s, namespace: %s,  err: %s", product.ProductName, product.Namespace, err)
 			return e.ErrGetRenderSet.AddDesc(err.Error())
@@ -796,7 +796,7 @@ func UpdateProductV2(envName, productName, user, requestID string, serviceNames 
 	}
 
 	// 检查renderset是否覆盖产品所有key
-	renderSet, err := commonservice.ValidateRenderSet(exitedProd.ProductName, exitedProd.Render.Name, nil, log)
+	renderSet, err := commonservice.ValidateRenderSet(exitedProd.ProductName, exitedProd.Render.Name, exitedProd.EnvName, nil, log)
 	if err != nil {
 		log.Errorf("[%s][P:%s] validate product renderset error: %v", envName, exitedProd.ProductName, err)
 		return e.ErrUpdateEnv.AddDesc(err.Error())
@@ -1195,7 +1195,11 @@ func copySingleHelmProduct(templateProduct *templatemodels.Product, productName,
 	productInfo.EnvConfigYamls = arg.EnvConfigYamls
 
 	// merge chart infos, use chart info in product to override charts in template_project
-	sourceRenderSet, _, err := commonrepo.NewRenderSetColl().FindRenderSet(&commonrepo.RenderSetFindOption{Name: sourceRendersetName})
+	sourceRenderSet, _, err := commonrepo.NewRenderSetColl().FindRenderSet(&commonrepo.RenderSetFindOption{
+		Name:        sourceRendersetName,
+		EnvName:     arg.EnvName,
+		ProductTmpl: arg.ProductName,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to find source renderset: %s, err: %s", productInfo.Namespace, err)
 	}
@@ -1403,7 +1407,12 @@ func prepareEstimatedData(productName, envName, serviceName, usageScenario, defa
 	}
 
 	// find chart info from cur render set
-	opt := &commonrepo.RenderSetFindOption{Name: productInfo.Render.Name, Revision: productInfo.Render.Revision}
+	opt := &commonrepo.RenderSetFindOption{
+		Name:        productInfo.Render.Name,
+		Revision:    productInfo.Render.Revision,
+		EnvName:     productInfo.EnvName,
+		ProductTmpl: productInfo.ProductName,
+	}
 	renderSet, err := commonrepo.NewRenderSetColl().Find(opt)
 	if err != nil {
 		log.Errorf("renderset Find error, productName:%s, envName:%s, err:%s", productInfo.ProductName, productInfo.EnvName, err)
@@ -1524,7 +1533,11 @@ func UpdateHelmProductDefaultValues(productName, envName, userName, requestID st
 		log.Errorf("UpdateHelmProductRenderset GetProductEnv envName:%s productName: %s error, error msg:%s", envName, productName, err)
 		return err
 	}
-	opt := &commonrepo.RenderSetFindOption{Name: product.Namespace}
+	opt := &commonrepo.RenderSetFindOption{
+		Name:        product.Namespace,
+		EnvName:     envName,
+		ProductTmpl: productName,
+	}
 	productRenderset, _, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
 	if err != nil || productRenderset == nil {
 		if err != nil {
@@ -1573,7 +1586,11 @@ func UpdateHelmProductCharts(productName, envName, userName, requestID string, a
 		log.Errorf("UpdateHelmProductRenderset GetProductEnv envName:%s productName: %s error, error msg:%s", envName, productName, err)
 		return err
 	}
-	opt := &commonrepo.RenderSetFindOption{Name: product.Namespace}
+	opt := &commonrepo.RenderSetFindOption{
+		Name:        product.Namespace,
+		EnvName:     envName,
+		ProductTmpl: productName,
+	}
 	productRenderset, _, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
 	if err != nil || productRenderset == nil {
 		if err != nil {
@@ -1665,7 +1682,11 @@ func SyncHelmProductEnvironment(productName, envName, requestID string, log *zap
 		log.Errorf("UpdateHelmProductRenderset GetProductEnv envName:%s productName: %s error, error msg:%s", envName, productName, err)
 		return err
 	}
-	opt := &commonrepo.RenderSetFindOption{Name: product.Namespace}
+	opt := &commonrepo.RenderSetFindOption{
+		Name:        product.Namespace,
+		EnvName:     envName,
+		ProductTmpl: productName,
+	}
 	productRenderset, _, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
 	if err != nil || productRenderset == nil {
 		if err != nil {
@@ -1725,7 +1746,11 @@ func UpdateHelmProductRenderset(productName, envName, userName, requestID string
 		log.Errorf("UpdateHelmProductRenderset GetProductEnv envName:%s productName: %s error, error msg:%s", envName, productName, err)
 		return err
 	}
-	opt := &commonrepo.RenderSetFindOption{Name: product.Namespace}
+	opt := &commonrepo.RenderSetFindOption{
+		Name:        product.Namespace,
+		EnvName:     envName,
+		ProductTmpl: productName,
+	}
 	productRenderset, _, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
 	if err != nil || productRenderset == nil {
 		if err != nil {
@@ -1811,7 +1836,7 @@ func UpdateHelmProductVariable(productName, envName, username, requestID string,
 	if productResp.Render == nil {
 		productResp.Render = &commonmodels.RenderInfo{ProductTmpl: productResp.ProductName}
 	}
-	renderSet, err := FindHelmRenderSet(productResp.ProductName, productResp.Namespace, log)
+	renderSet, err := FindHelmRenderSet(productResp.ProductName, productResp.Namespace, envName, log)
 	if err != nil {
 		log.Errorf("[%s][P:%s] find product renderset error: %s", productResp.EnvName, productResp.ProductName, err)
 		return e.ErrUpdateEnv.AddDesc(err.Error())
@@ -1918,7 +1943,9 @@ func UpdateMultipleHelmEnv(requestID, userName string, args *UpdateMultiHelmProd
 	// extract values.yaml and update renderset
 	for envName := range productMap {
 		renderSet, _, err := commonrepo.NewRenderSetColl().FindRenderSet(&commonrepo.RenderSetFindOption{
-			Name: commonservice.GetProductEnvNamespace(envName, productName, ""),
+			Name:        commonservice.GetProductEnvNamespace(envName, productName, ""),
+			EnvName:     envName,
+			ProductTmpl: productName,
 		})
 		if err != nil || renderSet == nil {
 			if err != nil {
@@ -1962,7 +1989,7 @@ func GetProductInfo(username, envName, productName string, log *zap.SugaredLogge
 	}
 
 	renderSetName := prod.Namespace
-	renderSetOpt := &commonrepo.RenderSetFindOption{Name: renderSetName, Revision: prod.Render.Revision}
+	renderSetOpt := &commonrepo.RenderSetFindOption{Name: renderSetName, Revision: prod.Render.Revision, ProductTmpl: productName}
 	renderSet, err := commonrepo.NewRenderSetColl().Find(renderSetOpt)
 	if err != nil {
 		log.Errorf("find helm renderset[%s] error: %v", renderSetName, err)
@@ -1993,7 +2020,7 @@ func GetHelmChartVersions(productName, envName string, log *zap.SugaredLogger) (
 
 	//当前环境的renderset
 	renderSetName := prod.Namespace
-	renderSetOpt := &commonrepo.RenderSetFindOption{Name: renderSetName, Revision: prod.Render.Revision}
+	renderSetOpt := &commonrepo.RenderSetFindOption{Name: renderSetName, Revision: prod.Render.Revision, ProductTmpl: prod.ProductName}
 	renderSet, err := commonrepo.NewRenderSetColl().Find(renderSetOpt)
 	if err != nil {
 		log.Errorf("find helm renderset[%s] error: %v", renderSetName, err)
@@ -2315,7 +2342,9 @@ func deleteHelmProductServices(userName, requestID string, productInfo *commonmo
 		}
 	}
 	renderset, err := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{
-		Name: productInfo.Namespace,
+		Name:        productInfo.Namespace,
+		EnvName:     productInfo.EnvName,
+		ProductTmpl: productInfo.ProductName,
 	})
 	if err != nil {
 		log.Errorf("get renderSet error: %v", err)
@@ -2400,6 +2429,7 @@ func deleteK8sProductServices(productInfo *commonmodels.Product, serviceNames []
 		}
 	}
 	rs, err := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{
+		EnvName:     productInfo.EnvName,
 		Name:        productInfo.Namespace,
 		ProductTmpl: productInfo.ProductName,
 	})
@@ -2906,7 +2936,12 @@ func removeOldResources(
 	kubeClient client.Client,
 	log *zap.SugaredLogger,
 ) error {
-	opt := &commonrepo.RenderSetFindOption{Name: oldService.Render.Name, Revision: oldService.Render.Revision}
+	opt := &commonrepo.RenderSetFindOption{
+		Name:        oldService.Render.Name,
+		Revision:    oldService.Render.Revision,
+		EnvName:     env.EnvName,
+		ProductTmpl: env.ProductName,
+	}
 	resp, err := commonrepo.NewRenderSetColl().Find(opt)
 	if err != nil {
 		log.Errorf("find renderset[%s/%d] error: %v", opt.Name, opt.Revision, err)
@@ -3198,11 +3233,15 @@ func ensureKubeEnv(namespace, registryId string, enableShare bool, kubeClient cl
 	return nil
 }
 
-func FindHelmRenderSet(productName, renderName string, log *zap.SugaredLogger) (*commonmodels.RenderSet, error) {
+func FindHelmRenderSet(productName, renderName, envName string, log *zap.SugaredLogger) (*commonmodels.RenderSet, error) {
 	resp := &commonmodels.RenderSet{ProductTmpl: productName}
 	var err error
 	if renderName != "" {
-		opt := &commonrepo.RenderSetFindOption{Name: renderName, ProductTmpl: productName}
+		opt := &commonrepo.RenderSetFindOption{
+			Name:        renderName,
+			ProductTmpl: productName,
+			EnvName:     envName,
+		}
 		resp, err = commonrepo.NewRenderSetColl().Find(opt)
 		if err != nil {
 			log.Errorf("find helm renderset[%s] error: %v", renderName, err)
@@ -3483,7 +3522,7 @@ func updateProductGroup(username, productName, envName string, productResp *comm
 // generate a new renderset and insert into db
 func diffRenderSet(username, productName, envName string, productResp *commonmodels.Product, overrideCharts []*commonservice.RenderChartArg, log *zap.SugaredLogger) (*commonmodels.RenderSet, error) {
 	// default renderset
-	latestRenderSet, err := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{Name: productName})
+	latestRenderSet, err := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{Name: productName, IsDefault: true})
 	if err != nil {
 		log.Errorf("[RenderSet.find] err: %v", err)
 		return nil, err
@@ -3503,7 +3542,11 @@ func diffRenderSet(username, productName, envName string, productResp *commonmod
 		}
 	}
 
-	renderSetOpt := &commonrepo.RenderSetFindOption{Name: productResp.Render.Name, Revision: productResp.Render.Revision}
+	renderSetOpt := &commonrepo.RenderSetFindOption{
+		Name:        productResp.Render.Name,
+		Revision:    productResp.Render.Revision,
+		ProductTmpl: productName,
+	}
 	currentEnvRenderSet, err := commonrepo.NewRenderSetColl().Find(renderSetOpt)
 	if err != nil {
 		log.Errorf("[RenderSet.find] err: %v", err)
@@ -3605,7 +3648,7 @@ func diffRenderSet(username, productName, envName string, productResp *commonmod
 		return nil, err
 	}
 
-	renderSet, err := FindHelmRenderSet(productName, productResp.Render.Name, log)
+	renderSet, err := FindHelmRenderSet(productName, productResp.Render.Name, envName, log)
 	if err != nil {
 		log.Errorf("[RenderSet.find] err: %v", err)
 		return nil, err

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -291,7 +291,7 @@ func FillProductVars(products []*commonmodels.Product, log *zap.SugaredLogger) e
 			renderName = product.Render.Name
 			revision = product.Render.Revision
 		}
-		renderSet, err := commonservice.GetRenderSet(renderName, revision, false, log)
+		renderSet, err := commonservice.GetRenderSet(renderName, revision, false, product.EnvName, log)
 		if err != nil {
 			log.Errorf("Failed to find render set, productName: %s, namespace: %s,  err: %s", product.ProductName, product.Namespace, err)
 			return e.ErrGetRenderSet.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/environment/service/environment_creator.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_creator.go
@@ -172,7 +172,9 @@ func (creator *HelmProductCreator) Create(user, requestID string, args *models.P
 	var renderSet *models.RenderSet
 	if args.Render == nil || args.Render.Revision == 0 {
 		renderSet, _, err = commonrepo.NewRenderSetColl().FindRenderSet(&commonrepo.RenderSetFindOption{
-			Name: args.Namespace,
+			EnvName:     args.EnvName,
+			Name:        args.Namespace,
+			ProductTmpl: args.ProductName,
 		})
 
 		if err != nil {
@@ -207,7 +209,7 @@ func (creator *HelmProductCreator) Create(user, requestID string, args *models.P
 		return e.ErrCreateEnv.AddDesc(err.Error())
 	}
 
-	renderSet, err = FindHelmRenderSet(args.ProductName, args.Render.Name, log)
+	renderSet, err = FindHelmRenderSet(args.ProductName, args.Render.Name, args.EnvName, log)
 	if err != nil {
 		log.Errorf("[%s][P:%s] find product renderset error: %v", args.EnvName, args.ProductName, err)
 		return e.ErrCreateEnv.AddDesc(err.Error())
@@ -370,7 +372,7 @@ func (creator *DefaultProductCreator) Create(user, requestID string, args *model
 	// 如果是版本回滚，则args.Render.Revision > 0
 	if args.Render.Revision == 0 {
 		// 检查renderset是否覆盖产品所有key
-		renderSet, err = commonservice.ValidateRenderSet(args.ProductName, args.Render.Name, nil, log)
+		renderSet, err = commonservice.ValidateRenderSet(args.ProductName, args.Render.Name, args.EnvName, nil, log)
 		if err != nil {
 			log.Errorf("[%s][P:%s] validate product renderset error: %v", args.EnvName, args.ProductName, err)
 			return e.ErrCreateEnv.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/environment/service/environment_group.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_group.go
@@ -145,7 +145,7 @@ func GetIngressInfo(product *commonmodels.Product, service *commonmodels.Service
 
 	renderSet := &commonmodels.RenderSet{}
 	if product.Render != nil {
-		renderSet, err = commonservice.GetRenderSet(product.Render.Name, 0, log)
+		renderSet, err = commonservice.GetRenderSet(product.Render.Name, 0, false, log)
 		if err != nil {
 			log.Errorf("GetRenderSet %s error: %v", product.ProductName, err)
 			return ingressInfo

--- a/pkg/microservice/aslan/core/environment/service/environment_group.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_group.go
@@ -145,7 +145,7 @@ func GetIngressInfo(product *commonmodels.Product, service *commonmodels.Service
 
 	renderSet := &commonmodels.RenderSet{}
 	if product.Render != nil {
-		renderSet, err = commonservice.GetRenderSet(product.Render.Name, 0, false, log)
+		renderSet, err = commonservice.GetRenderSet(product.Render.Name, 0, false, product.EnvName, log)
 		if err != nil {
 			log.Errorf("GetRenderSet %s error: %v", product.ProductName, err)
 			return ingressInfo

--- a/pkg/microservice/aslan/core/environment/service/environment_update.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_update.go
@@ -142,8 +142,10 @@ func reInstallHelmServiceInEnv(productInfo *commonmodels.Product, templateSvc *c
 	}()
 
 	renderInfo, errRender := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{
-		Name:     productInfo.Render.Name,
-		Revision: productInfo.Render.Revision})
+		ProductTmpl: productInfo.ProductName,
+		EnvName:     productInfo.EnvName,
+		Name:        productInfo.Render.Name,
+		Revision:    productInfo.Render.Revision})
 	if errRender != nil {
 		err = fmt.Errorf("failed to find renderset, %s:%d, err: %s", productInfo.Render.Name, productInfo.Render.Revision, errRender)
 		return
@@ -210,8 +212,10 @@ func updateHelmServiceInEnv(userName string, productInfo *commonmodels.Product, 
 	}()
 
 	renderInfo, errFindRender := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{
-		Name:     productInfo.Render.Name,
-		Revision: productInfo.Render.Revision})
+		ProductTmpl: productInfo.ProductName,
+		EnvName:     productInfo.EnvName,
+		Name:        productInfo.Render.Name,
+		Revision:    productInfo.Render.Revision})
 	if errFindRender != nil {
 		err = fmt.Errorf("failed to find renderset, %s:%d, err: %s", productInfo.Render.Name, productInfo.Render.Revision, errFindRender)
 		return

--- a/pkg/microservice/aslan/core/environment/service/helm.go
+++ b/pkg/microservice/aslan/core/environment/service/helm.go
@@ -434,7 +434,7 @@ func GetChartInfos(productName, envName, serviceName string, log *zap.SugaredLog
 	if err != nil {
 		return nil, e.ErrGetHelmCharts.AddErr(err)
 	}
-	renderSet, err := FindHelmRenderSet(productName, prod.Render.Name, log)
+	renderSet, err := FindHelmRenderSet(productName, prod.Render.Name, prod.EnvName, log)
 	if err != nil {
 		log.Errorf("[%s][P:%s] find product renderset error: %v", envName, productName, err)
 		return nil, e.ErrGetHelmCharts.AddErr(err)

--- a/pkg/microservice/aslan/core/environment/service/image.go
+++ b/pkg/microservice/aslan/core/environment/service/image.go
@@ -87,7 +87,12 @@ func prepareData(namespace, serviceName, containerName, image string, product *m
 		return
 	}
 
-	renderSet, err = commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{Name: namespace, Revision: product.Render.Revision})
+	renderSet, err = commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{
+		ProductTmpl: product.ProductName,
+		Name:        namespace,
+		EnvName:     product.EnvName,
+		Revision:    product.Render.Revision,
+	})
 	if err != nil {
 		log.Errorf("[RenderSet.find] update product %s error: %s", product.ProductName, err.Error())
 		err = fmt.Errorf("failed to find redset name %s revision %d", namespace, product.Render.Revision)

--- a/pkg/microservice/aslan/core/environment/service/k8s.go
+++ b/pkg/microservice/aslan/core/environment/service/k8s.go
@@ -121,7 +121,7 @@ func (k *K8sService) updateService(args *SvcOptArgs) error {
 		exitedProd.Render = &commonmodels.RenderInfo{ProductTmpl: exitedProd.ProductName}
 	}
 	// 检查renderset是否覆盖服务所有key
-	newRender, err := commonservice.ValidateRenderSet(args.ProductName, exitedProd.Render.Name, serviceInfo, k.log)
+	newRender, err := commonservice.ValidateRenderSet(args.ProductName, exitedProd.Render.Name, exitedProd.EnvName, serviceInfo, k.log)
 	if err != nil {
 		k.log.Errorf("[%s][P:%s] validate product renderset error: %v", args.EnvName, args.ProductName, err)
 		return e.ErrUpdateProduct.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/environment/service/renderset.go
+++ b/pkg/microservice/aslan/core/environment/service/renderset.go
@@ -116,8 +116,9 @@ func GetDefaultValues(productName, envName string, log *zap.SugaredLogger) (*Def
 	}
 
 	opt := &commonrepo.RenderSetFindOption{
-		Name:     productInfo.Render.Name,
-		Revision: productInfo.Render.Revision,
+		Name:        productInfo.Render.Name,
+		Revision:    productInfo.Render.Revision,
+		ProductTmpl: productName,
 	}
 	rendersetObj, existed, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
 	if err != nil {

--- a/pkg/microservice/aslan/core/environment/service/renderset.go
+++ b/pkg/microservice/aslan/core/environment/service/renderset.go
@@ -119,6 +119,7 @@ func GetDefaultValues(productName, envName string, log *zap.SugaredLogger) (*Def
 		Name:        productInfo.Render.Name,
 		Revision:    productInfo.Render.Revision,
 		ProductTmpl: productName,
+		EnvName:     productInfo.EnvName,
 	}
 	rendersetObj, existed, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
 	if err != nil {

--- a/pkg/microservice/aslan/core/environment/service/revision.go
+++ b/pkg/microservice/aslan/core/environment/service/revision.go
@@ -135,7 +135,7 @@ func GetProductRevision(product *commonmodels.Product, allServiceTmpls []*common
 		rendersetName := ""
 		if product.Render != nil {
 			rendersetName = product.Render.Name
-			newRender, err = commonservice.GetRenderSet(product.Render.Name, 0, false, log)
+			newRender, err = commonservice.GetRenderSet(product.Render.Name, 0, false, product.EnvName, log)
 			if err != nil {
 				return prodRev, err
 			}

--- a/pkg/microservice/aslan/core/environment/service/revision.go
+++ b/pkg/microservice/aslan/core/environment/service/revision.go
@@ -135,7 +135,7 @@ func GetProductRevision(product *commonmodels.Product, allServiceTmpls []*common
 		rendersetName := ""
 		if product.Render != nil {
 			rendersetName = product.Render.Name
-			newRender, err = commonservice.GetRenderSet(product.Render.Name, 0, log)
+			newRender, err = commonservice.GetRenderSet(product.Render.Name, 0, false, log)
 			if err != nil {
 				return prodRev, err
 			}

--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -287,6 +287,7 @@ func GetService(envName, productName, serviceName string, workLoadType string, l
 			Name:        env.Render.Name,
 			Revision:    service.Render.Revision,
 			ProductTmpl: env.ProductName,
+			EnvName:     envName,
 		}
 		rs, err := commonrepo.NewRenderSetColl().Find(renderSetFindOpt)
 		if err != nil {
@@ -485,6 +486,7 @@ func RestartService(envName string, args *SvcOptArgs, log *zap.SugaredLogger) (e
 						Name:        serviceObj.Render.Name,
 						Revision:    serviceObj.Render.Revision,
 						ProductTmpl: productObj.ProductName,
+						EnvName:     productObj.EnvName,
 					}
 					newRender, err = commonrepo.NewRenderSetColl().Find(opt)
 					if err != nil {

--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -283,7 +283,11 @@ func GetService(envName, productName, serviceName string, workLoadType string, l
 			)
 		}
 
-		renderSetFindOpt := &commonrepo.RenderSetFindOption{Name: env.Render.Name, Revision: service.Render.Revision}
+		renderSetFindOpt := &commonrepo.RenderSetFindOption{
+			Name:        env.Render.Name,
+			Revision:    service.Render.Revision,
+			ProductTmpl: env.ProductName,
+		}
 		rs, err := commonrepo.NewRenderSetColl().Find(renderSetFindOpt)
 		if err != nil {
 			log.Errorf("find renderset[%s] error: %v", service.Render.Name, err)
@@ -477,7 +481,11 @@ func RestartService(envName string, args *SvcOptArgs, log *zap.SugaredLogger) (e
 						err = e.ErrDeleteProduct.AddDesc(e.DeleteServiceContainerErrMsg + ": " + err.Error())
 						return
 					}
-					opt := &commonrepo.RenderSetFindOption{Name: serviceObj.Render.Name, Revision: serviceObj.Render.Revision}
+					opt := &commonrepo.RenderSetFindOption{
+						Name:        serviceObj.Render.Name,
+						Revision:    serviceObj.Render.Revision,
+						ProductTmpl: productObj.ProductName,
+					}
 					newRender, err = commonrepo.NewRenderSetColl().Find(opt)
 					if err != nil {
 						log.Errorf("[%s][P:%s]renderset Find error: %v", productObj.EnvName, productObj.ProductName, err)

--- a/pkg/microservice/aslan/core/service/service/helm.go
+++ b/pkg/microservice/aslan/core/service/service/helm.go
@@ -1623,7 +1623,7 @@ func EditHelmService(args *HelmServiceArgs, log *zap.SugaredLogger) error {
 func compareHelmVariable(chartInfos []*templatemodels.RenderChart, productName, createdBy string, log *zap.SugaredLogger) {
 	// 对比上个版本的renderset，新增一个版本
 	latestChartInfos := make([]*templatemodels.RenderChart, 0)
-	renderOpt := &commonrepo.RenderSetFindOption{Name: productName}
+	renderOpt := &commonrepo.RenderSetFindOption{Name: productName, ProductTmpl: productName, IsDefault: true}
 	if latestDefaultRenderSet, err := commonrepo.NewRenderSetColl().Find(renderOpt); err == nil {
 		latestChartInfos = latestDefaultRenderSet.ChartInfos
 	}

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -1167,7 +1167,7 @@ func DeleteServiceTemplate(serviceName, serviceType, productName, isEnvTemplate,
 
 	if serviceType == setting.HelmDeployType {
 		// 更新helm renderset
-		err = removeServiceFromRenderset(productName, productName, serviceName)
+		err = removeServiceFromRenderset(productName, productName, "", serviceName)
 		if err != nil {
 			log.Warnf("failed to update renderset: %s when deleting service: %s, err: %s", productName, serviceName, err.Error())
 		}
@@ -1201,7 +1201,7 @@ func DeleteServiceTemplate(serviceName, serviceType, productName, isEnvTemplate,
 			envNames := []string{"dev", "qa"}
 			for _, envName := range envNames {
 				rendersetName := commonservice.GetProductEnvNamespace(envName, productName, "")
-				err := removeServiceFromRenderset(productName, rendersetName, serviceName)
+				err := removeServiceFromRenderset(productName, rendersetName, envName, serviceName)
 				if err != nil {
 					log.Warnf("failed to update renderset: %s when deleting service: %s, err: %s", rendersetName, serviceName, err.Error())
 				}
@@ -1215,8 +1215,8 @@ func DeleteServiceTemplate(serviceName, serviceType, productName, isEnvTemplate,
 }
 
 // remove specific services from rendersets.chartinfos
-func removeServiceFromRenderset(productName, renderName, serviceName string) error {
-	renderOpt := &commonrepo.RenderSetFindOption{Name: renderName, ProductTmpl: productName}
+func removeServiceFromRenderset(productName, renderName, envName, serviceName string) error {
+	renderOpt := &commonrepo.RenderSetFindOption{Name: renderName, ProductTmpl: productName, EnvName: envName}
 	if rs, err := commonrepo.NewRenderSetColl().Find(renderOpt); err == nil {
 		chartInfos := make([]*templatemodels.RenderChart, 0)
 		for _, chartInfo := range rs.ChartInfos {

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflow_task.go
@@ -707,7 +707,7 @@ func CreateEnvAndTaskByPR(workflowArgs *commonmodels.WorkflowTaskArgs, prID int,
 		mutex.Unlock()
 	}()
 	if baseProduct.Render != nil {
-		if renderSet, _ := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{Name: baseProduct.Render.Name, Revision: baseProduct.Render.Revision}); renderSet != nil {
+		if renderSet, _ := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{Name: baseProduct.Render.Name, Revision: baseProduct.Render.Revision, ProductTmpl: baseProduct.ProductName}); renderSet != nil {
 			baseProduct.Vars = renderSet.KVs
 		}
 	}


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when quering render set data from mongodb, the current query condition may be not accurate enough, this may cause data confusion in some situations. eg: different environments share the same namespace name (from different clusters) will use the renderset with the same name but different revision, when query renderset with condition {renderset_name + product name}, the result may be not the same as expected.

### What is changed and how it works?
add more query conditions to avoid data confusion.

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
