### PR TITLE
remove useless env name for onboarding ops workflow

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow.go
@@ -204,7 +204,6 @@ func AutoCreateWorkflow(productName string, log *zap.SugaredLogger) *EnvStatus {
 					Enabled: true,
 					Modules: artifactModules,
 				}
-				workflow.EnvName = "ops" //TODO necessary to set a fake env name?
 			}
 
 			workflow.Schedules = &commonmodels.ScheduleCtrl{


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
remove useless env name for onboarding ops workflow

### What is changed and how it works?
remove useless env name for onboarding ops workflow

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
