### PR TITLE
add label for namespaces when creating envs

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/actions.go
+++ b/pkg/microservice/aslan/core/common/service/kube/actions.go
@@ -89,17 +89,13 @@ func EnsureNamespaceLabels(namespace string, customLabels map[string]string, kub
 		Name: namespace,
 	}, nsObj)
 	if err != nil {
-		return nil
+		return err
 	}
 	if labels.SelectorFromValidatedSet(customLabels).Matches(labels.Set(nsObj.Labels)) {
 		return nil
 	}
 	nsObj.Labels = labels.Merge(nsObj.Labels, customLabels)
-	err = updater.UpdateNamespace(nsObj, kubeClient)
-	if err != nil {
-		log.Errorf("failed to patch namespace: %s, err: %s", nsObj, err)
-	}
-	return err
+	return updater.UpdateNamespace(nsObj, kubeClient)
 }
 
 func CreateOrUpdateRSASecret(publicKey, privateKey []byte, kubeClient client.Client) error {

--- a/pkg/microservice/aslan/core/common/service/kube/actions.go
+++ b/pkg/microservice/aslan/core/common/service/kube/actions.go
@@ -42,15 +42,19 @@ import (
 
 var registrySecretSuffix = "-registry-secret"
 
-func CreateNamespace(namespace string, enableShare bool, kubeClient client.Client) error {
-	labels := map[string]string{
+func CreateNamespace(namespace string, customLabels map[string]string, enableShare bool, kubeClient client.Client) error {
+	nsLabels := map[string]string{
 		setting.EnvCreatedBy: setting.EnvCreator,
 	}
 	if enableShare {
-		labels[zadigtypes.IstioLabelKeyInjection] = zadigtypes.IstioLabelValueInjection
+		nsLabels[zadigtypes.IstioLabelKeyInjection] = zadigtypes.IstioLabelValueInjection
 	}
 
-	err := updater.CreateNamespaceByName(namespace, labels, kubeClient)
+	if customLabels == nil {
+		customLabels = map[string]string{}
+	}
+	mergedLabels := labels.Merge(customLabels, nsLabels)
+	err := updater.CreateNamespaceByName(namespace, mergedLabels, kubeClient)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
@@ -73,10 +77,29 @@ func CreateNamespace(namespace string, enableShare bool, kubeClient client.Clien
 	}
 
 	if nsObj.Status.Phase == corev1.NamespaceTerminating {
-		return fmt.Errorf("namespace `%s` is in terminating state, please wait for a whilie and try again.", namespace)
+		return fmt.Errorf("namespace `%s` is in terminating state, please wait for a whilie and try again", namespace)
 	}
 
 	return nil
+}
+
+func EnsureNamespaceLabels(namespace string, customLabels map[string]string, kubeClient client.Client) error {
+	nsObj := &corev1.Namespace{}
+	err := kubeClient.Get(context.TODO(), client.ObjectKey{
+		Name: namespace,
+	}, nsObj)
+	if err != nil {
+		return nil
+	}
+	if labels.SelectorFromValidatedSet(customLabels).Matches(labels.Set(nsObj.Labels)) {
+		return nil
+	}
+	nsObj.Labels = labels.Merge(nsObj.Labels, customLabels)
+	err = updater.UpdateNamespace(nsObj, kubeClient)
+	if err != nil {
+		log.Errorf("failed to patch namespace: %s, err: %s", nsObj, err)
+	}
+	return err
 }
 
 func CreateOrUpdateRSASecret(publicKey, privateKey []byte, kubeClient client.Client) error {

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -708,7 +708,7 @@ func UpdateProductRegistry(envName, productName, registryID string, log *zap.Sug
 	if err != nil {
 		return e.ErrUpdateEnv.AddErr(err)
 	}
-	err = ensureKubeEnv(exitedProd.Namespace, registryID, false, kubeClient, log)
+	err = ensureKubeEnv(exitedProd.Namespace, registryID, map[string]string{setting.ProductLabel: productName}, false, kubeClient, log)
 
 	if err != nil {
 		log.Errorf("UpdateProductRegistry ensureKubeEnv by envName:%s,error: %v", envName, err)
@@ -769,7 +769,7 @@ func UpdateProductV2(envName, productName, user, requestID string, serviceNames 
 	}
 
 	if project.ProductFeature != nil && project.ProductFeature.BasicFacility != setting.BasicFacilityCVM {
-		err = ensureKubeEnv(exitedProd.Namespace, exitedProd.RegistryID, exitedProd.ShareEnv.Enable, kubeClient, log)
+		err = ensureKubeEnv(exitedProd.Namespace, exitedProd.RegistryID, map[string]string{setting.ProductLabel: project.ProductName}, exitedProd.ShareEnv.Enable, kubeClient, log)
 
 		if err != nil {
 			log.Errorf("[%s][P:%s] service.UpdateProductV2 create kubeEnv error: %v", envName, productName, err)
@@ -1571,7 +1571,7 @@ func UpdateHelmProductDefaultValues(productName, envName, userName, requestID st
 		log.Errorf("UpdateHelmProductRenderset GetKubeClient error, error msg:%s", err)
 		return err
 	}
-	return ensureKubeEnv(product.Namespace, product.RegistryID, false, kubeClient, log)
+	return ensureKubeEnv(product.Namespace, product.RegistryID, map[string]string{setting.ProductLabel: product.ProductName}, false, kubeClient, log)
 }
 
 func UpdateHelmProductCharts(productName, envName, userName, requestID string, args *EnvRendersetArg, log *zap.SugaredLogger) error {
@@ -1801,7 +1801,7 @@ func UpdateHelmProductRenderset(productName, envName, userName, requestID string
 		log.Errorf("UpdateHelmProductRenderset GetKubeClient error, error msg:%s", err)
 		return err
 	}
-	return ensureKubeEnv(product.Namespace, product.RegistryID, false, kubeClient, log)
+	return ensureKubeEnv(product.Namespace, product.RegistryID, map[string]string{setting.ProductLabel: product.ProductName}, false, kubeClient, log)
 }
 
 func UpdateHelmProductVariable(productName, envName, username, requestID string, updatedRcs []*templatemodels.RenderChart, renderset *commonmodels.RenderSet, log *zap.SugaredLogger) error {
@@ -3172,7 +3172,7 @@ func preCreateProduct(envName string, args *commonmodels.Product, kubeClient cli
 
 	args.Render = tmpRenderInfo
 	if preCreateNSAndSecret(productTmpl.ProductFeature) {
-		return ensureKubeEnv(args.Namespace, args.RegistryID, args.ShareEnv.Enable, kubeClient, log)
+		return ensureKubeEnv(args.Namespace, args.RegistryID, map[string]string{setting.ProductLabel: args.ProductName}, args.ShareEnv.Enable, kubeClient, log)
 	}
 	return nil
 }
@@ -3221,8 +3221,8 @@ func applySystemImagePullSecrets(podSpec *corev1.PodSpec) {
 		})
 }
 
-func ensureKubeEnv(namespace, registryId string, enableShare bool, kubeClient client.Client, log *zap.SugaredLogger) error {
-	err := kube.CreateNamespace(namespace, enableShare, kubeClient)
+func ensureKubeEnv(namespace, registryId string, customLabels map[string]string, enableShare bool, kubeClient client.Client, log *zap.SugaredLogger) error {
+	err := kube.CreateNamespace(namespace, customLabels, enableShare, kubeClient)
 	if err != nil {
 		log.Errorf("[%s] get or create namespace error: %v", namespace, err)
 		return e.ErrCreateNamspace.AddDesc(err.Error())

--- a/pkg/tool/kube/updater/namespace.go
+++ b/pkg/tool/kube/updater/namespace.go
@@ -46,3 +46,7 @@ func CreateNamespaceByName(ns string, labels map[string]string, cl client.Client
 	}
 	return CreateNamespace(n, cl)
 }
+
+func UpdateNamespace(ns *corev1.Namespace, cl client.Client) error {
+	return updateObject(ns, cl)
+}


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
add `s-product` label to related namespace when creating environment for k8s/helm/external projects

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
