### PR TITLE
fix panic when github tag event missing sender name

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/webhook/github_workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github_workflow_task.go
@@ -272,7 +272,9 @@ func (gtem githubTagEventMatcher) Match(hookRepo *commonmodels.MainHookRepo) (bo
 		}
 	}
 	hookRepo.Tag = getTagFromRef(*ev.Ref)
-	hookRepo.Committer = *ev.Sender.Name
+	if ev.Sender.Name != nil {
+		hookRepo.Committer = *ev.Sender.Name
+	}
 
 	return true, nil
 }

--- a/pkg/microservice/aslan/core/workflow/service/webhook/github_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github_workflowv4_task.go
@@ -177,7 +177,9 @@ func (gtem githubTagEventMatcherForWorkflowV4) Match(hookRepo *commonmodels.Main
 		}
 	}
 	hookRepo.Tag = getTagFromRef(*ev.Ref)
-	hookRepo.Committer = *ev.Sender.Name
+	if ev.Sender.Name != nil {
+		hookRepo.Committer = *ev.Sender.Name
+	}
 
 	return true, nil
 }
@@ -193,24 +195,6 @@ func (gtem *githubTagEventMatcherForWorkflowV4) GetHookRepo(hookRepo *commonmode
 		Source:        hookRepo.Source,
 	}
 }
-
-// func (gtem githubTagEventMatcher) UpdateTaskArgs(product *commonmodels.Product, args *commonmodels.WorkflowTaskArgs, hookRepo *commonmodels.MainHookRepo, requestID string) *commonmodels.WorkflowTaskArgs {
-// 	factory := &workflowArgsFactory{
-// 		workflow: gtem.workflow,
-// 		reqID:    requestID,
-// 	}
-
-// 	factory.Update(product, args, &types.Repository{
-// 		CodehostID:    hookRepo.CodehostID,
-// 		RepoName:      hookRepo.RepoName,
-// 		RepoOwner:     hookRepo.RepoOwner,
-// 		RepoNamespace: hookRepo.GetRepoNamespace(),
-// 		Branch:        hookRepo.Branch,
-// 		Tag:           hookRepo.Tag,
-// 	})
-
-// 	return args
-// }
 
 func createGithubEventMatcherForWorkflowV4(
 	event interface{}, diffSrv githubPullRequestDiffFunc, workflow *commonmodels.WorkflowV4, log *zap.SugaredLogger,
@@ -252,7 +236,7 @@ func TriggerWorkflowV4ByGithubEvent(event interface{}, baseURI, deliveryID, requ
 	diffSrv := func(pullRequestEvent *github.PullRequestEvent, codehostId int) ([]string, error) {
 		return findChangedFilesOfPullRequest(pullRequestEvent, codehostId)
 	}
-	var hookPayload *commonmodels.HookPayload
+	hookPayload := &commonmodels.HookPayload{}
 
 	for _, workflow := range workflows {
 		if workflow.HookCtls == nil {


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
aslan panic when recieve github tag event.
![image](https://user-images.githubusercontent.com/20654587/185068077-c11dfa87-0646-4abc-9dc0-2243b804c326.png)


### What is changed and how it works?
if sender name was nil,skip it.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
