### PR TITLE
fix aslan panic when showing env groups in helm project

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment_group.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_group.go
@@ -56,6 +56,12 @@ func ListGroups(serviceName, envName, productName string, perPage, page int, pro
 		resp            = make([]*commonservice.ServiceResp, 0)
 	)
 
+	projectType := getProjectType(productName)
+	if projectType == setting.HelmDeployType {
+		log.Infof("listing group for helm project is not supported: %s/%s", productName, envName)
+		return resp, count, nil
+	}
+
 	opt := &commonrepo.ProductFindOptions{Name: productName, EnvName: envName, Production: util.GetBoolPointer(production)}
 	productInfo, err := commonrepo.NewProductColl().Find(opt)
 	if err != nil {


### PR DESCRIPTION
### What this PR does / Why we need it:
fix panic bug of aslan when visiting production environment page of helm projects

### What is changed and how it works?


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
