### PR TITLE
update image infos for env when deploy workflow runs

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job.go
@@ -19,6 +19,7 @@ package jobcontroller
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -30,6 +31,7 @@ import (
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	"github.com/koderover/zadig/pkg/util/rand"
 )
 
@@ -217,4 +219,39 @@ func logError(job *commonmodels.JobTask, msg string, logger *zap.SugaredLogger) 
 	logger.Error(msg)
 	job.Status = config.StatusFailed
 	job.Error = msg
+}
+
+// update product image info
+func updateProductImageByNs(namespace, productName, serviceName string, targets map[string]string, logger *zap.SugaredLogger) error {
+	opt := &commonrepo.ProductEnvFindOptions{
+		Name:      productName,
+		Namespace: namespace,
+	}
+
+	prod, err := commonrepo.NewProductColl().FindEnv(opt)
+
+	if err != nil {
+		logger.Errorf("find product namespace error: %v", err)
+		return err
+	}
+
+	for i, group := range prod.Services {
+		for j, service := range group {
+			if service.ServiceName == serviceName {
+				for l, container := range service.Containers {
+					if image, ok := targets[container.Name]; ok {
+						prod.Services[i][j].Containers[l].Image = image
+					}
+				}
+			}
+		}
+	}
+
+	if err := commonrepo.NewProductColl().Update(prod); err != nil {
+		errMsg := fmt.Sprintf("[%s][%s] update product image error: %v", prod.EnvName, prod.ProductName, err)
+		logger.Errorf(errMsg)
+		return errors.New(errMsg)
+	}
+
+	return nil
 }

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -260,6 +260,9 @@ func (c *DeployJobCtl) run(ctx context.Context) error {
 		logError(c.job, msg, c.logger)
 		return errors.New(msg)
 	}
+	if err := updateProductImageByNs(env.Namespace, c.workflowCtx.ProjectName, c.jobTaskSpec.ServiceName, map[string]string{c.jobTaskSpec.ServiceModule: c.jobTaskSpec.Image}, c.logger); err != nil {
+		c.logger.Error(err)
+	}
 	c.job.Spec = c.jobTaskSpec
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
record current image so we can update it.

### What is changed and how it works?
record current image so we can update it.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
