### PR TITLE
add detail log for collaboration mode

### DIFF
--- a/pkg/microservice/aslan/core/collaboration/handler/collaboration_mode.go
+++ b/pkg/microservice/aslan/core/collaboration/handler/collaboration_mode.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/collaboration/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/collaboration/service"
@@ -31,6 +32,7 @@ import (
 	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 	"github.com/koderover/zadig/pkg/tool/log"
+	"github.com/koderover/zadig/pkg/types"
 )
 
 func GetCollaborationMode(c *gin.Context) {
@@ -61,7 +63,7 @@ func CreateCollaborationMode(c *gin.Context) {
 		return
 	}
 
-	detail, err := generateCollaborationDetailLog(args, ctx.Logger)
+	detail, err := generateCollaborationDetailLog(ctx.Account, args, ctx.Logger)
 	if err != nil {
 		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
 		return
@@ -89,7 +91,7 @@ func UpdateCollaborationMode(c *gin.Context) {
 		return
 	}
 
-	detail, err := generateCollaborationDetailLog(args, ctx.Logger)
+	detail, err := generateCollaborationDetailLog(ctx.Account, args, ctx.Logger)
 	if err != nil {
 		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
 		return
@@ -115,7 +117,7 @@ func DeleteCollaborationMode(c *gin.Context) {
 	ctx.Err = service.DeleteCollaborationMode(ctx.Account, projectName, name, ctx.Logger)
 }
 
-func generateCollaborationDetailLog(args *commonmodels.CollaborationMode, logger *zap.SugaredLogger) (string, error) {
+func generateCollaborationDetailLog(username string, args *commonmodels.CollaborationMode, logger *zap.SugaredLogger) (string, error) {
 	collaborationWorkflowVerbTranslateMap := map[string]string{
 		"get_workflow":   "查看",
 		"edit_workflow":  "编辑",
@@ -124,10 +126,13 @@ func generateCollaborationDetailLog(args *commonmodels.CollaborationMode, logger
 	}
 
 	collaborationProductVerbTranslateMap := map[string]string{
-		"get_environment":    "查看",
-		"config_environment": "配置",
-		"manage_environment": "管理服务实例",
-		"debug_pod":          "服务调试",
+		"get_environment":             "查看",
+		"config_environment":          "配置",
+		"manage_environment":          "管理服务实例",
+		"debug_pod":                   "服务调试",
+		"get_production_environment":  "查看",
+		"edit_production_environment": "编辑",
+		"production_debug_pod":        "服务调试",
 	}
 
 	collaborationTypeTranslateMap := map[string]string{
@@ -135,35 +140,230 @@ func generateCollaborationDetailLog(args *commonmodels.CollaborationMode, logger
 		"share": "共享",
 	}
 
-	detail := "用户名称："
-	userResp, err := user.SearchUsersByUIDs(args.Members, logger)
+	currMode, exists, err := service.GetCollaborationMode(username, args.ProjectName, args.Name, logger)
+	if err != nil {
+		return "", fmt.Errorf("can't get current collaboration mode, projectName: %v, name: %v err: %v", args.ProjectName, args.Name, err)
+	}
+	if !exists {
+		currMode = &commonmodels.CollaborationMode{
+			Name:      args.Name,
+			Members:   []string{},
+			Workflows: []commonmodels.WorkflowCMItem{},
+			Products:  []commonmodels.ProductCMItem{},
+		}
+	}
+
+	currUserIDSet := sets.NewString(currMode.Members...)
+	argsUserIDSet := sets.NewString(args.Members...)
+	addedUserIDSet := argsUserIDSet.Difference(currUserIDSet)
+	deletedUserIDSet := currUserIDSet.Difference(argsUserIDSet)
+
+	allUserIDSet := sets.NewString(args.Members...)
+	allUserIDSet.Insert(currMode.Members...)
+
+	detail := "协作模式名称：" + args.Name + "\n\n"
+
+	// user part
+	userResp, err := user.SearchUsersByUIDs(allUserIDSet.List(), logger)
 	if err != nil {
 		return "", fmt.Errorf("failed to search users by uids(%v), err: %v", args.Members, err)
 	}
+	userInfoMap := make(map[string]types.UserInfo)
 	for _, user := range userResp.Users {
-		detail += user.Name + "，"
+		userInfoMap[user.Uid] = user
 	}
-	detail = strings.Trim(detail, "，")
-	detail += "\n"
 
+	if deletedUserIDSet.Len() != 0 {
+		detail += "删除用户："
+		for _, userid := range deletedUserIDSet.List() {
+			detail += userInfoMap[userid].Name + "，"
+		}
+		detail = strings.Trim(detail, "，")
+		detail += "\n\n"
+	}
+
+	if addedUserIDSet.Len() != 0 {
+		detail += "新增用户："
+		for _, userid := range addedUserIDSet.List() {
+			detail += userInfoMap[userid].Name + "，"
+		}
+		detail = strings.Trim(detail, "，")
+		detail += "\n"
+
+		for _, workflow := range args.Workflows {
+			detail += "工作流名称：" + workflow.Name + "，类型：" + collaborationTypeTranslateMap[string(workflow.CollaborationType)] + "，"
+			detail += "权限："
+			for _, verb := range workflow.Verbs {
+				detail += collaborationWorkflowVerbTranslateMap[verb] + "，"
+			}
+			detail = strings.TrimSuffix(detail, "，")
+			detail += "\n"
+		}
+
+		for _, env := range args.Products {
+			detail += "环境名称：" + env.Name + "，类型：" + collaborationTypeTranslateMap[string(env.CollaborationType)] + "，权限："
+			for _, verb := range env.Verbs {
+				detail += collaborationProductVerbTranslateMap[verb] + "，"
+			}
+
+			detail = strings.TrimSuffix(detail, "，")
+			detail += "\n"
+		}
+
+		detail += "\n"
+	}
+
+	// workflow part
+	currWorklowMap := make(map[string]commonmodels.WorkflowCMItem)
+	argWorklowMap := make(map[string]commonmodels.WorkflowCMItem)
+	currWorklowSet := sets.NewString()
+	argWorklowSet := sets.NewString()
+
+	for _, workflow := range currMode.Workflows {
+		currWorklowSet.Insert(workflow.Name)
+		currWorklowMap[workflow.Name] = workflow
+	}
 	for _, workflow := range args.Workflows {
-		detail += "工作流名称：" + workflow.Name + "，类型：" + collaborationTypeTranslateMap[string(workflow.CollaborationType)] + "，权限："
+		argWorklowSet.Insert(workflow.Name)
+		argWorklowMap[workflow.Name] = workflow
+	}
+
+	addedWorkflowSet := argWorklowSet.Difference(currWorklowSet)
+	deletedWorkflowSet := currWorklowSet.Difference(argWorklowSet)
+	intersectionWorkflowSet := argWorklowSet.Intersection(currWorklowSet)
+
+	detail += "权限变更：\n"
+	for _, name := range addedWorkflowSet.List() {
+		workflow := argWorklowMap[name]
+		detail += "工作流名称：" + workflow.Name + "，类型：" + collaborationTypeTranslateMap[string(workflow.CollaborationType)] + "，"
+		detail += "增加权限："
 		for _, verb := range workflow.Verbs {
 			detail += collaborationWorkflowVerbTranslateMap[verb] + "，"
 		}
 		detail = strings.TrimSuffix(detail, "，")
-		detail += "；"
+		detail += "\n"
 	}
-	detail += "\n"
+	for _, name := range deletedWorkflowSet.List() {
+		workflow := currWorklowMap[name]
+		detail += "工作流名称：" + workflow.Name + "，类型：" + collaborationTypeTranslateMap[string(workflow.CollaborationType)] + "，"
+		detail += "移除权限："
+		for _, verb := range workflow.Verbs {
+			detail += collaborationWorkflowVerbTranslateMap[verb] + "，"
+		}
+		detail = strings.TrimSuffix(detail, "，")
+		detail += "\n"
+	}
+	for _, name := range intersectionWorkflowSet.List() {
+		workflow := argWorklowMap[name]
+		currWorkflow := currWorklowMap[name]
 
-	for _, env := range args.Products {
-		detail += "环境名称：" + env.Name + "，类型：" + collaborationTypeTranslateMap[string(env.CollaborationType)] + "，权限："
+		currVerbSet := sets.NewString(currWorkflow.Verbs...)
+		argVerbSet := sets.NewString(workflow.Verbs...)
+		addedVerbSet := argVerbSet.Difference(currVerbSet)
+		deletedVerbSet := currVerbSet.Difference(argVerbSet)
+
+		if addedVerbSet.Len() == 0 && deletedVerbSet.Len() == 0 {
+			continue
+		}
+
+		detail += "工作流名称：" + workflow.Name + "，类型：" + collaborationTypeTranslateMap[string(workflow.CollaborationType)] + "，"
+		if addedVerbSet.Len() != 0 {
+			detail += "增加权限："
+			for _, verb := range addedVerbSet.List() {
+				detail += collaborationWorkflowVerbTranslateMap[verb] + "，"
+			}
+		}
+		if deletedVerbSet.Len() != 0 {
+			detail += "移除权限："
+			for _, verb := range deletedVerbSet.List() {
+				detail += collaborationWorkflowVerbTranslateMap[verb] + "，"
+			}
+		}
+		detail = strings.TrimSuffix(detail, "，")
+		detail += "\n"
+	}
+
+	// product part
+	currProductMap := make(map[string]commonmodels.ProductCMItem)
+	argProductMap := make(map[string]commonmodels.ProductCMItem)
+	currProductSet := sets.NewString()
+	argProductSet := sets.NewString()
+
+	for _, product := range currMode.Products {
+		currProductSet.Insert(product.Name)
+		currProductMap[product.Name] = product
+	}
+	for _, product := range args.Products {
+		argProductSet.Insert(product.Name)
+		argProductMap[product.Name] = product
+	}
+
+	addedProductSet := argProductSet.Difference(currProductSet)
+	deletedProductSet := currProductSet.Difference(argProductSet)
+	intersectionProductSet := argProductSet.Intersection(currProductSet)
+
+	for _, envName := range addedProductSet.List() {
+		env := argProductMap[envName]
+		detail += "环境名称：" + env.Name + "，类型：" + collaborationTypeTranslateMap[string(env.CollaborationType)] + "，新增权限："
 		for _, verb := range env.Verbs {
 			detail += collaborationProductVerbTranslateMap[verb] + "，"
 		}
+
 		detail = strings.TrimSuffix(detail, "，")
-		detail += "；"
+		detail += "\n"
 	}
+	for _, envName := range deletedProductSet.List() {
+		env := currProductMap[envName]
+		detail += "环境名称：" + env.Name + "，类型：" + collaborationTypeTranslateMap[string(env.CollaborationType)] + "，移除权限："
+		for _, verb := range env.Verbs {
+			detail += collaborationProductVerbTranslateMap[verb] + "，"
+		}
+
+		detail = strings.TrimSuffix(detail, "，")
+		detail += "\n"
+	}
+	for _, envName := range intersectionProductSet.List() {
+		argProduct := argProductMap[envName]
+		currProduct := currProductMap[envName]
+
+		currVerbSet := sets.NewString(currProduct.Verbs...)
+		argVerbSet := sets.NewString(argProduct.Verbs...)
+		addedVerbSet := argVerbSet.Difference(currVerbSet)
+		deletedVerbSet := currVerbSet.Difference(argVerbSet)
+
+		if addedVerbSet.Len() == 0 && deletedVerbSet.Len() == 0 {
+			continue
+		}
+
+		detail += "环境名称：" + argProduct.Name + "，类型：" + collaborationTypeTranslateMap[string(argProduct.CollaborationType)] + "，"
+
+		if addedVerbSet.Len() != 0 {
+			detail += "增加权限："
+			for _, verb := range addedVerbSet.List() {
+				detail += collaborationProductVerbTranslateMap[verb] + "，"
+			}
+		}
+		if deletedVerbSet.Len() != 0 {
+			detail += "移除权限："
+			for _, verb := range deletedVerbSet.List() {
+				detail += collaborationProductVerbTranslateMap[verb] + "，"
+			}
+		}
+
+		detail = strings.TrimSuffix(detail, "，")
+		detail += "\n"
+	}
+
+	if strings.LastIndex(detail, "权限变更：\n") == len(detail)-len("权限变更：\n") {
+		detail = strings.TrimSuffix(detail, "权限变更：\n")
+		return detail, nil
+	}
+
+	detail += "影响用户："
+	for _, userID := range allUserIDSet.List() {
+		detail += userInfoMap[userID].Name + "，"
+	}
+	detail = strings.TrimSuffix(detail, "，")
 
 	return detail, nil
 }

--- a/pkg/microservice/aslan/core/collaboration/service/collaboration_mode.go
+++ b/pkg/microservice/aslan/core/collaboration/service/collaboration_mode.go
@@ -17,6 +17,7 @@ limitations under the License.
 package service
 
 import (
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.uber.org/zap"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/collaboration/repository/models"
@@ -48,4 +49,21 @@ func DeleteCollaborationMode(username, projectName, name string, logger *zap.Sug
 		return err
 	}
 	return mongodb.NewCollaborationInstanceColl().ResetRevision(name, projectName)
+}
+
+func GetCollaborationMode(username, projectName, name string, logger *zap.SugaredLogger) (*models.CollaborationMode, bool, error) {
+	opt := &mongodb.CollaborationModeFindOptions{
+		ProjectName: projectName,
+		Name:        name,
+	}
+	resp, err := mongodb.NewCollaborationModeColl().Find(opt)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, false, nil
+		}
+
+		logger.Errorf("UpdateCollaborationMode error, err msg:%s", err)
+		return nil, false, err
+	}
+	return resp, true, nil
 }

--- a/pkg/microservice/picket/core/filter/service/users.go
+++ b/pkg/microservice/picket/core/filter/service/users.go
@@ -33,10 +33,6 @@ type DeleteUserResp struct {
 }
 
 func DeleteUser(userID string, header http.Header, qs url.Values, _ *zap.SugaredLogger) ([]byte, error) {
-	_, err := user.New().DeleteUser(userID, header, qs)
-	if err != nil {
-		return []byte{}, err
-	}
 	return policy.New().DeleteRoleBindings(userID, header, qs)
 }
 

--- a/pkg/microservice/policy/core/handler/role_binding.go
+++ b/pkg/microservice/policy/core/handler/role_binding.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	picketuser "github.com/koderover/zadig/pkg/microservice/picket/client/user"
 	"github.com/koderover/zadig/pkg/microservice/policy/core/service"
 	"github.com/koderover/zadig/pkg/microservice/user/core/service/user"
 	"github.com/koderover/zadig/pkg/setting"
@@ -62,7 +63,11 @@ func UpdateRoleBinding(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam.AddErr(err)
 		return
 	}
-	detail := "用户：" + userInfo.Name + "，角色名称：" + args.Role
+	username := ""
+	if userInfo != nil {
+		username = userInfo.Name
+	}
+	detail := "用户：" + username + "，角色名称：" + args.Role
 	internalhandler.InsertDetailedOperationLog(c, ctx.UserName, projectName, setting.OperationSceneProject, "更新", "角色绑定", detail, string(data), ctx.Logger, args.Name)
 
 	ctx.Err = service.UpdateOrCreateRoleBinding(projectName, args, ctx.Logger)
@@ -108,7 +113,11 @@ func CreateRoleBinding(c *gin.Context) {
 			ctx.Err = e.ErrInvalidParam.AddErr(err)
 			return
 		}
-		detail += "用户：" + userInfo.Name + "，角色名称：" + arg.Role + "\n"
+		username := ""
+		if userInfo != nil {
+			username = userInfo.Name
+		}
+		detail += "用户：" + username + "，角色名称：" + arg.Role + "\n"
 	}
 	internalhandler.InsertDetailedOperationLog(c, ctx.UserName, projectName, setting.OperationSceneProject, "创建", "角色绑定", detail, string(data), ctx.Logger, "")
 
@@ -162,13 +171,23 @@ func DeleteRoleBindings(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam.AddErr(err)
 		return
 	}
-	detail := "用户：" + userInfo.Name + "，角色名称："
+
+	username := ""
+	if userInfo != nil {
+		username = userInfo.Name
+	}
+	detail := "用户：" + username + "，角色名称："
 	for _, name := range args.Names {
 		detail += name + "，"
 	}
 	detail = strings.Trim(detail, "，")
 
 	internalhandler.InsertDetailedOperationLog(c, ctx.UserName, projectName, setting.OperationSceneProject, "删除", "角色绑定", projectName, detail, ctx.Logger, args.Names...)
+
+	_, err = picketuser.New().DeleteUser(userID, c.Request.Header, c.Request.URL.Query())
+	if err != nil {
+		return
+	}
 
 	ctx.Err = service.DeleteRoleBindings(args.Names, projectName, userID, ctx.Logger)
 }
@@ -206,7 +225,12 @@ func UpdateRoleBindings(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam.AddErr(err)
 		return
 	}
-	detail := "用户：" + userInfo.Name + "，角色名称："
+
+	username := ""
+	if userInfo != nil {
+		username = userInfo.Name
+	}
+	detail := "用户：" + username + "，角色名称："
 	for _, arg := range args {
 		detail += arg.Role + "，"
 	}
@@ -265,7 +289,12 @@ func UpdateSystemRoleBindings(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam.AddErr(err)
 		return
 	}
-	detail := "用户：" + userInfo.Name + "，角色名称："
+
+	username := ""
+	if userInfo != nil {
+		username = userInfo.Name
+	}
+	detail := "用户：" + username + "，角色名称："
 	for _, arg := range args {
 		detail += arg.Role + "，"
 	}
@@ -311,7 +340,12 @@ func CreateSystemRoleBinding(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam.AddErr(err)
 		return
 	}
-	detail := "用户：" + userInfo.Name + "，角色名称：" + args.Role
+
+	username := ""
+	if userInfo != nil {
+		username = userInfo.Name
+	}
+	detail := "用户：" + username + "，角色名称：" + args.Role
 	internalhandler.InsertDetailedOperationLog(c, ctx.UserName, "", setting.OperationSceneSystem, "创建", "系统角色绑定", detail, string(data), ctx.Logger, args.Name)
 
 	ctx.Err = service.CreateRoleBindings(service.SystemScope, []*service.RoleBinding{args}, ctx.Logger)
@@ -342,7 +376,12 @@ func CreateOrUpdateSystemRoleBinding(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam.AddErr(err)
 		return
 	}
-	detail := "用户：" + userInfo.Name + "，角色名称：" + args.Role
+
+	username := ""
+	if userInfo != nil {
+		username = userInfo.Name
+	}
+	detail := "用户：" + username + "，角色名称：" + args.Role
 	internalhandler.InsertDetailedOperationLog(c, ctx.UserName, "", setting.OperationSceneSystem, "创建或更新", "系统角色绑定", detail, string(data), ctx.Logger, args.Name)
 
 	ctx.Err = service.CreateOrUpdateSystemRoleBinding(service.SystemScope, args, ctx.Logger)


### PR DESCRIPTION
### What this PR does / Why we need it:

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6c5ed26</samp>

This pull request improves the logging and user management for the collaboration and policy services. It adds a new function to format log messages for collaboration mode operations, and uses the picket user client to delete users from the picket service when deleting role bindings. It also removes a redundant call to delete users from the picket service in the picket filter.

### What is changed and how it works?

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6c5ed26</samp>

*  Added a new function `generateCollaborationDetailLog` to generate more detailed log messages for creating and updating collaboration modes in `collaboration_mode.go` ([link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-f29cd0ff5062a67ed7549e284c8218dc96602a3302d704a12b0c151119622a44R117-R169))
*  Called `generateCollaborationDetailLog` and handled the possible error in the `CreateCollaborationMode` and `UpdateCollaborationMode` handlers in `collaboration_mode.go` ([link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-f29cd0ff5062a67ed7549e284c8218dc96602a3302d704a12b0c151119622a44L60-R71), [link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-f29cd0ff5062a67ed7549e284c8218dc96602a3302d704a12b0c151119622a44L82-R99))
*  Added new imports for `fmt`, `strings`, and `go.uber.org/zap` in `collaboration_mode.go` ([link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-f29cd0ff5062a67ed7549e284c8218dc96602a3302d704a12b0c151119622a44L21-R30))
*  Moved the user deletion logic from the picket user service to the role binding handler in `role_binding.go` ([link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-08964597859f8341cdd472db331ab9db191fb0cdc9fb88c941c8bdbc84221a42L36-L39), [link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50R187-R191))
*  Called `picketuser.New().DeleteUser` and handled the possible error in the `DeleteRoleBindings` handler in `role_binding.go` ([link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50R187-R191))
*  Added a new import for `github.com/koderover/zadig/pkg/microservice/picket/client/user` as `picketuser` in `role_binding.go` ([link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50R26))
*  Added checks for the `userInfo` variable and assigned the `username` variable accordingly in various handlers in `role_binding.go` ([link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L65-R70), [link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L111-R120), [link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L165-R179), [link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L209-R233), [link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L268-R297), [link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L314-R348), [link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L345-R384))
*  Used the `username` variable to generate the log detail for creating, updating, and deleting role bindings in `role_binding.go` ([link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L65-R70), [link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L111-R120), [link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L165-R179), [link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L209-R233), [link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L268-R297), [link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L314-R348), [link](https://github.com/koderover/zadig/pull/2813/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L345-R384))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue


