### PR TITLE
fix: external project should not get mse

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -208,15 +208,16 @@ func GetService(envName, productName, serviceName string, production bool, workL
 				CronJobs:    make([]*internalresource.CronJob, 0),
 			}
 		}
-		mseResp, err := GetMseServiceImpl(serviceName, workLoadType, env, kubeClient, clientset, inf, log)
-		if err != nil {
-			return nil, e.ErrGetService.AddErr(errors.Wrap(err, "failed to get mse service"))
+		if env.Source == setting.SourceFromZadig {
+			mseResp, err := GetMseServiceImpl(serviceName, workLoadType, env, kubeClient, clientset, inf, log)
+			if err != nil {
+				return nil, e.ErrGetService.AddErr(errors.Wrap(err, "failed to get mse service"))
+			}
+			ret.Scales = append(ret.Scales, mseResp.Scales...)
+			ret.Services = append(ret.Services, mseResp.Services...)
+			ret.Workloads = nil
+			ret.Namespace = env.Namespace
 		}
-		ret.Scales = append(ret.Scales, mseResp.Scales...)
-		ret.Services = append(ret.Services, mseResp.Services...)
-		ret.Workloads = nil
-		ret.Namespace = env.Namespace
-
 	default:
 		ret, err = GetServiceImpl(serviceName, serviceTmpl, workLoadType, env, clientset, inf, log)
 		if err != nil {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e136e7</samp>

Fix bug where MSE services are shown in environments not managed by Zadig. Add environment source check before fetching MSE service information in `service.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1e136e7</samp>

*  Add a condition to check environment source before fetching MSE service information ([link](https://github.com/koderover/zadig/pull/2884/files?diff=unified&w=0#diff-06d37031b76a99e605f5abab3018e3a09695d7723162586b7dcaec04a6c23864L211-R220))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
