### PR TITLE
gives correct error message when creating jenkins task times out

### DIFF
--- a/pkg/microservice/jenkinsplugin/core/service/jenkins.go
+++ b/pkg/microservice/jenkinsplugin/core/service/jenkins.go
@@ -142,7 +142,7 @@ func (p *JenkinsPlugin) afterExec(ctx context.Context, jenkinsClient *gojenkins.
 		}
 	}
 	if buildID == 0 {
-		msg := "timeout waiting for jenkins job creation"
+		msg := "timeout waiting for jenkins job running"
 		log.Error(msg)
 		return errors.New(msg)
 	}

--- a/pkg/microservice/jenkinsplugin/core/service/jenkins.go
+++ b/pkg/microservice/jenkinsplugin/core/service/jenkins.go
@@ -19,6 +19,7 @@ package service
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -126,8 +127,8 @@ func (p *JenkinsPlugin) afterExec(ctx context.Context, jenkinsClient *gojenkins.
 	}
 
 	var buildID int64
-	// 最多等待30秒
-	for i := 0; i < 30; i++ {
+	// 最多等待120秒
+	for i := 0; i < 120; i++ {
 		buildID = task.Raw.Executable.Number
 		if buildID > 0 {
 			break
@@ -139,6 +140,11 @@ func (p *JenkinsPlugin) afterExec(ctx context.Context, jenkinsClient *gojenkins.
 			log.Errorf("get jenkins queue poll task err:%v", err)
 			return err
 		}
+	}
+	if buildID == 0 {
+		msg := "timeout waiting for jenkins job creation"
+		log.Error(msg)
+		return errors.New(msg)
 	}
 	log.Infof("Jenkins buildUrl: %s%d", task.Raw.Task.URL, buildID)
 	log.Infof("Jenkins buildNumber: %d", buildID)

--- a/pkg/microservice/jenkinsplugin/core/service/jenkins.go
+++ b/pkg/microservice/jenkinsplugin/core/service/jenkins.go
@@ -127,7 +127,7 @@ func (p *JenkinsPlugin) afterExec(ctx context.Context, jenkinsClient *gojenkins.
 	}
 
 	var buildID int64
-	// 最多等待120秒
+	// wait up to 120 seconds
 	for i := 0; i < 120; i++ {
 		buildID = task.Raw.Executable.Number
 		if buildID > 0 {


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
gives correct error message when creating jenkins task times out

### What is changed and how it works?
gives correct error message when creating jenkins task times out

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
