### PR TITLE
Init workflow service account should not fatal

### DIFF
--- a/pkg/microservice/aslan/core/service.go
+++ b/pkg/microservice/aslan/core/service.go
@@ -206,7 +206,8 @@ func initResourcesForExternalClusters() {
 	logger := log.SugaredLogger().With("func", "initResourcesForExternalClusters")
 	list, err := mongodb.NewK8sClusterColl().FindConnectedClusters()
 	if err != nil {
-		logger.Fatalf("FindConnectedClusters err: %v", err)
+		logger.Errorf("FindConnectedClusters err: %v", err)
+		return
 	}
 	namespace := "koderover-agent"
 
@@ -221,10 +222,12 @@ func initResourcesForExternalClusters() {
 		case setting.KubeConfigClusterType:
 			client, err = multicluster.GetKubeClientFromKubeConfig(cluster.ID.Hex(), cluster.KubeConfig)
 		default:
-			logger.Fatalf("failed to create kubeclient: unknown cluster type: %s", cluster.Type)
+			logger.Errorf("failed to create kubeclient: unknown cluster type: %s", cluster.Type)
+			return
 		}
 		if err != nil {
-			logger.Fatalf("GetKubeClient id-%s err: %v", cluster.ID.Hex(), err)
+			logger.Errorf("GetKubeClient id-%s err: %v", cluster.ID.Hex(), err)
+			return
 		}
 
 		// create role
@@ -245,7 +248,8 @@ func initResourcesForExternalClusters() {
 			if apierrors.IsAlreadyExists(err) {
 				logger.Infof("cluster %s role is already exist", cluster.Name)
 			} else {
-				logger.Fatalf("cluster %s create role err: %s", cluster.Name, err)
+				logger.Errorf("cluster %s create role err: %s", cluster.Name, err)
+				return
 			}
 		}
 
@@ -260,7 +264,8 @@ func initResourcesForExternalClusters() {
 			if apierrors.IsAlreadyExists(err) {
 				logger.Infof("cluster %s serviceAccount is already exist", cluster.Name)
 			} else {
-				logger.Fatalf("cluster %s create serviceAccount err: %s", cluster.Name, err)
+				logger.Errorf("cluster %s create serviceAccount err: %s", cluster.Name, err)
+				return
 			}
 		}
 
@@ -287,7 +292,8 @@ func initResourcesForExternalClusters() {
 			if apierrors.IsAlreadyExists(err) {
 				logger.Infof("cluster %s role binding is already exist", cluster.Name)
 			} else {
-				logger.Fatalf("cluster %s create role binding err: %s", cluster.Name, err)
+				logger.Errorf("cluster %s create role binding err: %s", cluster.Name, err)
+				return
 			}
 		}
 		logger.Infof("cluster %s done", cluster.Name)


### PR DESCRIPTION
### What this PR does / Why we need it:
Init workflow service account should not fatal

### What is changed and how it works?


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
