### PR TITLE
renders the scanned repository branch information to the user configuration

### DIFF
--- a/pkg/microservice/reaper/core/service/reaper/script.go
+++ b/pkg/microservice/reaper/core/service/reaper/script.go
@@ -264,6 +264,8 @@ func (r *Reaper) runSonarScanner() error {
 	for _, repo := range r.Ctx.Repos {
 		log.Infof("Writing sonar-project.properties for repo: %s", repo.Name)
 		repoConfigPath := filepath.Join("/workspace", repo.Name, "sonar-project.properties")
+		// renders the scanned repository branch information to the user configuration
+		r.Ctx.SonarParameter=strings.ReplaceAll(r.Ctx.SonarParameter,"$BRANCH",repo.Branch)
 		configContent := fmt.Sprintf("sonar.login=%s\nsonar.host.url=%s\n%s", r.Ctx.SonarLogin, r.Ctx.SonarServer, r.Ctx.SonarParameter)
 		err := os.WriteFile(repoConfigPath, []byte(configContent), fs.ModeAppend)
 		if err != nil {


### PR DESCRIPTION
…ration

Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
renders the scanned repository branch information to the user configuration

### What is changed and how it works?
renders the scanned repository branch information to the user configuration

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
