### PR TITLE
CP 2910 to 1.18.0

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflow_task.go
@@ -232,15 +232,25 @@ func (gpem *gitlabPushEventMatcher) Match(hookRepo *commonmodels.MainHookRepo) (
 		return false, err
 	}
 
-	// compare接口获取两个commit之间的最终的改动
-	diffs, err := client.Compare(ev.ProjectID, ev.Before, ev.After)
-	if err != nil {
-		gpem.log.Errorf("Failed to get push event diffs, error: %s", err)
-		return false, err
-	}
-	for _, diff := range diffs {
-		changedFiles = append(changedFiles, diff.NewPath)
-		changedFiles = append(changedFiles, diff.OldPath)
+	// When push a new branch, ev.Before will be a lot of "0"
+	// So we should not use Compare
+	if strings.Count(ev.Before, "0") == len(ev.Before) {
+		for _, commit := range ev.Commits {
+			changedFiles = append(changedFiles, commit.Added...)
+			changedFiles = append(changedFiles, commit.Removed...)
+			changedFiles = append(changedFiles, commit.Modified...)
+		}
+	} else {
+		// compare接口获取两个commit之间的最终的改动
+		diffs, err := client.Compare(ev.ProjectID, ev.Before, ev.After)
+		if err != nil {
+			gpem.log.Errorf("Failed to get push event diffs, error: %s", err)
+			return false, err
+		}
+		for _, diff := range diffs {
+			changedFiles = append(changedFiles, diff.NewPath)
+			changedFiles = append(changedFiles, diff.OldPath)
+		}
 	}
 	if gpem.isYaml {
 		serviceChangeds := ServicesMatchChangesFiles(gpem.trigger.Rules.MatchFolders, changedFiles)


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0238eda</samp>

Fix bugs in GitLab webhook handling for workflows. Check the number of zeros in `ev.Before` and use `ev.Commits` to get changed files when a new branch is pushed.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0238eda</samp>

*  Add a condition to handle new branch pushes with many zeros in ev.Before ([link](https://github.com/koderover/zadig/pull/2912/files?diff=unified&w=0#diff-9a9f8d26b928747ff3c5b2c3b49e587a740af9e07102c7f646788973063d8c99L235-R254), [link](https://github.com/koderover/zadig/pull/2912/files?diff=unified&w=0#diff-62f28fca89ab40df10467ceae2548884f001961407d569d6b600cf254ef7ab8fL196-R216))
  - Import strings package to use strings.Count function in `gitlab_workflowv4_task.go` ([link](https://github.com/koderover/zadig/pull/2912/files?diff=unified&w=0#diff-62f28fca89ab40df10467ceae2548884f001961407d569d6b600cf254ef7ab8fR23))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
