### PR TITLE
fix gitlab token refresh bug

### DIFF
--- a/pkg/tool/git/gitlab/client.go
+++ b/pkg/tool/git/gitlab/client.go
@@ -21,12 +21,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"time"
 
-	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/xanzy/go-gitlab"
 
-	"github.com/koderover/zadig/pkg/shared/client/systemconfig"
 	"github.com/koderover/zadig/pkg/tool/httpclient"
 )
 
@@ -61,29 +58,12 @@ func NewClient(id int, address, accessToken, proxyAddr string, enableProxy bool)
 		client = http.DefaultClient
 	}
 
-	if accessToken != "" {
-		ch, err := systemconfig.New().GetCodeHost(id)
-		// The normal expiration time is 7200
-		if err == nil && (time.Now().Unix()-ch.UpdatedAt) >= 7000 {
-			token, err := refreshAccessToken(ch.Address, ch.AccessKey, ch.SecretKey, ch.RefreshToken)
-			if err == nil {
-				accessToken = token.AccessToken
-				ch.AccessToken = token.AccessToken
-				ch.RefreshToken = token.RefreshToken
-				ch.UpdatedAt = int64(token.CreatedAt)
-
-				if err = systemconfig.New().UpdateCodeHost(ch.ID, ch); err != nil {
-					log.Errorf("failed to update codeHost err:%s", err)
-				}
-			} else {
-				log.Errorf("failed to refresh accessToken, err:%s", err)
-			}
-		} else if err != nil {
-			log.Errorf("failed to get codeHost id: %d, err:%s", id, err)
-		}
+	token, err := UpdateGitlabToken(id, accessToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to refresh gitlab token, err: %s", err)
 	}
 
-	cli, err := gitlab.NewOAuthClient(accessToken, gitlab.WithBaseURL(address), gitlab.WithHTTPClient(client))
+	cli, err := gitlab.NewOAuthClient(token, gitlab.WithBaseURL(address), gitlab.WithHTTPClient(client))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gitlab client, err: %s", err)
 	}
@@ -143,33 +123,4 @@ func wrapError(res *gitlab.Response, err error) error {
 		return httpclient.NewGenericServerResponse(res.StatusCode, res.Request.Method, string(body))
 	}
 	return nil
-}
-
-type AccessToken struct {
-	AccessToken  string `json:"access_token"`
-	TokenType    string `json:"token_type"`
-	ExpiresIn    int    `json:"expires_in"`
-	RefreshToken string `json:"refresh_token"`
-	Scope        string `json:"scope"`
-	CreatedAt    int    `json:"created_at"`
-}
-
-func refreshAccessToken(address, clientID, clientSecret, refreshToken string) (*AccessToken, error) {
-	httpClient := httpclient.New(
-		httpclient.SetHostURL(address),
-	)
-	url := "/oauth/token"
-	queryParams := make(map[string]string)
-	queryParams["grant_type"] = "refresh_token"
-	queryParams["refresh_token"] = refreshToken
-	queryParams["client_id"] = clientID
-	queryParams["client_secret"] = clientSecret
-
-	var accessToken *AccessToken
-	_, err := httpClient.Post(url, httpclient.SetQueryParams(queryParams), httpclient.SetResult(&accessToken))
-	if err != nil {
-		return nil, err
-	}
-
-	return accessToken, nil
 }

--- a/pkg/tool/git/gitlab/token.go
+++ b/pkg/tool/git/gitlab/token.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2022 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitlab
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/koderover/zadig/pkg/shared/client/systemconfig"
+	"github.com/koderover/zadig/pkg/tool/httpclient"
+	"github.com/koderover/zadig/pkg/tool/log"
+)
+
+type AccessToken struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+	Scope        string `json:"scope"`
+	CreatedAt    int    `json:"created_at"`
+}
+
+var CodeHostLock map[int]*sync.RWMutex
+
+const TokenExpirationThreshold int64 = 7000
+
+func UpdateGitlabToken(id int, accessToken string) (string, error) {
+	// if accessToken is empty, then it is either of ssh token type or username/password, we return empty
+	if accessToken == "" {
+		return "", nil
+	}
+
+	CodeHostLock[id].Lock()
+	defer CodeHostLock[id].Unlock()
+	ch, err := systemconfig.New().GetCodeHost(id)
+
+	if err != nil {
+		return "", fmt.Errorf("get codehost info error: [%s]", err)
+	}
+
+	if time.Now().Unix()-ch.UpdatedAt >= TokenExpirationThreshold {
+		token, err := refreshAccessToken(ch.Address, ch.AccessKey, ch.SecretKey, ch.RefreshToken)
+		if err != nil {
+			return "", err
+		}
+
+		ch.AccessToken = token.AccessToken
+		ch.RefreshToken = token.RefreshToken
+		ch.UpdatedAt = int64(token.CreatedAt)
+
+		// Since the new token is valid, we simply log the error
+		// No error will be returned, only the new token is returned
+		if err = systemconfig.New().UpdateCodeHost(ch.ID, ch); err != nil {
+			log.Errorf("failed to update codehost, err: %s", err)
+		}
+
+		return token.AccessToken, nil
+	}
+
+	return accessToken, nil
+}
+
+func refreshAccessToken(address, clientID, clientSecret, refreshToken string) (*AccessToken, error) {
+	httpClient := httpclient.New(
+		httpclient.SetHostURL(address),
+	)
+	url := "/oauth/token"
+	queryParams := make(map[string]string)
+	queryParams["grant_type"] = "refresh_token"
+	queryParams["refresh_token"] = refreshToken
+	queryParams["client_id"] = clientID
+	queryParams["client_secret"] = clientSecret
+
+	var accessToken *AccessToken
+	_, err := httpClient.Post(url, httpclient.SetQueryParams(queryParams), httpclient.SetResult(&accessToken))
+	if err != nil {
+		return nil, err
+	}
+
+	return accessToken, nil
+}

--- a/pkg/tool/git/gitlab/token.go
+++ b/pkg/tool/git/gitlab/token.go
@@ -49,6 +49,9 @@ func UpdateGitlabToken(id int, accessToken string) (string, error) {
 	lock := lockInterface.(*sync.RWMutex)
 	lock.Lock()
 	defer lock.Unlock()
+
+	log.Infof("Starting to update gitlab token")
+
 	ch, err := systemconfig.New().GetCodeHost(id)
 
 	if err != nil {
@@ -73,6 +76,8 @@ func UpdateGitlabToken(id int, accessToken string) (string, error) {
 	if err = systemconfig.New().UpdateCodeHost(ch.ID, ch); err != nil {
 		log.Errorf("failed to update codehost, err: %s", err)
 	}
+
+	log.Infof("gitlab token for client [%d] changed from [%s] to [%s]", id, accessToken, token.AccessToken)
 
 	return token.AccessToken, nil
 }


### PR DESCRIPTION
### What this PR does / Why we need it:
Currently the gitlab token refresh mechanism will fail if there are too many request in certain amount of time. I changed the code so it will work well in concurrency case.

### What is changed and how it works?
add a mutex lock to the refresh token mechanism

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
