### PR TITLE
开发流程 声明变量export IMAGE_REPOSITOR 与 makefile 中变量不一致IMAGE_REPOSITORY。

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@
 # Please make sure you have the right version of docker.
 .PHONY: microservice.push swag
 
-IMAGE_REPOSITORY = koderover.tencentcloudcr.com/koderover-public
+IMAGE_REPOSITORY ?= koderover.tencentcloudcr.com/koderover-public
+IMAGE_REPOSITORY := $(IMAGE_REPOSITORY)
+
 VERSION ?= $(shell date +'%Y%m%d%H%M%S')
 VERSION := $(VERSION)
 MICROSERVICE_TARGETS = aslan cron executor hub-agent hub-server init jenkins-plugin packager-plugin predator-plugin ua warpdrive

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,7 @@
 # Please make sure you have the right version of docker.
 .PHONY: microservice.push swag
 
-IMAGE_REPOSITORY ?= koderover.tencentcloudcr.com/koderover-public
-IMAGE_REPOSITORY := $(IMAGE_REPOSITORY)
-
+IMAGE_REPOSITORY = koderover.tencentcloudcr.com/koderover-public
 VERSION ?= $(shell date +'%Y%m%d%H%M%S')
 VERSION := $(VERSION)
 MICROSERVICE_TARGETS = aslan cron executor hub-agent hub-server init jenkins-plugin packager-plugin predator-plugin ua warpdrive

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 # Please make sure you have the right version of docker.
 .PHONY: microservice.push swag
 
-IMAGE_REPOSITORY = koderover.tencentcloudcr.com/koderover-public
+IMAGE_REPOSITORY ?= koderover.tencentcloudcr.com/koderover-public
+IMAGE_REPOSITORY := $(IMAGE_REPOSITORY)
 VERSION ?= $(shell date +'%Y%m%d%H%M%S')
 VERSION := $(VERSION)
 MICROSERVICE_TARGETS = aslan cron executor hub-agent hub-server init jenkins-plugin packager-plugin predator-plugin ua warpdrive

--- a/community/dev/contributor-workflow.md
+++ b/community/dev/contributor-workflow.md
@@ -45,7 +45,7 @@ Zadig 后端使用 Go 语言，在您贡献代码之前，本地需安装 Go 1.1
 > 服务列表：aslan cron hub-server hub-agent resource-server predator-plugin ua warpdrive
 > 请确认当前构建环境有推送镜像至开发环境的远端仓库的权限
 
-1. 执行 `export IMAGE_REPOSITOR={YOUR_IMAGE_REGISTRY_URL}`指定目标镜像仓库地址
+1. 执行 `export IMAGE_REPOSITORY={YOUR_IMAGE_REGISTRY_URL}`指定目标镜像仓库地址
 2. 执行 `export VERSION={YOUR_IMAGE_TAG}` 指定镜像 TAG
 3. 在 zadig 代码库根目录执行 `make {SERVICE}.push` 构建出镜像并上传至镜像仓库
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d11bfcb</samp>

Fixed a typo in the documentation for the backend build process in Chinese. The variable `IMAGE_REPOSITORY` was used consistently in the `community/dev/contributor-workflow.md` file.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d11bfcb</samp>

* Fix a typo in the variable name `IMAGE_REPOSITORY` in the Chinese documentation for the backend build process ([link](https://github.com/koderover/zadig/pull/2853/files?diff=unified&w=0#diff-b76dfce833abb4badecc3b040ccc3a1dc1a0965fbfa863a935acf0aaaa111214L48-R48))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [x] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
