### PR TITLE
optimize task timeout mechanism

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_freestyle.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_freestyle.go
@@ -260,7 +260,9 @@ func (c *FreestyleJobCtl) complete(ctx context.Context) {
 
 	if err := saveContainerLog(c.jobTaskSpec.Properties.Namespace, c.jobTaskSpec.Properties.ClusterID, c.workflowCtx.WorkflowName, c.job.Name, c.workflowCtx.TaskID, jobLabel, c.kubeclient); err != nil {
 		c.logger.Error(err)
-		c.job.Error = err.Error()
+		if c.job.Error == "" {
+			c.job.Error = err.Error()
+		}
 		return
 	}
 	if err := stepcontroller.SummarizeSteps(ctx, c.workflowCtx, &c.jobTaskSpec.Properties.Paths, c.job.Name, c.jobTaskSpec.Steps, c.logger); err != nil {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_plugin.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_plugin.go
@@ -186,7 +186,9 @@ func (c *PluginJobCtl) complete(ctx context.Context) {
 
 	if err := saveContainerLog(c.jobTaskSpec.Properties.Namespace, c.jobTaskSpec.Properties.ClusterID, c.workflowCtx.WorkflowName, c.job.Name, c.workflowCtx.TaskID, jobLabel, c.kubeclient); err != nil {
 		c.logger.Error(err)
-		c.job.Error = err.Error()
+		if c.job.Error == "" {
+			c.job.Error = err.Error()
+		}
 		return
 	}
 }

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_plugin.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_plugin.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
@@ -41,6 +42,7 @@ type PluginJobCtl struct {
 	kubeclient  crClient.Client
 	clientset   kubernetes.Interface
 	restConfig  *rest.Config
+	apiServer   crClient.Reader
 	jobTaskSpec *commonmodels.JobTaskPluginSpec
 	ack         func()
 }
@@ -95,10 +97,11 @@ func (c *PluginJobCtl) run(ctx context.Context) error {
 		c.kubeclient = krkubeclient.Client()
 		c.clientset = krkubeclient.Clientset()
 		c.restConfig = krkubeclient.RESTConfig()
+		c.apiServer = krkubeclient.APIReader()
 	default:
 		c.jobTaskSpec.Properties.Namespace = setting.AttachedClusterNamespace
 
-		crClient, clientset, restConfig, err := GetK8sClients(hubServerAddr, c.jobTaskSpec.Properties.ClusterID)
+		crClient, clientset, restConfig, apiServer, err := GetK8sClients(hubServerAddr, c.jobTaskSpec.Properties.ClusterID)
 		if err != nil {
 			logError(c.job, err.Error(), c.logger)
 			return err
@@ -106,6 +109,7 @@ func (c *PluginJobCtl) run(ctx context.Context) error {
 		c.kubeclient = crClient
 		c.clientset = clientset
 		c.restConfig = restConfig
+		c.apiServer = apiServer
 	}
 
 	jobLabel := &JobLabel{
@@ -144,13 +148,18 @@ func (c *PluginJobCtl) run(ctx context.Context) error {
 }
 
 func (c *PluginJobCtl) wait(ctx context.Context) {
-	c.job.Status = waitJobStart(ctx, c.jobTaskSpec.Properties.Namespace, c.job.K8sJobName, c.kubeclient, c.logger)
+	var err error
+	timeout := time.After(time.Duration(c.jobTaskSpec.Properties.Timeout) * time.Minute)
+	c.job.Status, err = waitJobStart(ctx, c.jobTaskSpec.Properties.Namespace, c.job.K8sJobName, c.kubeclient, c.apiServer, timeout, c.logger)
+	if err != nil {
+		c.logger.Errorf("wait job start error: %v", err)
+	}
 	if c.job.Status == config.StatusRunning {
 		c.ack()
 	} else {
 		return
 	}
-	status := waitPlainJobEnd(ctx, int(c.jobTaskSpec.Properties.Timeout), c.jobTaskSpec.Properties.Namespace, c.job.K8sJobName, c.kubeclient, c.logger)
+	status := waitPlainJobEnd(ctx, int(c.jobTaskSpec.Properties.Timeout), timeout, c.jobTaskSpec.Properties.Namespace, c.job.K8sJobName, c.kubeclient, c.logger)
 	c.job.Status = status
 }
 

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
@@ -870,7 +870,6 @@ func isPodFailed(podName, namespace string, apiReader client.Reader, xl *zap.Sug
 		xl.Errorf("list events failed: %s", err)
 		return nil
 	}
-	// var mErr error
 	var errMsg string
 	for _, event := range events {
 		if event.Type != "Warning" {
@@ -881,7 +880,6 @@ func isPodFailed(podName, namespace string, apiReader client.Reader, xl *zap.Sug
 			continue
 		}
 		errMsg = errMsg + fmt.Sprintf("pod %s/%s event: %s\n", namespace, podName, event.Message)
-		// mErr = multierror.Append(mErr, multierror.Flatten(fmt.Errorf("pod %s/%s event: %s", namespace, podName, event.Message)))
 	}
 	if errMsg != "" {
 		return errors.New(errMsg)

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
@@ -268,6 +268,11 @@ func (c *workflowCtl) CleanShareStorage() {
 			c.logger.Errorf("can't init k8s client: %v", err)
 			continue
 		}
+		kubeApiServer, err := kubeclient.GetKubeAPIReader(config.HubServerAddress(), clusterID)
+		if err != nil {
+			c.logger.Errorf("can't init k8s api reader: %v", err)
+			continue
+		}
 		job, err := jobcontroller.BuildCleanJob(cleanJobName, clusterID, c.workflowTask.WorkflowName, c.workflowTask.TaskID)
 		if err != nil {
 			c.logger.Errorf("build clean job error: %v", err)
@@ -283,7 +288,7 @@ func (c *workflowCtl) CleanShareStorage() {
 				c.logger.Errorf("delete job error: %v", err)
 			}
 		}(kubeClient, cleanJobName, namespace)
-		status := jobcontroller.WaitPlainJobEnd(context.Background(), 10, namespace, cleanJobName, kubeClient, c.logger)
+		status := jobcontroller.WaitPlainJobEnd(context.Background(), 10, namespace, cleanJobName, kubeClient, kubeApiServer, c.logger)
 		c.logger.Infof("clean job %s finished, status: %s", cleanJobName, status)
 	}
 }

--- a/pkg/microservice/warpdrive/core/service/taskplugin/artifact_deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/artifact_deploy.go
@@ -120,7 +120,7 @@ func (p *ArtifactDeployTaskPlugin) Run(ctx context.Context, pipelineTask *task.T
 	default:
 		p.KubeNamespace = setting.AttachedClusterNamespace
 
-		crClient, clientset, restConfig, err := GetK8sClients(pipelineTask.ConfigPayload.HubServerAddr, p.Task.ClusterID)
+		crClient, clientset, restConfig, _, err := GetK8sClients(pipelineTask.ConfigPayload.HubServerAddr, p.Task.ClusterID)
 		if err != nil {
 			p.Log.Error(err)
 			p.Task.TaskStatus = config.StatusFailed

--- a/pkg/microservice/warpdrive/core/service/taskplugin/artifact_deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/artifact_deploy.go
@@ -66,6 +66,7 @@ type ArtifactDeployTaskPlugin struct {
 	restConfig    *rest.Config
 	Task          *task.Build
 	Log           *zap.SugaredLogger
+	Timeout       <-chan time.Time
 
 	ack func()
 }
@@ -271,12 +272,13 @@ func (p *ArtifactDeployTaskPlugin) Run(ctx context.Context, pipelineTask *task.T
 		p.SetBuildStatusCompleted(config.StatusFailed)
 		return
 	}
+	p.Timeout = time.After(time.Duration(p.TaskTimeout()) * time.Second)
 	p.Log.Infof("succeed to create build job %s", p.JobName)
 }
 
 // Wait ...
 func (p *ArtifactDeployTaskPlugin) Wait(ctx context.Context) {
-	status, err := waitJobEndWithFile(ctx, p.TaskTimeout(), p.KubeNamespace, p.JobName, true, p.kubeClient, p.clientset, p.restConfig, p.Log)
+	status, err := waitJobEndWithFile(ctx, p.TaskTimeout(), p.Timeout, p.KubeNamespace, p.JobName, true, p.kubeClient, p.clientset, p.restConfig, p.Log)
 	p.SetBuildStatusCompleted(status)
 	if err != nil {
 		p.Task.Error = err.Error()

--- a/pkg/microservice/warpdrive/core/service/taskplugin/build.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/build.go
@@ -394,9 +394,6 @@ func (p *BuildTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipe
 	p.Log.Infof("succeed to create build job %s", p.JobName)
 
 	p.Timeout = time.After(time.Duration(p.TaskTimeout()) * time.Second)
-	if p.apiReader == nil {
-		p.Log.Errorf("@@@@ nil api reader: cluster %s", p.Task.ClusterID)
-	}
 	p.Task.TaskStatus, err = waitJobReady(ctx, p.KubeNamespace, p.JobName, p.kubeClient, p.apiReader, p.Timeout, p.Log)
 	if err != nil {
 		p.Task.Error = err.Error()

--- a/pkg/microservice/warpdrive/core/service/taskplugin/build.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/build.go
@@ -393,6 +393,9 @@ func (p *BuildTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipe
 	p.Log.Infof("succeed to create build job %s", p.JobName)
 
 	p.Timeout = time.After(time.Duration(p.TaskTimeout()) * time.Second)
+	if p.apiReader == nil {
+		p.Log.Errorf("@@@@ nil api reader: cluster %s", p.Task.ClusterID)
+	}
 	p.Task.TaskStatus, err = waitJobReady(ctx, p.KubeNamespace, p.JobName, p.kubeClient, p.apiReader, p.Timeout, p.Log)
 	if err != nil {
 		p.Task.Error = err.Error()

--- a/pkg/microservice/warpdrive/core/service/taskplugin/build.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/build.go
@@ -56,6 +56,7 @@ func InitializeBuildTaskPlugin(taskType config.TaskType) TaskPlugin {
 		kubeClient: krkubeclient.Client(),
 		clientset:  krkubeclient.Clientset(),
 		restConfig: krkubeclient.RESTConfig(),
+		apiReader:  krkubeclient.APIReader(),
 	}
 }
 

--- a/pkg/microservice/warpdrive/core/service/taskplugin/build.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/build.go
@@ -459,7 +459,9 @@ func (p *BuildTaskPlugin) Complete(ctx context.Context, pipelineTask *task.Task,
 	err := saveContainerLog(pipelineTask, p.KubeNamespace, p.Task.ClusterID, p.FileName, jobLabel, p.kubeClient)
 	if err != nil {
 		p.Log.Error(err)
-		p.Task.Error = err.Error()
+		if p.Task.Error == "" {
+			p.Task.Error = err.Error()
+		}
 		return
 	}
 

--- a/pkg/microservice/warpdrive/core/service/taskplugin/build_v3.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/build_v3.go
@@ -63,6 +63,7 @@ type BuildTaskV3Plugin struct {
 	restConfig    *rest.Config
 	Task          *task.Build
 	Log           *zap.SugaredLogger
+	Timeout       <-chan time.Time
 
 	ack func()
 }
@@ -212,12 +213,13 @@ func (p *BuildTaskV3Plugin) Run(ctx context.Context, pipelineTask *task.Task, pi
 		p.SetBuildStatusCompleted(config.StatusFailed)
 		return
 	}
+	p.Timeout = time.After(time.Duration(p.TaskTimeout()) * time.Second)
 	p.Log.Infof("succeed to create build job %s", p.JobName)
 }
 
 // Wait ...
 func (p *BuildTaskV3Plugin) Wait(ctx context.Context) {
-	status, err := waitJobEndWithFile(ctx, p.TaskTimeout(), p.KubeNamespace, p.JobName, true, p.kubeClient, p.clientset, p.restConfig, p.Log)
+	status, err := waitJobEndWithFile(ctx, p.TaskTimeout(), p.Timeout, p.KubeNamespace, p.JobName, true, p.kubeClient, p.clientset, p.restConfig, p.Log)
 	p.SetBuildStatusCompleted(status)
 	if err != nil {
 		p.Task.Error = err.Error()

--- a/pkg/microservice/warpdrive/core/service/taskplugin/docker_build.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/docker_build.go
@@ -48,6 +48,7 @@ type DockerBuildPlugin struct {
 	restConfig    *rest.Config
 	Task          *task.DockerBuild
 	Log           *zap.SugaredLogger
+	Timeout       <-chan time.Time
 }
 
 func (p *DockerBuildPlugin) SetAckFunc(func()) {
@@ -221,11 +222,12 @@ func (p *DockerBuildPlugin) Run(ctx context.Context, pipelineTask *task.Task, pi
 		p.Task.Error = msg
 		return
 	}
+	p.Timeout = time.After(time.Duration(p.TaskTimeout()) * time.Second)
 }
 
 // Wait ...
 func (p *DockerBuildPlugin) Wait(ctx context.Context) {
-	status, err := waitJobEnd(ctx, p.TaskTimeout(), p.KubeNamespace, p.JobName, p.kubeClient, p.clientset, p.restConfig, p.Log)
+	status, err := waitJobEnd(ctx, p.TaskTimeout(), p.Timeout, p.KubeNamespace, p.JobName, p.kubeClient, p.clientset, p.restConfig, p.Log)
 	p.SetStatus(status)
 	if err != nil {
 		p.Task.Error = err.Error()

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -903,7 +903,7 @@ func waitJobReady(ctx context.Context, namespace, jobName string, kubeClient cli
 				if !podReadyTimeout {
 					continue
 				}
-				if err := isPodFailed(pod.Name, namespace, kubeClient, xl); err != nil {
+				if err := isPodFailed(pod.Name, namespace, apiReader, xl); err != nil {
 					return config.StatusFailed, err
 				}
 			}

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -857,7 +857,7 @@ func waitJobEnd(ctx context.Context, taskTimeout int, timeout <-chan time.Time, 
 	return waitJobEndWithFile(ctx, taskTimeout, timeout, namspace, jobName, false, kubeClient, clientset, restConfig, xl)
 }
 
-func waitJobReady(ctx context.Context, namespace, jobName string, kubeClient client.Client, timeout <-chan time.Time, xl *zap.SugaredLogger) (status config.Status, err error) {
+func waitJobReady(ctx context.Context, namespace, jobName string, kubeClient client.Client, apiReader client.Reader, timeout <-chan time.Time, xl *zap.SugaredLogger) (status config.Status, err error) {
 	xl.Infof("Wait job to start: %s/%s", namespace, jobName)
 	waitPodReadyTimeout := time.After(120 * time.Second)
 
@@ -917,10 +917,10 @@ func waitJobReady(ctx context.Context, namespace, jobName string, kubeClient cli
 	return config.StatusRunning, nil
 }
 
-func isPodFailed(podName, namespace string, kubeClient client.Client, xl *zap.SugaredLogger) error {
+func isPodFailed(podName, namespace string, apiReader client.Reader, xl *zap.SugaredLogger) error {
 	xl.Errorf("@@@@pod name: %s", podName)
 	selector := fields.Set{"involvedObject.name": podName, "involvedObject.kind": setting.Pod}.AsSelector()
-	events, err := getter.ListEvents(namespace, selector, kubeClient)
+	events, err := getter.ListEvents(namespace, selector, apiReader)
 	if err != nil {
 		// list events error is not fatal
 		xl.Errorf("list events failed: %s", err)

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -37,11 +37,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/config"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/taskplugin/s3"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/types"
@@ -851,19 +853,22 @@ func generateResourceRequirements(req setting.Request, reqSpec setting.RequestSp
 
 // waitJobEnd
 // Returns job status
-func waitJobEnd(ctx context.Context, taskTimeout int, namspace, jobName string, kubeClient client.Client, clientset kubernetes.Interface, restConfig *rest.Config, xl *zap.SugaredLogger) (config.Status, error) {
-	return waitJobEndWithFile(ctx, taskTimeout, namspace, jobName, false, kubeClient, clientset, restConfig, xl)
+func waitJobEnd(ctx context.Context, taskTimeout int, timeout <-chan time.Time, namspace, jobName string, kubeClient client.Client, clientset kubernetes.Interface, restConfig *rest.Config, xl *zap.SugaredLogger) (config.Status, error) {
+	return waitJobEndWithFile(ctx, taskTimeout, timeout, namspace, jobName, false, kubeClient, clientset, restConfig, xl)
 }
 
-func waitJobReady(ctx context.Context, namespace, jobName string, kubeClient client.Client, xl *zap.SugaredLogger) (status config.Status) {
+func waitJobReady(ctx context.Context, namespace, jobName string, kubeClient client.Client, timeout <-chan time.Time, xl *zap.SugaredLogger) (status config.Status, err error) {
 	xl.Infof("Wait job to start: %s/%s", namespace, jobName)
-	podTimeout := time.After(120 * time.Second)
+	waitPodReadyTimeout := time.After(120 * time.Second)
 
 	var started bool
+	var podReadyTimeout bool
 	for {
 		select {
-		case <-podTimeout:
-			return config.StatusTimeout
+		case <-timeout:
+			return config.StatusTimeout, fmt.Errorf("wait job ready timeout")
+		case <-waitPodReadyTimeout:
+			podReadyTimeout = true
 		default:
 			time.Sleep(time.Second)
 
@@ -894,6 +899,13 @@ func waitJobReady(ctx context.Context, namespace, jobName string, kubeClient cli
 					started = true
 					break
 				}
+				// if pod is still pending afer 2 minutes, check pod events if is failed already
+				if !podReadyTimeout {
+					continue
+				}
+				if err := isPodFailed(pod.Name, namespace, kubeClient, xl); err != nil {
+					return config.StatusFailed, err
+				}
 			}
 		}
 
@@ -902,14 +914,34 @@ func waitJobReady(ctx context.Context, namespace, jobName string, kubeClient cli
 		}
 	}
 
-	return config.StatusRunning
+	return config.StatusRunning, nil
 }
 
-func waitJobEndWithFile(ctx context.Context, taskTimeout int, namespace, jobName string, checkFile bool, kubeClient client.Client, clientset kubernetes.Interface, restConfig *rest.Config, xl *zap.SugaredLogger) (status config.Status, err error) {
-	xl.Infof("wait job to start: %s/%s", namespace, jobName)
-	timeout := time.After(time.Duration(taskTimeout) * time.Second)
-	podTimeout := time.After(120 * time.Second)
+func isPodFailed(podName, namespace string, kubeClient client.Client, xl *zap.SugaredLogger) error {
+	selector := fields.Set{"involvedObject.name": podName, "involvedObject.kind": setting.Pod}.AsSelector()
+	events, err := getter.ListEvents(namespace, selector, kubeClient)
+	if err != nil {
+		// list events error is not fatal
+		xl.Errorf("list events failed: %s", err)
+		return nil
+	}
+	var mErr error
+	for _, event := range events {
+		if event.Type != "Warning" {
+			continue
+		}
+		// FailedScheduling means there is not enough resource to schedule the pod, so we should not fail the pod
+		if event.Reason == "FailedScheduling" {
+			continue
+		}
+		mErr = multierror.Append(mErr, multierror.Flatten(fmt.Errorf("pod %s/%s event: %s", namespace, podName, event.Message)))
+	}
+	return mErr
+}
 
+func waitJobEndWithFile(ctx context.Context, taskTimeout int, timeout <-chan time.Time, namespace, jobName string, checkFile bool, kubeClient client.Client, clientset kubernetes.Interface, restConfig *rest.Config, xl *zap.SugaredLogger) (status config.Status, err error) {
+	xl.Infof("wait job to start: %s/%s", namespace, jobName)
+	podTimeout := time.After(120 * time.Second)
 	xl.Infof("Timeout of preparing Pod: %s. Timeout of running task: %s.", 120*time.Second, time.Duration(taskTimeout)*time.Second)
 
 	var started bool

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -918,6 +918,7 @@ func waitJobReady(ctx context.Context, namespace, jobName string, kubeClient cli
 }
 
 func isPodFailed(podName, namespace string, kubeClient client.Client, xl *zap.SugaredLogger) error {
+	xl.Errorf("@@@@pod name: %s", podName)
 	selector := fields.Set{"involvedObject.name": podName, "involvedObject.kind": setting.Pod}.AsSelector()
 	events, err := getter.ListEvents(namespace, selector, kubeClient)
 	if err != nil {
@@ -927,6 +928,7 @@ func isPodFailed(podName, namespace string, kubeClient client.Client, xl *zap.Su
 	}
 	var mErr error
 	for _, event := range events {
+		xl.Errorf("@@@@event type: %s,event reason: %s", event.Type, event.Reason)
 		if event.Type != "Warning" {
 			continue
 		}

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -918,7 +918,6 @@ func waitJobReady(ctx context.Context, namespace, jobName string, kubeClient cli
 }
 
 func isPodFailed(podName, namespace string, apiReader client.Reader, xl *zap.SugaredLogger) error {
-	xl.Errorf("@@@@pod name: %s", podName)
 	selector := fields.Set{"involvedObject.name": podName, "involvedObject.kind": setting.Pod}.AsSelector()
 	events, err := getter.ListEvents(namespace, selector, apiReader)
 	if err != nil {
@@ -928,7 +927,6 @@ func isPodFailed(podName, namespace string, apiReader client.Reader, xl *zap.Sug
 	}
 	var mErr error
 	for _, event := range events {
-		xl.Errorf("@@@@event type: %s,event reason: %s", event.Type, event.Reason)
 		if event.Type != "Warning" {
 			continue
 		}

--- a/pkg/microservice/warpdrive/core/service/taskplugin/release_image.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/release_image.go
@@ -80,6 +80,7 @@ type ReleaseImagePlugin struct {
 	Log           *zap.SugaredLogger
 	httpClient    *httpclient.Client
 	StorageURI    string
+	Timeout       <-chan time.Time
 }
 
 func (p *ReleaseImagePlugin) SetAckFunc(func()) {
@@ -248,6 +249,7 @@ func (p *ReleaseImagePlugin) Run(ctx context.Context, pipelineTask *task.Task, p
 		p.Task.Error = msg
 		return
 	}
+	p.Timeout = time.After(time.Duration(p.TaskTimeout()) * time.Second)
 	p.Log.Infof("succeed to create image job %s", p.JobName)
 }
 
@@ -265,7 +267,7 @@ func (p *ReleaseImagePlugin) Wait(ctx context.Context) {
 			p.SetStatus(config.StatusPassed)
 		}
 	}()
-	status, err = waitJobEnd(ctx, p.TaskTimeout(), p.KubeNamespace, p.JobName, p.kubeClient, p.clientset, p.restConfig, p.Log)
+	status, err = waitJobEnd(ctx, p.TaskTimeout(), p.Timeout, p.KubeNamespace, p.JobName, p.kubeClient, p.clientset, p.restConfig, p.Log)
 	distributeEndtime := time.Now().Unix()
 	for _, distribute := range p.Task.DistributeInfo {
 		distribute.DistributeEndTime = distributeEndtime

--- a/pkg/microservice/warpdrive/core/service/taskplugin/scanning.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/scanning.go
@@ -321,7 +321,9 @@ func (p *ScanPlugin) Complete(ctx context.Context, pipelineTask *task.Task, serv
 	err := saveContainerLog(pipelineTask, p.KubeNamespace, p.Task.ClusterID, p.FileName, jobLabel, p.kubeClient)
 	if err != nil {
 		p.Log.Error(err)
-		p.Task.Error = err.Error()
+		if p.Task.Error == "" {
+			p.Task.Error = err.Error()
+		}
 		return
 	}
 }

--- a/pkg/microservice/warpdrive/core/service/taskplugin/scanning.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/scanning.go
@@ -46,6 +46,7 @@ func InitializeScanningTaskPlugin(taskType config.TaskType) TaskPlugin {
 		kubeClient: krkubeclient.Client(),
 		clientset:  krkubeclient.Clientset(),
 		restConfig: krkubeclient.RESTConfig(),
+		apiReader:  krkubeclient.APIReader(),
 	}
 }
 

--- a/pkg/microservice/warpdrive/core/service/taskplugin/testing.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/testing.go
@@ -51,6 +51,7 @@ func InitializeTestTaskPlugin(taskType config.TaskType) TaskPlugin {
 		kubeClient: krkubeclient.Client(),
 		clientset:  krkubeclient.Clientset(),
 		restConfig: krkubeclient.RESTConfig(),
+		apiReader:  krkubeclient.APIReader(),
 	}
 }
 

--- a/pkg/microservice/warpdrive/core/service/taskplugin/testing.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/testing.go
@@ -333,7 +333,9 @@ func (p *TestPlugin) Complete(ctx context.Context, pipelineTask *task.Task, serv
 	err := saveContainerLog(pipelineTask, p.KubeNamespace, p.Task.ClusterID, p.FileName, jobLabel, p.kubeClient)
 	if err != nil {
 		p.Log.Error(err)
-		p.Task.Error = err.Error()
+		if p.Task.Error == "" {
+			p.Task.Error = err.Error()
+		}
 		return
 	}
 	p.Task.LogFile = p.JobName

--- a/pkg/microservice/warpdrive/core/service/taskplugin/utils.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/utils.go
@@ -234,23 +234,27 @@ func ToExtensionTask(sb map[string]interface{}) (*task.Extension, error) {
 	return extension, nil
 }
 
-func GetK8sClients(hubServerAddr, clusterID string) (crClient.Client, kubernetes.Interface, *rest.Config, error) {
+func GetK8sClients(hubServerAddr, clusterID string) (crClient.Client, kubernetes.Interface, *rest.Config, crClient.Reader, error) {
 	controllerRuntimeClient, err := kubeclient.GetKubeClient(hubServerAddr, clusterID)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to get controller runtime client: %s", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to get controller runtime client: %s", err)
 	}
 
 	clientset, err := kubeclient.GetKubeClientSet(hubServerAddr, clusterID)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to get clientset: %s", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to get clientset: %s", err)
 	}
 
 	restConfig, err := kubeclient.GetRESTConfig(hubServerAddr, clusterID)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to get rest config: %s", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to get rest config: %s", err)
+	}
+	kubeClientReader, err := kubeclient.GetKubeAPIReader(hubServerAddr, clusterID)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("failed to get rest config: %s", err)
 	}
 
-	return controllerRuntimeClient, clientset, restConfig, nil
+	return controllerRuntimeClient, clientset, restConfig, kubeClientReader, nil
 }
 
 // InstantiateBuildSysVariables instantiate system variables for build module

--- a/pkg/microservice/warpdrive/core/service/taskplugin/utils.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/utils.go
@@ -251,7 +251,7 @@ func GetK8sClients(hubServerAddr, clusterID string) (crClient.Client, kubernetes
 	}
 	kubeClientReader, err := kubeclient.GetKubeAPIReader(hubServerAddr, clusterID)
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("failed to get rest config: %s", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to get api reader: %s", err)
 	}
 
 	return controllerRuntimeClient, clientset, restConfig, kubeClientReader, nil


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
if pod can not create because lack of resource, we should wait until job timeout not just 2 minutes.
if failed to create pod, print error to users.

### What is changed and how it works?
if pod can not create because lack of resource, we should wait until job timeout not just 2 minutes.
if failed to create pod, print error to users.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
