### PR TITLE
fix k8s workflow import deploy bug

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/apply.go
+++ b/pkg/microservice/aslan/core/common/service/kube/apply.go
@@ -529,6 +529,10 @@ func PrepareHelmServiceData(applyParam *ResourceApplyParam) (*commonmodels.Rende
 	productInfo := applyParam.ProductInfo
 	productService := applyParam.ProductInfo.GetServiceMap()[applyParam.ServiceName]
 	if productService == nil {
+		if !applyParam.UpdateServiceRevision {
+			return nil, nil, nil, fmt.Errorf("First time online service %s needs to check the update service configuration", applyParam.ServiceName)
+		}
+
 		productService = &commonmodels.ProductService{
 			ProductName: applyParam.ProductInfo.ProductName,
 			ServiceName: applyParam.ServiceName,

--- a/pkg/microservice/aslan/core/common/service/kube/helm.go
+++ b/pkg/microservice/aslan/core/common/service/kube/helm.go
@@ -356,20 +356,14 @@ func UpgradeHelmRelease(product *commonmodels.Product, renderSet *commonmodels.R
 	productSvcMap := newProductInfo.GetServiceMap()
 	productChartSvcMap := newProductInfo.GetChartServiceMap()
 	if productSvc.FromZadig() {
-		if !commonutil.ServiceDeployed(productSvc.ServiceName, newProductInfo.ServiceDeployStrategy) {
-			newProductInfo.ServiceDeployStrategy[productSvc.ServiceName] = setting.ServiceDeployStrategyDeploy
-		}
+		newProductInfo.ServiceDeployStrategy[productSvc.ServiceName] = setting.ServiceDeployStrategyDeploy
 
 		chartMap[productSvc.ServiceName] = chartInfo
-
 		productSvcMap[productSvc.ServiceName] = product.GetServiceMap()[productSvc.ServiceName]
 	} else {
-		if !commonutil.ReleaseDeployed(productSvc.ReleaseName, newProductInfo.ServiceDeployStrategy) {
-			newProductInfo.ServiceDeployStrategy[commonutil.GetReleaseDeployStrategyKey(productSvc.ReleaseName)] = setting.ServiceDeployStrategyDeploy
-		}
+		newProductInfo.ServiceDeployStrategy[commonutil.GetReleaseDeployStrategyKey(productSvc.ReleaseName)] = setting.ServiceDeployStrategyDeploy
 
 		chartDeployMap[productSvc.ReleaseName] = chartInfo
-
 		productChartSvcMap[productSvc.ReleaseName] = product.GetChartServiceMap()[productSvc.ReleaseName]
 		if productChartSvcMap[productSvc.ReleaseName] == nil {
 			productChartSvcMap[productSvc.ReleaseName] = productSvc

--- a/pkg/microservice/aslan/core/system/service/registry.go
+++ b/pkg/microservice/aslan/core/system/service/registry.go
@@ -337,7 +337,6 @@ func imagesProcessor(repos *registry.ReposResp, registryInfo *commonmodels.Regis
 			errChan <- err
 			return
 		}
-		logger.Infof("get image[%s] %d tags from db, get image[%s] %d tags from registry", repo.Name, len(dbTags), repo.Name, len(repo.Tags))
 
 		tags := ImageListGetter(repo, registryInfo, dbTags, regService, logger)
 		// update all imageTags to db,


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed166a3</samp>

Added debug logs to `job_helm_deploy.go` and `helm.go` to troubleshoot helm upgrade issues. The logs print out the relevant helm parameters and values for each helm release deployment.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ed166a3</samp>

*  Add debug logs to print out helm parameters and values for troubleshooting ([link](https://github.com/koderover/zadig/pull/2887/files?diff=unified&w=0#diff-622e96cd3987393e3ae95185c4555f59f3b3ace6292ef497487eb0e7b383a722L247-R254), [link](https://github.com/koderover/zadig/pull/2887/files?diff=unified&w=0#diff-0db98f8df1b5910f183b6a80b83d0a7e287b00d927e8b28e81c79c8e663de011R117), [link](https://github.com/koderover/zadig/pull/2887/files?diff=unified&w=0#diff-0db98f8df1b5910f183b6a80b83d0a7e287b00d927e8b28e81c79c8e663de011R141-R142))
  - In `helm.go`, log the chart info, product service, images and replaced merged values yaml before calling `helm.UpgradeRelease` ([link](https://github.com/koderover/zadig/pull/2887/files?diff=unified&w=0#diff-622e96cd3987393e3ae95185c4555f59f3b3ace6292ef497487eb0e7b383a722L247-R254))
  - In `job_helm_deploy.go`, log the product service object and the chart info object in the `Run` function ([link](https://github.com/koderover/zadig/pull/2887/files?diff=unified&w=0#diff-0db98f8df1b5910f183b6a80b83d0a7e287b00d927e8b28e81c79c8e663de011R117), [link](https://github.com/koderover/zadig/pull/2887/files?diff=unified&w=0#diff-0db98f8df1b5910f183b6a80b83d0a7e287b00d927e8b28e81c79c8e663de011R141-R142))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
