### PR TITLE
do not declare share storage volume if it's not set

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
@@ -571,10 +571,12 @@ func setJobShareStorages(job *batchv1.Job, workflowCtx *commonmodels.WorkflowTas
 	if cluster.ShareStorage.NFSProperties.PVC == "" {
 		return
 	}
-	// save cluster id so we can clean
-	if len(storageDetails) > 0 {
-		workflowCtx.ClusterIDAdd(cluster.ID.Hex())
+	if len(storageDetails) <= 0 {
+		return
 	}
+	// save cluster id so we can clean up share storage later
+	workflowCtx.ClusterIDAdd(cluster.ID.Hex())
+
 	volumeName := "share-storage"
 	job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, corev1.Volume{
 		Name: volumeName,


### PR DESCRIPTION
### What this PR does / Why we need it:
do not declare share storage volume if it's not set

### What is changed and how it works?
do not declare share storage volume if it's not set

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
