### PR TITLE
set default analysis config when create new env

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2369,6 +2369,24 @@ func preCreateProduct(envName string, args *commonmodels.Product, kubeClient cli
 		tmpRenderInfo.Revision = args.Render.Revision
 	}
 
+	if args.Source == setting.HelmDeployType || args.Source == setting.K8SDeployType {
+		args.AnalysisConfig = &commonmodels.AnalysisConfig{
+			ResourceTypes: []commonmodels.ResourceType{
+				commonmodels.ResourceTypePod,
+				commonmodels.ResourceTypeDeployment,
+				commonmodels.ResourceTypeReplicaSet,
+				commonmodels.ResourceTypePVC,
+				commonmodels.ResourceTypeService,
+				commonmodels.ResourceTypeIngress,
+				commonmodels.ResourceTypeStatefulSet,
+				commonmodels.ResourceTypeCronJob,
+				commonmodels.ResourceTypeHPA,
+				commonmodels.ResourceTypePDB,
+				commonmodels.ResourceTypeNetworkPolicy,
+			},
+		}
+	}
+
 	args.Render = tmpRenderInfo
 	if preCreateNSAndSecret(productTmpl.ProductFeature) {
 		return ensureKubeEnv(args.Namespace, args.RegistryID, map[string]string{setting.ProductLabel: args.ProductName}, args.ShareEnv.Enable, kubeClient, log)


### PR DESCRIPTION
### What this PR does / Why we need it:

set default analysis config when create new env

### What is changed and how it works?

set default analysis config when create new env

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
