### PR TITLE
add image_name to ListBuildModulesByServiceModule func

### DIFF
--- a/pkg/microservice/aslan/core/build/service/build.go
+++ b/pkg/microservice/aslan/core/build/service/build.go
@@ -54,6 +54,7 @@ type BuildResp struct {
 type ServiceModuleAndBuildResp struct {
 	ServiceName   string       `json:"service_name"`
 	ServiceModule string       `json:"service_module"`
+	ImageName     string       `json:"image_name"`
 	ModuleBuilds  []*BuildResp `json:"module_builds"`
 }
 
@@ -232,6 +233,7 @@ func ListBuildModulesByServiceModule(encryptedKey, productName, envName string, 
 			serviceModuleAndBuildResp = append(serviceModuleAndBuildResp, &ServiceModuleAndBuildResp{
 				ServiceName:   serviceTmpl.ServiceName,
 				ServiceModule: container.Name,
+				ImageName:     container.ImageName,
 				ModuleBuilds:  resp,
 			})
 		}


### PR DESCRIPTION
### What this PR does / Why we need it:

add image_name to ListBuildModulesByServiceModule func

### What is changed and how it works?

add image_name to ListBuildModulesByServiceModule func

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
