### PR TITLE
fix: external product should set is_existed

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/1180.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/1180.go
@@ -56,7 +56,10 @@ func V1170ToV1180() error {
 		log.Errorf("migrateWorkflowV4LarkApproval err: %v", err)
 		return err
 	}
-
+	if err := migrateExternalProductIsExisted(); err != nil {
+		log.Errorf("migrateExternalProductIsExisted err: %v", err)
+		return err
+	}
 	return nil
 }
 
@@ -293,4 +296,10 @@ func setLarkApprovalNodeForWorkflowV4Task(workflow *models.WorkflowTask) (update
 		}
 	}
 	return updated
+}
+
+func migrateExternalProductIsExisted() error {
+	_, err := mongodb.NewProductColl().UpdateMany(context.Background(),
+		bson.M{"source": "external"}, bson.M{"$set": bson.M{"is_existed": true}})
+	return err
 }

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -334,6 +334,7 @@ func CreateK8sWorkLoads(ctx context.Context, requestID, userName string, args *K
 			EnvName:     args.EnvName,
 			Namespace:   args.Namespace,
 			UpdateBy:    userName,
+			IsExisted:   true,
 		}, log); err != nil {
 			return e.ErrCreateProduct.AddDesc("create product Error for unknown reason")
 		}


### PR DESCRIPTION
### What this PR does / Why we need it:
fix: external product should set is_existed

### What is changed and how it works?


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
