### PR TITLE
fix ua combine env resource data error bug

### DIFF
--- a/pkg/cli/upgradeassistant/internal/repository/mongodb/env_resources.go
+++ b/pkg/cli/upgradeassistant/internal/repository/mongodb/env_resources.go
@@ -39,6 +39,9 @@ func NewEnvResourceColl() *EnvResourceColl {
 }
 
 func (c *EnvResourceColl) BatchInsert(resources []*models.EnvResource) error {
+	if len(resources) == 0 {
+		return nil
+	}
 	resList := make([]interface{}, 0, len(resources))
 	for _, res := range resources {
 		resList = append(resList, res)


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when running upgrade assistant to combine env resource, panic may occur if there is no env resources need to be combined

### What is changed and how it works?
fix bug

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
