### PR TITLE
fix kv convert to yaml when yaml type variable's value is empty

### DIFF
--- a/pkg/microservice/aslan/core/common/types/service_variable.go
+++ b/pkg/microservice/aslan/core/common/types/service_variable.go
@@ -95,6 +95,15 @@ func addValueToNode(key string, data interface{}, node *yaml.Node) *yaml.Node {
 		valueNode := data.(*yaml.Node)
 		if valueNode.Kind == yaml.DocumentNode {
 			node.Content = append(node.Content, valueNode.Content...)
+		} else {
+			if valueNode.Kind != yaml.DocumentNode &&
+				valueNode.Kind != yaml.SequenceNode &&
+				valueNode.Kind != yaml.MappingNode &&
+				valueNode.Kind != yaml.ScalarNode &&
+				valueNode.Kind != yaml.AliasNode {
+				valueNode.Kind = yaml.ScalarNode
+			}
+			node.Content = append(node.Content, valueNode)
 		}
 	default:
 		valueChild := convertValueToNode(data)

--- a/pkg/microservice/aslan/core/common/types/service_variable_test.go
+++ b/pkg/microservice/aslan/core/common/types/service_variable_test.go
@@ -52,6 +52,11 @@ var (
 			Options: []string{"11", "22", "33"},
 		},
 		{
+			Key:   "yamlEmpty",
+			Value: "",
+			Type:  types.ServiceVariableKVTypeYaml,
+		},
+		{
 			Key: "yamlMap",
 			Value: `
 A: 1
@@ -79,6 +84,7 @@ strStr: a string
 strBool: true
 bool: true
 enum: 11
+yamlEmpty:
 yamlMap:
   A: 1
   B: a string


### PR DESCRIPTION
### What this PR does / Why we need it:

fix kv convert to yaml when yaml type variable's value is empty

### What is changed and how it works?

fix kv convert to yaml when yaml type variable's value is empty

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
