### PR TITLE
fix: mse env groups should check deploy type

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment_group.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_group.go
@@ -158,18 +158,20 @@ func ListGroups(serviceName, envName, productName string, perPage, page int, pro
 	for _, serviceResp := range resp {
 		respMap[serviceResp.ServiceName] = serviceResp
 	}
-	mseService, err := listZadigXMseReleaseServices(productInfo.Namespace, productName, envName, kubeClient)
-	if err != nil {
-		return resp, count, e.ErrListGroups.AddErr(errors.Wrap(err, "list mse release services"))
-	}
-	log.Debugf("mse release services num: %d", len(mseService))
-	for _, serviceResp := range mseService {
-		if svc, ok := respMap[serviceResp.ServiceName]; !ok {
-			resp = append(resp, serviceResp)
-		} else {
-			// when zadigx release resource exists, should set ZadigXReleaseType field too
-			svc.ZadigXReleaseType = serviceResp.ZadigXReleaseType
-			svc.ZadigXReleaseTag = serviceResp.ZadigXReleaseTag
+	if projectType == setting.K8SDeployType {
+		mseService, err := listZadigXMseReleaseServices(productInfo.Namespace, productName, envName, kubeClient)
+		if err != nil {
+			return resp, count, e.ErrListGroups.AddErr(errors.Wrap(err, "list mse release services"))
+		}
+		log.Debugf("mse release services num: %d", len(mseService))
+		for _, serviceResp := range mseService {
+			if svc, ok := respMap[serviceResp.ServiceName]; !ok {
+				resp = append(resp, serviceResp)
+			} else {
+				// when zadigx release resource exists, should set ZadigXReleaseType field too
+				svc.ZadigXReleaseType = serviceResp.ZadigXReleaseType
+				svc.ZadigXReleaseTag = serviceResp.ZadigXReleaseTag
+			}
 		}
 	}
 	return resp, count, nil


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ea110c</samp>

Added project type check to `ListGroups` function in `environment_group.go`. This prevents listing mse release services for non-K8S deploy types, as they are not supported.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6ea110c</samp>

*  Added a condition to check the project type before listing mse release services ([link](https://github.com/koderover/zadig/pull/2880/files?diff=unified&w=0#diff-eec4c18c515883d414b4a4799d2611040710486b09f4a933d9b237309a88f1d7L161-R175))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
