### PR TITLE
feat: mse gray release support ingress source type

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_mse_gray_release.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_mse_gray_release.go
@@ -127,7 +127,7 @@ func (j *MseGrayReleaseJob) ToJobs(taskID int64) ([]*commonmodels.JobTask, error
 					types.ZadigReleaseMSEGrayTagLabelKey, types.ZadigReleaseTypeLabelKey); !exist {
 					return nil, errors.Errorf("service %s deployment template label must contain %s", service.ServiceName, key)
 				}
-			case setting.ConfigMap, setting.Secret, setting.Service:
+			case setting.ConfigMap, setting.Secret, setting.Service, setting.Ingress:
 			default:
 				return nil, errors.Errorf("service %s resource type %s not allowed", service.ServiceName, resource.GetKind())
 			}


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9465d4e</samp>

This pull request adds support for networking/v1 Ingress resources in the MSE feature of the workflow controller and service. It enables the creation, deletion, and distinction of Ingress resources for original and gray services in different Kubernetes server versions. It also validates the Ingress type in the service template.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9465d4e</samp>

*  Import networking/v1 package to handle Ingress resources of that version ([link](https://github.com/koderover/zadig/pull/2856/files?diff=unified&w=0#diff-5363a056661320caa047acf1338d1af4630517f7a81c1fb79669ace03e4cd29aR27-R28), [link](https://github.com/koderover/zadig/pull/2856/files?diff=unified&w=0#diff-d45fb1c7c0961d156f14259673a343ec6a8ee60d2f960787d4e20b98451670a9R29), [link](https://github.com/koderover/zadig/pull/2856/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R42))
*  Create and use informer to list and watch Ingress resources in the cluster ([link](https://github.com/koderover/zadig/pull/2856/files?diff=unified&w=0#diff-5363a056661320caa047acf1338d1af4630517f7a81c1fb79669ace03e4cd29aR40), [link](https://github.com/koderover/zadig/pull/2856/files?diff=unified&w=0#diff-5363a056661320caa047acf1338d1af4630517f7a81c1fb79669ace03e4cd29aR109-R114), [link](https://github.com/koderover/zadig/pull/2856/files?diff=unified&w=0#diff-5363a056661320caa047acf1338d1af4630517f7a81c1fb79669ace03e4cd29aR139-R160))
*  Delete Ingress resources associated with the service to be deleted as part of the gray offline job ([link](https://github.com/koderover/zadig/pull/2856/files?diff=unified&w=0#diff-5363a056661320caa047acf1338d1af4630517f7a81c1fb79669ace03e4cd29aR219-R246))
*  Create Ingress resource associated with the service to be released as part of the gray release job ([link](https://github.com/koderover/zadig/pull/2856/files?diff=unified&w=0#diff-d45fb1c7c0961d156f14259673a343ec6a8ee60d2f960787d4e20b98451670a9R192-R205))
*  Validate Ingress type as a valid option for service template ([link](https://github.com/koderover/zadig/pull/2856/files?diff=unified&w=0#diff-f200ef63b71dbb873c4f704c94fbcbbce5241b1df767b47b2475a004105316ebL130-R130))
*  Generate YAML for the original service Ingress resource as part of the MSE feature ([link](https://github.com/koderover/zadig/pull/2856/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R2161-R2173))
*  Generate YAML for the gray service Ingress resource as part of the MSE feature ([link](https://github.com/koderover/zadig/pull/2856/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R2306-R2318))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
