### PR TITLE
fix preset webhook info when args are nil and fix webhook notify

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/notification.go
+++ b/pkg/microservice/aslan/core/common/repository/models/notification.go
@@ -27,23 +27,24 @@ import (
 )
 
 type Notification struct {
-	ID         primitive.ObjectID  `bson:"_id,omitempty"                json:"id,omitempty"`
-	CodehostID int                 `bson:"codehost_id"                  json:"codehost_id"`
-	Tasks      []*NotificationTask `bson:"tasks,omitempty"              json:"tasks,omitempty"`
-	PrID       int                 `bson:"pr_id"                        json:"pr_id"`
-	CommentID  string              `bson:"comment_id"                   json:"comment_id"`
-	ProjectID  string              `bson:"project_id"                   json:"project_id"`
-	Created    int64               `bson:"create"                       json:"create"`
-	BaseURI    string              `bson:"base_uri"                     json:"base_uri"`
-	IsPipeline bool                `bson:"is_pipeline"                  json:"is_pipeline"`
-	IsTest     bool                `bson:"is_test"                      json:"is_test"`
-	IsScanning bool                `bson:"is_scanning"                  json:"is_scanning"`
-	ErrInfo    string              `bson:"err_info"                     json:"err_info"`
-	PrTask     *PrTaskInfo         `bson:"pr_task_info,omitempty"       json:"pr_task_info,omitempty"`
-	Label      string              `bson:"label"                        json:"label"  `
-	Revision   string              `bson:"revision"                     json:"revision"`
-	RepoOwner  string              `bson:"repo_owner"                   json:"repo_owner"`
-	RepoName   string              `bson:"repo_name"                    json:"repo_name"`
+	ID           primitive.ObjectID  `bson:"_id,omitempty"                json:"id,omitempty"`
+	CodehostID   int                 `bson:"codehost_id"                  json:"codehost_id"`
+	Tasks        []*NotificationTask `bson:"tasks,omitempty"              json:"tasks,omitempty"`
+	PrID         int                 `bson:"pr_id"                        json:"pr_id"`
+	CommentID    string              `bson:"comment_id"                   json:"comment_id"`
+	ProjectID    string              `bson:"project_id"                   json:"project_id"`
+	Created      int64               `bson:"create"                       json:"create"`
+	BaseURI      string              `bson:"base_uri"                     json:"base_uri"`
+	IsPipeline   bool                `bson:"is_pipeline"                  json:"is_pipeline"`
+	IsTest       bool                `bson:"is_test"                      json:"is_test"`
+	IsScanning   bool                `bson:"is_scanning"                  json:"is_scanning"`
+	IsWorkflowV4 bool                `bson:"is_workflowv4"                json:"is_workflowv4"`
+	ErrInfo      string              `bson:"err_info"                     json:"err_info"`
+	PrTask       *PrTaskInfo         `bson:"pr_task_info,omitempty"       json:"pr_task_info,omitempty"`
+	Label        string              `bson:"label"                        json:"label"  `
+	Revision     string              `bson:"revision"                     json:"revision"`
+	RepoOwner    string              `bson:"repo_owner"                   json:"repo_owner"`
+	RepoName     string              `bson:"repo_name"                    json:"repo_name"`
 }
 
 type PrTaskInfo struct {
@@ -133,6 +134,13 @@ func (n *Notification) CreateCommentBody() (comment string, err error) {
 			tmplSource =
 				"|触发的代码扫描|状态| \n |---|---| \n {{range .Tasks}}|[{{.ScanningName}}#{{.ID}}]({{$.BaseURI}}/v1/projects/detail/{{.ProductName}}/scanner/detail/{{.ScanningName}}/task/{{.ID}}?id={{.ScanningID}}) | {{if eq .StatusVerbose $.Success}} {+ {{.StatusVerbose}} +}{{else}}{- {{.StatusVerbose}} -}{{end}} | \n {{end}}"
 
+		}
+	} else if n.IsWorkflowV4 {
+		if len(n.Tasks) == 0 {
+			tmplSource = "触发的工作流：等待任务启动中"
+		} else {
+			tmplSource =
+				"|触发的工作流|状态| \n |---|---| \n {{range .Tasks}}|[{{.WorkflowName}}#{{.ID}}]({{$.BaseURI}}/v1/projects/detail/{{.ProductName}}/pipelines/custom/{{.WorkflowName}}/{{.ID}}) | {{if eq .StatusVerbose $.Success}} {+ {{.StatusVerbose}} +}{{else}}{- {{.StatusVerbose}} -}{{end}} | \n {{end}}"
 		}
 	} else {
 		if len(n.Tasks) == 0 {

--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -127,7 +127,7 @@ type JobProperties struct {
 	ImageFrom       string              `bson:"image_from"             json:"image_from"            yaml:"image_from,omitempty"`
 	ImageID         string              `bson:"image_id"               json:"image_id"              yaml:"image_id,omitempty"`
 	Namespace       string              `bson:"namespace"              json:"namespace"             yaml:"namespace"`
-	Envs            []*KeyVal           `bson:"envs"                   json:"envs"                  yaml:"envs,omitempty"`
+	Envs            []*KeyVal           `bson:"envs"                   json:"envs"                  yaml:"envs"`
 	// log user-defined variables, shows in workflow task detail.
 	CustomEnvs   []*KeyVal            `bson:"custom_envs"            json:"custom_envs"           yaml:"custom_envs,omitempty"`
 	Params       []*Param             `bson:"params"               	 json:"params"                yaml:"params"`

--- a/pkg/microservice/aslan/core/common/service/scmnotify/scmnotify.go
+++ b/pkg/microservice/aslan/core/common/service/scmnotify/scmnotify.go
@@ -54,20 +54,21 @@ func NewService() *Service {
 }
 
 func (s *Service) SendInitWebhookComment(
-	mainRepo *models.MainHookRepo, prID int, baseURI string, isPipeline, isTest, isScanning bool, logger *zap.SugaredLogger,
+	mainRepo *models.MainHookRepo, prID int, baseURI string, isPipeline, isTest, isScanning, isWorkflowV4 bool, logger *zap.SugaredLogger,
 ) (*models.Notification, error) {
 	notification := &models.Notification{
-		CodehostID: mainRepo.CodehostID,
-		PrID:       prID,
-		ProjectID:  strings.TrimLeft(mainRepo.GetRepoNamespace()+"/"+mainRepo.RepoName, "/"),
-		BaseURI:    baseURI,
-		IsPipeline: isPipeline,
-		IsTest:     isTest,
-		IsScanning: isScanning,
-		Label:      mainRepo.GetLabelValue(),
-		Revision:   mainRepo.Revision,
-		RepoOwner:  mainRepo.RepoOwner,
-		RepoName:   mainRepo.RepoName,
+		CodehostID:   mainRepo.CodehostID,
+		PrID:         prID,
+		ProjectID:    strings.TrimLeft(mainRepo.GetRepoNamespace()+"/"+mainRepo.RepoName, "/"),
+		BaseURI:      baseURI,
+		IsPipeline:   isPipeline,
+		IsTest:       isTest,
+		IsScanning:   isScanning,
+		IsWorkflowV4: isWorkflowV4,
+		Label:        mainRepo.GetLabelValue(),
+		Revision:     mainRepo.Revision,
+		RepoOwner:    mainRepo.RepoOwner,
+		RepoName:     mainRepo.RepoName,
 	}
 
 	if err := s.Client.Comment(notification); err != nil {

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflow_task.go
@@ -369,7 +369,7 @@ func TriggerWorkflowByGerritEvent(event *gerritTypeEvent, body []byte, uri, base
 								mainRepo.RepoOwner = ""
 								mainRepo.Revision = m.Event.PatchSet.Revision
 								notification, _ = scmnotify.NewService().SendInitWebhookComment(
-									mainRepo, m.Event.Change.Number, baseURI, false, false, false, log,
+									mainRepo, m.Event.Change.Number, baseURI, false, false, false, false, log,
 								)
 							}
 						}

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflowv4_task.go
@@ -234,7 +234,7 @@ func TriggerWorkflowV4ByGerritEvent(event *gerritTypeEvent, body []byte, uri, ba
 					mainRepo.RepoOwner = ""
 					mainRepo.Revision = m.Event.PatchSet.Revision
 					notification, _ = scmnotify.NewService().SendInitWebhookComment(
-						mainRepo, m.Event.Change.Number, baseURI, false, false, false, log,
+						mainRepo, m.Event.Change.Number, baseURI, false, false, false, true, log,
 					)
 				}
 

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitee_testing_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitee_testing_task.go
@@ -252,7 +252,7 @@ func TriggerTestByGiteeEvent(event interface{}, baseURI, requestID string, log *
 
 						if notification == nil {
 							notification, err = scmnotify.NewService().SendInitWebhookComment(
-								item.MainRepo, ev.PullRequest.Number, baseURI, false, true, false, log,
+								item.MainRepo, ev.PullRequest.Number, baseURI, false, true, false, false, log,
 							)
 							if err != nil {
 								log.Errorf("failed to init webhook comment due to %s", err)

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitee_workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitee_workflow_task.go
@@ -291,7 +291,7 @@ func TriggerWorkflowByGiteeEvent(event interface{}, baseURI, requestID string, l
 
 							if notification == nil {
 								notification, err = scmnotify.NewService().SendInitWebhookComment(
-									item.MainRepo, ev.PullRequest.Number, baseURI, false, false, false, log,
+									item.MainRepo, ev.PullRequest.Number, baseURI, false, false, false, false, log,
 								)
 								if err != nil {
 									log.Errorf("failed to init webhook comment due to %s", err)

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitee_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitee_workflowv4_task.go
@@ -275,7 +275,7 @@ func TriggerWorkflowV4ByGiteeEvent(event interface{}, baseURI, requestID string,
 
 				if notification == nil {
 					notification, err = scmnotify.NewService().SendInitWebhookComment(
-						item.MainRepo, ev.PullRequest.Number, baseURI, false, false, false, log,
+						item.MainRepo, ev.PullRequest.Number, baseURI, false, false, false, true, log,
 					)
 					if err != nil {
 						log.Errorf("failed to init webhook comment due to %s", err)

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab.go
@@ -198,7 +198,7 @@ func ProcessGitlabHook(payload []byte, req *http.Request, requestID string, log 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err = TriggerWorkflowV4ByGitlabEvent(pushEvent, baseURI, requestID, log); err != nil {
+			if err = TriggerWorkflowV4ByGitlabEvent(mergeEvent, baseURI, requestID, log); err != nil {
 				errorList = multierror.Append(errorList, err)
 			}
 		}()
@@ -234,7 +234,7 @@ func ProcessGitlabHook(payload []byte, req *http.Request, requestID string, log 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err = TriggerWorkflowV4ByGitlabEvent(pushEvent, baseURI, requestID, log); err != nil {
+			if err = TriggerWorkflowV4ByGitlabEvent(tagEvent, baseURI, requestID, log); err != nil {
 				errorList = multierror.Append(errorList, err)
 			}
 		}()

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_pipeline_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_pipeline_task.go
@@ -228,7 +228,7 @@ func TriggerPipelineByGitlabEvent(event interface{}, baseURI, requestID string, 
 					hookRepo.RepoOwner = taskargs.HookPayload.Owner
 					if notification == nil {
 						notification, _ = scmnotify.NewService().SendInitWebhookComment(
-							hookRepo, taskargs.Builds[0].PR, baseURI, true, false, false, log,
+							hookRepo, taskargs.Builds[0].PR, baseURI, true, false, false, false, log,
 						)
 					}
 				}

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_scanning_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_scanning_task.go
@@ -67,7 +67,7 @@ func TriggerScanningByGitlabEvent(event interface{}, baseURI, requestID string, 
 						if notification == nil {
 							mainRepo := ConvertScanningHookToMainHookRepo(item)
 							notification, _ = scmnotify.NewService().SendInitWebhookComment(
-								mainRepo, ev.ObjectAttributes.IID, baseURI, false, false, true, log,
+								mainRepo, ev.ObjectAttributes.IID, baseURI, false, false, true, false, log,
 							)
 						}
 					}

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_testing_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_testing_task.go
@@ -190,7 +190,7 @@ func TriggerTestByGitlabEvent(event interface{}, baseURI, requestID string, log 
 						// 发送本次commit的通知
 						if notification == nil {
 							notification, _ = scmnotify.NewService().SendInitWebhookComment(
-								item.MainRepo, ev.ObjectAttributes.IID, baseURI, false, true, false, log,
+								item.MainRepo, ev.ObjectAttributes.IID, baseURI, false, true, false, false, log,
 							)
 						}
 					}

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflow_task.go
@@ -630,7 +630,7 @@ func TriggerWorkflowByGitlabEvent(event interface{}, baseURI, requestID string, 
 				}
 				if notification == nil {
 					notification, _ = scmnotify.NewService().SendInitWebhookComment(
-						item.MainRepo, ev.ObjectAttributes.IID, baseURI, false, false, false, log,
+						item.MainRepo, ev.ObjectAttributes.IID, baseURI, false, false, false, false, log,
 					)
 				}
 			}

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflowv4_task.go
@@ -377,7 +377,7 @@ func TriggerWorkflowV4ByGitlabEvent(event interface{}, baseURI, requestID string
 
 				if notification == nil {
 					notification, _ = scmnotify.NewService().SendInitWebhookComment(
-						item.MainRepo, ev.ObjectAttributes.IID, baseURI, false, false, true, log,
+						item.MainRepo, ev.ObjectAttributes.IID, baseURI, false, false, false, true, log,
 					)
 				}
 			}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
@@ -124,14 +124,13 @@ func GetRepos(workflow *commonmodels.WorkflowV4) ([]*types.Repository, error) {
 }
 
 func MergeArgs(workflow, workflowArgs *commonmodels.WorkflowV4) error {
-	if workflowArgs == nil {
-		return nil
-	}
 	argsMap := make(map[string]*commonmodels.Job)
-	for _, stage := range workflowArgs.Stages {
-		for _, job := range stage.Jobs {
-			jobKey := strings.Join([]string{job.Name, string(job.JobType)}, "-")
-			argsMap[jobKey] = job
+	if workflowArgs != nil {
+		for _, stage := range workflowArgs.Stages {
+			for _, job := range stage.Jobs {
+				jobKey := strings.Join([]string{job.Name, string(job.JobType)}, "-")
+				argsMap[jobKey] = job
+			}
 		}
 	}
 	for _, stage := range workflow.Stages {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_build.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_build.go
@@ -361,7 +361,10 @@ func renderKeyVals(input, origin []*commonmodels.KeyVal) []*commonmodels.KeyVal 
 	for i, originKV := range origin {
 		for _, inputKV := range input {
 			if originKV.Key == inputKV.Key {
+				// always use origin credential config.
+				isCredential := originKV.IsCredential
 				origin[i] = inputKV
+				origin[i].IsCredential = isCredential
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
if webhook args were nil,there is no repo info.

### What is changed and how it works?
add repo infos when  webhook args were nil.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
