### PR TITLE
fix goroutine leak when different project use the same PM

### DIFF
--- a/pkg/microservice/cron/core/service/scheduler/schedule_env.go
+++ b/pkg/microservice/cron/core/service/scheduler/schedule_env.go
@@ -88,7 +88,7 @@ func (c *CronClient) UpsertEnvServiceScheduler(log *zap.SugaredLogger) {
 				}
 
 				for _, healthCheck := range svc.HealthChecks {
-					key := "service-" + serviceRevision.ServiceName + "-" + setting.PMDeployType + "-" +
+					key := "service-" + serviceRevision.ServiceName + "-" + env.ProductName + "-" + setting.PMDeployType + "-" +
 						env.EnvName + "-" + envStatus.HostID + "-" + healthCheck.Protocol + "-" + strconv.Itoa(healthCheck.Port) + "-" + healthCheck.Path
 					taskMap[key] = true
 					if _, ok := c.lastServiceSchedulers[key]; ok && reflect.DeepEqual(serviceRevision, c.lastServiceSchedulers[key]) {
@@ -390,7 +390,7 @@ func (c *CronClient) comparePMProductRevision(currentProductRevisions []*service
 			if serviceRevision.Type != setting.PMDeployType {
 				continue
 			}
-			key := "service-" + serviceRevision.ServiceName + "-" + setting.PMDeployType + "-" +
+			key := "service-" + serviceRevision.ServiceName + "-" + env.ProductName + "-" + setting.PMDeployType + "-" +
 				env.EnvName
 			for scheduleKey := range c.Schedulers {
 				if strings.Contains(scheduleKey, key) {
@@ -436,11 +436,12 @@ func (c *CronClient) comparePMProductRevision(currentProductRevisions []*service
 
 	for key, deleteSvcRevisions := range deleteSvcRevisionsMap {
 		envName := strings.Split(key, "-")[1]
+		productName := strings.Split(key, "-")[0]
 		for _, deleteSvcRevision := range deleteSvcRevisions {
 			if deleteSvcRevision.Type != setting.PMDeployType {
 				continue
 			}
-			key := "service-" + deleteSvcRevision.ServiceName + "-" + setting.PMDeployType + "-" +
+			key := "service-" + deleteSvcRevision.ServiceName + "-" + productName + "-" + setting.PMDeployType + "-" +
 				envName
 			for scheduleKey := range c.Schedulers {
 				if strings.Contains(scheduleKey, key) {
@@ -478,7 +479,8 @@ func (c *CronClient) comparePMProductRevision(currentProductRevisions []*service
 			continue
 		}
 		envName := strings.Split(key, "-")[1]
-		key := "service-" + oldRevisionService.ServiceName + "-" + setting.PMDeployType + "-" +
+		productName := strings.Split(key, "-")[0]
+		key := "service-" + oldRevisionService.ServiceName + "-" + productName + "-" + setting.PMDeployType + "-" +
 			envName
 		for scheduleKey := range c.Schedulers {
 			if strings.Contains(scheduleKey, key) {


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
if two project use the same pm and have the same env name, scheduler will re start every time.

### What is changed and how it works?
add project name to sheduler key.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
