### PR TITLE
fix permission mission issue when editing builds

### DIFF
--- a/pkg/microservice/policy/core/yamlconfig/metas.yaml
+++ b/pkg/microservice/policy/core/yamlconfig/metas.yaml
@@ -250,11 +250,11 @@ metas:
         description: ''
         rules:
           - method: GET
-            endpoint: /api/aslan/build/build/?*
+            endpoint: /api/aslan/template/build/?*
           - method: GET
-            endpoint: api/aslan/template/build
+            endpoint: /api/aslan/template/build
           - method: GET
-            endpoint: api/aslan/template/dockerfile
+            endpoint: /api/aslan/template/dockerfile
           - method: POST
             endpoint: /api/aslan/build/build
       - action: edit_build
@@ -262,7 +262,9 @@ metas:
         description: ''
         rules:
           - method: GET
-            endpoint: /api/aslan/build/build/?*
+            endpoint: /api/aslan/template/build/?*
+          - method: GET
+            endpoint: /api/aslan/template/build
           - method: PUT
             endpoint: /api/aslan/build/build
           - method: POST

--- a/pkg/microservice/policy/core/yamlconfig/metas.yaml
+++ b/pkg/microservice/policy/core/yamlconfig/metas.yaml
@@ -250,6 +250,8 @@ metas:
         description: ''
         rules:
           - method: GET
+            endpoint: /api/aslan/build/build/?*
+          - method: GET
             endpoint: api/aslan/template/build
           - method: GET
             endpoint: api/aslan/template/dockerfile
@@ -259,6 +261,8 @@ metas:
         alias: 编辑
         description: ''
         rules:
+          - method: GET
+            endpoint: /api/aslan/build/build/?*
           - method: PUT
             endpoint: /api/aslan/build/build
           - method: POST


### PR DESCRIPTION
### What this PR does / Why we need it:
add build template permission config when creating/editing build from build templates

### What is changed and how it works?


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
