### PR TITLE
save selected repo info so user can rerun task without select again

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -89,7 +89,7 @@ type ServiceAndBuild struct {
 	Image         string              `bson:"-"                   yaml:"-"                json:"image"`
 	Package       string              `bson:"-"                   yaml:"-"                json:"package"`
 	KeyVals       []*KeyVal           `bson:"key_vals"            yaml:"key_vals"         json:"key_vals"`
-	Repos         []*types.Repository `bson:"-"                   yaml:"-"                json:"repos"`
+	Repos         []*types.Repository `bson:"repos"               yaml:"-"                json:"repos"`
 }
 
 type ZadigDeployJobSpec struct {


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
when clone a workflow v4 task, repo info has lost.

### What is changed and how it works?
save selected repo info so user can rerun task without select again.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
