### PR TITLE
add build-in job to patch k8s resources

### DIFF
--- a/pkg/microservice/aslan/config/consts.go
+++ b/pkg/microservice/aslan/config/consts.go
@@ -187,6 +187,7 @@ const (
 	JobK8sBlueGreenRelease JobType = "k8s-blue-green-release"
 	JobK8sCanaryDeploy     JobType = "k8s-canary-deploy"
 	JobK8sCanaryRelease    JobType = "k8s-canary-release"
+	JobK8sPatch            JobType = "k8s-resource-patch"
 )
 
 type ApproveOrReject string

--- a/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
@@ -208,11 +208,12 @@ type JobTasK8sPatchSpec struct {
 }
 
 type PatchTaskItem struct {
-	ResourceName    string `bson:"resource_name"                json:"resource_name"               yaml:"resource_name"`
-	ResourceKind    string `bson:"resource_kind"                json:"resource_kind"               yaml:"resource_kind"`
-	ResourceGroup   string `bson:"resource_group"               json:"resource_group"              yaml:"resource_group"`
-	ResourceVersion string `bson:"resource_version"             json:"resource_version"            yaml:"resource_version"`
-	PatchContent    string `bson:"patch_content"                json:"patch_content"               yaml:"patch_content"`
+	ResourceName    string   `bson:"resource_name"                json:"resource_name"               yaml:"resource_name"`
+	ResourceKind    string   `bson:"resource_kind"                json:"resource_kind"               yaml:"resource_kind"`
+	ResourceGroup   string   `bson:"resource_group"               json:"resource_group"              yaml:"resource_group"`
+	ResourceVersion string   `bson:"resource_version"             json:"resource_version"            yaml:"resource_version"`
+	PatchContent    string   `bson:"patch_content"                json:"patch_content"               yaml:"patch_content"`
+	Params          []*Param `bson:"params"                       json:"params"                      yaml:"params"`
 	// support strategic-merge/merge/json
 	PatchStrategy string `bson:"patch_strategy"          json:"patch_strategy"         yaml:"patch_strategy"`
 	Error         string `bson:"error"                   json:"error"                  yaml:"error"`

--- a/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
@@ -201,6 +201,23 @@ type JobTaskCanaryReleaseSpec struct {
 	Events         *Events `bson:"events"                 json:"events"                yaml:"events"`
 }
 
+type JobTasK8sPatchSpec struct {
+	ClusterID  string           `bson:"cluster_id"             json:"cluster_id"             yaml:"cluster_id"`
+	Namespace  string           `bson:"namespace"              json:"namespace"              yaml:"namespace"`
+	PatchItems []*PatchTaskItem `bson:"patch_items"            json:"patch_items"           yaml:"patch_items"`
+}
+
+type PatchTaskItem struct {
+	ResourceName    string `bson:"resource_name"                json:"resource_name"               yaml:"resource_name"`
+	ResourceKind    string `bson:"resource_kind"                json:"resource_kind"               yaml:"resource_kind"`
+	ResourceGroup   string `bson:"resource_group"               json:"resource_group"              yaml:"resource_group"`
+	ResourceVersion string `bson:"resource_version"             json:"resource_version"            yaml:"resource_version"`
+	PatchContent    string `bson:"patch_content"                json:"patch_content"               yaml:"patch_content"`
+	// support strategic-merge/merge/json
+	PatchStrategy string `bson:"patch_strategy"          json:"patch_strategy"         yaml:"patch_strategy"`
+	Error         string `bson:"error"                   json:"error"                  yaml:"error"`
+}
+
 type Event struct {
 	EventType string `bson:"event_type"             json:"event_type"            yaml:"event_type"`
 	Time      string `bson:"time"                   json:"time"                  yaml:"time"`

--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -207,11 +207,12 @@ type K8sPatchJobSpec struct {
 }
 
 type PatchItem struct {
-	ResourceName    string `bson:"resource_name"                json:"resource_name"               yaml:"resource_name"`
-	ResourceKind    string `bson:"resource_kind"                json:"resource_kind"               yaml:"resource_kind"`
-	ResourceGroup   string `bson:"resource_group"               json:"resource_group"              yaml:"resource_group"`
-	ResourceVersion string `bson:"resource_version"             json:"resource_version"            yaml:"resource_version"`
-	PatchContent    string `bson:"patch_content"                json:"patch_content"               yaml:"patch_content"`
+	ResourceName    string   `bson:"resource_name"                json:"resource_name"               yaml:"resource_name"`
+	ResourceKind    string   `bson:"resource_kind"                json:"resource_kind"               yaml:"resource_kind"`
+	ResourceGroup   string   `bson:"resource_group"               json:"resource_group"              yaml:"resource_group"`
+	ResourceVersion string   `bson:"resource_version"             json:"resource_version"            yaml:"resource_version"`
+	PatchContent    string   `bson:"patch_content"                json:"patch_content"               yaml:"patch_content"`
+	Params          []*Param `bson:"params"                       json:"params"                      yaml:"params"`
 	// support strategic-merge/merge/json
 	PatchStrategy string `bson:"patch_strategy"          json:"patch_strategy"         yaml:"patch_strategy"`
 }
@@ -266,7 +267,7 @@ type WorkflowV4Hook struct {
 type Param struct {
 	Name        string `bson:"name"             json:"name"             yaml:"name"`
 	Description string `bson:"description"      json:"description"      yaml:"description"`
-	// support string/text type
+	// support string/text/choice type
 	ParamsType   string   `bson:"type"                      json:"type"                        yaml:"type"`
 	Value        string   `bson:"value"                     json:"value"                       yaml:"value,omitempty"`
 	ChoiceOption []string `bson:"choice_option,omitempty"   json:"choice_option,omitempty"     yaml:"choice_option,omitempty"`

--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -207,8 +207,11 @@ type K8sPatchJobSpec struct {
 }
 
 type PatchItem struct {
-	Resource     string `bson:"resource"                json:"resource"               yaml:"resource"`
-	PatchContent string `bson:"patch_content"           json:"patch_content"          yaml:"patch_content"`
+	ResourceName    string `bson:"resource_name"                json:"resource_name"               yaml:"resource_name"`
+	ResourceKind    string `bson:"resource_kind"                json:"resource_kind"               yaml:"resource_kind"`
+	ResourceGroup   string `bson:"resource_group"               json:"resource_group"              yaml:"resource_group"`
+	ResourceVersion string `bson:"resource_version"             json:"resource_version"            yaml:"resource_version"`
+	PatchContent    string `bson:"patch_content"                json:"patch_content"               yaml:"patch_content"`
 	// support strategic-merge/merge/json
 	PatchStrategy string `bson:"patch_strategy"          json:"patch_strategy"         yaml:"patch_strategy"`
 }

--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -200,6 +200,19 @@ type CanaryTarget struct {
 	WorkloadType  string `bson:"workload_type"          json:"workload_type"         yaml:"workload_type"`
 }
 
+type K8sPatchJobSpec struct {
+	ClusterID  string       `bson:"cluster_id"             json:"cluster_id"            yaml:"cluster_id"`
+	Namespace  string       `bson:"namespace"              json:"namespace"             yaml:"namespace"`
+	PatchItems []*PatchItem `bson:"patch_items"            json:"patch_items"           yaml:"patch_items"`
+}
+
+type PatchItem struct {
+	Resource     string `bson:"resource"                json:"resource"               yaml:"resource"`
+	PatchContent string `bson:"patch_content"           json:"patch_content"          yaml:"patch_content"`
+	// support strategic-merge/merge/json
+	PatchStrategy string `bson:"patch_strategy"          json:"patch_strategy"         yaml:"patch_strategy"`
+}
+
 type JobProperties struct {
 	Timeout         int64               `bson:"timeout"                json:"timeout"               yaml:"timeout"`
 	Retry           int64               `bson:"retry"                  json:"retry"                 yaml:"retry"`

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job.go
@@ -59,6 +59,8 @@ func initJobCtl(job *commonmodels.JobTask, workflowCtx *commonmodels.WorkflowTas
 		jobCtl = NewBlueGreenDeployJobCtl(job, workflowCtx, ack, logger)
 	case string(config.JobK8sBlueGreenRelease):
 		jobCtl = NewBlueGreenReleaseJobCtl(job, workflowCtx, ack, logger)
+	case string(config.JobK8sPatch):
+		jobCtl = NewK8sPatchJobCtl(job, workflowCtx, ack, logger)
 	default:
 		jobCtl = NewFreestyleJobCtl(job, workflowCtx, ack, logger)
 	}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_k8s_patch.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_k8s_patch.go
@@ -65,5 +65,14 @@ func (c *K8sPatchJobCtl) Run(ctx context.Context) {
 }
 
 func (c *K8sPatchJobCtl) runPatch(patchItem *commonmodels.PatchTaskItem) {
-	// updater.PatchPod()
+	// obj := &unstructured.Unstructured{}
+
+	// obj.SetGroupVersionKind(schema.GroupVersionKind{
+	// 	Group:   patchItem.ResourceGroup,
+	// 	Version: patchItem.ResourceVersion,
+	// 	Kind:    patchItem.ResourceKind,
+	// })
+	// obj.SetName(patchItem.ResourceName)
+	// obj.SetNamespace(c.jobTaskSpec.Namespace)
+	// updater.PatchUnstructured()
 }

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_k8s_patch.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_k8s_patch.go
@@ -18,14 +18,22 @@ package jobcontroller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"sync"
 
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	crClient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	kubeclient "github.com/koderover/zadig/pkg/shared/kube/client"
+	"github.com/koderover/zadig/pkg/tool/kube/updater"
 )
 
 type K8sPatchJobCtl struct {
@@ -62,17 +70,73 @@ func (c *K8sPatchJobCtl) Run(ctx context.Context) {
 		logError(c.job, msg, c.logger)
 		return
 	}
+	var wg sync.WaitGroup
+	var errList *multierror.Error
+	for _, patch := range c.jobTaskSpec.PatchItems {
+		c.runPatch(patch, wg, errList)
+	}
+	wg.Wait()
+	if err := errList.ErrorOrNil(); err != nil {
+		msg := fmt.Sprintf("pacth resources error: %v", err)
+		logError(c.job, msg, c.logger)
+		return
+	}
 }
 
-func (c *K8sPatchJobCtl) runPatch(patchItem *commonmodels.PatchTaskItem) {
-	// obj := &unstructured.Unstructured{}
+func (c *K8sPatchJobCtl) runPatch(patchItem *commonmodels.PatchTaskItem, wg sync.WaitGroup, errList *multierror.Error) {
+	wg.Add(1)
+	defer wg.Done()
+	var err error
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   patchItem.ResourceGroup,
+		Version: patchItem.ResourceVersion,
+		Kind:    patchItem.ResourceKind,
+	})
+	obj.SetName(patchItem.ResourceName)
+	obj.SetNamespace(c.jobTaskSpec.Namespace)
+	var patchBytes []byte
+	var patchType types.PatchType
+	switch patchItem.PatchStrategy {
+	case "merge":
+		resource := map[string]interface{}{}
+		if err = yaml.Unmarshal([]byte(patchItem.PatchContent), &resource); err != nil {
+			patchItem.Error = fmt.Sprintf("unmarshal yaml input error: %v", err)
+			errList = multierror.Append(errList, err)
+			return
+		}
+		patchBytes, err = json.Marshal(resource)
+		if err != nil {
+			patchItem.Error = fmt.Sprintf("marshal input into json error: %v", err)
+			errList = multierror.Append(errList, err)
+			return
+		}
+		patchType = types.MergePatchType
+	case "strategic-merge":
+		resource := map[string]interface{}{}
+		if err := yaml.Unmarshal([]byte(patchItem.PatchContent), &resource); err != nil {
+			patchItem.Error = fmt.Sprintf("unmarshal yaml input error: %v", err)
+			errList = multierror.Append(errList, err)
+			return
+		}
+		patchBytes, err = json.Marshal(resource)
+		if err != nil {
+			patchItem.Error = fmt.Sprintf("marshal input into json error: %v", err)
+			errList = multierror.Append(errList, err)
+			return
+		}
+		patchType = types.StrategicMergePatchType
+	case "json":
+		patchBytes = []byte(patchItem.PatchContent)
+		patchType = types.JSONPatchType
+	default:
+		patchItem.Error = fmt.Sprintf("pacth strategy %s not supported", patchItem.PatchStrategy)
+		errList = multierror.Append(errList, fmt.Errorf("pacth strategy %s not supported", patchItem.PatchStrategy))
+	}
 
-	// obj.SetGroupVersionKind(schema.GroupVersionKind{
-	// 	Group:   patchItem.ResourceGroup,
-	// 	Version: patchItem.ResourceVersion,
-	// 	Kind:    patchItem.ResourceKind,
-	// })
-	// obj.SetName(patchItem.ResourceName)
-	// obj.SetNamespace(c.jobTaskSpec.Namespace)
-	// updater.PatchUnstructured()
+	if err = updater.PatchUnstructured(obj, patchBytes, patchType, c.kubeClient); err != nil {
+		patchItem.Error = fmt.Sprintf("patch resoure error: %v", err)
+		errList = multierror.Append(errList, err)
+		return
+	}
 }

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_k8s_patch.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_k8s_patch.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2022 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobcontroller
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	crClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	kubeclient "github.com/koderover/zadig/pkg/shared/kube/client"
+)
+
+type K8sPatchJobCtl struct {
+	job         *commonmodels.JobTask
+	workflowCtx *commonmodels.WorkflowTaskCtx
+	logger      *zap.SugaredLogger
+	kubeClient  crClient.Client
+	jobTaskSpec *commonmodels.JobTasK8sPatchSpec
+	ack         func()
+}
+
+func NewK8sPatchJobCtl(job *commonmodels.JobTask, workflowCtx *commonmodels.WorkflowTaskCtx, ack func(), logger *zap.SugaredLogger) *K8sPatchJobCtl {
+	jobTaskSpec := &commonmodels.JobTasK8sPatchSpec{}
+	if err := commonmodels.IToi(job.Spec, jobTaskSpec); err != nil {
+		logger.Error(err)
+	}
+	job.Spec = jobTaskSpec
+	return &K8sPatchJobCtl{
+		job:         job,
+		workflowCtx: workflowCtx,
+		logger:      logger,
+		ack:         ack,
+		jobTaskSpec: jobTaskSpec,
+	}
+}
+
+func (c *K8sPatchJobCtl) Clean(ctx context.Context) {}
+
+func (c *K8sPatchJobCtl) Run(ctx context.Context) {
+	var err error
+	c.kubeClient, err = kubeclient.GetKubeClient(config.HubServerAddress(), c.jobTaskSpec.ClusterID)
+	if err != nil {
+		msg := fmt.Sprintf("can't init k8s client: %v", err)
+		logError(c.job, msg, c.logger)
+		return
+	}
+}
+
+func (c *K8sPatchJobCtl) runPatch(patchItem *commonmodels.PatchTaskItem) {
+	// updater.PatchPod()
+}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_k8s_patch.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_k8s_patch.go
@@ -81,6 +81,7 @@ func (c *K8sPatchJobCtl) Run(ctx context.Context) {
 		logError(c.job, msg, c.logger)
 		return
 	}
+	c.job.Status = config.StatusPassed
 }
 
 func (c *K8sPatchJobCtl) runPatch(patchItem *commonmodels.PatchTaskItem, wg sync.WaitGroup, errList *multierror.Error) {

--- a/pkg/microservice/aslan/core/environment/handler/kube.go
+++ b/pkg/microservice/aslan/core/environment/handler/kube.go
@@ -160,3 +160,10 @@ func ListCanaryDeploymentServiceInfo(c *gin.Context) {
 
 	ctx.Resp, ctx.Err = service.ListCanaryDeploymentServiceInfo(c.Param("clusterID"), c.Param("namespace"), ctx.Logger)
 }
+
+func ListAllK8sResourcesInNamespace(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	ctx.Resp, ctx.Err = service.ListAllK8sResourcesInNamespace(c.Param("clusterID"), c.Param("namespace"), ctx.Logger)
+}

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -114,6 +114,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		kube.GET("/namespace/cluster/:clusterID", ListNamespace)
 		kube.GET("/custom_workload/cluster/:clusterID/namespace/:namespace", ListCustomWorkload)
 		kube.GET("/canary_service/cluster/:clusterID/namespace/:namespace", ListCanaryDeploymentServiceInfo)
+		kube.GET("/resources/cluster/:clusterID/namespace/:namespace", ListAllK8sResourcesInNamespace)
 	}
 
 	operations := router.Group("operations")

--- a/pkg/microservice/aslan/core/environment/service/kube.go
+++ b/pkg/microservice/aslan/core/environment/service/kube.go
@@ -618,7 +618,7 @@ func ListAllK8sResourcesInNamespace(clusterID, namespace string, log *zap.Sugare
 			resources, err := getter.ListUnstructuredResourceInCache(namespace, labels.Everything(), nil, gvk, kubeClient)
 			if err != nil {
 				log.Errorf("list resources %s %s error:%v", apiGroup.GroupVersion, apiResource.Kind, err)
-				return resp, err
+				continue
 			}
 			for _, resource := range resources {
 				resp = append(resp, strings.Join([]string{resource.GetKind(), resource.GetName()}, "/"))

--- a/pkg/microservice/aslan/core/environment/service/kube.go
+++ b/pkg/microservice/aslan/core/environment/service/kube.go
@@ -606,13 +606,20 @@ func ListAllK8sResourcesInNamespace(clusterID, namespace string, log *zap.Sugare
 	}
 	for _, apiGroup := range apiResources {
 		for _, apiResource := range apiGroup.APIResources {
+			version := ""
+			group := ""
 			groupVersions := strings.Split(apiGroup.GroupVersion, "/")
-			if len(groupVersions) != 2 {
+			if len(groupVersions) == 2 {
+				group = groupVersions[0]
+				version = groupVersions[1]
+			} else if len(groupVersions) == 1 {
+				version = groupVersions[0]
+			} else {
 				continue
 			}
 			gvk := schema.GroupVersionKind{
-				Group:   groupVersions[0],
-				Version: groupVersions[1],
+				Group:   group,
+				Version: version,
 				Kind:    apiResource.Kind,
 			}
 			resources, err := getter.ListUnstructuredResourceInCache(namespace, labels.Everything(), nil, gvk, kubeClient)

--- a/pkg/microservice/aslan/core/environment/service/kube.go
+++ b/pkg/microservice/aslan/core/environment/service/kube.go
@@ -624,7 +624,7 @@ func ListAllK8sResourcesInNamespace(clusterID, namespace string, log *zap.Sugare
 			}
 			resources, err := getter.ListUnstructuredResourceInCache(namespace, labels.Everything(), nil, gvk, kubeClient)
 			if err != nil {
-				log.Errorf("list resources %s %s error:%v", apiGroup.GroupVersion, apiResource.Kind, err)
+				log.Warnf("list resources %s %s error:%v", apiGroup.GroupVersion, apiResource.Kind, err)
 				continue
 			}
 			for _, resource := range resources {

--- a/pkg/microservice/aslan/core/environment/service/kube.go
+++ b/pkg/microservice/aslan/core/environment/service/kube.go
@@ -606,14 +606,18 @@ func ListAllK8sResourcesInNamespace(clusterID, namespace string, log *zap.Sugare
 	}
 	for _, apiGroup := range apiResources {
 		for _, apiResource := range apiGroup.APIResources {
+			groupVersions := strings.Split(apiGroup.GroupVersion, "/")
+			if len(groupVersions) != 2 {
+				continue
+			}
 			gvk := schema.GroupVersionKind{
-				Group:   apiResource.Group,
-				Version: apiResource.Version,
+				Group:   groupVersions[0],
+				Version: groupVersions[1],
 				Kind:    apiResource.Kind,
 			}
 			resources, err := getter.ListUnstructuredResourceInCache(namespace, labels.Everything(), nil, gvk, kubeClient)
 			if err != nil {
-				log.Errorf("list resources %s/%s %s error:%v", apiResource.Group, apiResource.Version, apiResource.Kind, err)
+				log.Errorf("list resources %s %s error:%v", apiGroup.GroupVersion, apiResource.Kind, err)
 				return resp, err
 			}
 			for _, resource := range resources {

--- a/pkg/microservice/aslan/core/workflow/handler/router.go
+++ b/pkg/microservice/aslan/core/workflow/handler/router.go
@@ -185,6 +185,8 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		workflowV4.POST("/cron/:workflowName", CreateCronForWorkflowV4)
 		workflowV4.PUT("/cron", UpdateCronForWorkflowV4)
 		workflowV4.DELETE("/cron/:workflowName/trigger/:cronID", DeleteCronForWorkflowV4)
+		workflowV4.GET("/patch", GetPatchParams)
+
 	}
 
 	// ---------------------------------------------------------------------------------------

--- a/pkg/microservice/aslan/core/workflow/handler/router.go
+++ b/pkg/microservice/aslan/core/workflow/handler/router.go
@@ -185,7 +185,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		workflowV4.POST("/cron/:workflowName", CreateCronForWorkflowV4)
 		workflowV4.PUT("/cron", UpdateCronForWorkflowV4)
 		workflowV4.DELETE("/cron/:workflowName/trigger/:cronID", DeleteCronForWorkflowV4)
-		workflowV4.GET("/patch", GetPatchParams)
+		workflowV4.POST("/patch", GetPatchParams)
 
 	}
 

--- a/pkg/microservice/aslan/core/workflow/handler/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/handler/workflow_v4.go
@@ -27,6 +27,7 @@ import (
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/workflow/service/workflow"
 	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
+	"github.com/koderover/zadig/pkg/tool/errors"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 	"github.com/koderover/zadig/pkg/tool/log"
 )
@@ -252,4 +253,16 @@ func DeleteCronForWorkflowV4(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	ctx.Err = workflow.DeleteCronForWorkflowV4(c.Param("workflowName"), c.Param("cronID"), ctx.Logger)
+}
+
+func GetPatchParams(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+	req := &commonmodels.PatchItem{}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		ctx.Err = errors.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+
+	ctx.Resp, ctx.Err = workflow.GetPatchParams(req, ctx.Logger)
 }

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
@@ -61,6 +61,8 @@ func InitJobCtl(job *commonmodels.Job, workflow *commonmodels.WorkflowV4) (JobCt
 		resp = &CanaryReleaseJob{job: job, workflow: workflow}
 	case config.JobZadigTesting:
 		resp = &TestingJob{job: job, workflow: workflow}
+	case config.JobK8sPatch:
+		resp = &K8sPacthJob{job: job, workflow: workflow}
 	default:
 		return resp, fmt.Errorf("job type not found %s", job.JobType)
 	}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_k8s_patch.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_k8s_patch.go
@@ -97,6 +97,7 @@ func patchJobToTaskJob(job *commonmodels.K8sPatchJobSpec) *commonmodels.JobTasK8
 			ResourceVersion: patch.ResourceVersion,
 			PatchContent:    renderString(patch.PatchContent, setting.RenderValueTemplate, patch.Params),
 			PatchStrategy:   patch.PatchStrategy,
+			Params:          patch.Params,
 		}
 		resp.PatchItems = append(resp.PatchItems, patchTaskItem)
 	}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_k8s_patch.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_k8s_patch.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2022 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package job
+
+import (
+	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+)
+
+type K8sPacthJob struct {
+	job      *commonmodels.Job
+	workflow *commonmodels.WorkflowV4
+	spec     *commonmodels.K8sPatchJobSpec
+}
+
+func (j *K8sPacthJob) Instantiate() error {
+	j.spec = &commonmodels.K8sPatchJobSpec{}
+	if err := commonmodels.IToiYaml(j.job.Spec, j.spec); err != nil {
+		return err
+	}
+	j.job.Spec = j.spec
+	return nil
+}
+
+func (j *K8sPacthJob) SetPreset() error {
+	j.spec = &commonmodels.K8sPatchJobSpec{}
+	if err := commonmodels.IToi(j.job.Spec, j.spec); err != nil {
+		return err
+	}
+	j.job.Spec = j.spec
+	return nil
+}
+
+func (j *K8sPacthJob) MergeArgs(args *commonmodels.Job) error {
+	if j.job.Name == args.Name && j.job.JobType == args.JobType {
+		j.spec = &commonmodels.K8sPatchJobSpec{}
+		if err := commonmodels.IToi(j.job.Spec, j.spec); err != nil {
+			return err
+		}
+		j.job.Spec = j.spec
+		argsSpec := &commonmodels.K8sPatchJobSpec{}
+		if err := commonmodels.IToi(args.Spec, argsSpec); err != nil {
+			return err
+		}
+		j.spec.PatchItems = argsSpec.PatchItems
+		j.job.Spec = j.spec
+	}
+	return nil
+}
+
+func (j *K8sPacthJob) ToJobs(taskID int64) ([]*commonmodels.JobTask, error) {
+	// logger := log.SugaredLogger()
+	resp := []*commonmodels.JobTask{}
+	j.spec = &commonmodels.K8sPatchJobSpec{}
+	if err := commonmodels.IToi(j.job.Spec, j.spec); err != nil {
+		return resp, err
+	}
+
+	// kubeClient, err := kubeclient.GetKubeClient(config.HubServerAddress(), j.spec.ClusterID)
+	// if err != nil {
+	// 	logger.Errorf("Failed to get kube client, err: %v", err)
+	// 	return resp, err
+	// }
+
+	j.job.Spec = j.spec
+	return resp, nil
+}
+
+func (j *K8sPacthJob) LintJob() error {
+	return nil
+}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_k8s_patch.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_k8s_patch.go
@@ -19,6 +19,7 @@ package job
 import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/pkg/setting"
 )
 
 type K8sPacthJob struct {
@@ -94,7 +95,7 @@ func patchJobToTaskJob(job *commonmodels.K8sPatchJobSpec) *commonmodels.JobTasK8
 			ResourceKind:    patch.ResourceKind,
 			ResourceGroup:   patch.ResourceGroup,
 			ResourceVersion: patch.ResourceVersion,
-			PatchContent:    patch.PatchContent,
+			PatchContent:    renderString(patch.PatchContent, setting.RenderValueTemplate, patch.Params),
 			PatchStrategy:   patch.PatchStrategy,
 		}
 		resp.PatchItems = append(resp.PatchItems, patchTaskItem)

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -838,7 +838,8 @@ func GetPatchParams(patchItem *commonmodels.PatchItem, logger *zap.SugaredLogger
 			continue
 		}
 		resp = append(resp, &commonmodels.Param{
-			Name: kv.Key,
+			Name:       kv.Key,
+			ParamsType: "string",
 		})
 	}
 	return resp, nil

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -35,6 +35,7 @@ import (
 	commonservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/collaboration"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/nsq"
+	commomtemplate "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/template"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/webhook"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/workflow/service/workflow/job"
 	jobctl "github.com/koderover/zadig/pkg/microservice/aslan/core/workflow/service/workflow/job"
@@ -819,4 +820,26 @@ func cronJobToSchedule(input *commonmodels.Cronjob) *commonmodels.Schedule {
 		Cron:           input.Cron,
 		Enabled:        input.Enabled,
 	}
+}
+
+func GetPatchParams(patchItem *commonmodels.PatchItem, logger *zap.SugaredLogger) ([]*commonmodels.Param, error) {
+	resp := []*commonmodels.Param{}
+	kvs, err := commomtemplate.GetYamlVariables(patchItem.PatchContent, logger)
+	if err != nil {
+		return resp, fmt.Errorf("get kv from content error: %s", err)
+	}
+	paramMap := map[string]*commonmodels.Param{}
+	for _, param := range patchItem.Params {
+		paramMap[param.Name] = param
+	}
+	for _, kv := range kvs {
+		if param, ok := paramMap[kv.Key]; ok {
+			resp = append(resp, param)
+			continue
+		}
+		resp = append(resp, &commonmodels.Param{
+			Name: kv.Key,
+		})
+	}
+	return resp, nil
 }

--- a/pkg/tool/kube/client/cluster.go
+++ b/pkg/tool/kube/client/cluster.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -64,6 +65,14 @@ func NewDynamicClient() (dynamic.Interface, error) {
 		return nil, err
 	}
 	return dynamic.NewForConfig(config)
+}
+
+func NewDiscoveryClient() (*discovery.DiscoveryClient, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	return discovery.NewDiscoveryClientForConfig(config)
 }
 
 func Client() client.Client {

--- a/pkg/tool/kube/updater/base.go
+++ b/pkg/tool/kube/updater/base.go
@@ -18,6 +18,7 @@ package updater
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -123,6 +124,26 @@ func createOrPatchObject(modified client.Object, cl client.Client) error {
 		return nil
 	}
 
+	return patchObjectWithType(current.(client.Object), patchBytes, patchType, cl)
+}
+
+func PatchObject(modified client.Object, patchBytes []byte, patchType types.PatchType, cl client.Client) error {
+	c := modified.DeepCopyObject().(client.Object)
+	found, err := getter.GetResourceInCache(modified.GetNamespace(), modified.GetName(), c, cl)
+	if err != nil {
+		return err
+	} else if !found {
+		return errors.New("pacth resource not found")
+	}
+
+	// fill gvk in case it is missing.
+	// for objects retrieved from APIServer, gvk is not set, so we need to set it
+	// for objects in cache, gvk is set, nothing will be changed here
+	gvk := modified.GetObjectKind().GroupVersionKind()
+	current, err := util.SetGroupVersionKind(c, &gvk)
+	if err != nil {
+		return err
+	}
 	return patchObjectWithType(current.(client.Object), patchBytes, patchType, cl)
 }
 

--- a/pkg/tool/kube/updater/unstructured.go
+++ b/pkg/tool/kube/updater/unstructured.go
@@ -27,7 +27,7 @@ func CreateOrPatchUnstructured(u *unstructured.Unstructured, cl client.Client) e
 }
 
 func PatchUnstructured(u *unstructured.Unstructured, patchBytes []byte, patchType types.PatchType, cl client.Client) error {
-	return createOrPatchObject(u, cl)
+	return PatchObject(u, patchBytes, patchType, cl)
 }
 
 func CreateOrPatchUnstructuredNeverAnnotation(u *unstructured.Unstructured, cl client.Client) error {

--- a/pkg/tool/kube/updater/unstructured.go
+++ b/pkg/tool/kube/updater/unstructured.go
@@ -18,10 +18,15 @@ package updater
 
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func CreateOrPatchUnstructured(u *unstructured.Unstructured, cl client.Client) error {
+	return createOrPatchObject(u, cl)
+}
+
+func PatchUnstructured(u *unstructured.Unstructured, patchBytes []byte, patchType types.PatchType, cl client.Client) error {
 	return createOrPatchObject(u, cl)
 }
 


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
add build-in job to patch k8s resources

### What is changed and how it works?
add build-in job to patch k8s resources

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
