### PR TITLE
fix container missing error when creating envs

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2724,7 +2724,6 @@ func preCreateProduct(envName string, args *commonmodels.Product, kubeClient cli
 		args.Revision = productTmpl.Revision
 	}
 
-	// 检查产品是否存在，envName和productName唯一
 	opt := &commonrepo.ProductFindOptions{Name: args.ProductName, EnvName: envName}
 	if _, err := commonrepo.NewProductColl().Find(opt); err == nil {
 		log.Errorf("[%s][P:%s] duplicate product", envName, args.ProductName)

--- a/pkg/microservice/aslan/core/environment/service/environment_creator.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_creator.go
@@ -352,7 +352,6 @@ func (creator *K8sYamlProductCreator) Create(user, requestID string, args *model
 		return fmt.Errorf("failed to new istio client: %s", err)
 	}
 
-	//判断namespace是否存在
 	namespace := args.GetNamespace()
 	if args.Namespace == "" {
 		args.Namespace = namespace

--- a/pkg/microservice/aslan/core/environment/service/k8s.go
+++ b/pkg/microservice/aslan/core/environment/service/k8s.go
@@ -539,7 +539,7 @@ func (k *K8sService) createGroup(username string, product *commonmodels.Product,
 		updatableServiceNameList = append(updatableServiceNameList, group[i].ServiceName)
 		go func(svc *commonmodels.ProductService) {
 			defer wg.Done()
-			items, err := upsertService(prod, svc, nil, renderSet, nil, !prod.Production, informer, kubeClient, istioClient, k.log)
+			items, err := upsertService(prod, svc, svc, renderSet, nil, !prod.Production, informer, kubeClient, istioClient, k.log)
 			if err != nil {
 				lock.Lock()
 				switch e := err.(type) {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a302a57</samp>

This pull request removes some unnecessary comments in Chinese from the environment service code and fixes a bug in the createGroup function that could cause service updates to fail.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a302a57</samp>

* Fix a bug in createGroup function that caused service update with nil ([link](https://github.com/koderover/zadig/pull/2879/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136L542-R542))
* Remove comments in Chinese that are not consistent with code style and language ([link](https://github.com/koderover/zadig/pull/2879/files?diff=unified&w=0#diff-62964acc3cc5b564cb53f5cb178c7505bae0aa6c6398448e3869d8dd166209c1L355), [link](https://github.com/koderover/zadig/pull/2879/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L2727))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
