### PR TITLE
if workflow status was waitapprove, cancel it when restart aslan

### DIFF
--- a/pkg/microservice/aslan/config/consts.go
+++ b/pkg/microservice/aslan/config/consts.go
@@ -120,6 +120,10 @@ const (
 	StatusDebugAfter     Status = "debug_after"
 )
 
+func InCompletedStatus() []Status {
+	return []Status{StatusCreated, StatusRunning, StatusWaiting, StatusQueued, StatusBlocked, QueueItemPending, StatusPrepare, StatusWaitingApprove}
+}
+
 type TaskStatus string
 
 const (

--- a/pkg/microservice/aslan/core/common/repository/mongodb/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/workflow_task_v4.go
@@ -184,7 +184,7 @@ func (c *WorkflowTaskv4Coll) FindTodoTasksByWorkflowName(workflowName string) ([
 
 func (c *WorkflowTaskv4Coll) InCompletedTasks() ([]*models.WorkflowTask, error) {
 	ret := make([]*models.WorkflowTask, 0)
-	query := bson.M{"status": bson.M{"$in": []string{"created", "running"}}}
+	query := bson.M{"status": bson.M{"$in": config.InCompletedStatus()}}
 	query["is_deleted"] = false
 
 	opt := options.Find()


### PR DESCRIPTION
### What this PR does / Why we need it:
if workflow status was waitapprove, cancel it when restart aslan

### What is changed and how it works?
if workflow status was waitapprove, cancel it when restart aslan

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
