### PR TITLE
fix bug of rendering pvc subpath

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskplugin/build.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/build.go
@@ -248,8 +248,7 @@ func (p *BuildTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipe
 	}
 
 	// Since we allow users to use custom environment variables, variable resolution is required.
-	if pipelineCtx.CacheEnable && pipelineCtx.Cache.MediumType == types.NFSMedium &&
-		pipelineCtx.CacheDirType == types.UserDefinedCacheDir {
+	if pipelineCtx.CacheEnable && pipelineCtx.Cache.MediumType == types.NFSMedium {
 		pipelineCtx.CacheUserDir = p.renderEnv(pipelineCtx.CacheUserDir)
 		pipelineCtx.Cache.NFSProperties.Subpath = p.renderEnv(pipelineCtx.Cache.NFSProperties.Subpath)
 	}


### PR DESCRIPTION
Signed-off-by: zhangyifei <zhangyifei@koderover.com>

### What this PR does / Why we need it:

When user selects the default WORKSPACE as the cache directory, the subpath configured at the cluster level cannot be resolved as expected.

### What is changed and how it works?

Fix bug of cluster subpath resolution.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
