### PR TITLE
fix resource k8s resource remove fail bug

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2973,6 +2973,7 @@ func removeOldResources(
 
 	for name, item := range oldItemsMap {
 		_, exists := itemsMap[name]
+		item.SetNamespace(env.Namespace)
 		if !exists {
 			if err = updater.DeleteUnstructured(item, kubeClient); err != nil {
 				log.Errorf(


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when removing resource from service template for k8s yaml product and applying to environments, the deleted resource still exist in namespace which does't work as expected

### What is changed and how it works?
fix bug

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
