### PR TITLE
CP 2821

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/delivery_deploy.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/delivery_deploy.go
@@ -61,6 +61,7 @@ func (c *DeliveryDeployColl) EnsureIndex(ctx context.Context) error {
 			Keys: bson.D{
 				bson.E{Key: "release_id", Value: 1},
 				bson.E{Key: "service_name", Value: 1},
+				bson.E{Key: "container_name", Value: 1},
 				bson.E{Key: "deleted_at", Value: 1},
 			},
 			Options: options.Index().SetUnique(true),
@@ -74,8 +75,9 @@ func (c *DeliveryDeployColl) EnsureIndex(ctx context.Context) error {
 		},
 	}
 
+	_, _ = c.Indexes().DropOne(ctx, "release_id_1_service_name_1_deleted_at_1")
 	_, err := c.Indexes().CreateMany(ctx, mod)
-
+	
 	return err
 }
 

--- a/pkg/microservice/aslan/core/environment/service/kube.go
+++ b/pkg/microservice/aslan/core/environment/service/kube.go
@@ -712,6 +712,9 @@ func ListCanaryDeploymentServiceInfo(clusterID, namespace string, log *zap.Sugar
 		return resp, err
 	}
 	for _, service := range services {
+		if service.Spec.Selector == nil {
+			continue
+		}
 		deploymentContainers := &ServiceMatchedDeploymentContainers{
 			ServiceName: service.Name,
 		}


### PR DESCRIPTION
Signed-off-by: M-Cosmosss <yuzhou@koderover.com>### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e3f069b</samp>

This pull request improves the query performance of the delivery service by updating the MongoDB indexes of the `delivery_deploy` collection, and fixes a potential nil pointer dereference bug in the `ListCanaryDeploymentServiceInfo` function that handles canary deployments in Kubernetes.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e3f069b</samp>

*  Add and drop indexes on `delivery_deploy` collection to improve query performance ([link](https://github.com/koderover/zadig/pull/2822/files?diff=unified&w=0#diff-8d977008094a1e697d76e272986ccffa857d0be662e38be7da6a1c5d1583ed88R64), [link](https://github.com/koderover/zadig/pull/2822/files?diff=unified&w=0#diff-8d977008094a1e697d76e272986ccffa857d0be662e38be7da6a1c5d1583ed88L77-R80))
* Add nil check for `selector` field of `service` object to prevent nil pointer error ([link](https://github.com/koderover/zadig/pull/2822/files?diff=unified&w=0#diff-911246577caa021c865066caebafafc4a263bfd1fa3cac432a1ce75d598df345R715-R717))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
