### PR TITLE
eliminate custom workflow name length limit

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_freestyle.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_freestyle.go
@@ -45,7 +45,7 @@ const (
 
 type FreestyleJobCtl struct {
 	job         *commonmodels.JobTask
-	jobID       string
+	jobName     string
 	workflowCtx *commonmodels.WorkflowTaskCtx
 	logger      *zap.SugaredLogger
 	kubeclient  crClient.Client
@@ -68,7 +68,7 @@ func NewFreestyleJobCtl(job *commonmodels.JobTask, workflowCtx *commonmodels.Wor
 		logger:      logger,
 		ack:         ack,
 		paths:       &paths,
-		jobID:       getJobName(workflowCtx.WorkflowName, workflowCtx.TaskID),
+		jobName:     getJobName(workflowCtx.WorkflowName, workflowCtx.TaskID),
 		jobTaskSpec: jobTaskSpec,
 	}
 }
@@ -166,7 +166,7 @@ func (c *FreestyleJobCtl) run(ctx context.Context) error {
 
 	jobLabel := &JobLabel{
 		JobType: string(c.job.JobType),
-		JobID:   c.jobID,
+		JobName: c.jobName,
 	}
 	if err := ensureDeleteConfigMap(c.jobTaskSpec.Properties.Namespace, jobLabel, c.kubeclient); err != nil {
 		logError(c.job, err.Error(), c.logger)
@@ -174,13 +174,13 @@ func (c *FreestyleJobCtl) run(ctx context.Context) error {
 	}
 
 	if err := createJobConfigMap(
-		c.jobTaskSpec.Properties.Namespace, c.jobID, jobLabel, string(jobCtxBytes), c.kubeclient); err != nil {
+		c.jobTaskSpec.Properties.Namespace, c.jobName, jobLabel, string(jobCtxBytes), c.kubeclient); err != nil {
 		msg := fmt.Sprintf("createJobConfigMap error: %v", err)
 		logError(c.job, msg, c.logger)
 		return errors.New(msg)
 	}
 
-	c.logger.Infof("succeed to create cm for job %s", c.jobID)
+	c.logger.Infof("succeed to create cm for job %s", c.jobName)
 
 	// TODO: do not use default image
 	jobImage := getBaseImage(c.jobTaskSpec.Properties.BuildOS, c.jobTaskSpec.Properties.ImageFrom)
@@ -188,7 +188,7 @@ func (c *FreestyleJobCtl) run(ctx context.Context) error {
 	// jobImage := getReaperImage(config.ReaperImage(), c.job.Properties.BuildOS)
 
 	//Resource request default value is LOW
-	job, err := buildJob(c.job.JobType, jobImage, c.jobID, c.jobTaskSpec.Properties.ClusterID, c.jobTaskSpec.Properties.Namespace, c.jobTaskSpec.Properties.ResourceRequest, c.jobTaskSpec.Properties.ResReqSpec, c.job, c.jobTaskSpec, c.workflowCtx, nil)
+	job, err := buildJob(c.job.JobType, jobImage, c.jobName, c.jobTaskSpec.Properties.ClusterID, c.jobTaskSpec.Properties.Namespace, c.jobTaskSpec.Properties.ResourceRequest, c.jobTaskSpec.Properties.ResReqSpec, c.job, c.jobTaskSpec, c.workflowCtx, nil)
 	if err != nil {
 		msg := fmt.Sprintf("create job context error: %v", err)
 		logError(c.job, msg, c.logger)
@@ -217,19 +217,19 @@ func (c *FreestyleJobCtl) run(ctx context.Context) error {
 		logError(c.job, msg, c.logger)
 		return errors.New(msg)
 	}
-	c.logger.Infof("succeed to create job %s", c.jobID)
+	c.logger.Infof("succeed to create job %s", c.jobName)
 	return nil
 }
 
 func (c *FreestyleJobCtl) wait(ctx context.Context) {
-	status := waitJobEndWithFile(ctx, int(c.jobTaskSpec.Properties.Timeout), c.jobTaskSpec.Properties.Namespace, c.jobID, true, c.kubeclient, c.clientset, c.restConfig, c.logger)
+	status := waitJobEndWithFile(ctx, int(c.jobTaskSpec.Properties.Timeout), c.jobTaskSpec.Properties.Namespace, c.jobName, true, c.kubeclient, c.clientset, c.restConfig, c.logger)
 	c.job.Status = status
 }
 
 func (c *FreestyleJobCtl) complete(ctx context.Context) {
 	jobLabel := &JobLabel{
 		JobType: string(c.job.JobType),
-		JobID:   c.jobID,
+		JobName: c.jobName,
 	}
 
 	// 清理用户取消和超时的任务

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -42,7 +42,7 @@ import (
 
 const (
 	JobNameRegx  = "^[a-z][a-z0-9-]{0,31}$"
-	WorkflowRegx = "^[a-z0-9-]{1,32}$"
+	WorkflowRegx = "^[a-z0-9-]+$"
 )
 
 func CreateWorkflowV4(user string, workflow *commonmodels.WorkflowV4, logger *zap.SugaredLogger) error {


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
current custom workflow name max length was 32, when  collaboration mode copy a workflow, length may exceed.

### What is changed and how it works?
do not use workflow name as a key in k8s.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
