### PR TITLE
fixed build error for direct kubeconfig connection

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/service.go
+++ b/pkg/microservice/aslan/core/common/service/kube/service.go
@@ -489,6 +489,7 @@ func InitializeExternalCluster(hubserverAddr, clusterID string) error {
 			Labels: dindLabelMap,
 		},
 		Spec: appsv1.StatefulSetSpec{
+			ServiceName: "dind",
 			Selector: &metav1.LabelSelector{
 				MatchLabels: dindLabelMap,
 			},


### PR DESCRIPTION
Signed-off-by: Min Min <minmin@koderover.com>

### What this PR does / Why we need it:
fixed build error for direct kubeconfig connection

### What is changed and how it works?


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
