### PR TITLE
Fix: Api cost time metric should ignore SSE

### DIFF
--- a/pkg/middleware/gin/request_metrics.go
+++ b/pkg/middleware/gin/request_metrics.go
@@ -20,11 +20,15 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+
 	"github.com/koderover/zadig/pkg/tool/metrics"
 )
 
 func RegisterRequest() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if c.Request.Header.Get("Accept") == "text/event-stream" {
+			return
+		}
 		startTime := time.Now().UnixMilli()
 		path := c.Request.URL.Path
 		c.Next()


### PR DESCRIPTION
### What this PR does / Why we need it:
Api cost time metric should ignore SSE

### What is changed and how it works?


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
