### PR TITLE
fix aslan panic when fetching service details

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -218,9 +218,9 @@ func GetService(envName, productName, serviceName string, production bool, workL
 			}
 			ret.Scales = append(ret.Scales, mseResp.Scales...)
 			ret.Services = append(ret.Services, mseResp.Services...)
-			ret.Workloads = nil
-			ret.Namespace = env.Namespace
 		}
+		ret.Workloads = nil
+		ret.Namespace = env.Namespace
 	} else {
 		ret, err = GetServiceImpl(serviceName, serviceTmpl, workLoadType, env, clientset, inf, log)
 		if err != nil {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f7eca7</samp>

Fixed a bug in `GetService` that overwrote service workloads with multi-service environment workloads. Moved `ret.Workloads = nil` outside of `if` block in `service.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2f7eca7</samp>

*  Fix a bug that caused the workloads of a service to be overwritten by the workloads of a multi-service environment ([link](https://github.com/koderover/zadig/pull/2905/files?diff=unified&w=0#diff-06d37031b76a99e605f5abab3018e3a09695d7723162586b7dcaec04a6c23864L221-R223))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
