### PR TITLE
fix bug of keeping too many connections in hub-agent

### DIFF
--- a/pkg/tool/remotedialer/server.go
+++ b/pkg/tool/remotedialer/server.go
@@ -145,6 +145,7 @@ func (r *Server) GetTransport(clusterCaCert string, clientKey string) (http.Roun
 	d := r.Dialer(clientKey)
 	transport.DialContext = d
 	transport.Proxy = http.ProxyFromEnvironment
+	transport.IdleConnTimeout = 30 * time.Second
 
 	r.caCert = clusterCaCert
 	if r.httpTransport != nil {


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

According to https://github.com/koderover/zadig/issues/475 and https://github.com/koderover/zadig/issues/1535, `hub-agent` will keep too many connections to the local `kube-apiserver` without releasing them, which will put unnecessary pressure on the local cluster `kube-apiserver`.

### What is changed and how it works?

Set `IdleConnTimeout` for every connection from `hub-server` to `hub-agent` to close connection actively.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
