### PR TITLE
fix git clone fails when repo adress have extra path

### DIFF
--- a/pkg/microservice/jobexecutor/core/service/step/step_git.go
+++ b/pkg/microservice/jobexecutor/core/service/step/step_git.go
@@ -228,8 +228,9 @@ func (s *GitStep) buildGitCommands(repo *types.Repository, hostNames sets.String
 	}
 	if repo.Source == types.ProviderGitlab {
 		u, _ := url.Parse(repo.Address)
+		host := strings.TrimSuffix(strings.Join([]string{u.Host, u.Path}, "/"), "/")
 		cmds = append(cmds, &c.Command{
-			Cmd:          c.RemoteAdd(repo.RemoteName, OAuthCloneURL(repo.Source, repo.OauthToken, u.Host, owner, repo.RepoName, u.Scheme)),
+			Cmd:          c.RemoteAdd(repo.RemoteName, OAuthCloneURL(repo.Source, repo.OauthToken, host, owner, repo.RepoName, u.Scheme)),
 			DisableTrace: true,
 		})
 	} else if repo.Source == types.ProviderGerrit {
@@ -243,9 +244,10 @@ func (s *GitStep) buildGitCommands(repo *types.Repository, hostNames sets.String
 		})
 	} else if repo.Source == types.ProviderCodehub {
 		u, _ := url.Parse(repo.Address)
+		host := strings.TrimSuffix(strings.Join([]string{u.Host, u.Path}, "/"), "/")
 		user := url.QueryEscape(repo.Username)
 		cmds = append(cmds, &c.Command{
-			Cmd:          c.RemoteAdd(repo.RemoteName, fmt.Sprintf("%s://%s:%s@%s/%s/%s.git", u.Scheme, user, repo.Password, u.Host, owner, repo.RepoName)),
+			Cmd:          c.RemoteAdd(repo.RemoteName, fmt.Sprintf("%s://%s:%s@%s/%s/%s.git", u.Scheme, user, repo.Password, host, owner, repo.RepoName)),
 			DisableTrace: true,
 		})
 	} else if repo.Source == types.ProviderGitee {
@@ -273,8 +275,9 @@ func (s *GitStep) buildGitCommands(repo *types.Repository, hostNames sets.String
 			if err != nil {
 				log.Errorf("failed to parse url,err:%s", err)
 			} else {
+				host := strings.TrimSuffix(strings.Join([]string{u.Host, u.Path}, "/"), "/")
 				cmds = append(cmds, &c.Command{
-					Cmd:          c.RemoteAdd(repo.RemoteName, OAuthCloneURL(repo.Source, repo.PrivateAccessToken, u.Host, repo.RepoOwner, repo.RepoName, u.Scheme)),
+					Cmd:          c.RemoteAdd(repo.RemoteName, OAuthCloneURL(repo.Source, repo.PrivateAccessToken, host, repo.RepoOwner, repo.RepoName, u.Scheme)),
 					DisableTrace: true,
 				})
 			}

--- a/pkg/microservice/reaper/core/service/reaper/git.go
+++ b/pkg/microservice/reaper/core/service/reaper/git.go
@@ -201,8 +201,9 @@ func (r *Reaper) buildGitCommands(repo *meta.Repo, hostNames sets.String) []*c.C
 	}
 	if repo.Source == meta.ProviderGitlab {
 		u, _ := url.Parse(repo.Address)
+		host := strings.TrimSuffix(strings.Join([]string{u.Host, u.Path}, "/"), "/")
 		cmds = append(cmds, &c.Command{
-			Cmd:          c.RemoteAdd(repo.RemoteName, r.Ctx.Git.OAuthCloneURL(repo.Source, repo.OauthToken, u.Host, owner, repo.Name, u.Scheme)),
+			Cmd:          c.RemoteAdd(repo.RemoteName, r.Ctx.Git.OAuthCloneURL(repo.Source, repo.OauthToken, host, owner, repo.Name, u.Scheme)),
 			DisableTrace: true,
 		})
 	} else if repo.Source == meta.ProviderGerrit {
@@ -216,9 +217,10 @@ func (r *Reaper) buildGitCommands(repo *meta.Repo, hostNames sets.String) []*c.C
 		})
 	} else if repo.Source == meta.ProviderCodehub {
 		u, _ := url.Parse(repo.Address)
+		host := strings.TrimSuffix(strings.Join([]string{u.Host, u.Path}, "/"), "/")
 		user := url.QueryEscape(repo.User)
 		cmds = append(cmds, &c.Command{
-			Cmd:          c.RemoteAdd(repo.RemoteName, fmt.Sprintf("%s://%s:%s@%s/%s/%s.git", u.Scheme, user, repo.Password, u.Host, owner, repo.Name)),
+			Cmd:          c.RemoteAdd(repo.RemoteName, fmt.Sprintf("%s://%s:%s@%s/%s/%s.git", u.Scheme, user, repo.Password, host, owner, repo.Name)),
 			DisableTrace: true,
 		})
 	} else if repo.Source == meta.ProviderGitee {
@@ -246,8 +248,9 @@ func (r *Reaper) buildGitCommands(repo *meta.Repo, hostNames sets.String) []*c.C
 			if err != nil {
 				log.Errorf("failed to parse url,err:%s", err)
 			} else {
+				host := strings.TrimSuffix(strings.Join([]string{u.Host, u.Path}, "/"), "/")
 				cmds = append(cmds, &c.Command{
-					Cmd:          c.RemoteAdd(repo.RemoteName, r.Ctx.Git.OAuthCloneURL(repo.Source, repo.PrivateAccessToken, u.Host, repo.Owner, repo.Name, u.Scheme)),
+					Cmd:          c.RemoteAdd(repo.RemoteName, r.Ctx.Git.OAuthCloneURL(repo.Source, repo.PrivateAccessToken, host, repo.Owner, repo.Name, u.Scheme)),
 					DisableTrace: true,
 				})
 			}


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
eg https://gitlab.com/abc, git clone will fail. 

### What is changed and how it works?
add path when git clone 

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
