### PR TITLE
do not copy workflow webhook info

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -572,6 +572,8 @@ func BulkCopyWorkflowV4(args BulkCopyWorkflowArgs, username string, log *zap.Sug
 			newItem.Name = workflow.New
 			newItem.BaseName = workflow.BaseName
 			newItem.ID = primitive.NewObjectID()
+			// do not copy webhook triggers.
+			newItem.HookCtls = []*commonmodels.WorkflowV4Hook{}
 
 			newWorkflows = append(newWorkflows, &newItem)
 		} else {


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
when copy a workflow, webhook will also copyed, may cause some problem.

### What is changed and how it works?
do not copy webhook info.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
