### PR TITLE
fix stat issue for helm chart deploy job

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/job_info.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/job_info.go
@@ -70,9 +70,12 @@ func (c *JobInfoColl) GetProductionDeployJobs(startTime, endTime int64, projectN
 	query := bson.M{}
 	query["start_time"] = bson.M{"$gte": startTime, "$lt": endTime}
 	query["production"] = true
-	// TODO: currently the only job type with production env update function is zadig-deploy
-	// if we added production update for helm-deploy type job, we need to update this query
-	query["type"] = config.JobZadigDeploy
+	query["type"] = bson.M{"$in": []string{
+		string(config.JobZadigDeploy),
+		string(config.JobZadigHelmDeploy),
+		string(config.JobZadigHelmChartDeploy),
+		string(config.JobDeploy),
+	}}
 	if len(projectName) != 0 {
 		query["product_name"] = projectName
 	}
@@ -131,7 +134,12 @@ func (c *JobInfoColl) GetBuildJobs(startTime, endTime int64, projectName string)
 func (c *JobInfoColl) GetDeployJobs(startTime, endTime int64, projectName string) ([]*models.JobInfo, error) {
 	query := bson.M{}
 	query["start_time"] = bson.M{"$gte": startTime, "$lt": endTime}
-	query["type"] = bson.M{"$in": []string{string(config.JobZadigDeploy), string(config.JobZadigHelmDeploy), string(config.JobDeploy)}}
+	query["type"] = bson.M{"$in": []string{
+		string(config.JobZadigDeploy),
+		string(config.JobZadigHelmDeploy),
+		string(config.JobZadigHelmChartDeploy),
+		string(config.JobDeploy),
+	}}
 
 	if len(projectName) != 0 {
 		query["product_name"] = projectName

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
@@ -214,7 +214,7 @@ func (c *HelmDeployJobCtl) SaveInfo(ctx context.Context) error {
 		ServiceName:   c.jobTaskSpec.ServiceName,
 		TargetEnv:     c.jobTaskSpec.Env,
 		ServiceModule: moduleList,
-		// helm deploy does not have production deploy now
+		Production:    c.jobTaskSpec.IsProduction,
 	})
 }
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b6b445a</samp>

Added support for deploying helm charts from Zadig UI. Updated MongoDB query in `job_info.go` to include new job type `JobZadigHelmChartDeploy`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b6b445a</samp>

*  Add a new job type `JobZadigHelmChartDeploy` to the `JobType` enum and the `JobTypeToString` map (F0L9,F0L14)
*  Update the `FindDeployJobs` function to include the new job type in the query filter ([link](https://github.com/koderover/zadig/pull/2890/files?diff=unified&w=0#diff-3ec7c364c33d0b2afce379eddf32458feedd3d63ad179b98d3fd299abd5a895aL134-R139))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
