### PR TITLE
do not use env in job configuration

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -1493,12 +1493,12 @@ func GetFilteredEnvServices(workflowName, jobName, envName string, serviceNames 
 	}
 	var services *commonservice.EnvServices
 	if jobSpec.Production {
-		services, err = commonservice.ListServicesInProductionEnv(jobSpec.Env, workflow.Project, log)
+		services, err = commonservice.ListServicesInProductionEnv(envName, workflow.Project, log)
 		if err != nil {
 			return resp, e.ErrFilterWorkflowVars.AddErr(err)
 		}
 	} else {
-		services, err = commonservice.ListServicesInEnv(jobSpec.Env, workflow.Project, log)
+		services, err = commonservice.ListServicesInEnv(envName, workflow.Project, log)
 		if err != nil {
 			return resp, e.ErrFilterWorkflowVars.AddErr(err)
 		}


### PR DESCRIPTION
### What this PR does / Why we need it:
do not use env in job configuration

### What is changed and how it works?
do not use env in job configuration

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
