### PR TITLE
remove selector label

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/apply.go
+++ b/pkg/microservice/aslan/core/common/service/kube/apply.go
@@ -293,16 +293,6 @@ func CreateOrPatchResource(applyParam *ResourceApplyParam, log *zap.SugaredLogge
 			u.SetNamespace(namespace)
 			u.SetLabels(MergeLabels(labels, u.GetLabels()))
 
-			//if _, ok := u.GetLabels()["endpoints"]; !ok {
-			//	selector, _, _ := unstructured.NestedStringMap(u.Object, "spec", "selector")
-			//	err := unstructured.SetNestedStringMap(u.Object, selector, "spec", "selector")
-			//	if err != nil {
-			//		errList = multierror.Append(errList, errors.Wrapf(err, "failed to set nested string map for service: %v, err: %s", applyParam.ServiceName, err))
-			//		log.Errorf("failed to set nested string map: %v", err)
-			//		continue
-			//	}
-			//}
-
 			err = updater.CreateOrPatchUnstructured(u, kubeClient)
 			if err != nil {
 				log.Errorf("Failed to create or update %s, manifest is\n%v\n, error: %v", u.GetKind(), u, err)

--- a/pkg/microservice/aslan/core/common/service/kube/apply.go
+++ b/pkg/microservice/aslan/core/common/service/kube/apply.go
@@ -293,15 +293,15 @@ func CreateOrPatchResource(applyParam *ResourceApplyParam, log *zap.SugaredLogge
 			u.SetNamespace(namespace)
 			u.SetLabels(MergeLabels(labels, u.GetLabels()))
 
-			if _, ok := u.GetLabels()["endpoints"]; !ok {
-				selector, _, _ := unstructured.NestedStringMap(u.Object, "spec", "selector")
-				err := unstructured.SetNestedStringMap(u.Object, MergeLabels(labels, selector), "spec", "selector")
-				if err != nil {
-					errList = multierror.Append(errList, errors.Wrapf(err, "failed to set nested string map for service: %v, err: %s", applyParam.ServiceName, err))
-					log.Errorf("failed to set nested string map: %v", err)
-					continue
-				}
-			}
+			//if _, ok := u.GetLabels()["endpoints"]; !ok {
+			//	selector, _, _ := unstructured.NestedStringMap(u.Object, "spec", "selector")
+			//	err := unstructured.SetNestedStringMap(u.Object, selector, "spec", "selector")
+			//	if err != nil {
+			//		errList = multierror.Append(errList, errors.Wrapf(err, "failed to set nested string map for service: %v, err: %s", applyParam.ServiceName, err))
+			//		log.Errorf("failed to set nested string map: %v", err)
+			//		continue
+			//	}
+			//}
 
 			err = updater.CreateOrPatchUnstructured(u, kubeClient)
 			if err != nil {


### PR DESCRIPTION
### What this PR does / Why we need it:
remove unnesessary selector lables when updating services 

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9a723f7</samp>

*  Removed the selector field from the service resource to avoid conflicts with the endpoints resource ([link](https://github.com/koderover/zadig/pull/2825/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L296-R304))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
