### PR TITLE
fix common workflow failed to download tools when default s3 server was http

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/stepcontroller/step_tool_install.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/stepcontroller/step_tool_install.go
@@ -78,6 +78,7 @@ func (s *toolInstallCtl) PreRun(ctx context.Context) error {
 		spec.S3Storage.Ak = objectStorage.Ak
 		spec.S3Storage.Subfolder = objectStorage.Subfolder
 		spec.S3Storage.Bucket = objectStorage.Bucket
+		spec.S3Storage.Insecure = objectStorage.Insecure
 		spec.S3Storage.Protocol = "https"
 		if objectStorage.Insecure {
 			spec.S3Storage.Protocol = "http"


### PR DESCRIPTION
…as http

Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
fix common workflow failed to download tools when default s3 server was http

### What is changed and how it works?
pass insecure info to jobexecutor

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
