### PR TITLE
fix cluster reconnect bug

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -269,11 +269,11 @@ func GetService(envName, productName, serviceName string, workLoadType string, l
 
 		// 获取服务模板
 		opt := &commonrepo.ServiceFindOption{
-			ServiceName:   service.ServiceName,
-			ProductName:   service.ProductName,
-			Type:          service.Type,
-			Revision:      service.Revision,
-			ExcludeStatus: setting.ProductStatusDeleting,
+			ServiceName: service.ServiceName,
+			ProductName: service.ProductName,
+			Type:        service.Type,
+			Revision:    service.Revision,
+			//ExcludeStatus: setting.ProductStatusDeleting,
 		}
 
 		svcTmpl, err := commonrepo.NewServiceColl().Find(opt)

--- a/pkg/microservice/aslan/core/multicluster/service/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/service/clusters.go
@@ -588,13 +588,6 @@ func ClusterApplyUpgrade() {
 		}
 
 		for _, cluster := range k8sClusters {
-			if cluster.Type == setting.KubeConfigClusterType {
-				err = kube.InitializeExternalCluster(config.HubServerAddress(), cluster.ID.Hex())
-				if err != nil {
-					log.Errorf("[ClusterApplyUpgrade] InitializeExternalCluster cluster %s error:%s", cluster.Name, err)
-				}
-				continue
-			}
 			if cluster.Status != setting.Normal {
 				log.Warnf("[ClusterApplyUpgrade] not support apply. cluster %s status %s ", cluster.Name, cluster.Status)
 				continue

--- a/pkg/microservice/aslan/core/service.go
+++ b/pkg/microservice/aslan/core/service.go
@@ -157,7 +157,7 @@ func Start(ctx context.Context) {
 
 	go StartControllers(ctx.Done())
 
-	go multiclusterservice.ClusterApplyUpgradeAgent()
+	go multiclusterservice.ClusterApplyUpgrade()
 
 	initRsaKey()
 


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
error occurs when running 'exec' command into pod deployed in external cluster which is connected directly

### What is changed and how it works?
fix bug

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
