### PR TITLE
add pm build infos to servicemodule api

### DIFF
--- a/pkg/microservice/aslan/core/build/service/build.go
+++ b/pkg/microservice/aslan/core/build/service/build.go
@@ -127,6 +127,25 @@ func ListBuildModulesByServiceModule(encryptedKey, productName string, excludeJe
 
 	serviceModuleAndBuildResp := make([]*ServiceModuleAndBuildResp, 0)
 	for _, serviceTmpl := range services {
+		if serviceTmpl.Type == setting.PMDeployType {
+			buildModule, err := commonrepo.NewBuildColl().Find(&commonrepo.BuildFindOption{Name: serviceTmpl.BuildName})
+			if err != nil {
+				log.Errorf("find build module info error: %v", err)
+				continue
+			}
+			build := &BuildResp{
+				ID:      buildModule.ID.Hex(),
+				Name:    buildModule.Name,
+				KeyVals: buildModule.PreBuild.Envs,
+				Repos:   buildModule.Repos,
+			}
+			serviceModuleAndBuildResp = append(serviceModuleAndBuildResp, &ServiceModuleAndBuildResp{
+				ServiceName:   serviceTmpl.ServiceName,
+				ServiceModule: serviceTmpl.ServiceName,
+				ModuleBuilds:  []*BuildResp{build},
+			})
+			continue
+		}
 		for _, container := range serviceTmpl.Containers {
 			opt := &commonrepo.BuildListOption{
 				ServiceName: serviceTmpl.ServiceName,


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
pm project can not get webhook repo infos.

### What is changed and how it works?
add pm build infos

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
