### PR TITLE
when deploy target not exist, return error

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -201,6 +201,7 @@ func (c *DeployJobCtl) run(ctx context.Context) error {
 			var found bool
 			statefulSet, found, err = getter.GetStatefulSet(env.Namespace, c.jobTaskSpec.ServiceName, c.kubeClient)
 			if err != nil {
+				logError(c.job, err.Error(), c.logger)
 				return err
 			}
 			if !found {
@@ -231,6 +232,7 @@ func (c *DeployJobCtl) run(ctx context.Context) error {
 			var found bool
 			deployment, found, err = getter.GetDeployment(env.Namespace, c.jobTaskSpec.ServiceName, c.kubeClient)
 			if err != nil {
+				logError(c.job, err.Error(), c.logger)
 				return err
 			}
 			if !found {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -204,7 +204,9 @@ func (c *DeployJobCtl) run(ctx context.Context) error {
 				return err
 			}
 			if !found {
-				return fmt.Errorf("statefulset: %s not found", c.jobTaskSpec.ServiceName)
+				msg := fmt.Sprintf("statefulset %s not found", c.jobTaskSpec.ServiceName)
+				logError(c.job, msg, c.logger)
+				return errors.New(msg)
 			}
 			for _, container := range statefulSet.Spec.Template.Spec.Containers {
 				if container.Name == c.jobTaskSpec.ServiceModule {
@@ -232,7 +234,9 @@ func (c *DeployJobCtl) run(ctx context.Context) error {
 				return err
 			}
 			if !found {
-				return fmt.Errorf("deployment: %s not found", c.jobTaskSpec.ServiceName)
+				msg := fmt.Sprintf("deployment %s not found", c.jobTaskSpec.ServiceName)
+				logError(c.job, msg, c.logger)
+				return errors.New(msg)
 			}
 			for _, container := range deployment.Spec.Template.Spec.Containers {
 				if container.Name == c.jobTaskSpec.ServiceModule {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -198,9 +198,13 @@ func (c *DeployJobCtl) run(ctx context.Context) error {
 		switch serviceInfo.WorkloadType {
 		case setting.StatefulSet:
 			var statefulSet *appsv1.StatefulSet
-			statefulSet, _, err = getter.GetStatefulSet(env.Namespace, c.jobTaskSpec.ServiceName, c.kubeClient)
+			var found bool
+			statefulSet, found, err = getter.GetStatefulSet(env.Namespace, c.jobTaskSpec.ServiceName, c.kubeClient)
 			if err != nil {
 				return err
+			}
+			if !found {
+				return fmt.Errorf("statefulset: %s not found", c.jobTaskSpec.ServiceName)
 			}
 			for _, container := range statefulSet.Spec.Template.Spec.Containers {
 				if container.Name == c.jobTaskSpec.ServiceModule {
@@ -222,9 +226,13 @@ func (c *DeployJobCtl) run(ctx context.Context) error {
 			}
 		case setting.Deployment:
 			var deployment *appsv1.Deployment
-			deployment, _, err = getter.GetDeployment(env.Namespace, c.jobTaskSpec.ServiceName, c.kubeClient)
+			var found bool
+			deployment, found, err = getter.GetDeployment(env.Namespace, c.jobTaskSpec.ServiceName, c.kubeClient)
 			if err != nil {
 				return err
+			}
+			if !found {
+				return fmt.Errorf("deployment: %s not found", c.jobTaskSpec.ServiceName)
 			}
 			for _, container := range deployment.Spec.Template.Spec.Containers {
 				if container.Name == c.jobTaskSpec.ServiceModule {

--- a/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
@@ -236,8 +236,13 @@ func (p *DeployTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, _ *
 		switch serviceInfo.WorkloadType {
 		case setting.StatefulSet:
 			var statefulSet *appsv1.StatefulSet
-			statefulSet, _, err = getter.GetStatefulSet(p.Task.Namespace, p.Task.ServiceName, p.kubeClient)
+			var found bool
+			statefulSet, found, err = getter.GetStatefulSet(p.Task.Namespace, p.Task.ServiceName, p.kubeClient)
 			if err != nil {
+				return
+			}
+			if !found {
+				err = fmt.Errorf("statefulset: %s not found", p.Task.ServiceName)
 				return
 			}
 			for _, container := range statefulSet.Spec.Template.Spec.Containers {
@@ -262,8 +267,13 @@ func (p *DeployTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, _ *
 			}
 		case setting.Deployment:
 			var deployment *appsv1.Deployment
-			deployment, _, err = getter.GetDeployment(p.Task.Namespace, p.Task.ServiceName, p.kubeClient)
-			if err != nil {
+			var found bool
+			deployment, found, err = getter.GetDeployment(p.Task.Namespace, p.Task.ServiceName, p.kubeClient)
+			if err != nil || !found {
+				return
+			}
+			if !found {
+				err = fmt.Errorf("deployment: %s not found", p.Task.ServiceName)
 				return
 			}
 			for _, container := range deployment.Spec.Template.Spec.Containers {

--- a/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
@@ -269,7 +269,7 @@ func (p *DeployTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, _ *
 			var deployment *appsv1.Deployment
 			var found bool
 			deployment, found, err = getter.GetDeployment(p.Task.Namespace, p.Task.ServiceName, p.kubeClient)
-			if err != nil || !found {
+			if err != nil {
 				return
 			}
 			if !found {


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
in host mode, when service workload not exist, deploy will panic.

### What is changed and how it works?
return error when workload not found.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
