### PR TITLE
log: keep 10 backups (1GB) to avoid run out of disk space

### DIFF
--- a/pkg/tool/log/log.go
+++ b/pkg/tool/log/log.go
@@ -113,10 +113,14 @@ func getEncoder(cfg *Config, jsonFormat bool) zapcore.Encoder {
 }
 
 func getLogWriter(filename string, maxSize, maxBackup, maxAge int) zapcore.WriteSyncer {
+	// keep 10 backups (1GB) if not set to avoid run out of disk space
+	if maxBackup == 0 {
+		maxBackup = 10
+	}
 	lumberJackLogger := &lumberjack.Logger{
-		Filename: filename,
+		Filename:   filename,
+		MaxBackups: maxBackup,
 		// MaxSize:    maxSize,
-		// MaxBackups: maxBackup,
 		// MaxAge:     maxAge,
 	}
 


### PR DESCRIPTION
### What this PR does / Why we need it:

Currently there is no maxbackups or maxage for logs, then the container may use too much disk space.

### What is changed and how it works?
Add a default 10 backups (or maybe one month max age?).

### Does this PR introduce a user-facing change?
No.

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
