### PR TITLE
fix: delivery deploy unique index

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/delivery_deploy.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/delivery_deploy.go
@@ -61,6 +61,7 @@ func (c *DeliveryDeployColl) EnsureIndex(ctx context.Context) error {
 			Keys: bson.D{
 				bson.E{Key: "release_id", Value: 1},
 				bson.E{Key: "service_name", Value: 1},
+				bson.E{Key: "container_name", Value: 1},
 				bson.E{Key: "deleted_at", Value: 1},
 			},
 			Options: options.Index().SetUnique(true),
@@ -74,8 +75,9 @@ func (c *DeliveryDeployColl) EnsureIndex(ctx context.Context) error {
 		},
 	}
 
+	_, _ = c.Indexes().DropOne(ctx, "release_id_1_service_name_1_deleted_at_1")
 	_, err := c.Indexes().CreateMany(ctx, mod)
-
+	
 	return err
 }
 


### PR DESCRIPTION
### What this PR does / Why we need it:
Product version can't save multiple service module caused by an incorrect unique index

### What is changed and how it works?


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
