### PR TITLE
clean configmap and job after task finished

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -523,6 +523,8 @@ func buildJobWithLinkedNs(taskType config.TaskType, jobImage, jobName, serviceNa
 			Completions:  int32Ptr(1),
 			Parallelism:  int32Ptr(1),
 			BackoffLimit: int32Ptr(0),
+			// in case finished zombie job not cleaned up by zadig
+			TTLSecondsAfterFinished: int32Ptr(3600),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,

--- a/pkg/microservice/warpdrive/core/service/taskplugin/release_image.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/release_image.go
@@ -786,12 +786,11 @@ func (p *ReleaseImagePlugin) Complete(ctx context.Context, pipelineTask *task.Ta
 
 	// 清理用户取消和超时的任务
 	defer func() {
-		if p.Task.TaskStatus == config.StatusCancelled || p.Task.TaskStatus == config.StatusTimeout {
-			if err := ensureDeleteJob(p.KubeNamespace, jobLabel, p.kubeClient); err != nil {
-				p.Log.Error(err)
-				p.Task.Error = err.Error()
-			}
-			return
+		if err := ensureDeleteConfigMap(p.KubeNamespace, jobLabel, p.kubeClient); err != nil {
+			p.Log.Error(err)
+		}
+		if err := ensureDeleteJob(p.KubeNamespace, jobLabel, p.kubeClient); err != nil {
+			p.Log.Error(err)
 		}
 	}()
 


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
clean configmap and job after task finished

### What is changed and how it works?
clean configmap and job after task finished

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
