### PR TITLE
fix gitee fetch project bug

### DIFF
--- a/pkg/tool/gitee/repositories.go
+++ b/pkg/tool/gitee/repositories.go
@@ -43,6 +43,7 @@ func (c *Client) ListRepositoriesForAuthenticatedUser(accessToken, keyword strin
 	httpClient := httpclient.New(
 		httpclient.SetHostURL(GiteeHOSTURL),
 	)
+	// api reference: https://gitee.com/api/v5/swagger#/getV5UserRepos
 	url := "/v5/user/repos"
 	queryParams := make(map[string]string)
 	queryParams["access_token"] = accessToken
@@ -66,6 +67,7 @@ func (c *Client) ListRepositoriesForOrg(accessToken, org string, page, perPage i
 	httpClient := httpclient.New(
 		httpclient.SetHostURL(GiteeHOSTURL),
 	)
+	// api reference: https://gitee.com/api/v5/swagger#/getV5OrgsOrgRepos
 	url := fmt.Sprintf("/v5/orgs/%s/repos", org)
 	queryParams := make(map[string]string)
 	queryParams["access_token"] = accessToken

--- a/pkg/tool/gitee/repositories.go
+++ b/pkg/tool/gitee/repositories.go
@@ -48,7 +48,7 @@ func (c *Client) ListRepositoriesForAuthenticatedUser(accessToken, keyword strin
 	queryParams["access_token"] = accessToken
 	//queryParams["visibility"] = "all"
 	//queryParams["affiliation"] = "owner"
-	queryParams["type"] = "owner"
+	queryParams["type"] = "personal"
 	queryParams["q"] = keyword
 	queryParams["page"] = strconv.Itoa(page)
 	queryParams["per_page"] = strconv.Itoa(perPage)


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when fetching projects for personal accounts, projects belong to associated organization will be returned, if irrelevant projects are selected to proceed next operations(like list branches) errors will occur

### What is changed and how it works?
use correct query parameter to list projects

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
