### PR TITLE
fix product render version error bug

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -3505,17 +3505,18 @@ func updateProductGroup(username, productName, envName string, productResp *comm
 		return svcNameSet.Has(svc.ServiceName)
 	}
 
+	productResp.Render.Revision = renderSet.Revision
+	if err = commonrepo.NewProductColl().Update(productResp); err != nil {
+		log.Errorf("Failed to update env, err: %s", err)
+		return err
+	}
+
 	err = proceedHelmRelease(productName, envName, productResp, renderSet, helmClient, filter, log)
 	if err != nil {
 		log.Errorf("error occurred when upgrading services in env: %s/%s, err: %s ", productName, envName, err)
 		return err
 	}
 
-	productResp.Render.Revision = renderSet.Revision
-	if err = commonrepo.NewProductColl().Update(productResp); err != nil {
-		log.Errorf("Failed to update env, err: %s", err)
-		return err
-	}
 	return nil
 }
 
@@ -3807,11 +3808,8 @@ func proceedHelmRelease(productName, envName string, productResp *commonmodels.P
 			log.Errorf("Failed to update service group %d. Error: %v", groupIndex, err)
 			return err
 		}
-		if errList.ErrorOrNil() != nil {
-			return errList.ErrorOrNil()
-		}
 	}
-	return nil
+	return errList.ErrorOrNil()
 }
 
 func setFieldValueIsNotExist(obj map[string]interface{}, value interface{}, fields ...string) map[string]interface{} {

--- a/pkg/microservice/aslan/core/project/handler/router.go
+++ b/pkg/microservice/aslan/core/project/handler/router.go
@@ -63,6 +63,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 	project := router.Group("projects")
 	{
 		project.GET("", ListProjects)
+		product.POST("/clear", gin2.UpdateOperationLogStatus, ClearProject)
 	}
 
 	pms := router.Group("pms")

--- a/pkg/microservice/aslan/core/project/handler/router.go
+++ b/pkg/microservice/aslan/core/project/handler/router.go
@@ -63,7 +63,6 @@ func (*Router) Inject(router *gin.RouterGroup) {
 	project := router.Group("projects")
 	{
 		project.GET("", ListProjects)
-		product.POST("/clear", gin2.UpdateOperationLogStatus, ClearProject)
 	}
 
 	pms := router.Group("pms")


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when adding services to environment of helm projects, the revision value of render in product will be wrong if some service failed to be installed, this would case `no chart found` error when running workflows to deploy services.

### What is changed and how it works?
fix bug

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
