### PR TITLE
fix share vars bugs

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_freestyle.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_freestyle.go
@@ -247,7 +247,6 @@ func (c *FreestyleJobCtl) complete(ctx context.Context) {
 	// get job outputs info from pod terminate message.
 	if err := getJobOutputFromRunningPod(c.jobTaskSpec.Properties.Namespace, c.job.Name, c.job, c.workflowCtx, c.kubeclient, c.clientset, c.restConfig); err != nil {
 		c.logger.Error(err)
-		c.job.Error = err.Error()
 	}
 
 	if err := saveContainerLog(c.jobTaskSpec.Properties.Namespace, c.jobTaskSpec.Properties.ClusterID, c.workflowCtx.WorkflowName, c.job.Name, c.workflowCtx.TaskID, jobLabel, c.kubeclient); err != nil {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
@@ -873,6 +873,7 @@ func getJobOutputFromRunningPod(namespace, containerName string, jobTask *common
 		if !success {
 			return nil
 		}
+		log.Errorf("@@@@ output msg was: %s", stdout)
 		if err := json.Unmarshal([]byte(stdout), &outputs); err != nil {
 			return err
 		}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
@@ -873,7 +873,6 @@ func getJobOutputFromRunningPod(namespace, containerName string, jobTask *common
 		if !success {
 			return nil
 		}
-		log.Errorf("@@@@ output msg was: %s", stdout)
 		if err := json.Unmarshal([]byte(stdout), &outputs); err != nil {
 			return err
 		}

--- a/pkg/microservice/jobexecutor/core/service/step/step_docker_build.go
+++ b/pkg/microservice/jobexecutor/core/service/step/step_docker_build.go
@@ -154,17 +154,14 @@ func dockerBuildCmd(dockerfile, fullImage, ctx, buildArgs string, ignoreCache bo
 	}
 	dockerCommand = dockerCommand + " -t " + fullImage + " -f " + dockerfile + " " + ctx
 	args = append(args, dockerCommand)
-	log.Errorf("@@@@ docker build command: %v", args)
 	return exec.Command("sh", args...)
 }
 
 func dockerPush(fullImage string) *exec.Cmd {
-	args := []string{
-		"push",
-		fullImage,
-	}
-	log.Errorf("@@@@ docker build command: %v", args)
-	return exec.Command(dockerExe, args...)
+	args := []string{"-c"}
+	dockerPushCommand := "docker push " + fullImage
+	args = append(args, dockerPushCommand)
+	return exec.Command("sh", args...)
 }
 
 func dockerLogin(user, password, registry string) *exec.Cmd {

--- a/pkg/microservice/jobexecutor/core/service/step/step_docker_build.go
+++ b/pkg/microservice/jobexecutor/core/service/step/step_docker_build.go
@@ -154,6 +154,7 @@ func dockerBuildCmd(dockerfile, fullImage, ctx, buildArgs string, ignoreCache bo
 	}
 	dockerCommand = dockerCommand + " -t " + fullImage + " -f " + dockerfile + " " + ctx
 	args = append(args, dockerCommand)
+	log.Errorf("@@@@ docker build command: %v", args)
 	return exec.Command("sh", args...)
 }
 
@@ -162,6 +163,7 @@ func dockerPush(fullImage string) *exec.Cmd {
 		"push",
 		fullImage,
 	}
+	log.Errorf("@@@@ docker build command: %v", args)
 	return exec.Command(dockerExe, args...)
 }
 


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
when docker push,we can not read vars for env.

### What is changed and how it works?
use shell to excute docker push.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
