### PR TITLE
Fix workflow job outputs contained their own variables

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -1460,10 +1460,10 @@ func GetPatchParams(patchItem *commonmodels.PatchItem, logger *zap.SugaredLogger
 }
 
 func GetWorkflowGlabalVars(workflow *commonmodels.WorkflowV4, currentJobName string, log *zap.SugaredLogger) []string {
-	return append(getDefaultVars(workflow), jobctl.GetWorkflowOutputs(workflow, currentJobName, log)...)
+	return append(getDefaultVars(workflow, currentJobName), jobctl.GetWorkflowOutputs(workflow, currentJobName, log)...)
 }
 
-func getDefaultVars(workflow *commonmodels.WorkflowV4) []string {
+func getDefaultVars(workflow *commonmodels.WorkflowV4, currentJobName string) []string {
 	vars := []string{}
 	vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, "project"))
 	vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, "workflow.name"))
@@ -1474,6 +1474,9 @@ func getDefaultVars(workflow *commonmodels.WorkflowV4) []string {
 	}
 	for _, stage := range workflow.Stages {
 		for _, j := range stage.Jobs {
+			if j.Name == currentJobName {
+				continue
+			}
 			switch j.JobType {
 			case config.JobZadigBuild:
 				spec := new(commonmodels.ZadigBuildJobSpec)


### PR DESCRIPTION
### What this PR does / Why we need it:
Fix workflow job outputs contained their own variables

### What is changed and how it works?


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
