### PR TITLE
fix workload add label error

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/apply.go
+++ b/pkg/microservice/aslan/core/common/service/kube/apply.go
@@ -42,9 +42,6 @@ import (
 type SharedEnvHandler func(context.Context, *commonmodels.Product, string, client.Client, versionedclient.Interface) error
 
 type ResourceApplyParam struct {
-	//ProductName         string
-	//EnvName             string
-	//Namespace           string
 	ProductInfo         *commonmodels.Product
 	ServiceName         string
 	CurrentResourceYaml string
@@ -219,6 +216,11 @@ func CreateOrPatchResource(applyParam *ResourceApplyParam, log *zap.SugaredLogge
 
 	labels := GetPredefinedLabels(productName, applyParam.ServiceName)
 	clusterLabels := GetPredefinedClusterLabels(productName, applyParam.ServiceName, envName)
+	if !applyParam.AddZadigLabel {
+		labels = map[string]string{}
+		clusterLabels = map[string]string{}
+	}
+
 	var res []*unstructured.Unstructured
 
 	for _, u := range resources {

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2282,6 +2282,7 @@ func upsertService(env *commonmodels.Product, service *commonmodels.ProductServi
 		KubeClient:          kubeClient,
 		IstioClient:         istioClient,
 		InjectSecrets:       true,
+		AddZadigLabel:       true,
 		SharedEnvHandler:    EnsureUpdateZadigService,
 	}
 	return kube.CreateOrPatchResource(resourceApplyParam, log)


### PR DESCRIPTION
### What this PR does / Why we need it:
add param to supply if add zadig lables to resoruces when deploying by zadig workflows

### What is changed and how it works?


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
