### PR TITLE
fail deploy job if it's already failed

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -337,7 +337,6 @@ func (c *DeployJobCtl) wait(ctx context.Context) {
 
 		default:
 			time.Sleep(time.Second * 2)
-			c.logger.Error("@@@ default ticker")
 			ready := true
 			var err error
 		L:

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -342,7 +342,7 @@ func (c *DeployJobCtl) wait(ctx context.Context) {
 			var err error
 		L:
 			for _, resource := range c.jobTaskSpec.ReplaceResources {
-				if workLoadDeployStat(c.kubeClient, c.namespace, c.jobTaskSpec.RelatedPodLabels) != nil {
+				if err := workLoadDeployStat(c.kubeClient, c.namespace, c.jobTaskSpec.RelatedPodLabels); err != nil {
 					logError(c.job, err.Error(), c.logger)
 					return
 				}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -337,10 +337,15 @@ func (c *DeployJobCtl) wait(ctx context.Context) {
 
 		default:
 			time.Sleep(time.Second * 2)
+			c.logger.Error("@@@ default ticker")
 			ready := true
 			var err error
 		L:
 			for _, resource := range c.jobTaskSpec.ReplaceResources {
+				if workLoadDeployStat(c.kubeClient, c.namespace, c.jobTaskSpec.RelatedPodLabels) != nil {
+					logError(c.job, err.Error(), c.logger)
+					return
+				}
 				switch resource.Kind {
 				case setting.Deployment:
 					d, found, e := getter.GetDeployment(c.namespace, resource.Name, c.kubeClient)
@@ -385,11 +390,6 @@ func (c *DeployJobCtl) wait(ctx context.Context) {
 						break L
 					}
 				}
-			}
-
-			if workLoadDeployStat(c.kubeClient, c.namespace, c.jobTaskSpec.RelatedPodLabels) != nil {
-				logError(c.job, err.Error(), c.logger)
-				return
 			}
 
 			if ready {

--- a/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
@@ -464,7 +464,7 @@ func (p *DeployTaskPlugin) Wait(ctx context.Context) {
 			var err error
 		L:
 			for _, resource := range p.Task.ReplaceResources {
-				if workLoadDeployStat(p.kubeClient, p.Task.Namespace, p.Task.RelatedPodLabels) != nil {
+				if err := workLoadDeployStat(p.kubeClient, p.Task.Namespace, p.Task.RelatedPodLabels); err != nil {
 					p.Task.TaskStatus = config.StatusFailed
 					p.Task.Error = err.Error()
 					return

--- a/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
@@ -459,7 +459,6 @@ func (p *DeployTaskPlugin) Wait(ctx context.Context) {
 
 		default:
 			time.Sleep(time.Second * 2)
-			p.Log.Error("@@@ default ticker")
 			ready := true
 			var err error
 		L:


### PR DESCRIPTION
Signed-off-by: guoyu <guoyu@koderover.com>

### What this PR does / Why we need it:
The logical reference for judging deployment failure is from https://github.com/werf/kubedog

### What is changed and how it works?
The logical reference for judging deployment failure is from https://github.com/werf/kubedog

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
