### PR TITLE
WIP: zadig openapi v2

### DIFF
--- a/pkg/microservice/aslan/config/consts.go
+++ b/pkg/microservice/aslan/config/consts.go
@@ -479,3 +479,9 @@ const (
 const (
 	CUSTOME_THEME = "custom"
 )
+
+const (
+	TestFunction    = "function"
+	TestPerformance = "performance"
+	TestSecurity    = "security"
+)

--- a/pkg/microservice/aslan/core/workflow/testing/handler/openapi.go
+++ b/pkg/microservice/aslan/core/workflow/testing/handler/openapi.go
@@ -17,6 +17,10 @@ limitations under the License.
 package handler
 
 import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
 	"github.com/gin-gonic/gin"
 
 	testingservice "github.com/koderover/zadig/pkg/microservice/aslan/core/workflow/testing/service"
@@ -41,4 +45,51 @@ func OpenAPICreateScanningModule(c *gin.Context) {
 	}
 
 	ctx.Err = testingservice.OpenAPICreateScanningModule(ctx.UserName, args, ctx.Logger)
+}
+
+func OpenAPICreateTestTask(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	args := new(testingservice.OpenAPICreateTestTaskReq)
+	data, err := c.GetRawData()
+	if err != nil {
+		ctx.Logger.Errorf("CreateTestTask c.GetRawData() err : %v", err)
+	}
+	if err = json.Unmarshal(data, args); err != nil {
+		ctx.Logger.Errorf("CreateTestTask json.Unmarshal err : %v", err)
+	}
+
+	isValid, err := args.Validate()
+	if !isValid {
+		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+	internalhandler.InsertOperationLog(c, ctx.UserName, args.ProjectKey, "新增", "OpenAPI"+"测试-task", fmt.Sprintf("%s-%s", args.TestName, "job"), string(data), ctx.Logger)
+
+	taskID, err := testingservice.OpenAPICreateTestTask(ctx.UserName, args, ctx.Logger)
+	ctx.Resp = testingservice.OpenAPICreateTestTaskResp{
+		TaskID: taskID,
+	}
+	ctx.Err = err
+}
+
+func OpenAPIGetTestTaskResult(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	taskID, err := strconv.ParseInt(c.Param("taskID"), 10, 64)
+	if err != nil {
+		ctx.Err = e.ErrInvalidParam.AddDesc("invalid taskID")
+		return
+	}
+	// projectName is display name in db and productName is project unique key in db
+	productName := c.Query("projectName")
+	testName := c.Query("testName")
+	if taskID == 0 || productName == "" || testName == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("invalid params")
+		return
+	}
+
+	ctx.Resp, ctx.Err = testingservice.OpenAPIGetTestTaskResult(taskID, productName, testName, ctx.Logger)
 }

--- a/pkg/microservice/aslan/core/workflow/testing/handler/router.go
+++ b/pkg/microservice/aslan/core/workflow/testing/handler/router.go
@@ -111,4 +111,10 @@ func (*QualityRouter) Inject(router *gin.RouterGroup) {
 	{
 		scan.POST("", OpenAPICreateScanningModule)
 	}
+
+	test := router.Group("testing")
+	{
+		test.POST("/task", OpenAPICreateTestTask)
+		test.GET("/task/:taskID/pipeline/:pipelineName", OpenAPIGetTestTaskResult)
+	}
 }

--- a/pkg/microservice/aslan/core/workflow/testing/service/types.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/types.go
@@ -176,3 +176,24 @@ func ConvertDBScanningModule(scanning *commonmodels.Scanning) *Scanning {
 		Outputs:          scanning.Outputs,
 	}
 }
+
+type OpenAPICreateTestTaskReq struct {
+	ProjectKey string `json:"project_key"`
+	TestName   string `json:"test_name"`
+}
+
+func (t *OpenAPICreateTestTaskReq) Validate() (bool, error) {
+	if t.ProjectKey == "" {
+		return false, fmt.Errorf("project key cannot be empty")
+	}
+	if t.TestName == "" {
+		return false, fmt.Errorf("test name cannot be empty")
+	}
+
+	return true, nil
+}
+
+type OpenAPICreateTestTaskResp struct {
+	TaskID     int64 `json:"task_id"`
+	ErrMessage error `json:"err_message"`
+}


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 560f3d0</samp>

Added support for creating and getting openapi test tasks in the testing package. This involves adding new handler and service functions, routes, types, and constants for the openapi test logic. Modified files are `openapi.go`, `router.go`, `types.go`, and `consts.go` in the `testing` package.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 560f3d0</samp>

*  Add constants for test types ([link](https://github.com/koderover/zadig/pull/2828/files?diff=unified&w=0#diff-b75a929528a6cc3d65392ca838a5f63796ed0a4ec0f239f69a4e8c4bf61ba04cR482-R487))
*  Implement handler functions for openapi test requests ([link](https://github.com/koderover/zadig/pull/2828/files?diff=unified&w=0#diff-3869d8942bf28c324a4d1b2755bb7ec36d7b0b5d9650132c9420db277c173a5fR20-R23), [link](https://github.com/koderover/zadig/pull/2828/files?diff=unified&w=0#diff-3869d8942bf28c324a4d1b2755bb7ec36d7b0b5d9650132c9420db277c173a5fR49-R95))
*  Add routes for openapi test requests to `router.go` ([link](https://github.com/koderover/zadig/pull/2828/files?diff=unified&w=0#diff-8d298c3819fc5f4b8bc2893b8ddb88d260d1831de31160ae860bf3d6b2d55637R114-R119))
   * `/task` maps to `OpenAPICreateTestTask` handler function ([link](https://github.com/koderover/zadig/pull/2828/files?diff=unified&w=0#diff-8d298c3819fc5f4b8bc2893b8ddb88d260d1831de31160ae860bf3d6b2d55637R114-R119))
   * `/task/:taskID/pipeline/:pipelineName` maps to `OpenAPIGetTestTaskResult` handler function ([link](https://github.com/koderover/zadig/pull/2828/files?diff=unified&w=0#diff-8d298c3819fc5f4b8bc2893b8ddb88d260d1831de31160ae860bf3d6b2d55637R114-R119))
*  Implement service functions for openapi test tasks ([link](https://github.com/koderover/zadig/pull/2828/files?diff=unified&w=0#diff-56f097cd49c8e9ac38eaa59e10932b66d0ae2ee643a78efb18c4f6e3e4ee3fd7L23-R29), [link](https://github.com/koderover/zadig/pull/2828/files?diff=unified&w=0#diff-56f097cd49c8e9ac38eaa59e10932b66d0ae2ee643a78efb18c4f6e3e4ee3fd7R96-R119))
*  Add types for openapi test task request and response ([link](https://github.com/koderover/zadig/pull/2828/files?diff=unified&w=0#diff-c76ce97d0bbad006a475686268fd2e1bab3ea25b780e963aaf9fa3e7182b61bcR179-R199))
   * `OpenAPICreateTestTaskReq` defines request body and has `Validate` method ([link](https://github.com/koderover/zadig/pull/2828/files?diff=unified&w=0#diff-c76ce97d0bbad006a475686268fd2e1bab3ea25b780e963aaf9fa3e7182b61bcR179-R199))
   * `OpenAPICreateTestTaskResp` defines response body and has `TaskID` and `ErrMessage` fields ([link](https://github.com/koderover/zadig/pull/2828/files?diff=unified&w=0#diff-c76ce97d0bbad006a475686268fd2e1bab3ea25b780e963aaf9fa3e7182b61bcR179-R199))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
