### PR TITLE
fix custom workflow using wrong image

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_build.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_build.go
@@ -119,13 +119,17 @@ func (j *BuildJob) ToJobs(taskID int64) ([]*commonmodels.JobTask, error) {
 		if err := fillBuildDetail(buildInfo, build.ServiceName, build.ServiceModule); err != nil {
 			return resp, err
 		}
+		basicImage, err := commonrepo.NewBasicImageColl().Find(buildInfo.PreBuild.ImageID)
+		if err != nil {
+			return resp, err
+		}
 		jobTask.Properties = commonmodels.JobProperties{
 			Timeout:         int64(buildInfo.Timeout),
 			ResourceRequest: buildInfo.PreBuild.ResReq,
 			ResReqSpec:      buildInfo.PreBuild.ResReqSpec,
 			Envs:            renderKeyVals(build.KeyVals, buildInfo.PreBuild.Envs),
 			ClusterID:       buildInfo.PreBuild.ClusterID,
-			BuildOS:         buildInfo.PreBuild.BuildOS,
+			BuildOS:         basicImage.Value,
 			ImageFrom:       buildInfo.PreBuild.ImageFrom,
 		}
 		clusterInfo, err := commonrepo.NewK8SClusterColl().Get(buildInfo.PreBuild.ClusterID)


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
if user defined image changes, custom workflow will still use old image.

### What is changed and how it works?
get latest image from database every time runs worflow.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
