### PR TITLE
Add the linkColor field to custom theme

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/1180.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/1180.go
@@ -103,6 +103,7 @@ func migrateSystemTheme() error {
 				ProjectItemIconColor:     "#0066ff",
 				ProjectNameColor:         "#121212",
 				TableCellBackgroundColor: "#eaeaea",
+				LinkColor:                "#0066ff",
 			},
 		}
 		err := mdb.UpdateTheme(theme)

--- a/pkg/microservice/aslan/core/common/repository/models/settings.go
+++ b/pkg/microservice/aslan/core/common/repository/models/settings.go
@@ -56,6 +56,7 @@ type CustomTheme struct {
 	ProjectItemIconColor     string `bson:"project_item_icon_color" json:"project_item_icon_color"`
 	ProjectNameColor         string `bson:"project_name_color" json:"project_name_color"`
 	TableCellBackgroundColor string `bson:"table_cell_background_color" json:"table_cell_background_color"`
+	LinkColor                string `bson:"link_color" json:"link_color"`
 }
 
 func (SystemSetting) TableName() string {

--- a/pkg/microservice/aslan/core/common/repository/mongodb/settings.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/settings.go
@@ -114,6 +114,7 @@ func (c *SystemSettingColl) InitSystemSettings() error {
 					ProjectItemIconColor:     "#0066ff",
 					ProjectNameColor:         "#121212",
 					TableCellBackgroundColor: "#eaeaea",
+					LinkColor:                "#0066ff",
 				},
 			},
 		})

--- a/pkg/microservice/aslan/core/system/service/custom_theme.go
+++ b/pkg/microservice/aslan/core/system/service/custom_theme.go
@@ -58,6 +58,7 @@ func convertThemeToRsp(m *models.Theme) *types.Theme {
 			ProjectItemIconColor:     m.CustomTheme.ProjectItemIconColor,
 			ProjectNameColor:         m.CustomTheme.ProjectNameColor,
 			TableCellBackgroundColor: m.CustomTheme.TableCellBackgroundColor,
+			LinkColor:                m.CustomTheme.LinkColor,
 		},
 	}
 }

--- a/pkg/types/system_settings.go
+++ b/pkg/types/system_settings.go
@@ -29,4 +29,5 @@ type CustomTheme struct {
 	ProjectItemIconColor     string `json:"project_item_icon_color"`
 	ProjectNameColor         string `json:"project_name_color"`
 	TableCellBackgroundColor string `json:"table_cell_background_color"`
+	LinkColor                string `json:"link_color"`
 }


### PR DESCRIPTION
### What this PR does / Why we need it:
add the linkColor field to custom theme.

### What is changed and how it works?


### Does this PR introduce a user-facing change?

- [ ] API change
- [x] database schema change
- [x] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
