### PR TITLE
get workflow failed when test module from other project

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/workflow.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow.go
@@ -267,8 +267,9 @@ type TestStage struct {
 
 // TestExecArgs ...
 type TestExecArgs struct {
-	Name string    `bson:"test_name"             json:"test_name"`
-	Envs []*KeyVal `bson:"envs"           json:"envs"`
+	Name    string    `bson:"test_name"             json:"test_name"`
+	Envs    []*KeyVal `bson:"envs"                  json:"envs"`
+	Project string    `bson:"project"               json:"project"`
 }
 
 type SecurityStage struct {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
@@ -340,7 +340,14 @@ func FindWorkflow(workflowName string, log *zap.SugaredLogger) (*commonmodels.Wo
 			bf.RepoNamespace = bf.GetNamespace()
 		}
 	}
-
+	for _, test := range resp.TestStage.Tests {
+		testModule, err := commonrepo.NewTestingColl().Find(test.Name, "")
+		if err != nil {
+			log.Errorf("test module: %s not found", test.Name)
+			continue
+		}
+		test.Project = testModule.ProductName
+	}
 	return resp, nil
 }
 


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
when modify a workflow where test module from other project, get test module info fails.

### What is changed and how it works?
give project info to frontend.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
