### PR TITLE
add filter when listing gitHub projects

### DIFF
--- a/pkg/microservice/aslan/core/code/client/github/github.go
+++ b/pkg/microservice/aslan/core/code/client/github/github.go
@@ -140,6 +140,10 @@ func (c *Client) ListProjects(opt client.ListOpt) ([]*client.Project, error) {
 	}
 	var res []*client.Project
 	for _, o := range repos {
+		// since we can't filter the repo by gitHub api, we filter by ourselves
+		if len(opt.Namespace) > 0 && o.GetOwner().GetLogin() != opt.Namespace {
+			continue
+		}
 		res = append(res, &client.Project{
 			ID:            int(o.GetID()),
 			Name:          o.GetName(),

--- a/pkg/microservice/aslan/core/code/client/github/github.go
+++ b/pkg/microservice/aslan/core/code/client/github/github.go
@@ -140,7 +140,8 @@ func (c *Client) ListProjects(opt client.ListOpt) ([]*client.Project, error) {
 	}
 	var res []*client.Project
 	for _, o := range repos {
-		// since we can't filter the repo by gitHub api, we filter by ourselves
+		// Note. when using gitHub api to filter repos, private repo will not be returned
+		// we need to filter the repos with query namespace when repo list is returned
 		if len(opt.Namespace) > 0 && o.GetOwner().GetLogin() != opt.Namespace {
 			continue
 		}


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
When listing github repos, repos of all accounts are listed while only those owned by the selected account should be listed

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
