### PR TITLE
clone private repo to load private plugins

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/plugin_repo.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/plugin_repo.go
@@ -76,7 +76,8 @@ func (c *PluginRepoColl) Delete(id string) error {
 }
 
 func (c *PluginRepoColl) Upsert(pluginRepo *models.PluginRepo) error {
-	query := bson.M{"repo_owner": pluginRepo.RepoOwner, "repo_name": pluginRepo.RepoName, "branch": pluginRepo.Branch}
+	// for now, we support only one unoffical plugin repo.
+	query := bson.M{"is_offical": pluginRepo.IsOffical}
 	change := bson.M{"$set": pluginRepo}
 	pluginRepo.UpdateTime = time.Now().Unix()
 

--- a/pkg/microservice/aslan/core/common/repository/mongodb/plugin_repo.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/plugin_repo.go
@@ -52,9 +52,12 @@ func (c *PluginRepoColl) GetCollectionName() string {
 	return c.coll
 }
 
-func (c *PluginRepoColl) List() ([]*models.PluginRepo, error) {
+func (c *PluginRepoColl) List(offical *bool) ([]*models.PluginRepo, error) {
 	var res []*models.PluginRepo
 	query := bson.M{}
+	if offical != nil {
+		query["is_offical"] = *offical
+	}
 	cursor, err := c.Collection.Find(context.TODO(), query)
 	if err != nil {
 		return nil, err

--- a/pkg/microservice/aslan/core/workflow/handler/plugin_repo.go
+++ b/pkg/microservice/aslan/core/workflow/handler/plugin_repo.go
@@ -37,11 +37,11 @@ func ListPluginTemplates(c *gin.Context) {
 	ctx.Resp, ctx.Err = workflow.ListPluginTemplates(ctx.Logger)
 }
 
-func ListPluginRepositories(c *gin.Context) {
+func ListUnofficalPluginRepositories(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
-	ctx.Resp, ctx.Err = workflow.ListPluginRepositories(ctx.Logger)
+	ctx.Resp, ctx.Err = workflow.ListUnofficalPluginRepositories(ctx.Logger)
 }
 
 func DeletePluginRepo(c *gin.Context) {

--- a/pkg/microservice/aslan/core/workflow/handler/plugin_repo.go
+++ b/pkg/microservice/aslan/core/workflow/handler/plugin_repo.go
@@ -17,10 +17,17 @@ limitations under the License.
 package handler
 
 import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+
 	"github.com/gin-gonic/gin"
 
+	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/workflow/service/workflow"
 	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
+	"github.com/koderover/zadig/pkg/tool/errors"
+	"github.com/koderover/zadig/pkg/tool/log"
 )
 
 func ListPluginTemplates(c *gin.Context) {
@@ -28,4 +35,40 @@ func ListPluginTemplates(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	ctx.Resp, ctx.Err = workflow.ListPluginTemplates(ctx.Logger)
+}
+
+func ListPluginRepositories(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	ctx.Resp, ctx.Err = workflow.ListPluginRepositories(ctx.Logger)
+}
+
+func DeletePluginRepo(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	ctx.Err = workflow.DeletePluginRepo(c.Param("id"), ctx.Logger)
+}
+
+func UpsertUserPluginRepository(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	req := &commonmodels.PluginRepo{}
+	data, err := c.GetRawData()
+	if err != nil {
+		log.Errorf("UpsertUserPluginRepository err: %s", err)
+	}
+	if err = json.Unmarshal(data, req); err != nil {
+		log.Errorf("UpsertUserPluginRepository unmarshal json err: %s", err)
+	}
+	c.Request.Body = ioutil.NopCloser(bytes.NewBuffer(data))
+
+	if err := c.ShouldBindJSON(&req); err != nil {
+		ctx.Err = errors.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+
+	go workflow.UpsertUserPluginRepository(req, ctx.Logger)
 }

--- a/pkg/microservice/aslan/core/workflow/handler/plugin_repo.go
+++ b/pkg/microservice/aslan/core/workflow/handler/plugin_repo.go
@@ -69,6 +69,5 @@ func UpsertUserPluginRepository(c *gin.Context) {
 		ctx.Err = errors.ErrInvalidParam.AddDesc(err.Error())
 		return
 	}
-
-	go workflow.UpsertUserPluginRepository(req, ctx.Logger)
+	ctx.Err = workflow.UpsertUserPluginRepository(req, ctx.Logger)
 }

--- a/pkg/microservice/aslan/core/workflow/handler/plugin_repo.go
+++ b/pkg/microservice/aslan/core/workflow/handler/plugin_repo.go
@@ -17,17 +17,12 @@ limitations under the License.
 package handler
 
 import (
-	"bytes"
-	"encoding/json"
-	"io/ioutil"
-
 	"github.com/gin-gonic/gin"
 
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/workflow/service/workflow"
 	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
 	"github.com/koderover/zadig/pkg/tool/errors"
-	"github.com/koderover/zadig/pkg/tool/log"
 )
 
 func ListPluginTemplates(c *gin.Context) {
@@ -55,17 +50,8 @@ func UpsertUserPluginRepository(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
-	req := &commonmodels.PluginRepo{}
-	data, err := c.GetRawData()
-	if err != nil {
-		log.Errorf("UpsertUserPluginRepository err: %s", err)
-	}
-	if err = json.Unmarshal(data, req); err != nil {
-		log.Errorf("UpsertUserPluginRepository unmarshal json err: %s", err)
-	}
-	c.Request.Body = ioutil.NopCloser(bytes.NewBuffer(data))
-
-	if err := c.ShouldBindJSON(&req); err != nil {
+	req := new(commonmodels.PluginRepo)
+	if err := c.ShouldBindJSON(req); err != nil {
 		ctx.Err = errors.ErrInvalidParam.AddDesc(err.Error())
 		return
 	}

--- a/pkg/microservice/aslan/core/workflow/handler/router.go
+++ b/pkg/microservice/aslan/core/workflow/handler/router.go
@@ -196,6 +196,9 @@ func (*Router) Inject(router *gin.RouterGroup) {
 	plugin := router.Group("plugin")
 	{
 		plugin.GET("/template", ListPluginTemplates)
+		plugin.POST("", UpsertUserPluginRepository)
+		plugin.GET("", ListPluginRepositories)
+		plugin.DELETE(":id", DeletePluginRepo)
 	}
 
 	bundles := router.Group("bundle-resources")

--- a/pkg/microservice/aslan/core/workflow/handler/router.go
+++ b/pkg/microservice/aslan/core/workflow/handler/router.go
@@ -197,7 +197,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 	{
 		plugin.GET("/template", ListPluginTemplates)
 		plugin.POST("", UpsertUserPluginRepository)
-		plugin.GET("", ListPluginRepositories)
+		plugin.GET("", ListUnofficalPluginRepositories)
 		plugin.DELETE(":id", DeletePluginRepo)
 	}
 

--- a/pkg/microservice/aslan/core/workflow/handler/router.go
+++ b/pkg/microservice/aslan/core/workflow/handler/router.go
@@ -198,7 +198,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		plugin.GET("/template", ListPluginTemplates)
 		plugin.POST("", UpsertUserPluginRepository)
 		plugin.GET("", ListUnofficalPluginRepositories)
-		plugin.DELETE(":id", DeletePluginRepo)
+		plugin.DELETE("/:id", DeletePluginRepo)
 	}
 
 	bundles := router.Group("bundle-resources")

--- a/pkg/microservice/aslan/core/workflow/service/workflow/plugin_repo.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/plugin_repo.go
@@ -155,19 +155,13 @@ func loadPluginRepoInfos(baseDir string, isOffical bool, readDir readDir, readFi
 }
 
 func ListUnofficalPluginRepositories(log *zap.SugaredLogger) ([]*commonmodels.PluginRepo, error) {
-	resp := []*commonmodels.PluginRepo{}
-	repos, err := commonrepo.NewPluginRepoColl().List()
+	offical := false
+	repos, err := commonrepo.NewPluginRepoColl().List(&offical)
 	if err != nil {
 		log.Errorf("list Plugin repos error: %v", err)
-		return resp, e.ErrListPluginRepo.AddDesc(err.Error())
+		return repos, e.ErrListPluginRepo.AddDesc(err.Error())
 	}
-	for _, repo := range repos {
-		if repo.IsOffical {
-			continue
-		}
-		resp = append(resp, repo)
-	}
-	return resp, nil
+	return repos, nil
 }
 
 func DeletePluginRepo(id string, log *zap.SugaredLogger) error {
@@ -180,7 +174,7 @@ func DeletePluginRepo(id string, log *zap.SugaredLogger) error {
 
 func ListPluginTemplates(log *zap.SugaredLogger) ([]*commonmodels.PluginTemplate, error) {
 	resp := []*commonmodels.PluginTemplate{}
-	repos, err := commonrepo.NewPluginRepoColl().List()
+	repos, err := commonrepo.NewPluginRepoColl().List(nil)
 	if err != nil {
 		log.Errorf("list plugin templates error: %v", err)
 		return resp, e.ErrListPluginRepo.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/workflow/service/workflow/plugin_repo.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/plugin_repo.go
@@ -165,7 +165,7 @@ func ListPluginRepositories(log *zap.SugaredLogger) ([]*commonmodels.PluginRepo,
 
 func DeletePluginRepo(id string, log *zap.SugaredLogger) error {
 	if err := commonrepo.NewPluginRepoColl().Delete(id); err != nil {
-		log.Errorf("list Plugin repos error: %v", err)
+		log.Errorf("delete Plugin repos error: %v", err)
 		return e.ErrListPluginRepo.AddDesc(err.Error())
 	}
 	return nil

--- a/pkg/microservice/aslan/core/workflow/service/workflow/plugin_repo.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/plugin_repo.go
@@ -148,10 +148,17 @@ func loadPluginRepoInfos(baseDir string, isOffical bool, readDir readDir, readFi
 }
 
 func ListPluginRepositories(log *zap.SugaredLogger) ([]*commonmodels.PluginRepo, error) {
-	resp, err := commonrepo.NewPluginRepoColl().List()
+	resp := []*commonmodels.PluginRepo{}
+	repos, err := commonrepo.NewPluginRepoColl().List()
 	if err != nil {
 		log.Errorf("list Plugin repos error: %v", err)
 		return resp, e.ErrListPluginRepo.AddDesc(err.Error())
+	}
+	for _, repo := range repos {
+		if repo.IsOffical {
+			continue
+		}
+		resp = append(resp, repo)
 	}
 	return resp, nil
 }

--- a/pkg/microservice/aslan/core/workflow/service/workflow/plugin_repo.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/plugin_repo.go
@@ -61,6 +61,7 @@ func UpsertUserPluginRepository(args *commonmodels.PluginRepo, log *zap.SugaredL
 		errMsg := fmt.Sprintf("get code host %d error: %v", args.CodehostID, err)
 		log.Error(errMsg)
 		args.Error = errMsg
+		return
 	}
 
 	checkoutPath := path.Join(config.S3StoragePath(), args.RepoName)
@@ -68,6 +69,7 @@ func UpsertUserPluginRepository(args *commonmodels.PluginRepo, log *zap.SugaredL
 		errMsg := fmt.Sprintf("run git cmds error: %v", err)
 		log.Error(errMsg)
 		args.Error = errMsg
+		return
 	}
 
 	plugins, err := loadPluginRepoInfos(checkoutPath, args.IsOffical, os.ReadDir, os.ReadFile)
@@ -75,6 +77,7 @@ func UpsertUserPluginRepository(args *commonmodels.PluginRepo, log *zap.SugaredL
 		errMsg := fmt.Sprintf("load plugin from user user repo error: %s", err)
 		log.Error(errMsg)
 		args.Error = errMsg
+		return
 	}
 	args.PluginTemplates = plugins
 }

--- a/pkg/microservice/aslan/core/workflow/service/workflow/plugin_repo.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/plugin_repo.go
@@ -154,7 +154,7 @@ func loadPluginRepoInfos(baseDir string, isOffical bool, readDir readDir, readFi
 	return resp, nil
 }
 
-func ListPluginRepositories(log *zap.SugaredLogger) ([]*commonmodels.PluginRepo, error) {
+func ListUnofficalPluginRepositories(log *zap.SugaredLogger) ([]*commonmodels.PluginRepo, error) {
 	resp := []*commonmodels.PluginRepo{}
 	repos, err := commonrepo.NewPluginRepoColl().List()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
user can define their own plugins and loaded to zadig.

### What is changed and how it works?
give api to load user plugins from their repo.

### Does this PR introduce a user-facing change?

- [x] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
