### PR TITLE
fix development documentation error and Makefile not taking effect for the IMAGE_REPOSITORY variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 # Please make sure you have the right version of docker.
 .PHONY: microservice.push swag
 
-IMAGE_REPOSITORY = koderover.tencentcloudcr.com/koderover-public
+IMAGE_REPOSITORY ?= koderover.tencentcloudcr.com/koderover-public
+IMAGE_REPOSITORY := $(IMAGE_REPOSITORY)
 VERSION ?= $(shell date +'%Y%m%d%H%M%S')
 VERSION := $(VERSION)
 MICROSERVICE_TARGETS = aslan cron executor hub-agent hub-server init jenkins-plugin packager-plugin predator-plugin ua warpdrive

--- a/community/dev/contributor-workflow.md
+++ b/community/dev/contributor-workflow.md
@@ -52,7 +52,7 @@ Zadig 后端使用 Go 语言，在您贡献代码之前，本地需安装 Go 1.1
 ### 前端构建
 > 请确认当前构建环境有推送镜像至远端仓库的权限
 1. 切换至 zadig-portal 目录
-2. 执行 `export IMAGE_REPOSITOR={YOUR_IMAGE_REGISTRY_URL}`指定目标镜像仓库地址
+2. 执行 `export IMAGE_REPOSITORY={YOUR_IMAGE_REGISTRY_URL}`指定目标镜像仓库地址
 3. 执行 `export VERSION={YOUR_IMAGE_TAG}` 指定镜像 TAG
 4. 执行 make all 构建镜像并上传至镜像仓库
 

--- a/community/dev/contributor-workflow.md
+++ b/community/dev/contributor-workflow.md
@@ -45,7 +45,7 @@ Zadig 后端使用 Go 语言，在您贡献代码之前，本地需安装 Go 1.1
 > 服务列表：aslan cron hub-server hub-agent resource-server predator-plugin ua warpdrive
 > 请确认当前构建环境有推送镜像至开发环境的远端仓库的权限
 
-1. 执行 `export IMAGE_REPOSITOR={YOUR_IMAGE_REGISTRY_URL}`指定目标镜像仓库地址
+1. 执行 `export IMAGE_REPOSITORY={YOUR_IMAGE_REGISTRY_URL}`指定目标镜像仓库地址
 2. 执行 `export VERSION={YOUR_IMAGE_TAG}` 指定镜像 TAG
 3. 在 zadig 代码库根目录执行 `make {SERVICE}.push` 构建出镜像并上传至镜像仓库
 

--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -189,21 +189,25 @@ func GetService(envName, productName, serviceName string, production bool, workL
 		return nil, e.ErrGetService.AddErr(err)
 	}
 
-	productSvc := env.GetServiceMap()[serviceName]
-	if productSvc == nil {
-		return nil, e.ErrGetService.AddErr(fmt.Errorf("failed to find service %s in product %s", serviceName, productName))
+	projectType := getProjectType(productName)
+	var serviceTmpl *commonmodels.Service
+	if projectType == setting.K8SDeployType {
+		productSvc := env.GetServiceMap()[serviceName]
+		if productSvc == nil {
+			return nil, e.ErrGetService.AddErr(fmt.Errorf("failed to find service %s in product %s", serviceName, productName))
+		}
+
+		serviceTmpl, err = repository.QueryTemplateService(&commonrepo.ServiceFindOption{
+			ServiceName: serviceName,
+			Revision:    productSvc.Revision,
+			ProductName: productSvc.ProductName,
+		}, env.Production)
+		if err != nil {
+			return nil, e.ErrGetService.AddErr(fmt.Errorf("failed to find template service %s in product %s", serviceName, productName))
+		}
 	}
 
-	serviceTmpl, err := repository.QueryTemplateService(&commonrepo.ServiceFindOption{
-		ServiceName: serviceName,
-		Revision:    productSvc.Revision,
-		ProductName: productSvc.ProductName,
-	}, env.Production)
-	if err != nil {
-		return nil, e.ErrGetService.AddErr(fmt.Errorf("failed to find template service %s in product %s", serviceName, productName))
-	}
-
-	ret, err = GetServiceImpl(serviceTmpl, workLoadType, env, clientset, inf, log)
+	ret, err = GetServiceImpl(serviceName, serviceTmpl, workLoadType, env, clientset, inf, log)
 	if err != nil {
 		return nil, e.ErrGetService.AddErr(err)
 	}
@@ -305,8 +309,8 @@ func GetServiceWorkloads(svcTmpl *commonmodels.Service, env *commonmodels.Produc
 	return ret, nil
 }
 
-func GetServiceImpl(serviceTmpl *commonmodels.Service, workLoadType string, env *commonmodels.Product, clientset *kubernetes.Clientset, inf informers.SharedInformerFactory, log *zap.SugaredLogger) (ret *SvcResp, err error) {
-	envName, productName, serviceName := env.EnvName, env.ProductName, serviceTmpl.ServiceName
+func GetServiceImpl(serviceName string, serviceTmpl *commonmodels.Service, workLoadType string, env *commonmodels.Product, clientset *kubernetes.Clientset, inf informers.SharedInformerFactory, log *zap.SugaredLogger) (ret *SvcResp, err error) {
+	envName, productName := env.EnvName, env.ProductName
 	ret = &SvcResp{
 		ServiceName: serviceName,
 		EnvName:     envName,
@@ -717,7 +721,7 @@ func queryPodsStatus(productInfo *commonmodels.Product, serviceTmpl *commonmodel
 		return resp
 	}
 
-	svcResp, err := GetServiceImpl(serviceTmpl, "", productInfo, clientset, informer, log)
+	svcResp, err := GetServiceImpl(serviceTmpl.ServiceName, serviceTmpl, "", productInfo, clientset, informer, log)
 	if err != nil {
 		return resp
 	}


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6e98827</samp>

This pull request fixes a typo in the contributor workflow document and adds flexibility to the `IMAGE_REPOSITORY` variable in the `Makefile`. These changes improve the documentation and the build process for zadig.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6e98827</samp>

*  Allow customizing image registry URL by reading `IMAGE_REPOSITORY` value from the environment ([link](https://github.com/koderover/zadig/pull/2854/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L7-R8))
*  Fix typo in contributor workflow document to match `IMAGE_REPOSITORY` variable in Makefile ([link](https://github.com/koderover/zadig/pull/2854/files?diff=unified&w=0#diff-b76dfce833abb4badecc3b040ccc3a1dc1a0965fbfa863a935acf0aaaa111214L48-R48), [link](https://github.com/koderover/zadig/pull/2854/files?diff=unified&w=0#diff-b76dfce833abb4badecc3b040ccc3a1dc1a0965fbfa863a935acf0aaaa111214L55-R55))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
