### PR TITLE
add skip verify tls certificate

### DIFF
--- a/pkg/shared/client/aslan/client.go
+++ b/pkg/shared/client/aslan/client.go
@@ -17,6 +17,8 @@ limitations under the License.
 package aslan
 
 import (
+	"crypto/tls"
+
 	"github.com/koderover/zadig/pkg/tool/httpclient"
 )
 
@@ -44,6 +46,8 @@ func NewExternal(host, token string) *Client {
 		httpclient.SetAuthToken(token),
 		httpclient.SetHostURL(host+"/api/aslan"),
 	)
+
+	c.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
 
 	return &Client{
 		Client:   c,


### PR DESCRIPTION
Signed-off-by: Min Min <minmin@koderover.com>

### What this PR does / Why we need it:
 add skip verify tls certificate to external zadig client since it might be a self-signed certificate

### What is changed and how it works?
 add skip verify tls certificate to external zadig client since it might be a self-signed certificate

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [x] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
