### PR TITLE
fix error message when workflow name already exists

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
@@ -431,9 +431,9 @@ func PreSetWorkflow(productName string, log *zap.SugaredLogger) ([]*PreSetResp, 
 }
 
 func CreateWorkflow(workflow *commonmodels.Workflow, log *zap.SugaredLogger) error {
-	_, err := commonrepo.NewWorkflowColl().Find(workflow.Name)
+	existedWorkflow, err := commonrepo.NewWorkflowColl().Find(workflow.Name)
 	if err == nil {
-		errStr := fmt.Sprintf("workflow [%s] 在项目 [%s] 中已经存在!", workflow.Name, workflow.ProductTmplName)
+		errStr := fmt.Sprintf("workflow [%s] 在项目 [%s] 中已经存在!", workflow.Name, existedWorkflow.ProductTmplName)
 		return e.ErrUpsertWorkflow.AddDesc(errStr)
 	}
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -39,9 +39,9 @@ const (
 )
 
 func CreateWorkflowV4(user string, workflow *commonmodels.WorkflowV4, logger *zap.SugaredLogger) error {
-	_, err := commonrepo.NewWorkflowV4Coll().Find(workflow.Name)
+	existedWorkflow, err := commonrepo.NewWorkflowV4Coll().Find(workflow.Name)
 	if err == nil {
-		errStr := fmt.Sprintf("workflow v4 [%s] 在项目 [%s] 中已经存在!", workflow.Name, workflow.Project)
+		errStr := fmt.Sprintf("workflow v4 [%s] 在项目 [%s] 中已经存在!", workflow.Name, existedWorkflow.Project)
 		return e.ErrUpsertWorkflow.AddDesc(errStr)
 	}
 	if err := LintWorkflowV4(workflow, logger); err != nil {


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
when create a workflow with the same name, error message gives wrong project name.

### What is changed and how it works?
fix error message when workflow name already exists 

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
