### PR TITLE
Feature/helm reinstall check

### DIFF
--- a/pkg/microservice/aslan/core/common/util/enviroment.go
+++ b/pkg/microservice/aslan/core/common/util/enviroment.go
@@ -136,7 +136,7 @@ func GetReleaseNameToChartNameMap(prod *models.Product) (map[string]string, erro
 	renderMap := rendersetObj.GetChartDeployRenderMap()
 
 	for _, svc := range prod.GetChartServiceMap() {
-		if renderInfo, ok := renderMap[svc.ServiceName]; ok {
+		if renderInfo, ok := renderMap[svc.ReleaseName]; ok {
 			releaseNameMap[svc.ReleaseName] = renderInfo.ChartName
 		}
 	}

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -1216,7 +1216,7 @@ func UpdateProductionServiceReleaseNamingRule(userName, requestID, projectName s
 		}
 	}
 
-	log.Info("-------- product count: %v", len(products))
+	log.Infof("-------- product count: %v", len(products))
 	// check if the release name already exists
 	for _, product := range products {
 		releaseName := util.GeneReleaseName(args.NamingRule, product.ProductName, product.Namespace, product.EnvName, args.ServiceName)

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -1216,16 +1216,13 @@ func UpdateProductionServiceReleaseNamingRule(userName, requestID, projectName s
 		}
 	}
 
-	log.Infof("-------- product count: %v", len(products))
 	// check if the release name already exists
 	for _, product := range products {
 		releaseName := util.GeneReleaseName(args.NamingRule, product.ProductName, product.Namespace, product.EnvName, args.ServiceName)
-		log.Infof("releaseName: %s", releaseName)
 		releaseNameMap, err := commonutil.GetReleaseNameToChartNameMap(product)
 		if err != nil {
 			return fmt.Errorf("failed to get release name to chart name map, err: %s", err)
 		}
-		log.Infof("releaseNameMap: %v", releaseNameMap)
 		if chartOrSvcName, ok := releaseNameMap[releaseName]; ok && chartOrSvcName != args.ServiceName {
 			return fmt.Errorf("release name %s already exists for chart or service %s in environment: %s", releaseName, chartOrSvcName, product.EnvName)
 		}

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -1216,6 +1216,7 @@ func UpdateProductionServiceReleaseNamingRule(userName, requestID, projectName s
 		}
 	}
 
+	log.Info("-------- product count: %v", len(products))
 	// check if the release name already exists
 	for _, product := range products {
 		releaseName := util.GeneReleaseName(args.NamingRule, product.ProductName, product.Namespace, product.EnvName, args.ServiceName)

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -1219,10 +1219,12 @@ func UpdateProductionServiceReleaseNamingRule(userName, requestID, projectName s
 	// check if the release name already exists
 	for _, product := range products {
 		releaseName := util.GeneReleaseName(args.NamingRule, product.ProductName, product.Namespace, product.EnvName, args.ServiceName)
+		log.Infof("releaseName: %s", releaseName)
 		releaseNameMap, err := commonutil.GetReleaseNameToChartNameMap(product)
 		if err != nil {
 			return fmt.Errorf("failed to get release name to chart name map, err: %s", err)
 		}
+		log.Infof("releaseNameMap: %v", releaseNameMap)
 		if chartOrSvcName, ok := releaseNameMap[releaseName]; ok && chartOrSvcName != args.ServiceName {
 			return fmt.Errorf("release name %s already exists for chart or service %s in environment: %s", releaseName, chartOrSvcName, product.EnvName)
 		}

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -1105,6 +1105,14 @@ func UpdateReleaseNamingRule(userName, requestID, projectName string, args *Rele
 		return err
 	}
 
+	products, err := commonrepo.NewProductColl().List(&commonrepo.ProductListOptions{
+		Name:       projectName,
+		Production: util.GetBoolPointer(false),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list envs for product: %s, err: %s", projectName, err)
+	}
+
 	// check if namings rule changes for services deployed in envs
 	if serviceTemplate.GetReleaseNaming() == args.NamingRule {
 		products, err := commonrepo.NewProductColl().List(&commonrepo.ProductListOptions{
@@ -1123,6 +1131,18 @@ func UpdateReleaseNamingRule(userName, requestID, projectName string, args *Rele
 		}
 		if !modified {
 			return nil
+		}
+	}
+
+	// check if the release name already exists
+	for _, product := range products {
+		releaseName := util.GeneReleaseName(args.NamingRule, product.ProductName, product.Namespace, product.EnvName, args.ServiceName)
+		releaseNameMap, err := commonutil.GetReleaseNameToChartNameMap(product)
+		if err != nil {
+			return fmt.Errorf("failed to get release name to chart name map, err: %s", err)
+		}
+		if chartOrSvcName, ok := releaseNameMap[releaseName]; ok && chartOrSvcName != args.ServiceName {
+			return fmt.Errorf("release name %s already exists for chart or service %s in environment: %s", releaseName, chartOrSvcName, product.EnvName)
 		}
 	}
 
@@ -1204,7 +1224,7 @@ func UpdateProductionServiceReleaseNamingRule(userName, requestID, projectName s
 			return fmt.Errorf("failed to get release name to chart name map, err: %s", err)
 		}
 		if chartOrSvcName, ok := releaseNameMap[releaseName]; ok && chartOrSvcName != args.ServiceName {
-			return fmt.Errorf("release name %s already exists for chart or service %s", releaseName, chartOrSvcName)
+			return fmt.Errorf("release name %s already exists for chart or service %s in environment: %s", releaseName, chartOrSvcName, product.EnvName)
 		}
 	}
 


### PR DESCRIPTION
### What this PR does / Why we need it:
add duplicate release name check when changing release namingrule

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 25c4a0d</samp>

*  Validate the release naming rule for a service and check for conflicts with existing release names in non-production and production environments ([link](https://github.com/koderover/zadig/pull/2891/files?diff=unified&w=0#diff-fcfbf6b1c510bcc0aac99a96af3adfab8a03337a991e91e0b1a7f79b0faac5f0R1108-R1115), [link](https://github.com/koderover/zadig/pull/2891/files?diff=unified&w=0#diff-fcfbf6b1c510bcc0aac99a96af3adfab8a03337a991e91e0b1a7f79b0faac5f0R1137-R1148), [link](https://github.com/koderover/zadig/pull/2891/files?diff=unified&w=0#diff-fcfbf6b1c510bcc0aac99a96af3adfab8a03337a991e91e0b1a7f79b0faac5f0L1177-R1206), [link](https://github.com/koderover/zadig/pull/2891/files?diff=unified&w=0#diff-fcfbf6b1c510bcc0aac99a96af3adfab8a03337a991e91e0b1a7f79b0faac5f0R1219-R1230)) in `service.go`

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
