### PR TITLE
eliminate custom workflow name length limit

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
@@ -64,16 +64,17 @@ type StageTask struct {
 }
 
 type JobTask struct {
-	Name      string        `bson:"name"                json:"name"`
-	JobType   string        `bson:"type"                json:"type"`
-	Status    config.Status `bson:"status"              json:"status"`
-	StartTime int64         `bson:"start_time"          json:"start_time,omitempty"`
-	EndTime   int64         `bson:"end_time"            json:"end_time,omitempty"`
-	Error     string        `bson:"error"               json:"error"`
-	Timeout   int64         `bson:"timeout"             json:"timeout"`
-	Retry     int64         `bson:"retry"               json:"retry"`
-	Spec      interface{}   `bson:"spec"                json:"spec"`
-	Outputs   []*Output     `bson:"outputs"             json:"outputs"`
+	Name       string        `bson:"name"                json:"name"`
+	K8sJobName string        `bson:"k8s_job_name"        json:"k8s_job_name"`
+	JobType    string        `bson:"type"                json:"type"`
+	Status     config.Status `bson:"status"              json:"status"`
+	StartTime  int64         `bson:"start_time"          json:"start_time,omitempty"`
+	EndTime    int64         `bson:"end_time"            json:"end_time,omitempty"`
+	Error      string        `bson:"error"               json:"error"`
+	Timeout    int64         `bson:"timeout"             json:"timeout"`
+	Retry      int64         `bson:"retry"               json:"retry"`
+	Spec       interface{}   `bson:"spec"                json:"spec"`
+	Outputs    []*Output     `bson:"outputs"             json:"outputs"`
 }
 
 type JobTaskCustomDeploySpec struct {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job.go
@@ -75,6 +75,7 @@ func runJob(ctx context.Context, job *commonmodels.JobTask, workflowCtx *commonm
 	})
 	job.Status = config.StatusRunning
 	job.StartTime = time.Now().Unix()
+	job.K8sJobName = getJobName(workflowCtx.WorkflowName, workflowCtx.TaskID)
 	ack()
 
 	logger.Infof("start job: %s,status: %s", job.Name, job.Status)

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
@@ -87,10 +87,8 @@ func GetK8sClients(hubServerAddr, clusterID string) (crClient.Client, kubernetes
 }
 
 type JobLabel struct {
-	WorkflowName string
-	TaskID       int64
-	JobName      string
-	JobType      string
+	JobName string
+	JobType string
 }
 
 func ensureDeleteConfigMap(namespace string, jobLabel *JobLabel, kubeClient crClient.Client) error {
@@ -106,7 +104,6 @@ func ensureDeleteJob(namespace string, jobLabel *JobLabel, kubeClient crClient.C
 // getJobLabels get labels k-v map from JobLabel struct
 func getJobLabels(jobLabel *JobLabel) map[string]string {
 	retMap := map[string]string{
-		setting.JobLabelTaskKey:  fmt.Sprintf("%s-%d", strings.ToLower(jobLabel.WorkflowName), jobLabel.TaskID),
 		setting.JobLabelNameKey:  strings.Replace(jobLabel.JobName, "_", "-", -1),
 		setting.JobLabelSTypeKey: strings.Replace(jobLabel.JobType, "_", "-", -1),
 	}
@@ -174,10 +171,8 @@ echo $result > %s
 	collectJobOutputCommand := fmt.Sprintf(collectJobOutput, strings.Join(files, ","), strings.Join(outputs, ","), job.JobTerminationFile)
 
 	labels := getJobLabels(&JobLabel{
-		WorkflowName: workflowCtx.WorkflowName,
-		TaskID:       workflowCtx.TaskID,
-		JobType:      string(jobTask.JobType),
-		JobName:      jobTask.Name,
+		JobType: string(jobTask.JobType),
+		JobName: jobTask.K8sJobName,
 	})
 
 	ImagePullSecrets, err := getImagePullSecrets(jobTaskSpec.Properties.Registries)
@@ -280,10 +275,8 @@ func buildJob(jobType, jobImage, jobName, clusterID, currentNamespace string, re
 	jobExecutorBootingScript = fmt.Sprintf("curl -m 10 --retry-delay 3 --retry 3 -sSL %s -o reaper && chmod +x reaper && mv reaper /usr/local/bin && /usr/local/bin/reaper", jobExecutorBinaryFile)
 
 	labels := getJobLabels(&JobLabel{
-		WorkflowName: workflowCtx.WorkflowName,
-		TaskID:       workflowCtx.TaskID,
-		JobType:      string(jobType),
-		JobName:      jobTask.Name,
+		JobType: string(jobType),
+		JobName: jobTask.K8sJobName,
 	})
 
 	ImagePullSecrets, err := getImagePullSecrets(jobTaskSpec.Properties.Registries)

--- a/pkg/microservice/aslan/core/log/service/sse.go
+++ b/pkg/microservice/aslan/core/log/service/sse.go
@@ -48,6 +48,8 @@ type GetContainerOptions struct {
 	Namespace     string
 	PipelineName  string
 	SubTask       string
+	JobName       string
+	JobType       string
 	TailLines     int64
 	TaskID        int64
 	PipelineType  string
@@ -214,6 +216,8 @@ func WorkflowTaskV4ContainerLogStream(ctx context.Context, streamChan chan inter
 			if job.Name != options.SubTask {
 				continue
 			}
+			options.JobName = job.K8sJobName
+			options.JobType = job.JobType
 			switch job.JobType {
 			case string(config.JobZadigBuild):
 				fallthrough
@@ -348,8 +352,8 @@ func getPipelineSelector(options *GetContainerOptions) labels.Selector {
 
 func getWorkflowSelector(options *GetContainerOptions) labels.Selector {
 	retMap := map[string]string{
-		setting.JobLabelTaskKey: fmt.Sprintf("%s-%d", strings.ToLower(options.PipelineName), options.TaskID),
-		setting.JobLabelNameKey: strings.Replace(options.SubTask, "_", "-", -1),
+		setting.JobLabelSTypeKey: strings.Replace(options.JobType, "_", "-", -1),
+		setting.JobLabelNameKey:  strings.Replace(options.JobName, "_", "-", -1),
 	}
 	// no need to add labels with empty value to a job
 	for k, v := range retMap {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -42,7 +42,7 @@ import (
 
 const (
 	JobNameRegx  = "^[a-z][a-z0-9-]{0,31}$"
-	WorkflowRegx = "^[a-z0-9-]{1,32}$"
+	WorkflowRegx = "^[a-z0-9-]+$"
 )
 
 func CreateWorkflowV4(user string, workflow *commonmodels.WorkflowV4, logger *zap.SugaredLogger) error {


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
current custom workflow name max length was 32, when collaboration mode copy a workflow, length may exceed.

### What is changed and how it works?
do not use workflow name as a key in k8s.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
