### PR TITLE
fix llm integration check api permission

### DIFF
--- a/pkg/microservice/policy/core/yamlconfig/urls.yaml
+++ b/pkg/microservice/policy/core/yamlconfig/urls.yaml
@@ -224,6 +224,9 @@ exemption_urls:
     - endpoint: api/aslan/system/theme
       methods:
         - GET
+    - endpoint: api/aslan/system/llm/integration/check
+      methods:
+        - GET
   system_admin:
     - endpoint: api/v1/features/?*
       methods:


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fb65da1</samp>

Added a new endpoint to `urls.yaml` for checking the LLM integration status. This endpoint is used by the policy microservice to communicate with the Aslan platform.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fb65da1</samp>

*  Add a new endpoint for checking LLM integration status ([link](https://github.com/koderover/zadig/pull/2895/files?diff=unified&w=0#diff-59606179c6b3374faeafb8e52b46af35a5b633af38bdd085ba3dcf90830d2d3bR227-R229))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
