### PR TITLE
Fix list available environments when creating the environment

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/product.go
@@ -515,13 +515,16 @@ type nsObject struct {
 	Namespace string             `bson:"namespace"`
 }
 
-func (c *ProductColl) ListExistedNamespace() ([]string, error) {
+func (c *ProductColl) ListExistedNamespace(clusterID string) ([]string, error) {
 	nsList := make([]*nsObject, 0)
 	resp := sets.NewString()
 	selector := bson.D{
 		{"namespace", 1},
 	}
 	query := bson.M{"is_existed": true}
+	if clusterID != "" {
+		query["cluster_id"] = clusterID
+	}
 	opt := options.Find()
 	opt.SetProjection(selector)
 	cursor, err := c.Collection.Find(context.TODO(), query, opt)

--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -130,7 +130,7 @@ func ensureProductionNamespace(createArgs []*service.CreateSingleProductArg) err
 
 	for _, arg := range createArgs {
 		if !namespaceList[arg.ClusterID].Has(arg.Namespace) {
-			return fmt.Errorf("namespace %s is not valid for production environments", arg.Namespace)
+			return fmt.Errorf("namespace %s is invalid or has been used for other environment", arg.Namespace)
 		}
 	}
 	return nil

--- a/pkg/microservice/aslan/core/environment/service/kube.go
+++ b/pkg/microservice/aslan/core/environment/service/kube.go
@@ -189,7 +189,7 @@ func ListAvailableNamespaces(clusterID, listType string, log *zap.SugaredLogger)
 
 	filterK8sNamespaces := sets.NewString("kube-node-lease", "kube-public", "kube-system")
 	if listType == setting.ListNamespaceTypeCreate {
-		nsList, err := commonrepo.NewProductColl().ListExistedNamespace()
+		nsList, err := commonrepo.NewProductColl().ListExistedNamespace(clusterID)
 		if err != nil {
 			log.Errorf("Failed to list existed namespace from the env List, error: %s", err)
 			return nil, err


### PR DESCRIPTION
### What this PR does / Why we need it:
Selecting namespace of `is_existed` production should set the clusterID query condition

### What is changed and how it works?


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
