### PR TITLE
Fix retry custom workflow not clear job and stage infos

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -479,6 +479,9 @@ func RetryWorkflowTaskV4(workflowName string, taskID int64, logger *zap.SugaredL
 			continue
 		}
 		stage.Status = ""
+		stage.StartTime = 0
+		stage.EndTime = 0
+		stage.Error = ""
 
 		if stage.Approval != nil && stage.Approval.Enabled &&
 			stage.Approval.Status != config.StatusPassed && stage.Approval.Status != "" {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -494,6 +494,9 @@ func RetryWorkflowTaskV4(workflowName string, taskID int64, logger *zap.SugaredL
 				continue
 			}
 			jobTask.Status = ""
+			jobTask.StartTime = 0
+			jobTask.EndTime = 0
+			jobTask.Error = ""
 			if t, ok := m[jobTask.Name]; ok {
 				jobTask.Spec = t.Spec
 			} else {


### PR DESCRIPTION
### What this PR does / Why we need it:
We should clear some info of failed jobs and stages before retry workflow

### What is changed and how it works?


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
