### PR TITLE
CP 2874

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/product.go
@@ -120,21 +120,6 @@ type ProductEnvFindOptions struct {
 	Namespace string
 }
 
-func (c *ProductColl) FindEnv(opt *ProductEnvFindOptions) (*models.Product, error) {
-	query := bson.M{}
-	if opt.Name != "" {
-		query["product_name"] = opt.Name
-	}
-
-	if opt.Namespace != "" {
-		query["namespace"] = opt.Namespace
-	}
-
-	ret := new(models.Product)
-	err := c.FindOne(context.TODO(), query).Decode(ret)
-	return ret, err
-}
-
 func (c *ProductColl) Find(opt *ProductFindOptions) (*models.Product, error) {
 	res := &models.Product{}
 	query := bson.M{}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go
@@ -213,7 +213,7 @@ func (h *TaskAckHandler) handle(message *nsq.Message) error {
 	for _, deploy := range deploys {
 		if deploy.Enabled && !pt.ResetImage {
 			containerName := strings.TrimSuffix(deploy.ContainerName, "_"+deploy.ServiceName)
-			if err := h.updateProductImageByNs(deploy.Namespace, deploy.ProductName, deploy.ServiceName, containerName, deploy.Image); err != nil {
+			if err := h.updateProductImageByNs(deploy.Namespace, deploy.ProductName, deploy.ServiceName, containerName, deploy.Image, deploy.EnvName); err != nil {
 				h.log.Errorf("updateProductImage %v error: %v", deploy, err)
 				continue
 			} else {
@@ -792,13 +792,14 @@ func (h *TaskAckHandler) getDeployTasks(subTasks []map[string]interface{}) ([]*t
 }
 
 // 更新subtasks中的所有容器部署任务对应服务的镜像
-func (h *TaskAckHandler) updateProductImageByNs(namespace, productName, serviceName, containerName, imageName string) error {
-	opt := &commonrepo.ProductEnvFindOptions{
+func (h *TaskAckHandler) updateProductImageByNs(namespace, productName, serviceName, containerName, imageName, envName string) error {
+	opt := &commonrepo.ProductFindOptions{
 		Name:      productName,
 		Namespace: namespace,
+		EnvName:   envName,
 	}
 
-	prod, err := h.productColl.FindEnv(opt)
+	prod, err := h.productColl.Find(opt)
 
 	if err != nil {
 		h.log.Errorf("find product namespace error: %v", err)

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
@@ -215,7 +215,7 @@ func CreatePipelineTask(args *commonmodels.TaskArgs, log *zap.SugaredLogger) (*C
 
 		t, err := base.ToDeployTask(t)
 		if err == nil && t.Enabled {
-			env, err := commonrepo.NewProductColl().FindEnv(&commonrepo.ProductEnvFindOptions{
+			env, err := commonrepo.NewProductColl().Find(&commonrepo.ProductFindOptions{
 				Namespace: pt.TaskArgs.Deploy.Namespace,
 				Name:      pt.ProductName,
 			})


### PR DESCRIPTION
Signed-off-by: M-Cosmosss <yuzhou@koderover.com>### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e4c28c5</samp>

Refactored the product environment model and queries in the `workflow` and `mongodb` packages. Removed the `FindEnv` function and replaced it with the `Find` function that accepts an environment name as an option. This simplifies the code and avoids duplication of logic.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e4c28c5</samp>

*  Removed `FindEnv` function from `ProductColl` struct and replaced it with a more general `Find` function that accepts an environment name as an option ([link](https://github.com/koderover/zadig/pull/2875/files?diff=unified&w=0#diff-150810b9b9a9ae4e2d85ea333a4ca97a7ca4ca8c02b80ff11d17cc853f75ba14L123-L137))
*  Modified `updateProductImageByNs` function in `TaskAckHandler` struct to pass the environment name to the `Find` function of `ProductColl` struct and use the `ProductFindOptions` struct instead of the `ProductEnvFindOptions` struct ([link](https://github.com/koderover/zadig/pull/2875/files?diff=unified&w=0#diff-e218f812e52cd5c33f94c9edbcf770ce914482fb57deb3824c58c7efedcaa250L216-R216), [link](https://github.com/koderover/zadig/pull/2875/files?diff=unified&w=0#diff-e218f812e52cd5c33f94c9edbcf770ce914482fb57deb3824c58c7efedcaa250L795-R802))
*  Modified `CreatePipelineTask` function in `pipeline_task.go` to use the `Find` function of `ProductColl` struct and the `ProductFindOptions` struct instead of the `FindEnv` function and the `ProductEnvFindOptions` struct ([link](https://github.com/koderover/zadig/pull/2875/files?diff=unified&w=0#diff-3a9aed32d3722a7eb3a76d79dfd8c1a994acb4f875829cb8f1f80ebaf367b8abL218-R218))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
