### PR TITLE
fix webhook task lost deploy infos in hosting environment

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/webhook/github_workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github_workflow_task.go
@@ -30,6 +30,7 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
+	commonservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service"
 	git "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/github"
 	workflowservice "github.com/koderover/zadig/pkg/microservice/aslan/core/workflow/service/workflow"
 	"github.com/koderover/zadig/pkg/setting"
@@ -207,7 +208,10 @@ func (waf *workflowArgsFactory) Update(product *commonmodels.Product, args *comm
 		target.Build.Repos = append(target.Build.Repos, repo)
 		if len(target.Deploy) == 0 {
 			if targetMap == nil {
-				targetMap = getProductTargetMap(product, waf.IsYaml)
+				targetMap, _ = commonservice.GetProductTargetMap(product)
+			}
+			if waf.IsYaml {
+				targetMap = make(map[string][]commonmodels.DeployEnv)
 			}
 			serviceModuleTarget := fmt.Sprintf("%s%s%s%s%s", args.ProductTmplName, SplitSymbol, target.ServiceName, SplitSymbol, target.Name)
 			target.Deploy = targetMap[serviceModuleTarget]

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -79,7 +79,7 @@ func GetWorkflowArgs(productName, namespace string, log *zap.SugaredLogger) (*Cr
 		return resp, e.ErrListBuildModule.AddDesc(err.Error())
 	}
 
-	targetMap, _ := getProductTargetMap(product)
+	targetMap, _ := commonservice.GetProductTargetMap(product)
 	projectTargets := getProjectTargets(product.ProductName)
 	targets := make([]*commonmodels.TargetArgs, 0)
 	for _, container := range projectTargets {
@@ -130,79 +130,6 @@ func GetWorkflowArgs(productName, namespace string, log *zap.SugaredLogger) (*Cr
 	}
 	resp.Target = targets
 	return resp, nil
-}
-
-func getProductTargetMap(prod *commonmodels.Product) (map[string][]commonmodels.DeployEnv, map[string]string) {
-	resp := make(map[string][]commonmodels.DeployEnv)
-	imageNameM := make(map[string]string)
-	if prod.Source == setting.SourceFromExternal {
-		services, _ := commonrepo.NewServiceColl().ListExternalWorkloadsBy(prod.ProductName, prod.EnvName)
-
-		currentServiceNames := sets.NewString()
-		for _, service := range services {
-			currentServiceNames.Insert(service.ServiceName)
-		}
-
-		servicesInExternalEnv, _ := commonrepo.NewServicesInExternalEnvColl().List(&commonrepo.ServicesInExternalEnvArgs{
-			ProductName: prod.ProductName,
-			EnvName:     prod.EnvName,
-		})
-
-		externalServiceNames := sets.NewString()
-		for _, serviceInExternalEnv := range servicesInExternalEnv {
-			if !currentServiceNames.Has(serviceInExternalEnv.ServiceName) {
-				externalServiceNames.Insert(serviceInExternalEnv.ServiceName)
-			}
-		}
-
-		if len(externalServiceNames) > 0 {
-			newServices, _ := commonrepo.NewServiceColl().ListExternalWorkloadsBy(prod.ProductName, "", externalServiceNames.List()...)
-			for _, service := range newServices {
-				services = append(services, service)
-			}
-		}
-
-		for _, service := range services {
-			for _, container := range service.Containers {
-				env := service.ServiceName + "/" + container.Name
-				deployEnv := commonmodels.DeployEnv{Type: setting.K8SDeployType, Env: env}
-				target := strings.Join([]string{service.ProductName, service.ServiceName, container.Name}, SplitSymbol)
-				resp[target] = append(resp[target], deployEnv)
-
-				imageNameM[target] = util.GetImageNameFromContainerInfo(container.ImageName, container.Name)
-			}
-		}
-		return resp, imageNameM
-	}
-	for _, services := range prod.Services {
-		for _, serviceObj := range services {
-			switch serviceObj.Type {
-			case setting.K8SDeployType:
-				for _, container := range serviceObj.Containers {
-					env := serviceObj.ServiceName + "/" + container.Name
-					deployEnv := commonmodels.DeployEnv{Type: setting.K8SDeployType, Env: env}
-					target := strings.Join([]string{serviceObj.ProductName, serviceObj.ServiceName, container.Name}, SplitSymbol)
-					resp[target] = append(resp[target], deployEnv)
-
-					imageNameM[target] = util.GetImageNameFromContainerInfo(container.ImageName, container.Name)
-				}
-			case setting.PMDeployType:
-				deployEnv := commonmodels.DeployEnv{Type: setting.PMDeployType, Env: serviceObj.ServiceName}
-				target := strings.Join([]string{serviceObj.ProductName, serviceObj.ServiceName, serviceObj.ServiceName}, SplitSymbol)
-				resp[target] = append(resp[target], deployEnv)
-			case setting.HelmDeployType:
-				for _, container := range serviceObj.Containers {
-					env := serviceObj.ServiceName + "/" + container.Name
-					deployEnv := commonmodels.DeployEnv{Type: setting.HelmDeployType, Env: env}
-					target := strings.Join([]string{serviceObj.ProductName, serviceObj.ServiceName, container.Name}, SplitSymbol)
-					resp[target] = append(resp[target], deployEnv)
-
-					imageNameM[target] = util.GetImageNameFromContainerInfo(container.ImageName, container.Name)
-				}
-			}
-		}
-	}
-	return resp, imageNameM
 }
 
 func getHideServiceModules(workflow *commonmodels.Workflow) sets.String {
@@ -442,7 +369,7 @@ func PresetWorkflowArgs(namespace, workflowName string, log *zap.SugaredLogger) 
 		return resp, e.ErrListTestModule.AddDesc(err.Error())
 	}
 
-	targetMap, imageNameM := getProductTargetMap(product)
+	targetMap, imageNameM := commonservice.GetProductTargetMap(product)
 	projectTargets := getProjectTargets(product.ProductName)
 	hideServiceModules := getHideServiceModules(workflow)
 	targets := make([]*commonmodels.TargetArgs, 0)


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
if we have two or more  hosting environments with same name services, webhook triggered task will lost deploy infos when deploy the services.

### What is changed and how it works?
fix webhook task lost deploy infos in hosting environment

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
