### PR TITLE
if production project, do not get service info

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -152,37 +152,37 @@ func (c *DeployJobCtl) run(ctx context.Context) error {
 		return errors.New(msg)
 	}
 
-	// get servcie info
-	var (
-		serviceInfo *commonmodels.Service
-	)
-	serviceInfo, err = commonrepo.NewServiceColl().Find(
-		&commonrepo.ServiceFindOption{
-			ServiceName:   c.jobTaskSpec.ServiceName,
-			ProductName:   c.workflowCtx.ProjectName,
-			ExcludeStatus: setting.ProductStatusDeleting,
-			Type:          c.jobTaskSpec.ServiceType,
-		})
-	if err != nil {
-		// Maybe it is a share service, the entity is not under the project
-		serviceInfo, err = commonrepo.NewServiceColl().Find(
-			&commonrepo.ServiceFindOption{
-				ServiceName:   c.jobTaskSpec.ServiceName,
-				ExcludeStatus: setting.ProductStatusDeleting,
-				Type:          c.jobTaskSpec.ServiceType,
-			})
-		if err != nil {
-			msg := fmt.Sprintf("find service %s error: %v", c.jobTaskSpec.ServiceName, err)
-			logError(c.job, msg, c.logger)
-			return errors.New(msg)
-		}
-	}
 	if c.jobTaskSpec.CreateEnvType == "system" {
 		if err := c.updateSystemService(env); err != nil {
 			logError(c.job, err.Error(), c.logger)
 			return err
 		}
 	} else {
+		// get servcie info
+		var (
+			serviceInfo *commonmodels.Service
+		)
+		serviceInfo, err = commonrepo.NewServiceColl().Find(
+			&commonrepo.ServiceFindOption{
+				ServiceName:   c.jobTaskSpec.ServiceName,
+				ProductName:   c.workflowCtx.ProjectName,
+				ExcludeStatus: setting.ProductStatusDeleting,
+				Type:          c.jobTaskSpec.ServiceType,
+			})
+		if err != nil {
+			// Maybe it is a share service, the entity is not under the project
+			serviceInfo, err = commonrepo.NewServiceColl().Find(
+				&commonrepo.ServiceFindOption{
+					ServiceName:   c.jobTaskSpec.ServiceName,
+					ExcludeStatus: setting.ProductStatusDeleting,
+					Type:          c.jobTaskSpec.ServiceType,
+				})
+			if err != nil {
+				msg := fmt.Sprintf("find service %s error: %v", c.jobTaskSpec.ServiceName, err)
+				logError(c.job, msg, c.logger)
+				return errors.New(msg)
+			}
+		}
 		errList := new(multierror.Error)
 		wg := sync.WaitGroup{}
 		for _, serviceModule := range c.jobTaskSpec.ServiceAndImages {


### PR DESCRIPTION
### What this PR does / Why we need it:
if production project, do not get service info

### What is changed and how it works?
if production project, do not get service info

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
