### PR TITLE
add repo namespace saving logic

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
@@ -335,6 +335,12 @@ func FindWorkflow(workflowName string, log *zap.SugaredLogger) (*commonmodels.Wo
 		}
 	}
 
+	for _, module := range resp.BuildStage.Modules {
+		for _, bf := range module.BranchFilter {
+			bf.RepoNamespace = bf.GetNamespace()
+		}
+	}
+
 	return resp, nil
 }
 

--- a/pkg/types/repo.go
+++ b/pkg/types/repo.go
@@ -65,12 +65,19 @@ type Repository struct {
 
 type BranchFilterInfo struct {
 	// repository identifier
-	CodehostID int    `bson:"codehost_id"  json:"codehost_id"`
-	RepoOwner  string `bson:"repo_owner"   json:"repo_owner"`
-	RepoName   string `bson:"repo_name"    json:"repo_name"`
-
+	CodehostID    int    `bson:"codehost_id"  json:"codehost_id"`
+	RepoOwner     string `bson:"repo_owner"   json:"repo_owner"`
+	RepoName      string `bson:"repo_name"    json:"repo_name"`
+	RepoNamespace string `bson:"repo_namespace" json:"repo_namespace"`
 	// actual regular expression filter
 	FilterRegExp string `bson:"filter_regexp" json:"filter_regexp"`
+}
+
+func (bf *BranchFilterInfo) GetNamespace() string {
+	if len(bf.RepoNamespace) > 0 {
+		return bf.RepoNamespace
+	}
+	return bf.RepoOwner
 }
 
 // GetReleaseCandidateTag 返回待发布对象Tag


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when setting branch filter of build stage for workflows, the `repo_namespace` property is not saved on serverside while it is used as request parameters for some api, this would cause `repo owner is nil` error

### What is changed and how it works?
fix bug

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
