### PR TITLE
fix panic when set service deploy strategy

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/helm.go
+++ b/pkg/microservice/aslan/core/common/service/kube/helm.go
@@ -356,12 +356,12 @@ func UpgradeHelmRelease(product *commonmodels.Product, renderSet *commonmodels.R
 	productSvcMap := newProductInfo.GetServiceMap()
 	productChartSvcMap := newProductInfo.GetChartServiceMap()
 	if productSvc.FromZadig() {
-		newProductInfo.ServiceDeployStrategy[productSvc.ServiceName] = setting.ServiceDeployStrategyDeploy
+		newProductInfo.ServiceDeployStrategy = commonutil.SetServiceDeployStrategyDepoly(newProductInfo.ServiceDeployStrategy, productSvc.ServiceName)
 
 		chartMap[productSvc.ServiceName] = chartInfo
 		productSvcMap[productSvc.ServiceName] = product.GetServiceMap()[productSvc.ServiceName]
 	} else {
-		newProductInfo.ServiceDeployStrategy[commonutil.GetReleaseDeployStrategyKey(productSvc.ReleaseName)] = setting.ServiceDeployStrategyDeploy
+		newProductInfo.ServiceDeployStrategy = commonutil.SetChartServiceDeployStrategyDepoly(newProductInfo.ServiceDeployStrategy, productSvc.ReleaseName)
 
 		chartDeployMap[productSvc.ReleaseName] = chartInfo
 		productChartSvcMap[productSvc.ReleaseName] = product.GetChartServiceMap()[productSvc.ReleaseName]

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_env.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_env.go
@@ -30,6 +30,7 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/render"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/repository"
 	commontypes "github.com/koderover/zadig/pkg/microservice/aslan/core/common/types"
+	commonutil "github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/tool/log"
 )
@@ -189,10 +190,7 @@ func UpdateProductServiceDeployInfo(deployInfo *ProductServiceDeployInfo) error 
 		productInfo.Render.Revision = curRenderset.Revision
 		log.Infof("UpdateServiceRevision : %v, sevOnline: %v, variableYamlNil %v, serviceName: %s", deployInfo.UpdateServiceRevision, sevOnline, variableYamlNil(deployInfo.VariableYaml), deployInfo.ServiceName)
 		if deployInfo.UpdateServiceRevision || sevOnline || !variableYamlNil(deployInfo.VariableYaml) {
-			if productInfo.ServiceDeployStrategy == nil {
-				productInfo.ServiceDeployStrategy = make(map[string]string)
-			}
-			productInfo.ServiceDeployStrategy[deployInfo.ServiceName] = setting.ServiceDeployStrategyDeploy
+			productInfo.ServiceDeployStrategy = commonutil.SetServiceDeployStrategyDepoly(productInfo.ServiceDeployStrategy, deployInfo.ServiceName)
 		}
 	} else {
 		// uninstall service

--- a/pkg/microservice/aslan/core/common/util/service.go
+++ b/pkg/microservice/aslan/core/common/util/service.go
@@ -99,6 +99,38 @@ func DeployStrategyChanged(serviceName string, strategyMapOld map[string]string,
 	return ServiceDeployed(serviceName, strategyMapOld) != ServiceDeployed(serviceName, strategyMapNew)
 }
 
+func SetServiceDeployStrategyDepoly(strategyMap map[string]string, serviceName string) map[string]string {
+	if strategyMap == nil {
+		strategyMap = make(map[string]string)
+	}
+	strategyMap[serviceName] = setting.ServiceDeployStrategyDeploy
+	return strategyMap
+}
+
+func SetServiceDeployStrategyImport(strategyMap map[string]string, serviceName string) map[string]string {
+	if strategyMap == nil {
+		strategyMap = make(map[string]string)
+	}
+	strategyMap[serviceName] = setting.ServiceDeployStrategyImport
+	return strategyMap
+}
+
+func SetChartServiceDeployStrategyDepoly(strategyMap map[string]string, releaseName string) map[string]string {
+	if strategyMap == nil {
+		strategyMap = make(map[string]string)
+	}
+	strategyMap[GetReleaseDeployStrategyKey(releaseName)] = setting.ServiceDeployStrategyDeploy
+	return strategyMap
+}
+
+func SetChartServiceDeployStrategyImport(strategyMap map[string]string, releaseName string) map[string]string {
+	if strategyMap == nil {
+		strategyMap = make(map[string]string)
+	}
+	strategyMap[GetReleaseDeployStrategyKey(releaseName)] = setting.ServiceDeployStrategyImport
+	return strategyMap
+}
+
 func SetCurrentContainerImages(args *commonmodels.Service) error {
 	var srvContainers []*commonmodels.Container
 	for _, data := range args.KubeYamls {

--- a/pkg/microservice/aslan/core/environment/service/k8s.go
+++ b/pkg/microservice/aslan/core/environment/service/k8s.go
@@ -271,9 +271,7 @@ func (k *K8sService) updateService(args *SvcOptArgs) error {
 		}
 	}
 
-	if exitedProd.ServiceDeployStrategy != nil {
-		exitedProd.ServiceDeployStrategy[args.ServiceName] = setting.ServiceDeployStrategyDeploy
-	}
+	exitedProd.ServiceDeployStrategy = commonutil.SetServiceDeployStrategyDepoly(exitedProd.ServiceDeployStrategy, args.ServiceName)
 
 	// Note update logic need to be optimized since we only need to update one service
 	if err := commonrepo.NewProductColl().Update(exitedProd); err != nil {

--- a/pkg/microservice/aslan/core/project/service/product.go
+++ b/pkg/microservice/aslan/core/project/service/product.go
@@ -559,11 +559,8 @@ func transferProducts(user string, projectInfo *template.Product, templateServic
 		}
 
 		// mark service as only import
-		if product.ServiceDeployStrategy == nil {
-			product.ServiceDeployStrategy = make(map[string]string)
-		}
 		for _, svc := range product.GetServiceMap() {
-			product.ServiceDeployStrategy[svc.ServiceName] = setting.ServiceDeployStrategyImport
+			product.ServiceDeployStrategy = commonutil.SetServiceDeployStrategyImport(product.ServiceDeployStrategy, svc.ServiceName)
 		}
 
 		product.Source = setting.SourceFromZadig


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee95458</samp>

Refactor the code to use helper functions for setting service deploy strategy in `helm.go`. Add the helper functions and a constant to the `util` package.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ee95458</samp>

*  Refactor code to use helper functions to set service deploy strategy ([link](https://github.com/koderover/zadig/pull/2904/files?diff=unified&w=0#diff-622e96cd3987393e3ae95185c4555f59f3b3ace6292ef497487eb0e7b383a722L359-R364))
* Add helper functions to util package to set service deploy strategy ([link](https://github.com/koderover/zadig/pull/2904/files?diff=unified&w=0#diff-8df27544149913484895c51bd32c6d5db8708553e47cc1a29eadd1b4642ae6d3R102-R133))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
