### PR TITLE
fix auto generate job name was illegal

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
@@ -18,6 +18,7 @@ package job
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
@@ -67,9 +68,11 @@ func ToJobs(job *commonmodels.Job, workflow *commonmodels.WorkflowV4, taskID int
 	return jobCtl.ToJobs(taskID)
 }
 
+// use service name and service module hash to generate job name
 func jobNameFormat(jobName string) string {
 	if len(jobName) > 50 {
-		return jobName[:50]
+		jobName = jobName[:50]
 	}
+	jobName = strings.Trim(jobName, "-")
 	return jobName
 }

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
@@ -70,8 +70,8 @@ func ToJobs(job *commonmodels.Job, workflow *commonmodels.WorkflowV4, taskID int
 
 // use service name and service module hash to generate job name
 func jobNameFormat(jobName string) string {
-	if len(jobName) > 50 {
-		jobName = jobName[:50]
+	if len(jobName) > 63 {
+		jobName = jobName[:63]
 	}
 	jobName = strings.Trim(jobName, "-")
 	return jobName


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
fix auto generate job name was illegal

### What is changed and how it works?
k8s label should not start or end with `-`

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
