### PR TITLE
fix can not delete webhook trigger in workflow

### DIFF
--- a/pkg/tool/git/gitlab/token.go
+++ b/pkg/tool/git/gitlab/token.go
@@ -48,7 +48,7 @@ func UpdateGitlabToken(id int, accessToken string) (string, error) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	ch, err := systemconfig.New().GetCodeHost(id)
+	ch, err := systemconfig.New().GetRawCodeHost(id)
 
 	if err != nil {
 		return "", fmt.Errorf("get codehost info error: [%s]", err)


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
fix can not delete webhook trigger in workflow

### What is changed and how it works?
fix can not delete webhook trigger in workflow

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] behavioral change
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
