### PR TITLE
add CheckLLMIntegration api

### DIFF
--- a/pkg/microservice/aslan/core/system/handler/llm.go
+++ b/pkg/microservice/aslan/core/system/handler/llm.go
@@ -98,6 +98,26 @@ func ListLLMIntegration(c *gin.Context) {
 	ctx.Resp, ctx.Err = service.ListLLMIntegration(context.TODO())
 }
 
+type checkLLMIntegrationResponse struct {
+	Check bool `json:"check"`
+}
+
+// @Summary Check llm integrations
+// @Description Check llm integrations
+// @Tags 	system
+// @Accept 	json
+// @Produce json
+// @Success 200 		{object} 		checkLLMIntegrationResponse
+// @Router /api/aslan/system/llm/integration/check [get]
+func CheckLLMIntegration(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	resp := &checkLLMIntegrationResponse{}
+	resp.Check, ctx.Err = service.CheckLLMIntegration(context.TODO())
+	ctx.Resp = resp
+}
+
 // @Summary Update a llm integration
 // @Description Update a llm integration
 // @Tags 	system

--- a/pkg/microservice/aslan/core/system/handler/router.go
+++ b/pkg/microservice/aslan/core/system/handler/router.go
@@ -352,6 +352,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 	{
 		llm.POST("/integration", CreateLLMIntegration)
 		llm.GET("/integration", ListLLMIntegration)
+		llm.GET("/integration/check", CheckLLMIntegration)
 		llm.GET("/integration/:id", GetLLMIntegration)
 		llm.PUT("/integration/:id", UpdateLLMIntegration)
 		llm.DELETE("/integration/:id", DeleteLLMIntegration)

--- a/pkg/microservice/aslan/core/system/service/llm.go
+++ b/pkg/microservice/aslan/core/system/service/llm.go
@@ -26,6 +26,21 @@ import (
 	"github.com/koderover/zadig/pkg/tool/log"
 )
 
+func CheckLLMIntegration(ctx context.Context) (bool, error) {
+	count, err := commonrepo.NewLLMIntegrationColl().Count(ctx)
+	if err != nil {
+		fmtErr := fmt.Errorf("CheckLLMIntegration err: %w", err)
+		log.Error(fmtErr)
+		return false, e.ErrListLLMIntegration.AddErr(fmtErr)
+	}
+
+	if count == 0 {
+		return false, nil
+	}
+
+	return true, nil
+}
+
 func GetLLMIntegration(ctx context.Context, id string) (*commonmodels.LLMIntegration, error) {
 	llmIntegration, err := commonrepo.NewLLMIntegrationColl().FindByID(ctx, id)
 	if err != nil {

--- a/pkg/microservice/aslan/server/rest/doc/docs.go
+++ b/pkg/microservice/aslan/server/rest/doc/docs.go
@@ -2154,6 +2154,29 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/aslan/system/llm/integration/check": {
+            "get": {
+                "description": "Check llm integrations",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "Check llm integrations",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.checkLLMIntegrationResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/aslan/system/llm/integration/{id}": {
             "get": {
                 "description": "Get a llm integration",
@@ -2789,6 +2812,14 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
+                }
+            }
+        },
+        "handler.checkLLMIntegrationResponse": {
+            "type": "object",
+            "properties": {
+                "check": {
+                    "type": "boolean"
                 }
             }
         },

--- a/pkg/microservice/aslan/server/rest/doc/swagger.json
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.json
@@ -2145,6 +2145,29 @@
                 }
             }
         },
+        "/api/aslan/system/llm/integration/check": {
+            "get": {
+                "description": "Check llm integrations",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "Check llm integrations",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.checkLLMIntegrationResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/aslan/system/llm/integration/{id}": {
             "get": {
                 "description": "Get a llm integration",
@@ -2780,6 +2803,14 @@
                 },
                 "name": {
                     "type": "string"
+                }
+            }
+        },
+        "handler.checkLLMIntegrationResponse": {
+            "type": "object",
+            "properties": {
+                "check": {
+                    "type": "boolean"
                 }
             }
         },

