### PR TITLE
Remove deprecated service_option field

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -234,7 +234,6 @@ type FreestyleJobSpec struct {
 type ZadigBuildJobSpec struct {
 	DockerRegistryID string             `bson:"docker_registry_id"     yaml:"docker_registry_id"     json:"docker_registry_id"`
 	ServiceAndBuilds []*ServiceAndBuild `bson:"service_and_builds"     yaml:"service_and_builds"     json:"service_and_builds"`
-	ServiceOptions   []*ServiceAndBuild `bson:"service_options"        yaml:"service_options"        json:"service_options"`
 }
 
 type ServiceAndBuild struct {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_build.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_build.go
@@ -109,7 +109,6 @@ func (j *BuildJob) SetPreset() error {
 		newBuilds = append(newBuilds, build)
 	}
 	j.spec.ServiceAndBuilds = newBuilds
-	j.spec.ServiceOptions = newBuilds
 	j.job.Spec = j.spec
 	return nil
 }


### PR DESCRIPTION
### What this PR does / Why we need it:
Remove deprecated service_option field

### What is changed and how it works?


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
