### PR TITLE
fix: WarpDrive wait job start not handle context.Done

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -878,6 +878,8 @@ func waitJobReady(ctx context.Context, namespace, jobName string, kubeClient cli
 			return config.StatusTimeout, fmt.Errorf("wait job ready timeout")
 		case <-waitPodReadyTimeout:
 			podReadyTimeout = true
+		case <-ctx.Done():
+			return config.StatusCancelled, fmt.Errorf("cancel")
 		default:
 			time.Sleep(time.Second)
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee8303b</samp>

Handle context cancellation in `waitJobReady` function. This improves the responsiveness and error handling of the task plugin that waits for jobs to be ready.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ee8303b</samp>

*  Handle context cancellation in `waitJobReady` function ([link](https://github.com/koderover/zadig/pull/2913/files?diff=unified&w=0#diff-ce47c76b9b06eaac0a677b21c12775707e19c389dfaa70cdeaf82ff964cff232R881-R882))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
