### PR TITLE
 add resource permission control function to the cluster (#2909)

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/k8s_cluster.go
+++ b/pkg/microservice/aslan/core/common/repository/models/k8s_cluster.go
@@ -69,10 +69,12 @@ type K8SClusterInfo struct {
 }
 
 type AdvancedConfig struct {
-	Strategy     string                     `json:"strategy,omitempty"       bson:"strategy,omitempty"`
-	NodeLabels   []*NodeSelectorRequirement `json:"node_labels,omitempty"    bson:"node_labels,omitempty"`
-	ProjectNames []string                   `json:"-"                        bson:"-"`
-	Tolerations  string                     `json:"tolerations"              bson:"tolerations"`
+	Strategy          string                     `json:"strategy,omitempty"       bson:"strategy,omitempty"`
+	NodeLabels        []*NodeSelectorRequirement `json:"node_labels,omitempty"    bson:"node_labels,omitempty"`
+	ProjectNames      []string                   `json:"-"                        bson:"-"`
+	Tolerations       string                     `json:"tolerations"              bson:"tolerations"`
+	ClusterAccessYaml string                     `json:"cluster_access_yaml"      bson:"cluster_access_yaml"`
+	ScheduleWorkflow  bool                       `json:"schedule_workflow"        bson:"schedule_workflow"`
 }
 
 type NodeSelectorRequirement struct {

--- a/pkg/microservice/aslan/core/multicluster/service/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/service/clusters.go
@@ -81,10 +81,12 @@ type K8SCluster struct {
 }
 
 type AdvancedConfig struct {
-	Strategy     string   `json:"strategy,omitempty"        bson:"strategy,omitempty"`
-	NodeLabels   []string `json:"node_labels,omitempty"     bson:"node_labels,omitempty"`
-	ProjectNames []string `json:"project_names"             bson:"project_names"`
-	Tolerations  string   `json:"tolerations"               bson:"tolerations"`
+	Strategy          string   `json:"strategy,omitempty"        bson:"strategy,omitempty"`
+	NodeLabels        []string `json:"node_labels,omitempty"     bson:"node_labels,omitempty"`
+	ProjectNames      []string `json:"project_names"             bson:"project_names"`
+	Tolerations       string   `json:"tolerations"               bson:"tolerations"`
+	ClusterAccessYaml string   `json:"cluster_access_yaml"       bson:"cluster_access_yaml"`
+	ScheduleWorkflow  bool     `json:"schedule_workflow"         bson:"schedule_workflow"`
 }
 
 func (k *K8SCluster) Clean() error {
@@ -131,10 +133,18 @@ func ListClusters(ids []string, projectName string, logger *zap.SugaredLogger) (
 		var advancedConfig *AdvancedConfig
 		if c.AdvancedConfig != nil {
 			advancedConfig = &AdvancedConfig{
-				Strategy:     c.AdvancedConfig.Strategy,
-				NodeLabels:   convertToNodeLabels(c.AdvancedConfig.NodeLabels),
-				ProjectNames: getProjectNames(c.ID.Hex(), logger),
-				Tolerations:  c.AdvancedConfig.Tolerations,
+				Strategy:          c.AdvancedConfig.Strategy,
+				NodeLabels:        convertToNodeLabels(c.AdvancedConfig.NodeLabels),
+				ProjectNames:      getProjectNames(c.ID.Hex(), logger),
+				Tolerations:       c.AdvancedConfig.Tolerations,
+				ClusterAccessYaml: c.AdvancedConfig.ClusterAccessYaml,
+			}
+			if advancedConfig.ClusterAccessYaml != "" {
+				advancedConfig.ScheduleWorkflow = c.AdvancedConfig.ScheduleWorkflow
+				advancedConfig.ClusterAccessYaml = c.AdvancedConfig.ClusterAccessYaml
+			} else {
+				advancedConfig.ScheduleWorkflow = true
+				advancedConfig.ClusterAccessYaml = kube.ClusterAccessYamlTemplate
 			}
 		}
 
@@ -248,6 +258,18 @@ func CreateCluster(args *K8SCluster, logger *zap.SugaredLogger) (*commonmodels.K
 			ProjectNames: args.AdvancedConfig.ProjectNames,
 			Tolerations:  args.AdvancedConfig.Tolerations,
 		}
+		if args.AdvancedConfig.ClusterAccessYaml == "" {
+			advancedConfig.ClusterAccessYaml = kube.ClusterAccessYamlTemplate
+			advancedConfig.ScheduleWorkflow = true
+		} else {
+			// check the cluster access yaml
+			err = kube.ValidateClusterRoleYAML(args.AdvancedConfig.ClusterAccessYaml, logger)
+			if err != nil {
+				return nil, fmt.Errorf("invalid cluster access yaml: %s", err)
+			}
+			advancedConfig.ClusterAccessYaml = args.AdvancedConfig.ClusterAccessYaml
+			advancedConfig.ScheduleWorkflow = args.AdvancedConfig.ScheduleWorkflow
+		}
 	}
 
 	err = buildConfigs(args)
@@ -285,6 +307,20 @@ func UpdateCluster(id string, args *K8SCluster, logger *zap.SugaredLogger) (*com
 		advancedConfig.Strategy = args.AdvancedConfig.Strategy
 		advancedConfig.NodeLabels = convertToNodeSelectorRequirements(args.AdvancedConfig.NodeLabels)
 		advancedConfig.Tolerations = args.AdvancedConfig.Tolerations
+
+		if args.AdvancedConfig.ClusterAccessYaml == "" || args.Local {
+			advancedConfig.ClusterAccessYaml = kube.ClusterAccessYamlTemplate
+			advancedConfig.ScheduleWorkflow = true
+		} else {
+			// check the cluster access yaml
+			err = kube.ValidateClusterRoleYAML(args.AdvancedConfig.ClusterAccessYaml, logger)
+			if err != nil {
+				return nil, fmt.Errorf("invalid cluster access yaml: %s", err)
+			}
+			advancedConfig.ClusterAccessYaml = args.AdvancedConfig.ClusterAccessYaml
+			advancedConfig.ScheduleWorkflow = args.AdvancedConfig.ScheduleWorkflow
+		}
+
 		// Delete all projects associated with clusterID
 		err := commonrepo.NewProjectClusterRelationColl().Delete(&commonrepo.ProjectClusterRelationOption{ClusterID: id})
 		if err != nil {
@@ -307,6 +343,27 @@ func UpdateCluster(id string, args *K8SCluster, logger *zap.SugaredLogger) (*com
 		return nil, err
 	}
 
+	cluster := &commonmodels.K8SCluster{
+		Name:           args.Name,
+		Description:    args.Description,
+		AdvancedConfig: advancedConfig,
+		Production:     args.Production,
+		Cache:          args.Cache,
+		DindCfg:        args.DindCfg,
+		Type:           args.Type,
+		KubeConfig:     args.KubeConfig,
+		ShareStorage:   args.ShareStorage,
+		Provider:       args.Provider,
+	}
+	cluster, err = s.UpdateCluster(id, cluster, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update cluster %q: %s", id, err)
+	}
+	// if we don't need this cluster to schedule workflow, we don't need to upgrade hub-agent
+	if cluster.AdvancedConfig != nil && !cluster.AdvancedConfig.ScheduleWorkflow {
+		return cluster, nil
+	}
+
 	// If the user chooses to use dynamically generated storage resources, the system automatically creates the PVC.
 	// TODO: If the PVC is not successfully bound to the PV, it is necessary to consider how to expose this abnormal information.
 	//       Depends on product design.
@@ -324,24 +381,6 @@ func UpdateCluster(id string, args *K8SCluster, logger *zap.SugaredLogger) (*com
 		if err := createDynamicPVC(id, "share-storage", &args.ShareStorage.NFSProperties, logger); err != nil {
 			return nil, err
 		}
-	}
-
-	cluster := &commonmodels.K8SCluster{
-		Name:           args.Name,
-		Description:    args.Description,
-		AdvancedConfig: advancedConfig,
-		Production:     args.Production,
-		Cache:          args.Cache,
-		DindCfg:        args.DindCfg,
-		Type:           args.Type,
-		KubeConfig:     args.KubeConfig,
-		ShareStorage:   args.ShareStorage,
-		Provider:       args.Provider,
-	}
-
-	cluster, err = s.UpdateCluster(id, cluster, logger)
-	if err != nil {
-		return nil, fmt.Errorf("failed to update cluster %q: %s", id, err)
 	}
 
 	return cluster, UpgradeAgent(id, logger)
@@ -443,7 +482,15 @@ func UpgradeAgent(id string, logger *zap.SugaredLogger) error {
 
 	for _, u := range resources {
 		if u.GetKind() == "StatefulSet" && u.GetName() == types.DindStatefulSetName {
-			err = UpgradeDind(kubeClient, clusterInfo, setting.AttachedClusterNamespace)
+			if err = kubeClient.Get(context.TODO(), client.ObjectKey{
+				Name:      types.DindStatefulSetName,
+				Namespace: setting.AttachedClusterNamespace,
+			}, &appsv1.StatefulSet{}); err != nil {
+				logger.Infof("failed to get dind from %s, start to create dind", setting.AttachedClusterNamespace)
+				err = updater.CreateOrPatchUnstructured(u, kubeClient)
+			} else {
+				err = UpgradeDind(kubeClient, clusterInfo, setting.AttachedClusterNamespace)
+			}
 		} else {
 			err = updater.CreateOrPatchUnstructured(u, kubeClient)
 		}

--- a/pkg/microservice/hubagent/config/config.go
+++ b/pkg/microservice/hubagent/config/config.go
@@ -43,3 +43,7 @@ func KubernetesServicePort() string {
 func AslanBaseAddr() string {
 	return viper.GetString(setting.AslanBaseAddr)
 }
+
+func ScheduleWorkflow() string {
+	return viper.GetString(setting.ScheduleWorkflow)
+}

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -83,6 +83,7 @@ const (
 	Token                 = "X-API-Tunnel-Token"
 	Params                = "X-API-Tunnel-Params"
 	AslanBaseAddr         = "ASLAN_BASE_ADDR"
+	ScheduleWorkflow      = "SCHEDULE_WORKFLOW"
 
 	// warpdrive
 	WarpDrivePodName    = "WD_POD_NAME"
@@ -443,7 +444,7 @@ const (
 	// GerritDefaultOwner
 	GerritDefaultOwner = "dafault"
 	// YamlFileSeperator ...
-	YamlFileSeperator = "\n---\n"
+	YamlFileSeperator             = "\n---\n"
 	HelmChartDeployStrategySuffix = "<+helm_chart>"
 )
 

--- a/pkg/shared/client/aslan/multicluster.go
+++ b/pkg/shared/client/aslan/multicluster.go
@@ -101,7 +101,16 @@ type ClusterDetail struct {
 	KubeConfig string `json:"kube_config"    bson:"kube_config"`
 
 	// Deprecated field, it should be deleted in version 1.15 since no more namespace settings is used
-	Namespace string `json:"namespace"                 bson:"namespace"`
+	Namespace      string          `json:"namespace"                 bson:"namespace"`
+	AdvancedConfig *AdvancedConfig `json:"advanced_config"           bson:"advanced_config"`
+}
+
+type AdvancedConfig struct {
+	Strategy          string   `json:"strategy,omitempty"       bson:"strategy,omitempty"`
+	ProjectNames      []string `json:"-"                        bson:"-"`
+	Tolerations       string   `json:"tolerations"              bson:"tolerations"`
+	ClusterAccessYaml string   `json:"cluster_access_yaml"      bson:"cluster_access_yaml"`
+	ScheduleWorkflow  bool     `json:"schedule_workflow"        bson:"schedule_workflow"`
 }
 
 func (c *Client) GetClusterInfo(clusterID string) (*ClusterDetail, error) {
@@ -120,6 +129,5 @@ func (c *Client) GetClusterInfo(clusterID string) (*ClusterDetail, error) {
 		}
 		return nil, fmt.Errorf("Failed to get cluster, error: %s", err)
 	}
-
 	return clusterResp, nil
 }


### PR DESCRIPTION
* add resource permission control function to the cluster
2909


* resolve the problem that can not update yaml to db
2909


---------

### What this PR does / Why we need it:
copilot:summary

### What is changed and how it works?
copilot:walkthrough

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
