### PR TITLE
add env resource update logic

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/product.go
+++ b/pkg/microservice/aslan/core/common/repository/models/product.go
@@ -77,6 +77,7 @@ type CreateUpdateCommonEnvCfgArgs struct {
 	GitRepoConfig        *templatemodels.GitRepoConfig `json:"git_repo_config"`
 	SourceDetail         *CreateFromRepo               `json:"-"`
 	AutoSync             bool                          `json:"auto_sync"`
+	LatestEnvResource    *EnvResource                  `json:"-"`
 }
 
 type RenderInfo struct {

--- a/pkg/microservice/aslan/core/common/repository/mongodb/env_resource.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/env_resource.go
@@ -81,6 +81,20 @@ type QueryEnvResourceOption struct {
 	Name           string
 	Type           string
 	IgnoreNotFound bool
+	AutoSync       bool
+	Active         bool
+}
+
+type EnvResourceBaseData struct {
+	ProjectName string `bson:"product_name"`
+	EnvName     string `bson:"env_name"`
+	Name        string `bson:"name"`
+	Type        string `bson:"type"`
+}
+
+type EnvResourceAggregateData struct {
+	ID         EnvResourceBaseData `bson:"_id"`
+	CreateTime int64               `bson:"create_time"`
 }
 
 func (c *EnvResourceColl) List(opt *QueryEnvResourceOption) ([]*models.EnvResource, error) {
@@ -140,6 +154,12 @@ func (c *EnvResourceColl) Find(opt *QueryEnvResourceOption) (*models.EnvResource
 	if len(opt.Type) > 0 {
 		query["type"] = opt.Type
 	}
+	if opt.Active {
+		query["deleted_at"] = bson.M{"$or": []bson.M{
+			bson.M{"deleted_at": bson.M{"$eq": 0}},
+			bson.M{"deleted_at": bson.M{"$eq": nil}},
+		}}
+	}
 	if len(opt.Id) > 0 {
 		oid, err := primitive.ObjectIDFromHex(opt.Id)
 		if err != nil {
@@ -163,6 +183,71 @@ func (c *EnvResourceColl) Find(opt *QueryEnvResourceOption) (*models.EnvResource
 		return nil, err
 	}
 	return rs, err
+}
+
+func (c *EnvResourceColl) ListLatestResource(opt *QueryEnvResourceOption) ([]*EnvResourceAggregateData, error) {
+	query := bson.M{}
+	if len(opt.ProductName) > 0 {
+		query["product_name"] = opt.ProductName
+	}
+	if len(opt.Namespace) > 0 {
+		query["namespace"] = opt.Namespace
+	}
+	if len(opt.EnvName) > 0 {
+		query["env_name"] = opt.EnvName
+	}
+	if len(opt.Name) > 0 {
+		query["name"] = opt.Name
+	}
+	if len(opt.Type) > 0 {
+		query["type"] = opt.Type
+	}
+
+	var pipeline []bson.M
+	if len(query) > 0 {
+		pipeline = append(pipeline, bson.M{"$match": query})
+	}
+
+	pipeline = append(pipeline,
+		bson.M{"$sort": bson.M{"create_time": -1}},
+		bson.M{
+			"$group": bson.M{
+				"_id": bson.M{
+					"product_name": "$product_name",
+					"env_name":     "$env_name",
+					"name":         "$name",
+					"type":         "$type",
+				},
+				"create_time": bson.M{"$first": "$create_time"},
+				"deleted_at":  bson.M{"$first": "$deleted_at"},
+				"auto_sync":   bson.M{"$first": "$auto_sync"},
+			},
+		},
+	)
+
+	pipeline = append(pipeline, bson.M{
+		"$match": bson.M{"$or": []bson.M{
+			bson.M{"deleted_at": bson.M{"$eq": 0}},
+			bson.M{"deleted_at": bson.M{"$eq": nil}},
+		}},
+	})
+
+	if opt.AutoSync {
+		pipeline = append(pipeline, bson.M{
+			"$match": bson.M{"auto_sync": true},
+		})
+	}
+
+	cursor, err := c.Aggregate(context.TODO(), pipeline)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*EnvResourceAggregateData, 0)
+	if err := cursor.All(context.TODO(), &result); err != nil {
+		return nil, err
+	}
+	return result, err
 }
 
 func (c *EnvResourceColl) Delete(oid primitive.ObjectID) error {

--- a/pkg/microservice/aslan/core/common/repository/mongodb/env_resource.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/env_resource.go
@@ -86,7 +86,7 @@ type QueryEnvResourceOption struct {
 }
 
 type EnvResourceBaseData struct {
-	ProjectName string `bson:"product_name"`
+	ProductName string `bson:"product_name"`
 	EnvName     string `bson:"env_name"`
 	Name        string `bson:"name"`
 	Type        string `bson:"type"`
@@ -155,10 +155,7 @@ func (c *EnvResourceColl) Find(opt *QueryEnvResourceOption) (*models.EnvResource
 		query["type"] = opt.Type
 	}
 	if opt.Active {
-		query["deleted_at"] = bson.M{"$or": []bson.M{
-			bson.M{"deleted_at": bson.M{"$eq": 0}},
-			bson.M{"deleted_at": bson.M{"$eq": nil}},
-		}}
+		query["deleted_at"] = 0
 	}
 	if len(opt.Id) > 0 {
 		oid, err := primitive.ObjectIDFromHex(opt.Id)
@@ -226,10 +223,7 @@ func (c *EnvResourceColl) ListLatestResource(opt *QueryEnvResourceOption) ([]*En
 	)
 
 	pipeline = append(pipeline, bson.M{
-		"$match": bson.M{"$or": []bson.M{
-			bson.M{"deleted_at": bson.M{"$eq": 0}},
-			bson.M{"deleted_at": bson.M{"$eq": nil}},
-		}},
+		"$match": bson.M{"deleted_at": 0},
 	})
 
 	if opt.AutoSync {

--- a/pkg/microservice/aslan/core/common/repository/mongodb/template/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/template/product.go
@@ -192,7 +192,8 @@ func (c *ProductColl) ListWithOption(opt *ProductListOpt) ([]*template.Product, 
 		query["product_feature.basic_facility"] = opt.BasicFacility
 	}
 	if opt.DeployType != "" {
-		query["product_feature.deploy_type"] = opt.DeployType
+		//query["product_feature.deploy_type"] = opt.DeployType
+		query["product_feature.deploy_type"] = bson.M{"$in": strings.Split(opt.DeployType, ",")}
 	}
 
 	cursor, err := c.Collection.Find(context.TODO(), query)

--- a/pkg/microservice/aslan/core/common/repository/mongodb/template/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/template/product.go
@@ -192,7 +192,6 @@ func (c *ProductColl) ListWithOption(opt *ProductListOpt) ([]*template.Product, 
 		query["product_feature.basic_facility"] = opt.BasicFacility
 	}
 	if opt.DeployType != "" {
-		//query["product_feature.deploy_type"] = opt.DeployType
 		query["product_feature.deploy_type"] = bson.M{"$in": strings.Split(opt.DeployType, ",")}
 	}
 

--- a/pkg/microservice/aslan/core/environment/handler/common_env_cfg.go
+++ b/pkg/microservice/aslan/core/environment/handler/common_env_cfg.go
@@ -131,3 +131,33 @@ func ListCommonEnvCfgHistory(c *gin.Context) {
 
 	ctx.Resp, ctx.Err = service.ListEnvResourceHistory(args, ctx.Logger)
 }
+
+func ListLatestEnvCfg(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	args := new(service.ListCommonEnvCfgHistoryArgs)
+	if err := c.ShouldBindQuery(args); err != nil {
+		ctx.Err = e.ErrInvalidParam.AddErr(err)
+		return
+	}
+
+	ctx.Resp, ctx.Err = service.ListLatestEnvResources(args, ctx.Logger)
+}
+
+func SyncEnvResource(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	envName := c.Param("envName")
+	resType := c.Param("type")
+	resName := c.Param("objectName")
+
+	args := &service.SyncEnvResourceArg{
+		EnvName:     envName,
+		ProductName: c.Query("projectName"),
+		Name:        resName,
+		Type:        resType,
+	}
+	ctx.Err = service.SyncEnvResource(args, ctx.Logger)
+}

--- a/pkg/microservice/aslan/core/environment/handler/common_env_cfg.go
+++ b/pkg/microservice/aslan/core/environment/handler/common_env_cfg.go
@@ -125,7 +125,7 @@ func ListCommonEnvCfgHistory(c *gin.Context) {
 
 	args := new(service.ListCommonEnvCfgHistoryArgs)
 	args.EnvName = c.Param("envName")
-	args.ProductName = c.Query("projectName")
+	args.ProjectName = c.Query("projectName")
 	args.CommonEnvCfgType = config.CommonEnvCfgType(c.Query("commonEnvCfgType"))
 	args.Name = c.Param("objectName")
 

--- a/pkg/microservice/aslan/core/environment/handler/common_env_cfg.go
+++ b/pkg/microservice/aslan/core/environment/handler/common_env_cfg.go
@@ -141,7 +141,6 @@ func ListLatestEnvCfg(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam.AddErr(err)
 		return
 	}
-
 	ctx.Resp, ctx.Err = service.ListLatestEnvResources(args, ctx.Logger)
 }
 

--- a/pkg/microservice/aslan/core/environment/handler/common_env_cfg.go
+++ b/pkg/microservice/aslan/core/environment/handler/common_env_cfg.go
@@ -149,15 +149,11 @@ func SyncEnvResource(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
-	envName := c.Param("envName")
-	resType := c.Param("type")
-	resName := c.Param("objectName")
-
 	args := &service.SyncEnvResourceArg{
-		EnvName:     envName,
+		EnvName:     c.Param("envName"),
 		ProductName: c.Query("projectName"),
-		Name:        resName,
-		Type:        resType,
+		Name:        c.Param("objectName"),
+		Type:        c.Param("type"),
 	}
 	ctx.Err = service.SyncEnvResource(args, ctx.Logger)
 }

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -50,6 +50,8 @@ func (*Router) Inject(router *gin.RouterGroup) {
 	commonEnvCfgs := router.Group("envcfgs")
 	{
 		commonEnvCfgs.GET("/:envName/cfg/:objectName", ListCommonEnvCfgHistory)
+		commonEnvCfgs.GET("", ListLatestEnvCfg)
+		commonEnvCfgs.PUT("/:envName/:type/:objectName/sync", SyncEnvResource)
 		commonEnvCfgs.PUT("/:envName", gin2.UpdateOperationLogStatus, UpdateCommonEnvCfg)
 		commonEnvCfgs.POST("/:envName", gin2.UpdateOperationLogStatus, CreateCommonEnvCfg)
 		commonEnvCfgs.DELETE("/:envName/cfg/:objectName", gin2.UpdateOperationLogStatus, DeleteCommonEnvCfg)

--- a/pkg/microservice/aslan/core/environment/service/common_env_cfg.go
+++ b/pkg/microservice/aslan/core/environment/service/common_env_cfg.go
@@ -550,7 +550,6 @@ func ListLatestEnvResources(args *ListCommonEnvCfgHistoryArgs, log *zap.SugaredL
 }
 
 func SyncEnvResource(args *SyncEnvResourceArg, log *zap.SugaredLogger) error {
-
 	product, err := commonrepo.NewProductColl().Find(&commonrepo.ProductFindOptions{
 		Name:    args.ProductName,
 		EnvName: args.EnvName,
@@ -565,7 +564,7 @@ func SyncEnvResource(args *SyncEnvResourceArg, log *zap.SugaredLogger) error {
 		Type:        args.Type,
 	})
 	if err != nil {
-		return e.ErrUpdateResource.AddErr(fmt.Errorf("failed to find env resource: %s:%s of env: %s:%s", args.Type, args.Name, args.ProductName, args.EnvName))
+		return e.ErrUpdateResource.AddErr(fmt.Errorf("failed to find env resource: %s:%s of env: %s:%s, err: %s", args.Type, args.Name, args.ProductName, args.EnvName, err))
 	}
 
 	if !envResource.AutoSync {

--- a/pkg/microservice/aslan/core/environment/service/common_env_cfg.go
+++ b/pkg/microservice/aslan/core/environment/service/common_env_cfg.go
@@ -423,9 +423,9 @@ func UpdateCommonEnvCfg(args *models.CreateUpdateCommonEnvCfgArgs, userName stri
 
 type ListCommonEnvCfgHistoryArgs struct {
 	EnvName          string                  `json:"env_name"            form:"envName"`
-	ProductName      string                  `json:"product_name"        form:"projectName"`
+	ProjectName      string                  `json:"project_name"        form:"projectName"`
 	Name             string                  `json:"name"                form:"name"`
-	CommonEnvCfgType config.CommonEnvCfgType `json:"common_env_cfg_type" form:"CommonEnvCfgType"`
+	CommonEnvCfgType config.CommonEnvCfgType `json:"common_env_cfg_type" form:"commonEnvCfgType"`
 	AutoSync         bool                    `json:"auto_sync"           form:"autoSync"`
 }
 
@@ -473,7 +473,7 @@ func ListEnvResourceHistory(args *ListCommonEnvCfgHistoryArgs, log *zap.SugaredL
 	}
 
 	product, err := commonrepo.NewProductColl().Find(&commonrepo.ProductFindOptions{
-		Name:    args.ProductName,
+		Name:    args.ProjectName,
 		EnvName: args.EnvName,
 	})
 	if err != nil {
@@ -498,7 +498,7 @@ func ListEnvResourceHistory(args *ListCommonEnvCfgHistoryArgs, log *zap.SugaredL
 
 	opts := &commonrepo.QueryEnvResourceOption{
 		IsSort:      true,
-		ProductName: args.ProductName,
+		ProductName: args.ProjectName,
 		EnvName:     args.EnvName,
 		Name:        args.Name,
 		Type:        string(args.CommonEnvCfgType),
@@ -526,7 +526,7 @@ func ListEnvResourceHistory(args *ListCommonEnvCfgHistoryArgs, log *zap.SugaredL
 
 func ListLatestEnvResources(args *ListCommonEnvCfgHistoryArgs, log *zap.SugaredLogger) ([]*ListCommonEnvCfgHistoryRes, error) {
 	opts := &commonrepo.QueryEnvResourceOption{
-		ProductName: args.ProductName,
+		ProductName: args.ProjectName,
 		EnvName:     args.EnvName,
 		Name:        args.Name,
 		AutoSync:    args.AutoSync,

--- a/pkg/microservice/aslan/core/environment/service/configmap.go
+++ b/pkg/microservice/aslan/core/environment/service/configmap.go
@@ -40,11 +40,9 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/kube"
 	"github.com/koderover/zadig/pkg/setting"
 	kubeclient "github.com/koderover/zadig/pkg/shared/kube/client"
-	"github.com/koderover/zadig/pkg/shared/kube/wrapper"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 	"github.com/koderover/zadig/pkg/tool/kube/getter"
 	"github.com/koderover/zadig/pkg/tool/kube/updater"
-	"github.com/koderover/zadig/pkg/tool/kube/util"
 )
 
 type ListConfigMapArgs struct {
@@ -71,33 +69,11 @@ type UpdateConfigMapArgs struct {
 	Services             []string `json:"services"`
 }
 
-type configMap struct {
-	Name              string            `json:"name"`
-	Data              map[string]string `json:"data"`
-	ModifiedBy        string            `json:"modifiedBy"`
-	CreationTimestamp string            `json:"creationTimestamp"`
-	LastUpdateTime    string            `json:"lastUpdateTime"`
-	lastUpdateTime    time.Time
-}
-
 type ListConfigMapRes struct {
 	*ResourceResponseBase
 	CmName    string            `json:"cm_name"`
 	Immutable bool              `json:"immutable"`
 	CmData    map[string]string `json:"cm_data"`
-}
-
-func generateConfigMapResponse(cm *corev1.ConfigMap) *configMap {
-	icm := wrapper.ConfigMap(cm)
-	u, _ := icm.LastUpdateTime()
-	return &configMap{
-		Name:              icm.Name,
-		Data:              icm.Data,
-		ModifiedBy:        icm.ModifiedBy(),
-		CreationTimestamp: util.FormatTime(icm.CreationTimestamp.Time),
-		LastUpdateTime:    util.FormatTime(u),
-		lastUpdateTime:    u,
-	}
 }
 
 func ListConfigMaps(args *ListConfigMapArgs, log *zap.SugaredLogger) ([]*ListConfigMapRes, error) {

--- a/pkg/microservice/cron/core/service/client/env.go
+++ b/pkg/microservice/cron/core/service/client/env.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -31,7 +32,7 @@ import (
 
 type EvnListOption struct {
 	BasicFacility string
-	DeployType    string
+	DeployType    []string
 }
 
 func (c *Client) ListEnvs(log *zap.SugaredLogger, option *EvnListOption) ([]*service.ProductRevision, error) {
@@ -40,7 +41,7 @@ func (c *Client) ListEnvs(log *zap.SugaredLogger, option *EvnListOption) ([]*ser
 		resp = make([]*service.ProductRevision, 0)
 	)
 
-	url := fmt.Sprintf("%s/environment/revision/products?basicFacility=%s&deployType=%s", c.APIBase, option.BasicFacility, option.DeployType)
+	url := fmt.Sprintf("%s/environment/revision/products?basicFacility=%s&deployType=%s", c.APIBase, option.BasicFacility, strings.Join(option.DeployType, ","))
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		log.Errorf("ListEnvs new http request error: %v", err)
@@ -59,6 +60,33 @@ func (c *Client) ListEnvs(log *zap.SugaredLogger, option *EvnListOption) ([]*ser
 		}
 	}
 	return resp, errors.WithMessage(err, "failed to list envs")
+}
+
+func (c *Client) ListEnvResources(productName, envName string, log *zap.SugaredLogger) ([]*service.EnvResource, error) {
+	var (
+		err  error
+		resp = make([]*service.EnvResource, 0)
+	)
+	url := fmt.Sprintf("%s/environment/envcfgs?autoSync=true&projectName=%s&envName=%s", c.APIBase, productName, envName)
+	request, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		log.Errorf("ListEnvs new http request error: %v", err)
+		return nil, err
+	}
+
+	var ret *http.Response
+	if ret, err = c.Conn.Do(request); err == nil {
+		defer func() { _ = ret.Body.Close() }()
+		var body []byte
+		body, err = ioutil.ReadAll(ret.Body)
+		if err == nil {
+			if err = json.Unmarshal(body, &resp); err == nil {
+				return resp, nil
+			}
+		}
+	}
+
+	return resp, err
 }
 
 func (c *Client) GetEnvService(productName, envName string, log *zap.SugaredLogger) (*service.ProductResp, error) {
@@ -169,6 +197,25 @@ func (c *Client) UpdateService(args *service.ServiceTmplObject, log *zap.Sugared
 
 func (c *Client) SyncEnvVariables(productName, envName string, log *zap.SugaredLogger) error {
 	url := fmt.Sprintf("%s/environment/environments/%s/syncVariables?projectName=%s", c.APIBase, envName, productName)
+	request, err := http.NewRequest("PUT", url, nil)
+	if err != nil {
+		log.Errorf("SyncEnvVariables new http request error: %v", err)
+		return err
+	}
+
+	var ret *http.Response
+	if ret, err = c.Conn.Do(request); err == nil {
+		defer func() { _ = ret.Body.Close() }()
+		_, err := ioutil.ReadAll(ret.Body)
+		if err != nil {
+			return errors.WithMessage(err, "failed to sync product variables ")
+		}
+	}
+	return nil
+}
+
+func (c *Client) SyncEnvResource(productName, envName, resType, resName string, log *zap.SugaredLogger) error {
+	url := fmt.Sprintf("%s/environment/envcfgs/%s/%s/%s/sync?projectName=%s", c.APIBase, envName, resType, resName, productName)
 	request, err := http.NewRequest("PUT", url, nil)
 	if err != nil {
 		log.Errorf("SyncEnvVariables new http request error: %v", err)

--- a/pkg/microservice/cron/core/service/client/env.go
+++ b/pkg/microservice/cron/core/service/client/env.go
@@ -70,7 +70,7 @@ func (c *Client) ListEnvResources(productName, envName string, log *zap.SugaredL
 	url := fmt.Sprintf("%s/environment/envcfgs?autoSync=true&projectName=%s&envName=%s", c.APIBase, productName, envName)
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		log.Errorf("ListEnvs new http request error: %v", err)
+		log.Errorf("ListEnvResources new http request error: %s", err)
 		return nil, err
 	}
 
@@ -218,7 +218,7 @@ func (c *Client) SyncEnvResource(productName, envName, resType, resName string, 
 	url := fmt.Sprintf("%s/environment/envcfgs/%s/%s/%s/sync?projectName=%s", c.APIBase, envName, resType, resName, productName)
 	request, err := http.NewRequest("PUT", url, nil)
 	if err != nil {
-		log.Errorf("SyncEnvVariables new http request error: %v", err)
+		log.Errorf("SyncEnvResource new http request error: %v", err)
 		return err
 	}
 

--- a/pkg/microservice/cron/core/service/client/env.go
+++ b/pkg/microservice/cron/core/service/client/env.go
@@ -225,10 +225,6 @@ func (c *Client) SyncEnvResource(productName, envName, resType, resName string, 
 	var ret *http.Response
 	if ret, err = c.Conn.Do(request); err == nil {
 		defer func() { _ = ret.Body.Close() }()
-		_, err := ioutil.ReadAll(ret.Body)
-		if err != nil {
-			return errors.WithMessage(err, "failed to sync product variables ")
-		}
 	}
 	return nil
 }

--- a/pkg/microservice/cron/core/service/scheduler/schedule_env_update.go
+++ b/pkg/microservice/cron/core/service/scheduler/schedule_env_update.go
@@ -41,7 +41,7 @@ func needCreateSchedule(rendersetObj *service.ProductRenderset) bool {
 }
 
 func (c *CronClient) UpsertEnvValueSyncScheduler(log *zap.SugaredLogger) {
-	envs, err := c.AslanCli.ListEnvs(log, &client.EvnListOption{DeployType: setting.HelmDeployType})
+	envs, err := c.AslanCli.ListEnvs(log, &client.EvnListOption{DeployType: []string{setting.HelmDeployType}})
 	if err != nil {
 		log.Error(err)
 		return

--- a/pkg/microservice/cron/core/service/scheduler/schedule_workflow.go
+++ b/pkg/microservice/cron/core/service/scheduler/schedule_workflow.go
@@ -144,6 +144,10 @@ func (c *CronClient) UpsertWorkflowScheduler(log *zap.SugaredLogger) {
 			if strings.HasPrefix(name, "helm-values-sync-") {
 				continue
 			}
+			// exclude env resource sync timers
+			if strings.HasPrefix(name, "env-resource") {
+				continue
+			}
 			log.Warnf("[%s]deleted workflow detached", name)
 			if _, ok := c.SchedulerController[name]; ok {
 				c.SchedulerController[name] <- true

--- a/pkg/microservice/cron/core/service/scheduler/schedule_workflow.go
+++ b/pkg/microservice/cron/core/service/scheduler/schedule_workflow.go
@@ -123,7 +123,8 @@ func (c *CronClient) UpsertWorkflowScheduler(log *zap.SugaredLogger) {
 	ScheduleNames := sets.NewString(
 		CleanJobScheduler, UpsertWorkflowScheduler, UpsertTestScheduler,
 		InitStatScheduler, InitOperationStatScheduler,
-		CleanProductScheduler, InitHealthCheckScheduler, InitHealthCheckPmHostScheduler, UpsertColliePipelineScheduler)
+		CleanProductScheduler, InitHealthCheckScheduler, InitHealthCheckPmHostScheduler,
+		UpsertColliePipelineScheduler, InitHelmEnvSyncValuesScheduler, EnvResourceSyncScheduler)
 
 	// 停掉已被删除的pipeline对应的scheduler
 	for name := range c.Schedulers {

--- a/pkg/microservice/cron/core/service/scheduler/shedule_env_resource_update.go
+++ b/pkg/microservice/cron/core/service/scheduler/shedule_env_resource_update.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2022 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"fmt"
+
+	"github.com/koderover/zadig/pkg/setting"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/koderover/zadig/pkg/microservice/cron/core/service"
+	"github.com/koderover/zadig/pkg/microservice/cron/core/service/client"
+	"github.com/koderover/zadig/pkg/tool/log"
+
+	"github.com/jasonlvhit/gocron"
+	"go.uber.org/zap"
+)
+
+func buildEnvResourceCronKey(envResource *service.EnvResource) string {
+	return fmt.Sprintf("env-resource:%s:%s-type:%s-name:%s", envResource.ProductName, envResource.EnvName, envResource.Type, envResource.Name)
+}
+
+func (c *CronClient) deleteEnvResourceScheduler(envResourceKey string) {
+	log.Infof("deleting single env resource scheduler: %s", envResourceKey)
+	if _, ok := c.SchedulerController[envResourceKey]; ok {
+		c.SchedulerController[envResourceKey] <- true
+	}
+	if _, ok := c.Schedulers[envResourceKey]; ok {
+		c.Schedulers[envResourceKey].Clear()
+		delete(c.Schedulers, envResourceKey)
+	}
+}
+
+func (c *CronClient) UpsertEnvResourceSyncScheduler(log *zap.SugaredLogger) {
+
+	envs, err := c.AslanCli.ListEnvs(log, &client.EvnListOption{DeployType: []string{setting.HelmDeployType, setting.K8SDeployType}})
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	log.Info("start init env resource sync scheduler.")
+
+	lastScheduler := sets.NewString()
+	for k := range c.lastEnvResourceSchedulerData {
+		lastScheduler.Insert(k)
+	}
+
+	for _, env := range envs {
+		envResources, err := c.AslanCli.ListEnvResources(env.ProductName, env.EnvName, log)
+		if err != nil {
+			log.Error(err)
+			return
+		}
+
+		for _, envResource := range envResources {
+			envResourceKey := buildEnvResourceCronKey(envResource)
+
+			lastScheduler.Delete(envResourceKey)
+
+			if lastEnvResConfig, ok := c.lastEnvResourceSchedulerData[envResourceKey]; ok {
+				if envResource.CreateTime == lastEnvResConfig.CreateTime {
+					continue
+				}
+			}
+			c.lastEnvResourceSchedulerData[envResourceKey] = envResource
+
+			c.deleteEnvResourceScheduler(envResourceKey)
+
+			newScheduler := gocron.NewScheduler()
+			newScheduler.Every(EnvUpdateInterval).Seconds().Do(c.RunScheduledEnvResourceUpdate, envResource.ProductName, envResource.EnvName, envResource.Type, envResource.Name, log)
+
+			log.Infof("[%s] add env resource schedulers..", envResourceKey)
+			c.Schedulers[envResourceKey] = newScheduler
+			c.SchedulerController[envResourceKey] = c.Schedulers[envResourceKey].Start()
+		}
+
+	}
+
+	for _, k := range lastScheduler.List() {
+		c.deleteEnvResourceScheduler(k)
+	}
+}
+
+func (c *CronClient) RunScheduledEnvResourceUpdate(productName, envName, resType, resName string, log *zap.SugaredLogger) {
+	log.Infof("start to Run RunScheduledEnvResourceUpdate, productName: %s, envName: %s, resType: %s, resName: %s", productName, envName, resType, resName)
+	err := c.AslanCli.SyncEnvResource(productName, envName, resType, resName, log)
+	if err != nil {
+		log.Errorf("failed to sync variables for env: %s:%s", productName, envName)
+	}
+}

--- a/pkg/microservice/cron/core/service/scheduler/shedule_env_resource_update.go
+++ b/pkg/microservice/cron/core/service/scheduler/shedule_env_resource_update.go
@@ -99,6 +99,6 @@ func (c *CronClient) RunScheduledEnvResourceUpdate(productName, envName, resType
 	log.Infof("start to Run RunScheduledEnvResourceUpdate, productName: %s, envName: %s, resType: %s, resName: %s", productName, envName, resType, resName)
 	err := c.AslanCli.SyncEnvResource(productName, envName, resType, resName, log)
 	if err != nil {
-		log.Errorf("failed to sync variables for env: %s:%s", productName, envName)
+		log.Warnf("failed to sync variables for env: %s:%s", productName, envName)
 	}
 }

--- a/pkg/microservice/cron/core/service/scheduler/shedule_env_resource_update.go
+++ b/pkg/microservice/cron/core/service/scheduler/shedule_env_resource_update.go
@@ -19,16 +19,14 @@ package scheduler
 import (
 	"fmt"
 
-	"github.com/koderover/zadig/pkg/setting"
-
+	"github.com/jasonlvhit/gocron"
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/koderover/zadig/pkg/microservice/cron/core/service"
 	"github.com/koderover/zadig/pkg/microservice/cron/core/service/client"
+	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/tool/log"
-
-	"github.com/jasonlvhit/gocron"
-	"go.uber.org/zap"
 )
 
 func buildEnvResourceCronKey(envResource *service.EnvResource) string {

--- a/pkg/microservice/cron/core/service/service.go
+++ b/pkg/microservice/cron/core/service/service.go
@@ -61,6 +61,20 @@ type ProductRevision struct {
 	IsPublic         bool           `json:"isPublic"`
 }
 
+type EnvResource struct {
+	ID             primitive.ObjectID `bson:"_id,omitempty"             json:"id,omitempty"`
+	Type           string             `bson:"type"                      json:"type"`
+	ProductName    string             `bson:"product_name"              json:"product_name"`
+	CreateTime     int64              `bson:"create_time"               json:"create_time"`
+	UpdateUserName string             `bson:"update_user_name"          json:"update_user_name"`
+	DeletedAt      int64              `bson:"deleted_at"                json:"deleted_at" `
+	Namespace      string             `bson:"namespace,omitempty"       json:"namespace,omitempty"`
+	EnvName        string             `bson:"env_name"                  json:"env_name"`
+	Name           string             `bson:"name"                      json:"name"`
+	YamlData       string             `bson:"yaml_data"                 json:"yaml_data"`
+	AutoSync       bool               `bson:"auto_sync"                 json:"auto_sync"`
+}
+
 type ProductResp struct {
 	ID          string      `json:"id"`
 	ProductName string      `json:"product_name"`

--- a/pkg/microservice/policy/core/yamlconfig/urls.yaml
+++ b/pkg/microservice/policy/core/yamlconfig/urls.yaml
@@ -300,6 +300,12 @@ exemption_urls:
     - endpoint: api/v1/system-policybindings/?*
       methods:
         - DELETE
+    - endpoint: api/aslan/environment/envcfgs
+      methods:
+        - GET
+    - endpoint: api/aslan/environment/envcfgs/?*/sync
+      methods:
+        - PUT
   project_admin:
     - endpoint: api/aslan/project/products
       methods:


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
add abily to sync  from remote git repo and update to k8s for resources created from zadig on environemnt resource management page

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
