### PR TITLE
add ability to get all namespaces

### DIFF
--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -659,6 +659,7 @@ const UpdateEnvTimeout = 60 * 5 * time.Second
 // list namespace type
 const (
 	ListNamespaceTypeCreate = "create"
+	ListNamespaceTypeALL    = "all"
 )
 
 const (


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
add ability to get all namespaces of particular cluster

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
