### PR TITLE
fix error when fetch service workloads

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -189,21 +189,25 @@ func GetService(envName, productName, serviceName string, production bool, workL
 		return nil, e.ErrGetService.AddErr(err)
 	}
 
-	productSvc := env.GetServiceMap()[serviceName]
-	if productSvc == nil {
-		return nil, e.ErrGetService.AddErr(fmt.Errorf("failed to find service %s in product %s", serviceName, productName))
+	projectType := getProjectType(productName)
+	var serviceTmpl *commonmodels.Service
+	if projectType == setting.K8SDeployType {
+		productSvc := env.GetServiceMap()[serviceName]
+		if productSvc == nil {
+			return nil, e.ErrGetService.AddErr(fmt.Errorf("failed to find service %s in product %s", serviceName, productName))
+		}
+
+		serviceTmpl, err = repository.QueryTemplateService(&commonrepo.ServiceFindOption{
+			ServiceName: serviceName,
+			Revision:    productSvc.Revision,
+			ProductName: productSvc.ProductName,
+		}, env.Production)
+		if err != nil {
+			return nil, e.ErrGetService.AddErr(fmt.Errorf("failed to find template service %s in product %s", serviceName, productName))
+		}
 	}
 
-	serviceTmpl, err := repository.QueryTemplateService(&commonrepo.ServiceFindOption{
-		ServiceName: serviceName,
-		Revision:    productSvc.Revision,
-		ProductName: productSvc.ProductName,
-	}, env.Production)
-	if err != nil {
-		return nil, e.ErrGetService.AddErr(fmt.Errorf("failed to find template service %s in product %s", serviceName, productName))
-	}
-
-	ret, err = GetServiceImpl(serviceTmpl, workLoadType, env, clientset, inf, log)
+	ret, err = GetServiceImpl(serviceName, serviceTmpl, workLoadType, env, clientset, inf, log)
 	if err != nil {
 		return nil, e.ErrGetService.AddErr(err)
 	}
@@ -305,8 +309,8 @@ func GetServiceWorkloads(svcTmpl *commonmodels.Service, env *commonmodels.Produc
 	return ret, nil
 }
 
-func GetServiceImpl(serviceTmpl *commonmodels.Service, workLoadType string, env *commonmodels.Product, clientset *kubernetes.Clientset, inf informers.SharedInformerFactory, log *zap.SugaredLogger) (ret *SvcResp, err error) {
-	envName, productName, serviceName := env.EnvName, env.ProductName, serviceTmpl.ServiceName
+func GetServiceImpl(serviceName string, serviceTmpl *commonmodels.Service, workLoadType string, env *commonmodels.Product, clientset *kubernetes.Clientset, inf informers.SharedInformerFactory, log *zap.SugaredLogger) (ret *SvcResp, err error) {
+	envName, productName := env.EnvName, env.ProductName
 	ret = &SvcResp{
 		ServiceName: serviceName,
 		EnvName:     envName,
@@ -717,7 +721,7 @@ func queryPodsStatus(productInfo *commonmodels.Product, serviceTmpl *commonmodel
 		return resp
 	}
 
-	svcResp, err := GetServiceImpl(serviceTmpl, "", productInfo, clientset, informer, log)
+	svcResp, err := GetServiceImpl(serviceTmpl.ServiceName, serviceTmpl, "", productInfo, clientset, informer, log)
 	if err != nil {
 		return resp
 	}


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a74f45</samp>

This pull request improves the `GetServiceImpl` function to support more project and service types. It also fixes a bug where the wrong service template was used for non-k8s projects.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a74f45</samp>

*  Add a condition to check the project type and pass the service name to `GetServiceImpl` for helm or kustomize projects ([link](https://github.com/koderover/zadig/pull/2849/files?diff=unified&w=0#diff-06d37031b76a99e605f5abab3018e3a09695d7723162586b7dcaec04a6c23864L192-R210))
*  Change the signature of `GetServiceImpl` to accept the service name and the service template as parameters, and update the references to the service name in the function body ([link](https://github.com/koderover/zadig/pull/2849/files?diff=unified&w=0#diff-06d37031b76a99e605f5abab3018e3a09695d7723162586b7dcaec04a6c23864L308-R313))
*  Update the call to `GetServiceImpl` in `queryPodsStatus` to match the new signature and pass the service name and the service template as arguments ([link](https://github.com/koderover/zadig/pull/2849/files?diff=unified&w=0#diff-06d37031b76a99e605f5abab3018e3a09695d7723162586b7dcaec04a6c23864L720-R724))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
