### PR TITLE
fix get cluster info panic when cluster was deleted

### DIFF
--- a/pkg/shared/kube/client/client.go
+++ b/pkg/shared/kube/client/client.go
@@ -42,6 +42,9 @@ func GetKubeClient(hubserverAddr, clusterID string) (client.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	if cluster == nil {
+		return nil, fmt.Errorf("cluster %s not found", clusterID)
+	}
 
 	switch cluster.Type {
 	case setting.AgentClusterType, "":


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
fix get cluster info panic when cluster was deleted

### What is changed and how it works?
fix get cluster info panic when cluster was deleted

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
