### PR TITLE
fix: release workflow ignore nil selector service

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/kube.go
+++ b/pkg/microservice/aslan/core/environment/service/kube.go
@@ -712,6 +712,9 @@ func ListCanaryDeploymentServiceInfo(clusterID, namespace string, log *zap.Sugar
 		return resp, err
 	}
 	for _, service := range services {
+		if service.Spec.Selector == nil {
+			continue
+		}
 		deploymentContainers := &ServiceMatchedDeploymentContainers{
 			ServiceName: service.Name,
 		}


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a02930</samp>

Fix a potential panic in `ListCanaryDeploymentServiceInfo` by skipping services with no selector labels. This prevents errors when fetching service information for canary deployments in `pkg/microservice/aslan/core/environment/service/kube.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4a02930</samp>

* Skip services with no selector labels in `ListCanaryDeploymentServiceInfo` to avoid panic ([link](https://github.com/koderover/zadig/pull/2821/files?diff=unified&w=0#diff-911246577caa021c865066caebafafc4a263bfd1fa3cac432a1ce75d598df345R715-R717))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
