### PR TITLE
when there is only one build,use it as the default build

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/service_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/service_task.go
@@ -220,6 +220,7 @@ func CreateServiceTask(args *commonmodels.ServiceTaskArgs, log *zap.SugaredLogge
 		Target:      args.ServiceName,
 		ServiceName: args.ServiceName,
 		ProductName: args.ProductName,
+		BuildName:   args.BuildName,
 	}
 	subTasks, err := BuildModuleToSubTasks(buildModuleArgs, log)
 	if err != nil {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -3017,6 +3017,9 @@ func getBuildModule(buildName, serviceName, serviceModule, productName string) (
 			return nil, err
 		}
 	}
+	if len(modules) == 0 {
+		return nil, fmt.Errorf("no build module found for %s/%s/%s", productName, serviceName, serviceModule)
+	}
 
 	for _, module := range modules {
 		if module.Name == buildName {
@@ -3027,5 +3030,5 @@ func getBuildModule(buildName, serviceName, serviceModule, productName string) (
 	if len(modules) == 1 {
 		return modules[0], nil
 	}
-	return nil, fmt.Errorf("no build module found for %s/%s/%s", productName, serviceName, serviceModule)
+	return nil, fmt.Errorf("multiple build module found for %s/%s/%s, please select one in workflow configuration", productName, serviceName, serviceModule)
 }


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
when there is only one build,use it as the default build

### What is changed and how it works?
when there is only one build,use it as the default build

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
