### PR TITLE
fix for other git source clone failed in custom workflow

### DIFF
--- a/pkg/microservice/jobexecutor/core/service/step/step_git.go
+++ b/pkg/microservice/jobexecutor/core/service/step/step_git.go
@@ -78,7 +78,9 @@ func (s *GitStep) RunGitGc(folder string) error {
 }
 
 func (s *GitStep) runGitCmds() error {
-
+	if err := os.MkdirAll(path.Join(config.Home(), "/.ssh"), os.ModePerm); err != nil {
+		return fmt.Errorf("create ssh folder error: %v", err)
+	}
 	envs := s.envs
 	// 如果存在github代码库，则设置代理，同时保证非github库不走代理
 	if s.spec.Proxy != nil && s.spec.Proxy.EnableRepoProxy && s.spec.Proxy.Type == "http" {


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
other git source clone failed because of dir .ssh not exist.

### What is changed and how it works?
create .ssh dir.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
