### PR TITLE
fix: workflow find product should use envName

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/product.go
@@ -120,21 +120,6 @@ type ProductEnvFindOptions struct {
 	Namespace string
 }
 
-func (c *ProductColl) FindEnv(opt *ProductEnvFindOptions) (*models.Product, error) {
-	query := bson.M{}
-	if opt.Name != "" {
-		query["product_name"] = opt.Name
-	}
-
-	if opt.Namespace != "" {
-		query["namespace"] = opt.Namespace
-	}
-
-	ret := new(models.Product)
-	err := c.FindOne(context.TODO(), query).Decode(ret)
-	return ret, err
-}
-
 func (c *ProductColl) Find(opt *ProductFindOptions) (*models.Product, error) {
 	res := &models.Product{}
 	query := bson.M{}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go
@@ -785,7 +785,6 @@ func (h *TaskAckHandler) updateProductImageByNs(namespace, productName, serviceN
 		Namespace: namespace,
 		EnvName:   envName,
 	}
-	log.Infof("updateProductImageByNs %s", envName)
 
 	prod, err := h.productColl.Find(opt)
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go
@@ -200,7 +200,7 @@ func (h *TaskAckHandler) handle(pt *task.Task) error {
 	for _, deploy := range deploys {
 		if deploy.Enabled && !pt.ResetImage {
 			containerName := strings.TrimSuffix(deploy.ContainerName, "_"+deploy.ServiceName)
-			if err := h.updateProductImageByNs(deploy.Namespace, deploy.ProductName, deploy.ServiceName, containerName, deploy.Image); err != nil {
+			if err := h.updateProductImageByNs(deploy.Namespace, deploy.ProductName, deploy.ServiceName, containerName, deploy.Image, deploy.EnvName); err != nil {
 				h.log.Errorf("updateProductImage %v error: %v", deploy, err)
 				continue
 			} else {
@@ -779,13 +779,15 @@ func (h *TaskAckHandler) getDeployTasks(subTasks []map[string]interface{}) ([]*t
 }
 
 // 更新subtasks中的所有容器部署任务对应服务的镜像
-func (h *TaskAckHandler) updateProductImageByNs(namespace, productName, serviceName, containerName, imageName string) error {
-	opt := &commonrepo.ProductEnvFindOptions{
+func (h *TaskAckHandler) updateProductImageByNs(namespace, productName, serviceName, containerName, imageName, envName string) error {
+	opt := &commonrepo.ProductFindOptions{
 		Name:      productName,
 		Namespace: namespace,
+		EnvName:   envName,
 	}
+	log.Infof("updateProductImageByNs %s", envName)
 
-	prod, err := h.productColl.FindEnv(opt)
+	prod, err := h.productColl.Find(opt)
 
 	if err != nil {
 		h.log.Errorf("find product namespace error: %v", err)

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
@@ -215,7 +215,7 @@ func CreatePipelineTask(args *commonmodels.TaskArgs, log *zap.SugaredLogger) (*C
 
 		t, err := base.ToDeployTask(t)
 		if err == nil && t.Enabled {
-			env, err := commonrepo.NewProductColl().FindEnv(&commonrepo.ProductEnvFindOptions{
+			env, err := commonrepo.NewProductColl().Find(&commonrepo.ProductFindOptions{
 				Namespace: pt.TaskArgs.Deploy.Namespace,
 				Name:      pt.ProductName,
 			})


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0f16297</samp>

Refactored `updateProductImageByNs` function to handle multiple environments and updated data model for products. Modified `pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go` accordingly.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0f16297</samp>

*  Add `envName` parameter to `updateProductImageByNs` function to support multiple environments for the same product and namespace ([link](https://github.com/koderover/zadig/pull/2874/files?diff=unified&w=0#diff-e218f812e52cd5c33f94c9edbcf770ce914482fb57deb3824c58c7efedcaa250L203-R203), [link](https://github.com/koderover/zadig/pull/2874/files?diff=unified&w=0#diff-e218f812e52cd5c33f94c9edbcf770ce914482fb57deb3824c58c7efedcaa250L782-R790))
*  Use `ProductFindOptions` struct instead of `ProductEnvFindOptions` struct to query products by environment name in `updateProductImageByNs` function ([link](https://github.com/koderover/zadig/pull/2874/files?diff=unified&w=0#diff-e218f812e52cd5c33f94c9edbcf770ce914482fb57deb3824c58c7efedcaa250L782-R790))
*  Pass `envName` parameter to `updateProductImageByNs` function call in `handle` function, which handles deployment messages from NSQ ([link](https://github.com/koderover/zadig/pull/2874/files?diff=unified&w=0#diff-e218f812e52cd5c33f94c9edbcf770ce914482fb57deb3824c58c7efedcaa250L203-R203))
*  Add log statement to print `envName` in `updateProductImageByNs` function for debugging ([link](https://github.com/koderover/zadig/pull/2874/files?diff=unified&w=0#diff-e218f812e52cd5c33f94c9edbcf770ce914482fb57deb3824c58c7efedcaa250L782-R790))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
