### PR TITLE
logout feature for special case

### DIFF
--- a/pkg/microservice/user/config/consts.go
+++ b/pkg/microservice/user/config/consts.go
@@ -24,6 +24,7 @@ const (
 	AppState           = setting.ProductName + "user"
 	SystemIdentityType = "system"
 	OauthIdentityType  = "oauth"
+	CLICIdentityType   = "clic"
 	FeiShuEmailHost    = "smtp.feishu.cn"
 )
 
@@ -32,3 +33,16 @@ type LoginType int
 const (
 	AccountLoginType LoginType = 0
 )
+
+type CLICConnectorConfig struct {
+	ClientID           string   `json:"clientID"`
+	ClientSecret       string   `json:"clientSecret"`
+	SystemURL          string   `json:"systemURL"`
+	RedirectURI        string   `json:"redirectURI"`
+	TokenURL           string   `json:"tokenURL"`
+	AuthorizationURL   string   `json:"authorizationURL"`
+	LogoutURL          string   `json:"logoutURL"`
+	UserInfoURL        string   `json:"userInfoURL"`
+	Scopes             []string `json:"scopes"`
+	InsecureSkipVerify bool     `json:"insecureSkipVerify"`
+}

--- a/pkg/microservice/user/core/service/login/local.go
+++ b/pkg/microservice/user/core/service/login/local.go
@@ -227,7 +227,7 @@ func LocalLogout(userID string, logger *zap.SugaredLogger) (bool, string, error)
 			}
 		}
 
-		redirectURL := fmt.Sprintf("%s?%s", connConfig.LogoutURL, url.QueryEscape(connConfig.SystemURL))
+		redirectURL := fmt.Sprintf("%s?service=%s", connConfig.LogoutURL, url.QueryEscape(connConfig.SystemURL))
 		return true, redirectURL, nil
 	}
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f308dcc</samp>

Add support for CLIC as a new external identity provider for user authentication and logout. Modify `consts.go` and `local.go` in the `user` microservice to handle CLIC config and logout URL.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f308dcc</samp>

*  Add support for CLIC identity provider for user authentication ([link](https://github.com/koderover/zadig/pull/2834/files?diff=unified&w=0#diff-a88a919c2716cd5a7f3b0ff7f279275e1c48a66633932aac635d3b9036d3b920R27), [link](https://github.com/koderover/zadig/pull/2834/files?diff=unified&w=0#diff-a88a919c2716cd5a7f3b0ff7f279275e1c48a66633932aac635d3b9036d3b920R36-R48), [link](https://github.com/koderover/zadig/pull/2834/files?diff=unified&w=0#diff-6edc8543c3f426bae078caf11911512ccec56b3c70e9e89d19db91b4d56eefc7L20-R22), [link](https://github.com/koderover/zadig/pull/2834/files?diff=unified&w=0#diff-6edc8543c3f426bae078caf11911512ccec56b3c70e9e89d19db91b4d56eefc7L198-R231))
  - Define a new constant `CLICIdentityType` in `consts.go` to identify the CLIC identity type ([link](https://github.com/koderover/zadig/pull/2834/files?diff=unified&w=0#diff-a88a919c2716cd5a7f3b0ff7f279275e1c48a66633932aac635d3b9036d3b920R27))
  - Define a new struct `CLICConnectorConfig` in `consts.go` to store the configuration fields for the CLIC connector, such as client ID, client secret, URLs, scopes, and insecure skip verify flag ([link](https://github.com/koderover/zadig/pull/2834/files?diff=unified&w=0#diff-a88a919c2716cd5a7f3b0ff7f279275e1c48a66633932aac635d3b9036d3b920R36-R48))
  - Import `encoding/json` and `net/url` packages in `local.go` to parse the CLIC connector config and construct the redirect URL for CLIC logout ([link](https://github.com/koderover/zadig/pull/2834/files?diff=unified&w=0#diff-6edc8543c3f426bae078caf11911512ccec56b3c70e9e89d19db91b4d56eefc7L20-R22))
  - Modify the `LocalLogout` function in `local.go` to handle the case when the user's identity type is `CLICIdentityType` by querying the CLIC connector info from the database, parsing the config, and returning a redirect URL for CLIC logout ([link](https://github.com/koderover/zadig/pull/2834/files?diff=unified&w=0#diff-6edc8543c3f426bae078caf11911512ccec56b3c70e9e89d19db91b4d56eefc7L198-R231))
  - Restructure the original branch for `OauthIdentityType` in the `LocalLogout` function to make it more readable and consistent ([link](https://github.com/koderover/zadig/pull/2834/files?diff=unified&w=0#diff-6edc8543c3f426bae078caf11911512ccec56b3c70e9e89d19db91b4d56eefc7L198-R231))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
