### PR TITLE
remove remnant file before update chart templates

### DIFF
--- a/pkg/microservice/aslan/core/templatestore/service/chart.go
+++ b/pkg/microservice/aslan/core/templatestore/service/chart.go
@@ -402,6 +402,12 @@ func processChartFromSource(name string, args *fs.DownloadFromSourceArgs, logger
 		localBase := configbase.LocalChartTemplatePath(name)
 		s3Base := configbase.ObjectStorageChartTemplatePath(name)
 
+		err = os.RemoveAll(localBase)
+		if err != nil {
+			log.Errorf("failed to remove current template dir: %s, err: %s", localBase, err)
+			return
+		}
+
 		err1 := fs.SaveAndUploadFiles(tree, []string{name}, localBase, s3Base, logger)
 		if err1 != nil {
 			logger.Errorf("Failed to save files to disk, err: %s", err1)
@@ -464,6 +470,12 @@ func processChartFromGitRepo(name string, args *fs.DownloadFromSourceArgs, logge
 	wg.Start(func() {
 		logger.Debug("Start to save and upload chart")
 		localBase := configbase.LocalChartTemplatePath(name)
+
+		err = os.RemoveAll(path.Join(localBase, path.Base(args.Path)))
+		if err != nil {
+			log.Errorf("failed to remove current template dir: %s, err: %s", localBase, err)
+			return
+		}
 
 		err1 := fs.CopyAndUploadFiles([]string{}, path.Join(localBase, path.Base(args.Path)), "", currentChartPath, logger)
 		if err1 != nil {


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
when reloading chart templates from git repo, files of current chart template won't be deleted from disk before storing current files, this may cause different file structure than expected.

### What is changed and how it works?
fix bug, clear target dir before save files on disk

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
