### PR TITLE
Gerrit webhook trigger support branch regexp

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflow_task.go
@@ -36,6 +36,7 @@ import (
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/shared/client/systemconfig"
 	"github.com/koderover/zadig/pkg/tool/gerrit"
+	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/koderover/zadig/pkg/types"
 )
 
@@ -172,6 +173,8 @@ func (gruem *gerritChangeMergedEventMatcher) Match(hookRepo *commonmodels.MainHo
 	if event == nil {
 		return false, fmt.Errorf("event doesn't match")
 	}
+	b, _ := json.MarshalIndent(event, "", "  ")
+	log.Infof("gerrit raw: %s", string(b))
 
 	if event.Project.Name == gruem.Item.MainRepo.RepoName && strings.Contains(event.RefName, gruem.Item.MainRepo.Branch) {
 		existEventNames := make([]string, 0)
@@ -401,7 +404,7 @@ func TriggerWorkflowByGerritEvent(event *gerritTypeEvent, body []byte, uri, base
 	return errorList.ErrorOrNil()
 }
 
-//add webHook user
+// add webHook user
 func addWebHookUser(match gerritEventMatcher, domain string) {
 	if merge, ok := match.(*gerritChangeMergedEventMatcher); ok {
 		webhookUser := &commonmodels.WebHookUser{

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflow_task.go
@@ -37,7 +37,6 @@ import (
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/shared/client/systemconfig"
 	"github.com/koderover/zadig/pkg/tool/gerrit"
-	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/koderover/zadig/pkg/types"
 )
 
@@ -174,8 +173,6 @@ func (gruem *gerritChangeMergedEventMatcher) Match(hookRepo *commonmodels.MainHo
 	if event == nil {
 		return false, fmt.Errorf("event doesn't match")
 	}
-	b, _ := json.MarshalIndent(event, "", "  ")
-	log.Infof("gerrit raw: %s", string(b))
 
 	if event.Project.Name == gruem.Item.MainRepo.RepoName {
 		refName := getBranchFromRef(event.RefName)
@@ -190,6 +187,7 @@ func (gruem *gerritChangeMergedEventMatcher) Match(hookRepo *commonmodels.MainHo
 				return false, nil
 			}
 		}
+		hookRepo.Branch = refName
 		existEventNames := make([]string, 0)
 		for _, eventName := range gruem.Item.MainRepo.Events {
 			existEventNames = append(existEventNames, string(eventName))
@@ -247,6 +245,7 @@ func (gpcem *gerritPatchsetCreatedEventMatcher) Match(hookRepo *commonmodels.Mai
 				return false, nil
 			}
 		}
+		hookRepo.Branch = refName
 		existEventNames := make([]string, 0)
 		for _, eventName := range gpcem.Item.MainRepo.Events {
 			existEventNames = append(existEventNames, string(eventName))

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflowv4_task.go
@@ -70,6 +70,7 @@ func (gruem *gerritChangeMergedEventMatcherForWorkflowV4) Match(hookRepo *common
 				return false, nil
 			}
 		}
+		hookRepo.Branch = refName
 		existEventNames := make([]string, 0)
 		for _, eventName := range gruem.Item.MainRepo.Events {
 			existEventNames = append(existEventNames, string(eventName))
@@ -119,6 +120,7 @@ func (gpcem *gerritPatchsetCreatedEventMatcherForWorkflowV4) Match(hookRepo *com
 				return false, nil
 			}
 		}
+		hookRepo.Branch = refName
 		existEventNames := make([]string, 0)
 		for _, eventName := range gpcem.Item.MainRepo.Events {
 			existEventNames = append(existEventNames, string(eventName))

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflowv4_task.go
@@ -35,6 +35,7 @@ import (
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/shared/client/systemconfig"
 	"github.com/koderover/zadig/pkg/tool/gerrit"
+	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/koderover/zadig/pkg/types"
 )
 
@@ -55,6 +56,8 @@ func (gruem *gerritChangeMergedEventMatcherForWorkflowV4) Match(hookRepo *common
 	if event == nil {
 		return false, fmt.Errorf("event doesn't match")
 	}
+	b, _ := json.MarshalIndent(event, "", "  ")
+	log.Infof("gerrit raw: %s", string(b))
 
 	if event.Project.Name == gruem.Item.MainRepo.RepoName && strings.Contains(event.RefName, gruem.Item.MainRepo.Branch) {
 		existEventNames := make([]string, 0)

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflowv4_task.go
@@ -35,6 +35,7 @@ import (
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/shared/client/systemconfig"
 	"github.com/koderover/zadig/pkg/tool/gerrit"
+	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/koderover/zadig/pkg/types"
 )
 
@@ -55,6 +56,8 @@ func (gruem *gerritChangeMergedEventMatcherForWorkflowV4) Match(hookRepo *common
 	if event == nil {
 		return false, fmt.Errorf("event doesn't match")
 	}
+	b, _ := json.MarshalIndent(event, "", "  ")
+	log.Infof("gerrit raw: %s", string(b))
 
 	if event.Project.Name == gruem.Item.MainRepo.RepoName && strings.Contains(event.RefName, gruem.Item.MainRepo.Branch) {
 		existEventNames := make([]string, 0)
@@ -92,6 +95,8 @@ func (gpcem *gerritPatchsetCreatedEventMatcherForWorkflowV4) Match(hookRepo *com
 	if event == nil {
 		return false, fmt.Errorf("event doesn't match")
 	}
+	b, _ := json.MarshalIndent(event, "", "  ")
+	log.Infof("gerrit raw: %s", string(b))
 
 	if event.Project.Name == gpcem.Item.MainRepo.RepoName && strings.Contains(event.RefName, gpcem.Item.MainRepo.Branch) {
 		existEventNames := make([]string, 0)
@@ -149,8 +154,6 @@ func createGerritEventMatcherForWorkflowV4(event *gerritTypeEvent, body []byte, 
 
 func TriggerWorkflowV4ByGerritEvent(event *gerritTypeEvent, body []byte, uri, baseURI, domain, requestID string, log *zap.SugaredLogger) error {
 	log.Infof("gerrit webhook request url:%s\n", uri)
-	b, _ := json.MarshalIndent(event, "", "  ")
-	log.Infof("gerrit raw: %s", string(b))
 
 	workflows, _, err := commonrepo.NewWorkflowV4Coll().List(&commonrepo.ListWorkflowV4Option{}, 0, 0)
 	if err != nil {

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflowv4_task.go
@@ -35,7 +35,6 @@ import (
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/shared/client/systemconfig"
 	"github.com/koderover/zadig/pkg/tool/gerrit"
-	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/koderover/zadig/pkg/types"
 )
 
@@ -56,8 +55,6 @@ func (gruem *gerritChangeMergedEventMatcherForWorkflowV4) Match(hookRepo *common
 	if event == nil {
 		return false, fmt.Errorf("event doesn't match")
 	}
-	b, _ := json.MarshalIndent(event, "", "  ")
-	log.Infof("gerrit raw: %s", string(b))
 
 	if event.Project.Name == gruem.Item.MainRepo.RepoName && strings.Contains(event.RefName, gruem.Item.MainRepo.Branch) {
 		existEventNames := make([]string, 0)
@@ -152,6 +149,8 @@ func createGerritEventMatcherForWorkflowV4(event *gerritTypeEvent, body []byte, 
 
 func TriggerWorkflowV4ByGerritEvent(event *gerritTypeEvent, body []byte, uri, baseURI, domain, requestID string, log *zap.SugaredLogger) error {
 	log.Infof("gerrit webhook request url:%s\n", uri)
+	b, _ := json.MarshalIndent(event, "", "  ")
+	log.Infof("gerrit raw: %s", string(b))
 
 	workflows, _, err := commonrepo.NewWorkflowV4Coll().List(&commonrepo.ListWorkflowV4Option{}, 0, 0)
 	if err != nil {

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflowv4_task.go
@@ -19,6 +19,7 @@ package webhook
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -35,7 +36,6 @@ import (
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/shared/client/systemconfig"
 	"github.com/koderover/zadig/pkg/tool/gerrit"
-	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/koderover/zadig/pkg/types"
 )
 
@@ -56,10 +56,20 @@ func (gruem *gerritChangeMergedEventMatcherForWorkflowV4) Match(hookRepo *common
 	if event == nil {
 		return false, fmt.Errorf("event doesn't match")
 	}
-	b, _ := json.MarshalIndent(event, "", "  ")
-	log.Infof("gerrit raw: %s", string(b))
 
-	if event.Project.Name == gruem.Item.MainRepo.RepoName && strings.Contains(event.RefName, gruem.Item.MainRepo.Branch) {
+	if event.Project.Name == gruem.Item.MainRepo.RepoName {
+		refName := getBranchFromRef(event.RefName)
+		isRegular := gruem.Item.MainRepo.IsRegular
+		if !isRegular && hookRepo.Branch != refName {
+			return false, nil
+		}
+		if isRegular {
+			// Do not use regexp.MustCompile to avoid panic
+			matched, err := regexp.MatchString(gruem.Item.MainRepo.Branch, refName)
+			if err != nil || !matched {
+				return false, nil
+			}
+		}
 		existEventNames := make([]string, 0)
 		for _, eventName := range gruem.Item.MainRepo.Events {
 			existEventNames = append(existEventNames, string(eventName))
@@ -95,10 +105,20 @@ func (gpcem *gerritPatchsetCreatedEventMatcherForWorkflowV4) Match(hookRepo *com
 	if event == nil {
 		return false, fmt.Errorf("event doesn't match")
 	}
-	b, _ := json.MarshalIndent(event, "", "  ")
-	log.Infof("gerrit raw: %s", string(b))
 
-	if event.Project.Name == gpcem.Item.MainRepo.RepoName && strings.Contains(event.RefName, gpcem.Item.MainRepo.Branch) {
+	if event.Project.Name == gpcem.Item.MainRepo.RepoName {
+		refName := getBranchFromRef(event.RefName)
+		isRegular := gpcem.Item.MainRepo.IsRegular
+		if !isRegular && hookRepo.Branch != refName {
+			return false, nil
+		}
+		if isRegular {
+			// Do not use regexp.MustCompile to avoid panic
+			matched, err := regexp.MatchString(gpcem.Item.MainRepo.Branch, refName)
+			if err != nil || !matched {
+				return false, nil
+			}
+		}
 		existEventNames := make([]string, 0)
 		for _, eventName := range gpcem.Item.MainRepo.Events {
 			existEventNames = append(existEventNames, string(eventName))


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8681ffa</samp>

Improved gerrit webhook handling by adding logging and fixing code style in `gerrit_workflow_task.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8681ffa</samp>

* Import and use `log` package to print gerrit event data as JSON string for debugging ([link](https://github.com/koderover/zadig/pull/2889/files?diff=unified&w=0#diff-5c9ed151e1a2665d6a3746773c87f7525e15e9fadf77b47ec377c4402a4d6f38R39), [link](https://github.com/koderover/zadig/pull/2889/files?diff=unified&w=0#diff-5c9ed151e1a2665d6a3746773c87f7525e15e9fadf77b47ec377c4402a4d6f38R176-R177))
* Add space after comment delimiter "//" to follow Go code style convention in `gerrit_workflow_task.go` ([link](https://github.com/koderover/zadig/pull/2889/files?diff=unified&w=0#diff-5c9ed151e1a2665d6a3746773c87f7525e15e9fadf77b47ec377c4402a4d6f38L404-R407))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
