### PR TITLE
feat: save conditions for job pod start failed

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
@@ -845,6 +845,13 @@ func waitJobStart(ctx context.Context, namespace, jobName string, kubeClient crC
 					continue
 				}
 				for _, pod := range podList {
+					if pod.Status.Phase == corev1.PodFailed {
+						msg := ""
+						for _, condition := range pod.Status.Conditions {
+							msg += fmt.Sprintf("type:%s, status:%s, reason:%s, message:%s\n", condition.Type, condition.Status, condition.Reason, condition.Message)
+						}
+						return config.StatusFailed, fmt.Errorf("waitJobStart: pod failed, jobName:%s, podName:%s\nconditions info: %s", jobName, pod.Name, msg)
+					}
 					if pod.Status.Phase != corev1.PodPending {
 						xl.Infof("waitJobStart: pod status %s namespace:%s, jobName:%s podList num %d", pod.Status.Phase, namespace, jobName, len(podList))
 						return config.StatusRunning, nil


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43483a8</samp>

Improved error handling for Kubernetes jobs in `waitJobStart` function. Added pod status phase check and returned detailed error message with job and pod information in `pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 43483a8</samp>

*  Add pod status phase check for failed Kubernetes jobs in `waitJobStart` function ([link](https://github.com/koderover/zadig/pull/2902/files?diff=unified&w=0#diff-bb2babcde92658d4d89442ed331bc50625c1dded3c248c4771d68b5856ffe036R848-R854))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
