### PR TITLE
fix YamlToServiceVariableKV return err when input is null

### DIFF
--- a/pkg/microservice/aslan/core/common/types/service_variable.go
+++ b/pkg/microservice/aslan/core/common/types/service_variable.go
@@ -178,6 +178,10 @@ func ServiceVariableKVToYaml(kvs []*ServiceVariableKV) (string, error) {
 // not suitable for flatten kv
 // ServiceVariableKV is a kv which aggregate complicated struct to the first layer
 func YamlToServiceVariableKV(yamlStr string, origKVs []*ServiceVariableKV) ([]*ServiceVariableKV, error) {
+	if yamlStr == "null" || yamlStr == "null\n" {
+		return nil, nil
+	}
+
 	node := &yaml.Node{}
 	err := yaml.Unmarshal([]byte(yamlStr), node)
 	if err != nil {

--- a/pkg/microservice/aslan/core/common/types/service_variable_test.go
+++ b/pkg/microservice/aslan/core/common/types/service_variable_test.go
@@ -79,6 +79,11 @@ B: a string`,
 		},
 	}
 
+	nullYamlStr = `null
+`
+	expectNullYamlStr = `{}
+`
+
 	yamlStr = `strInt: 1
 strStr: a string
 strBool: true
@@ -202,6 +207,11 @@ var _ = Describe("Service", func() {
 			origKVs  []*types.ServiceVariableKV
 			expected string
 		}{
+			{
+				yamlStr:  nullYamlStr,
+				origKVs:  nil,
+				expected: expectNullYamlStr,
+			},
 			{
 				yamlStr:  yamlStr,
 				origKVs:  nil,


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77b1f43</samp>

Fix a bug in `ServiceVariableKVToYaml` that caused an error when the service variable was empty. Add a test case to verify the fix.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 77b1f43</samp>

* Return nil when service variable is empty ([link](https://github.com/koderover/zadig/pull/2893/files?diff=unified&w=0#diff-70855a969f935cd64e3572817493d8586c3f81887d7655b2fe57f216f12fbfc9R181-R184), [link](https://github.com/koderover/zadig/pull/2893/files?diff=unified&w=0#diff-6f72991b7fe1e83a633c1ed214970b3efdac3465bd05134c947829e0347c0225R82-R86), [link](https://github.com/koderover/zadig/pull/2893/files?diff=unified&w=0#diff-6f72991b7fe1e83a633c1ed214970b3efdac3465bd05134c947829e0347c0225R211-R215))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
