### PR TITLE
remove kubeconfig hub agent

### DIFF
--- a/pkg/microservice/aslan/core/multicluster/service/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/service/clusters.go
@@ -428,6 +428,10 @@ func UpgradeAgent(id string, logger *zap.SugaredLogger) error {
 	resources := make([]*unstructured.Unstructured, 0, len(manifests))
 	for _, item := range manifests {
 		u, err := serializer.NewDecoder().YamlToUnstructured([]byte(item))
+		// kubeconfig cluster does not need to upgrade hub-agent.
+		if clusterInfo.Type == setting.KubeConfigClusterType && u.GetName() == "hub-agent" {
+			continue
+		}
 		if err != nil {
 			log.Errorf("[UpgradeAgent] Failed to convert yaml to Unstructured, manifest is\n%s\n, error: %v", item, err)
 			errList = multierror.Append(errList, err)


### PR DESCRIPTION
### What this PR does / Why we need it:
remove kubeconfig cluster hub agent

### What is changed and how it works?


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
