### PR TITLE
fix env resource cron bug

### DIFF
--- a/pkg/microservice/cron/core/service/scheduler/shedule_env_resource_update.go
+++ b/pkg/microservice/cron/core/service/scheduler/shedule_env_resource_update.go
@@ -37,6 +37,7 @@ func (c *CronClient) deleteEnvResourceScheduler(envResourceKey string) {
 	log.Infof("deleting single env resource scheduler: %s", envResourceKey)
 	if _, ok := c.SchedulerController[envResourceKey]; ok {
 		c.SchedulerController[envResourceKey] <- true
+		delete(c.SchedulerController, envResourceKey)
 	}
 	if _, ok := c.Schedulers[envResourceKey]; ok {
 		c.Schedulers[envResourceKey].Clear()
@@ -48,7 +49,7 @@ func (c *CronClient) UpsertEnvResourceSyncScheduler(log *zap.SugaredLogger) {
 
 	envs, err := c.AslanCli.ListEnvs(log, &client.EvnListOption{DeployType: []string{setting.HelmDeployType, setting.K8SDeployType}})
 	if err != nil {
-		log.Error(err)
+		log.Errorf("failed to list envs for env resource update: %s", err)
 		return
 	}
 
@@ -92,6 +93,7 @@ func (c *CronClient) UpsertEnvResourceSyncScheduler(log *zap.SugaredLogger) {
 
 	for _, k := range lastScheduler.List() {
 		c.deleteEnvResourceScheduler(k)
+		delete(c.lastEnvResourceSchedulerData, k)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when disable auto sync from git repo for environment resource, it would not work when enable auto sync again

### What is changed and how it works?
fix bug

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