--- a/pkg/microservice/aslan/server/rest/doc/swagger.yaml
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.yaml
@@ -167,6 +167,11 @@ definitions:
       name:
         type: string
     type: object
+  handler.checkLLMIntegrationResponse:
+    properties:
+      check:
+        type: boolean
+    type: object
   handler.createServiceTemplateRequest:
     properties:
       product_name:
@@ -3414,6 +3419,21 @@ paths:
         "200":
           description: OK
       summary: Update a llm integration
+      tags:
+      - system
+  /api/aslan/system/llm/integration/check:
+    get:
+      consumes:
+      - application/json
+      description: Check llm integrations
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handler.checkLLMIntegrationResponse'
+      summary: Check llm integrations
       tags:
       - system
   /api/aslan/system/webhook/config:


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f4c55ba</samp>

This pull request adds a new API endpoint `/api/aslan/system/llm/integration/check` to the `aslan` microservice. The endpoint allows users to check the integration status of the LLM service. The pull request also updates the documentation and the code structure for the `doc`, `handler`, and `service` packages.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f4c55ba</samp>

*  Add a new API endpoint to check the existence of LLM integrations in the system ([link](https://github.com/koderover/zadig/pull/2894/files?diff=unified&w=0#diff-a788b6154d88f1681af6dd9bb4b9504e74a014ea5e30ba254f38beb73d7bf5d7R355), [link](https://github.com/koderover/zadig/pull/2894/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62R2157-R2179), [link](https://github.com/koderover/zadig/pull/2894/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216R2148-R2170), [link](https://github.com/koderover/zadig/pull/2894/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2R3424-R3438))
* Implement the handler function `CheckLLMIntegration` that responds with a JSON object containing a boolean value ([link](https://github.com/koderover/zadig/pull/2894/files?diff=unified&w=0#diff-655221ed1e17ce06216dcf0c16cfe158c99acdaaffe1d5c19f623f4b158acc8eR101-R119))
* Use the `internalhandler` package to handle the context and error handling in the handler function ([link](https://github.com/koderover/zadig/pull/2894/files?diff=unified&w=0#diff-655221ed1e17ce06216dcf0c16cfe158c99acdaaffe1d5c19f623f4b158acc8eR101-R119))
* Add a Swagger annotation to the handler function to document its API specification ([link](https://github.com/koderover/zadig/pull/2894/files?diff=unified&w=0#diff-655221ed1e17ce06216dcf0c16cfe158c99acdaaffe1d5c19f623f4b158acc8eR101-R119))
* Implement the service function `CheckLLMIntegration` that queries the `LLMIntegrationColl` collection to count the number of LLM integrations in the system ([link](https://github.com/koderover/zadig/pull/2894/files?diff=unified&w=0#diff-79980b900881e35123bdc9c1de08c1e3c54dd389191d2926ba4574e09d5d6561R29-R43))
* Use the `e` package to wrap the error with a predefined message in the service function ([link](https://github.com/koderover/zadig/pull/2894/files?diff=unified&w=0#diff-79980b900881e35123bdc9c1de08c1e3c54dd389191d2926ba4574e09d5d6561R29-R43))
* Define the `checkLLMIntegrationResponse` model that has a boolean property `check` ([link](https://github.com/koderover/zadig/pull/2894/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62R2818-R2825), [link](https://github.com/koderover/zadig/pull/2894/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216R2809-R2816), [link](https://github.com/koderover/zadig/pull/2894/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2R170-R174))
* Generate the `swagger.json` and `swagger.yaml` files from the `docs.go` file using the `swag` tool ([link](https://github.com/koderover/zadig/pull/2894/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62R2157-R2179), [link](https://github.com/koderover/zadig/pull/2894/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62R2818-R2825), [link](https://github.com/koderover/zadig/pull/2894/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216R2148-R2170), [link](https://github.com/koderover/zadig/pull/2894/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216R2809-R2816), [link](https://github.com/koderover/zadig/pull/2894/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2R170-R174), [link](https://github.com/koderover/zadig/pull/2894/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2R3424-R3438))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
