### PR TITLE
fix: should filter apollo empty line config

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_apollo.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_apollo.go
@@ -61,6 +61,9 @@ func (j *ApolloJob) SetPreset() error {
 			continue
 		}
 		for _, item := range result.Items {
+			if item.Key == "" {
+				continue
+			}
 			namespace.KeyValList = append(namespace.KeyValList, &commonmodels.ApolloKV{
 				Key: item.Key,
 				Val: item.Value,


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 560bedd</samp>

Skip empty keys in preset map for apollo service. This prevents setting empty environment variables that could cause errors or unexpected behavior in `job_apollo.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 560bedd</samp>

* Skip empty keys in the preset map to avoid setting empty environment variables for the apollo service ([link](https://github.com/koderover/zadig/pull/2840/files?diff=unified&w=0#diff-47f0982b1d8d9c52aff2c06f30179ab1ccddbf548cd3a6590d80e865b116dd42R64-R66))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
