### PR TITLE
add creation info for service templates

### DIFF
--- a/pkg/microservice/aslan/core/common/service/service.go
+++ b/pkg/microservice/aslan/core/common/service/service.go
@@ -98,6 +98,7 @@ type ServiceProductMap struct {
 	LoadFromDir      bool                      `json:"is_dir"`
 	GerritRemoteName string                    `json:"gerrit_remote_name,omitempty"`
 	CreateFrom       interface{}               `json:"create_from"`
+	AutoSync         bool                      `json:"auto_sync"`
 }
 
 var (
@@ -217,6 +218,7 @@ func ListServiceTemplate(productName string, log *zap.SugaredLogger) (*ServiceTm
 			LoadPath:         serviceObject.LoadPath,
 			GerritRemoteName: serviceObject.GerritRemoteName,
 			CreateFrom:       serviceObject.CreateFrom,
+			AutoSync:         serviceObject.AutoSync,
 		}
 
 		if _, ok := serviceToProject[serviceObject.ServiceName]; ok {


### PR DESCRIPTION
Signed-off-by: allenshen <shendongdong@koderover.com>

### What this PR does / Why we need it:
add service creation info to response when fetching service list of products

### Does this PR introduce a user-facing change?
no

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
