### PR TITLE
fix custom workflow missing webhook infos (Cherry pick 2042)

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflowv4_task.go
@@ -254,7 +254,7 @@ func TriggerWorkflowV4ByGerritEvent(event *gerritTypeEvent, body []byte, uri, ba
 				errorList = multierror.Append(errorList, fmt.Errorf(errMsg))
 				continue
 			}
-			if err := job.MergeWebhookRepo(item.WorkflowArg, eventRepo); err != nil {
+			if err := job.MergeWebhookRepo(workflow, eventRepo); err != nil {
 				errMsg := fmt.Sprintf("merge webhook repo info to workflowargs error: %v", err)
 				log.Error(errMsg)
 				errorList = multierror.Append(errorList, fmt.Errorf(errMsg))

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
@@ -114,6 +114,12 @@ func MergeWebhookRepo(workflow *commonmodels.WorkflowV4, repo *types.Repository)
 					return err
 				}
 			}
+			if job.JobType == config.JobZadigTesting {
+				jobCtl := &TestingJob{job: job, workflow: workflow}
+				if err := jobCtl.MergeWebhookRepo(repo); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	return nil

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_freestyle.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_freestyle.go
@@ -159,6 +159,7 @@ func (j *FreeStyleJob) MergeWebhookRepo(webhookRepo *types.Repository) error {
 			return err
 		}
 		stepSpec.Repos = mergeRepos(stepSpec.Repos, []*types.Repository{webhookRepo})
+		step.Spec = stepSpec
 	}
 	j.job.Spec = j.spec
 	return nil


### PR DESCRIPTION
### What this PR does / Why we need it:
add webhook repo info to testing job
add webhook info to custom workflow trigger by gerrit

### What is changed and how it works?
add infos back

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
