### PR TITLE
add env sleep feature

### DIFF
--- a/pkg/microservice/aslan/config/consts.go
+++ b/pkg/microservice/aslan/config/consts.go
@@ -46,6 +46,7 @@ const (
 	WorkflowV4Cronjob  = "workflow_v4"
 	TestingCronjob     = "test"
 	EnvAnalysisCronjob = "env_analysis"
+	EnvSleepCronjob    = "env_sleep"
 )
 
 var (

--- a/pkg/microservice/aslan/core/common/repository/models/cronjob.go
+++ b/pkg/microservice/aslan/core/common/repository/models/cronjob.go
@@ -41,6 +41,7 @@ type Cronjob struct {
 }
 
 type EnvArgs struct {
+	Name        string `bson:"name"                    json:"name"`
 	ProductName string `bson:"product_name"            json:"product_name"`
 	EnvName     string `bson:"env_name"                json:"env_name"`
 	Production  bool   `bson:"production"              json:"production"`

--- a/pkg/microservice/aslan/core/common/repository/models/cronjob.go
+++ b/pkg/microservice/aslan/core/common/repository/models/cronjob.go
@@ -34,12 +34,13 @@ type Cronjob struct {
 	WorkflowArgs    *WorkflowTaskArgs  `bson:"workflow_args,omitempty"             json:"workflow_args,omitempty"`
 	WorkflowV4Args  *WorkflowV4        `bson:"workflow_v4_args"                    json:"workflow_v4_args"`
 	TestArgs        *TestTaskArgs      `bson:"test_args,omitempty"                 json:"test_args,omitempty"`
-	EnvAnalysisArgs *EnvAnalysisArgs   `bson:"env_analysis_args,omitempty"         json:"env_analysis_args,omitempty"`
+	EnvAnalysisArgs *EnvArgs           `bson:"env_analysis_args,omitempty"         json:"env_analysis_args,omitempty"`
+	EnvArgs         *EnvArgs           `bson:"env_args,omitempty"                  json:"env_args,omitempty"`
 	JobType         string             `bson:"job_type"                            json:"job_type"`
 	Enabled         bool               `bson:"enabled"                             json:"enabled"`
 }
 
-type EnvAnalysisArgs struct {
+type EnvArgs struct {
 	ProductName string `bson:"product_name"            json:"product_name"`
 	EnvName     string `bson:"env_name"                json:"env_name"`
 	Production  bool   `bson:"production"              json:"production"`

--- a/pkg/microservice/aslan/core/common/repository/models/product.go
+++ b/pkg/microservice/aslan/core/common/repository/models/product.go
@@ -243,3 +243,7 @@ func (p *Product) EnsureRenderInfo() {
 	}
 	p.Render = &RenderInfo{ProductTmpl: p.ProductName, Name: p.Namespace}
 }
+
+func (p *Product) IsSleeping() bool {
+	return p.Status == setting.ProductStatusSleeping
+}

--- a/pkg/microservice/aslan/core/common/repository/models/product.go
+++ b/pkg/microservice/aslan/core/common/repository/models/product.go
@@ -68,9 +68,12 @@ type Product struct {
 	// New Since v1.16.0, used to determine whether to install resources
 	ServiceDeployStrategy map[string]string `bson:"service_deploy_strategy" json:"service_deploy_strategy"`
 
-	// New Since v.1.19.0, env configs
+	// New Since v.1.18.0, env configs
 	AnalysisConfig      *AnalysisConfig       `bson:"analysis_config"      json:"analysis_config"`
 	NotificationConfigs []*NotificationConfig `bson:"notification_configs" json:"notification_configs"`
+
+	// New Since v1.19.0, env sleep configs
+	PreSleepStatus map[string]int `bson:"pre_sleep_status" json:"pre_sleep_status"`
 
 	// For production environment
 	Production bool   `json:"production" bson:"production"`

--- a/pkg/microservice/aslan/core/common/repository/models/workflow.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow.go
@@ -126,7 +126,7 @@ type Schedule struct {
 	WorkflowArgs    *WorkflowTaskArgs   `bson:"workflow_args,omitempty"       json:"workflow_args,omitempty"`
 	TestArgs        *TestTaskArgs       `bson:"test_args,omitempty"           json:"test_args,omitempty"`
 	WorkflowV4Args  *WorkflowV4         `bson:"workflow_v4_args"              json:"workflow_v4_args"`
-	EnvAnalysisArgs *EnvAnalysisArgs    `bson:"env_analysis_args,omitempty"   json:"env_analysis_args,omitempty"`
+	EnvAnalysisArgs *EnvArgs            `bson:"env_analysis_args,omitempty"   json:"env_analysis_args,omitempty"`
 	Type            config.ScheduleType `bson:"type"                          json:"type"`
 	Cron            string              `bson:"cron"                          json:"cron"`
 	IsModified      bool                `bson:"-"                             json:"-"`

--- a/pkg/microservice/aslan/core/common/repository/models/workflow.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow.go
@@ -127,6 +127,7 @@ type Schedule struct {
 	TestArgs        *TestTaskArgs       `bson:"test_args,omitempty"           json:"test_args,omitempty"`
 	WorkflowV4Args  *WorkflowV4         `bson:"workflow_v4_args"              json:"workflow_v4_args"`
 	EnvAnalysisArgs *EnvArgs            `bson:"env_analysis_args,omitempty"   json:"env_analysis_args,omitempty"`
+	EnvArgs         *EnvArgs            `bson:"env_args,omitempty"            json:"env_args,omitempty"`
 	Type            config.ScheduleType `bson:"type"                          json:"type"`
 	Cron            string              `bson:"cron"                          json:"cron"`
 	IsModified      bool                `bson:"-"                             json:"-"`

--- a/pkg/microservice/aslan/core/common/repository/mongodb/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/product.go
@@ -386,6 +386,9 @@ func (c *ProductColl) Update(args *models.Product) error {
 	if args.ServiceDeployStrategy != nil {
 		changePayload["service_deploy_strategy"] = args.ServiceDeployStrategy
 	}
+	if args.PreSleepStatus != nil {
+		changePayload["pre_sleep_status"] = args.PreSleepStatus
+	}
 	change := bson.M{"$set": changePayload}
 	_, err := c.UpdateOne(context.TODO(), query, change)
 	return err

--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -463,7 +463,7 @@ func fillServiceInfo(svcList []*ServiceResp, productInfo *models.Product) {
 
 // ListWorkloadDetailsInEnv returns all workloads in the given env which meet the filter.
 // this function is used for two scenarios: 1. calculate product status 2. list workflow details
-func buildWorkloadFilterFunc(productInfo *models.Product, projectInfo *templatemodels.Product, filter string, log *zap.SugaredLogger) ([]FilterFunc, error) {
+func BuildWorkloadFilterFunc(productInfo *models.Product, projectInfo *templatemodels.Product, filter string, log *zap.SugaredLogger) ([]FilterFunc, error) {
 	productName, envName := productInfo.ProductName, productInfo.EnvName
 	filterArray := []FilterFunc{
 		func(workloads []*Workload) []*Workload {
@@ -565,7 +565,7 @@ func ListWorkloadsInEnv(envName, productName, filter string, perPage, page int, 
 		return 0, nil, e.ErrListGroups.AddDesc(err.Error())
 	}
 
-	filterArray, err := buildWorkloadFilterFunc(productInfo, projectInfo, filter, log)
+	filterArray, err := BuildWorkloadFilterFunc(productInfo, projectInfo, filter, log)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -605,7 +605,7 @@ func ListWorkloadDetailsInEnv(envName, productName, filter string, perPage, page
 		return 0, nil, e.ErrListGroups.AddDesc(err.Error())
 	}
 
-	filterArray, err := buildWorkloadFilterFunc(productInfo, projectInfo, filter, log)
+	filterArray, err := BuildWorkloadFilterFunc(productInfo, projectInfo, filter, log)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -712,6 +712,7 @@ func fillServiceName(envName, productName string, workloads []*Workload) error {
 	return nil
 }
 
+// @note list workloads
 func ListWorkloads(envName, productName string, perPage, page int, informer informers.SharedInformerFactory, version *version.Info, log *zap.SugaredLogger, filter ...FilterFunc) (int, []*Workload, error) {
 	var workLoads []*Workload
 	listDeployments, err := getter.ListDeploymentsWithCache(nil, informer)

--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -715,7 +715,6 @@ func fillServiceName(envName, productName string, workloads []*Workload) error {
 	return nil
 }
 
-// @note list workloads
 func ListWorkloads(envName, productName string, perPage, page int, informer informers.SharedInformerFactory, version *version.Info, log *zap.SugaredLogger, filter ...FilterFunc) (int, []*Workload, error) {
 	var workLoads []*Workload
 	listDeployments, err := getter.ListDeploymentsWithCache(nil, informer)
@@ -875,7 +874,7 @@ func ListWorkloadDetails(envName, clusterID, namespace, productName string, perP
 			selector := labels.SelectorFromSet(workload.Spec.Labels)
 			// Note: In some scenarios, such as environment sharing, there may be more containers in Pod than workload.
 			// We call GetSelectedPodsInfo to get the status and readiness to keep same logic with k8s projects
-			productRespInfo.Status, productRespInfo.Ready, productRespInfo.Images = kube.GetSelectedPodsInfo(selector, informer, log)
+			productRespInfo.Status, productRespInfo.Ready, productRespInfo.Images = kube.GetSelectedPodsInfo(selector, informer, workload.Images, log)
 			productRespInfo.Ingress = &IngressInfo{
 				HostInfo: FindServiceFromIngress(hostInfos, workload, allServices),
 			}

--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -673,6 +673,7 @@ type Workload struct {
 	EnvName     string                 `json:"env_name"`
 	Name        string                 `json:"name"`
 	Type        string                 `json:"type"`
+	ServiceName string                 `json:"-"`
 	ProductName string                 `json:"product_name"`
 	Spec        corev1.PodTemplateSpec `json:"-"`
 	Images      []string               `json:"-"`

--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -670,18 +670,20 @@ func (f *workloadFilter) Match(workload *Workload) bool {
 }
 
 type Workload struct {
-	EnvName     string                 `json:"env_name"`
-	Name        string                 `json:"name"`
-	Type        string                 `json:"type"`
-	ServiceName string                 `json:"-"`
-	ProductName string                 `json:"product_name"`
-	Spec        corev1.PodTemplateSpec `json:"-"`
-	Images      []string               `json:"-"`
-	Ready       bool                   `json:"ready"`
-	Annotation  map[string]string      `json:"-"`
-	Status      string                 `json:"-"`
-	ReleaseName string                 `json:"-"` //ReleaseName refers to the releaseName of helm services
-	ChartName   string                 `json:"-"` //ChartName refers to chartName of helm services
+	EnvName           string                 `json:"env_name"`
+	Name              string                 `json:"name"`
+	Type              string                 `json:"type"`
+	ServiceName       string                 `json:"-"`
+	DeployedFromZadig bool                   `json:"-"`
+	ProductName       string                 `json:"product_name"`
+	Replicas          int32                  `json:"-"`
+	Spec              corev1.PodTemplateSpec `json:"-"`
+	Images            []string               `json:"-"`
+	Ready             bool                   `json:"ready"`
+	Annotation        map[string]string      `json:"-"`
+	Status            string                 `json:"-"`
+	ReleaseName       string                 `json:"-"` //ReleaseName refers to the releaseName of helm services
+	ChartName         string                 `json:"-"` //ChartName refers to chartName of helm services
 }
 
 // fillServiceName set service name defined in zadig to workloads, this would be helpful for helm release view
@@ -726,6 +728,7 @@ func ListWorkloads(envName, productName string, perPage, page int, informer info
 			Name:       v.Name,
 			Spec:       v.Spec.Template,
 			Type:       setting.Deployment,
+			Replicas:   *v.Spec.Replicas,
 			Images:     wrapper.Deployment(v).ImageInfos(),
 			Ready:      wrapper.Deployment(v).Ready(),
 			Annotation: v.Annotations,
@@ -740,6 +743,7 @@ func ListWorkloads(envName, productName string, perPage, page int, informer info
 			Name:       v.Name,
 			Spec:       v.Spec.Template,
 			Type:       setting.StatefulSet,
+			Replicas:   *v.Spec.Replicas,
 			Images:     wrapper.StatefulSet(v).ImageInfos(),
 			Ready:      wrapper.StatefulSet(v).Ready(),
 			Annotation: v.Annotations,

--- a/pkg/microservice/aslan/core/common/service/kube/render.go
+++ b/pkg/microservice/aslan/core/common/service/kube/render.go
@@ -607,6 +607,10 @@ func RenderEnvService(prod *commonmodels.Product, render *commonmodels.RenderSet
 		return "", err
 	}
 
+	return RenderEnvServiceWithTempl(prod, render, service, svcTmpl)
+}
+
+func RenderEnvServiceWithTempl(prod *commonmodels.Product, render *commonmodels.RenderSet, service *commonmodels.ProductService, svcTmpl *commonmodels.Service) (yaml string, err error) {
 	// Note only the keys in TemplateService.ServiceVar can work
 	parsedYaml, err := RenderServiceYaml(svcTmpl.Yaml, prod.ProductName, svcTmpl.ServiceName, render)
 	if err != nil {

--- a/pkg/microservice/aslan/core/common/service/kube/status.go
+++ b/pkg/microservice/aslan/core/common/service/kube/status.go
@@ -28,17 +28,17 @@ import (
 	"github.com/koderover/zadig/pkg/tool/kube/getter"
 )
 
-func GetSelectedPodsInfo(selector labels.Selector, informer informers.SharedInformerFactory, log *zap.SugaredLogger) (string, string, []string) {
+func GetSelectedPodsInfo(selector labels.Selector, informer informers.SharedInformerFactory, currentImages []string, log *zap.SugaredLogger) (string, string, []string) {
 	pods, err := getter.ListPodsWithCache(selector, informer)
 	if err != nil {
 		return setting.PodError, setting.PodNotReady, nil
 	}
 
 	if len(pods) == 0 {
-		return setting.PodNonStarted, setting.PodNotReady, nil
+		return setting.PodNonStarted, setting.PodNotReady, currentImages
 	}
 
-	imageSet := sets.String{}
+	imageSet := sets.NewString()
 	for _, pod := range pods {
 		ipod := wrapper.Pod(pod)
 		imageSet.Insert(ipod.Containers()...)

--- a/pkg/microservice/aslan/core/common/service/service.go
+++ b/pkg/microservice/aslan/core/common/service/service.go
@@ -1397,7 +1397,7 @@ func GetServiceImpl(serviceName string, serviceTmpl *commonmodels.Service, workL
 		case setting.StatefulSet:
 			statefulSet, err := getter.GetStatefulSetByNameWWithCache(serviceName, namespace, inf)
 			if err != nil {
-				return nil, e.ErrGetService.AddDesc(fmt.Sprintf("service %s not found", serviceName))
+				return nil, e.ErrGetService.AddDesc(fmt.Sprintf("service %s not found for statuefulSet, err: %v", serviceName, err))
 			}
 			scale := getStatefulSetWorkloadResource(statefulSet, inf, log)
 			ret.Scales = append(ret.Scales, scale)
@@ -1412,7 +1412,7 @@ func GetServiceImpl(serviceName string, serviceTmpl *commonmodels.Service, workL
 		case setting.Deployment:
 			deploy, err := getter.GetDeploymentByNameWithCache(serviceName, namespace, inf)
 			if err != nil {
-				return nil, e.ErrGetService.AddDesc(fmt.Sprintf("service %s not found, err: %s", serviceName, err.Error()))
+				return nil, e.ErrGetService.AddDesc(fmt.Sprintf("service %s not found for deployment, err: %s", serviceName, err.Error()))
 			}
 			scale := GetDeploymentWorkloadResource(deploy, inf, log)
 			ret.Workloads = append(ret.Workloads, ToDeploymentWorkload(deploy))
@@ -1436,7 +1436,7 @@ func GetServiceImpl(serviceName string, serviceTmpl *commonmodels.Service, workL
 			}
 			ret.CronJobs = append(ret.CronJobs, getCronJobWorkLoadResource(cj, cjBeta, log))
 		default:
-			return nil, e.ErrGetService.AddDesc(fmt.Sprintf("service %s not found", serviceName))
+			return nil, e.ErrGetService.AddDesc(fmt.Sprintf("service %s not found, unknow type", serviceName))
 		}
 	default:
 		service := env.GetServiceMap()[serviceName]

--- a/pkg/microservice/aslan/core/common/service/service.go
+++ b/pkg/microservice/aslan/core/common/service/service.go
@@ -29,7 +29,14 @@ import (
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/api/batch/v1beta1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/helm/pkg/releaseutil"
 	"sigs.k8s.io/yaml"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
@@ -44,7 +51,12 @@ import (
 	commontypes "github.com/koderover/zadig/pkg/microservice/aslan/core/common/types"
 	commonutil "github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/pkg/setting"
+	kubeclient "github.com/koderover/zadig/pkg/shared/kube/client"
+	internalresource "github.com/koderover/zadig/pkg/shared/kube/resource"
+	"github.com/koderover/zadig/pkg/shared/kube/wrapper"
 	e "github.com/koderover/zadig/pkg/tool/errors"
+	"github.com/koderover/zadig/pkg/tool/kube/getter"
+	"github.com/koderover/zadig/pkg/tool/kube/serializer"
 	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/koderover/zadig/pkg/types"
 	"github.com/koderover/zadig/pkg/util"
@@ -1340,4 +1352,243 @@ func ConvertVaraibleKVAndYaml(args *ConvertVaraibleKVAndYamlArgs) (*ConvertVarai
 	}
 
 	return args, nil
+}
+
+// SvcResp struct 产品-服务详情页面Response
+type SvcResp struct {
+	ServiceName string                       `json:"service_name"`
+	Scales      []*internalresource.Workload `json:"scales"`
+	Ingress     []*internalresource.Ingress  `json:"ingress"`
+	Services    []*internalresource.Service  `json:"service_endpoints"`
+	CronJobs    []*internalresource.CronJob  `json:"cron_jobs"`
+	Namespace   string                       `json:"namespace"`
+	EnvName     string                       `json:"env_name"`
+	ProductName string                       `json:"product_name"`
+	GroupName   string                       `json:"group_name"`
+	Workloads   []*Workload                  `json:"-"`
+}
+
+func GetServiceImpl(serviceName string, serviceTmpl *commonmodels.Service, workLoadType string, env *commonmodels.Product, clientset *kubernetes.Clientset, inf informers.SharedInformerFactory, log *zap.SugaredLogger) (ret *SvcResp, err error) {
+	envName, productName := env.EnvName, env.ProductName
+	ret = &SvcResp{
+		ServiceName: serviceName,
+		EnvName:     envName,
+		ProductName: productName,
+		Services:    make([]*internalresource.Service, 0),
+		Ingress:     make([]*internalresource.Ingress, 0),
+		Scales:      make([]*internalresource.Workload, 0),
+		CronJobs:    make([]*internalresource.CronJob, 0),
+	}
+	err = nil
+
+	namespace := env.Namespace
+	switch env.Source {
+	case setting.SourceFromExternal, setting.SourceFromHelm:
+		if env.Source == setting.SourceFromExternal {
+			svcOpt := &commonrepo.ServiceFindOption{ProductName: productName, ServiceName: serviceName, Type: setting.K8SDeployType}
+			modelSvc, err := commonrepo.NewServiceColl().Find(svcOpt)
+			if err != nil {
+				return nil, e.ErrGetService.AddErr(err)
+			}
+			workLoadType = modelSvc.WorkloadType
+		}
+		k8sServices, _ := getter.ListServicesWithCache(nil, inf)
+		switch workLoadType {
+		case setting.StatefulSet:
+			statefulSet, err := getter.GetStatefulSetByNameWWithCache(serviceName, namespace, inf)
+			if err != nil {
+				return nil, e.ErrGetService.AddDesc(fmt.Sprintf("service %s not found", serviceName))
+			}
+			scale := getStatefulSetWorkloadResource(statefulSet, inf, log)
+			ret.Scales = append(ret.Scales, scale)
+			ret.Workloads = append(ret.Workloads, toStsWorkload(statefulSet))
+			podLabels := labels.Set(statefulSet.Spec.Template.GetLabels())
+			for _, svc := range k8sServices {
+				if labels.SelectorFromValidatedSet(svc.Spec.Selector).Matches(podLabels) {
+					ret.Services = append(ret.Services, wrapper.Service(svc).Resource())
+					break
+				}
+			}
+		case setting.Deployment:
+			deploy, err := getter.GetDeploymentByNameWithCache(serviceName, namespace, inf)
+			if err != nil {
+				return nil, e.ErrGetService.AddDesc(fmt.Sprintf("service %s not found, err: %s", serviceName, err.Error()))
+			}
+			scale := GetDeploymentWorkloadResource(deploy, inf, log)
+			ret.Workloads = append(ret.Workloads, ToDeploymentWorkload(deploy))
+			ret.Scales = append(ret.Scales, scale)
+			podLabels := labels.Set(deploy.Spec.Template.GetLabels())
+			for _, svc := range k8sServices {
+				if labels.SelectorFromValidatedSet(svc.Spec.Selector).Matches(podLabels) {
+					ret.Services = append(ret.Services, wrapper.Service(svc).Resource())
+					break
+				}
+			}
+		case setting.CronJob:
+			version, err := clientset.Discovery().ServerVersion()
+			if err != nil {
+				log.Warnf("Failed to determine server version, error is: %s", err)
+				return ret, nil
+			}
+			cj, cjBeta, err := getter.GetCronJobByNameWithCache(serviceName, namespace, inf, kubeclient.VersionLessThan121(version))
+			if err != nil {
+				return ret, nil
+			}
+			ret.CronJobs = append(ret.CronJobs, getCronJobWorkLoadResource(cj, cjBeta, log))
+		default:
+			return nil, e.ErrGetService.AddDesc(fmt.Sprintf("service %s not found", serviceName))
+		}
+	default:
+		service := env.GetServiceMap()[serviceName]
+		if service == nil {
+			return nil, e.ErrGetService.AddDesc(fmt.Sprintf("failed to find service in environment: %s", envName))
+		}
+
+		env.EnsureRenderInfo()
+		renderSetFindOpt := &commonrepo.RenderSetFindOption{
+			Name:        env.Render.Name,
+			Revision:    env.Render.Revision,
+			ProductTmpl: env.ProductName,
+			EnvName:     envName,
+		}
+		rs, err := commonrepo.NewRenderSetColl().Find(renderSetFindOpt)
+		if err != nil {
+			log.Errorf("find renderset[%s] error: %v", env.Render.Name, err)
+			return nil, e.ErrGetService.AddDesc(fmt.Sprintf("未找到变量集: %s", env.Render.Name))
+		}
+
+		parsedYaml, err := kube.RenderServiceYaml(serviceTmpl.Yaml, productName, serviceTmpl.ServiceName, rs)
+		if err != nil {
+			log.Errorf("failed to render service yaml, err: %s", err)
+			return nil, err
+		}
+		// 渲染系统变量键值
+		parsedYaml = kube.ParseSysKeys(namespace, envName, productName, service.ServiceName, parsedYaml)
+
+		manifests := releaseutil.SplitManifests(parsedYaml)
+		for _, item := range manifests {
+			u, err := serializer.NewDecoder().YamlToUnstructured([]byte(item))
+			if err != nil {
+				log.Warnf("Failed to decode yaml to Unstructured, err: %s", err)
+				continue
+			}
+
+			switch u.GetKind() {
+			case setting.Deployment:
+				d, err := getter.GetDeploymentByNameWithCache(u.GetName(), namespace, inf)
+				if err != nil {
+					continue
+				}
+
+				ret.Scales = append(ret.Scales, GetDeploymentWorkloadResource(d, inf, log))
+				ret.Workloads = append(ret.Workloads, ToDeploymentWorkload(d))
+			case setting.StatefulSet:
+				sts, err := getter.GetStatefulSetByNameWWithCache(u.GetName(), namespace, inf)
+				if err != nil {
+					continue
+				}
+
+				ret.Scales = append(ret.Scales, getStatefulSetWorkloadResource(sts, inf, log))
+				ret.Workloads = append(ret.Workloads, toStsWorkload(sts))
+			case setting.CronJob:
+				version, err := clientset.Discovery().ServerVersion()
+				if err != nil {
+					log.Warnf("Failed to determine server version, error is: %s", err)
+					continue
+				}
+				cj, cjBeta, err := getter.GetCronJobByNameWithCache(u.GetName(), namespace, inf, kubeclient.VersionLessThan121(version))
+				if err != nil {
+					continue
+				}
+				ret.CronJobs = append(ret.CronJobs, getCronJobWorkLoadResource(cj, cjBeta, log))
+			case setting.Ingress:
+				version, err := clientset.Discovery().ServerVersion()
+				if err != nil {
+					log.Warnf("Failed to determine server version, error is: %s", err)
+					continue
+				}
+				if kubeclient.VersionLessThan122(version) {
+					ing, found, err := getter.GetExtensionsV1Beta1Ingress(namespace, u.GetName(), inf)
+					if err != nil || !found {
+						//log.Warnf("no ingress %s found in %s:%s %v", u.GetName(), service.ServiceName, namespace, err)
+						continue
+					}
+
+					ret.Ingress = append(ret.Ingress, wrapper.Ingress(ing).Resource())
+				} else {
+					ing, err := getter.GetNetworkingV1Ingress(namespace, u.GetName(), inf)
+					if err != nil {
+						//log.Warnf("no ingress %s found in %s:%s %v", u.GetName(), service.ServiceName, namespace, err)
+						continue
+					}
+
+					ingress := &internalresource.Ingress{
+						Name:     ing.Name,
+						Labels:   ing.Labels,
+						HostInfo: wrapper.GetIngressHostInfo(ing),
+						IPs:      []string{},
+						Age:      util.Age(ing.CreationTimestamp.Unix()),
+					}
+
+					ret.Ingress = append(ret.Ingress, ingress)
+				}
+
+			case setting.Service:
+				svc, err := getter.GetServiceByNameFromCache(u.GetName(), namespace, inf)
+				if err != nil {
+					//log.Warnf("no svc %s found in %s:%s %v", u.GetName(), service.ServiceName, namespace, err)
+					continue
+				}
+
+				ret.Services = append(ret.Services, wrapper.Service(svc).Resource())
+			}
+		}
+	}
+	return
+}
+
+func GetDeploymentWorkloadResource(d *appsv1.Deployment, informer informers.SharedInformerFactory, log *zap.SugaredLogger) *internalresource.Workload {
+	pods, err := getter.ListPodsWithCache(labels.SelectorFromValidatedSet(d.Spec.Selector.MatchLabels), informer)
+	if err != nil {
+		log.Warnf("Failed to get pods, err: %s", err)
+	}
+
+	return wrapper.Deployment(d).WorkloadResource(pods)
+}
+
+func getStatefulSetWorkloadResource(sts *appsv1.StatefulSet, informer informers.SharedInformerFactory, log *zap.SugaredLogger) *internalresource.Workload {
+	pods, err := getter.ListPodsWithCache(labels.SelectorFromValidatedSet(sts.Spec.Selector.MatchLabels), informer)
+	if err != nil {
+		log.Warnf("Failed to get pods, err: %s", err)
+	}
+
+	return wrapper.StatefulSet(sts).WorkloadResource(pods)
+}
+
+func getCronJobWorkLoadResource(cornJob *batchv1.CronJob, cronJobBeta *v1beta1.CronJob, log *zap.SugaredLogger) *internalresource.CronJob {
+	return wrapper.CronJob(cornJob, cronJobBeta).CronJobResource()
+}
+
+func ToDeploymentWorkload(v *appsv1.Deployment) *Workload {
+	workload := &Workload{
+		Name:       v.Name,
+		Spec:       v.Spec.Template,
+		Type:       setting.Deployment,
+		Images:     wrapper.Deployment(v).ImageInfos(),
+		Ready:      wrapper.Deployment(v).Ready(),
+		Annotation: v.Annotations,
+	}
+	return workload
+}
+
+func toStsWorkload(v *appsv1.StatefulSet) *Workload {
+	workload := &Workload{
+		Name:       v.Name,
+		Spec:       v.Spec.Template,
+		Type:       setting.StatefulSet,
+		Images:     wrapper.StatefulSet(v).ImageInfos(),
+		Ready:      wrapper.StatefulSet(v).Ready(),
+		Annotation: v.Annotations,
+	}
+	return workload
 }

--- a/pkg/microservice/aslan/core/common/service/service.go
+++ b/pkg/microservice/aslan/core/common/service/service.go
@@ -1384,6 +1384,7 @@ func GetServiceImpl(serviceName string, serviceTmpl *commonmodels.Service, workL
 	namespace := env.Namespace
 	switch env.Source {
 	case setting.SourceFromExternal, setting.SourceFromHelm:
+		// helm and external
 		if env.Source == setting.SourceFromExternal {
 			svcOpt := &commonrepo.ServiceFindOption{ProductName: productName, ServiceName: serviceName, Type: setting.K8SDeployType}
 			modelSvc, err := commonrepo.NewServiceColl().Find(svcOpt)
@@ -1439,6 +1440,7 @@ func GetServiceImpl(serviceName string, serviceTmpl *commonmodels.Service, workL
 			return nil, e.ErrGetService.AddDesc(fmt.Sprintf("service %s not found, unknow type", serviceName))
 		}
 	default:
+		// k8s
 		service := env.GetServiceMap()[serviceName]
 		if service == nil {
 			return nil, e.ErrGetService.AddDesc(fmt.Sprintf("failed to find service in environment: %s", envName))

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -112,6 +112,12 @@ func (c *DeployJobCtl) run(ctx context.Context) error {
 		logError(c.job, msg, c.logger)
 		return errors.New(msg)
 	}
+	if env.IsSleeping() {
+		msg := fmt.Sprintf("Environment %s/%s is sleeping", env.ProductName, env.EnvName)
+		logError(c.job, msg, c.logger)
+		return errors.New(msg)
+	}
+
 	c.namespace = env.Namespace
 	c.jobTaskSpec.ClusterID = env.ClusterID
 

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_chart_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_chart_deploy.go
@@ -75,6 +75,12 @@ func (c *HelmChartDeployJobCtl) Run(ctx context.Context) {
 		logError(c.job, msg, c.logger)
 		return
 	}
+	if productInfo.IsSleeping() {
+		msg := fmt.Sprintf("Environment %s/%s is sleeping", productInfo.ProductName, productInfo.EnvName)
+		logError(c.job, msg, c.logger)
+		return
+	}
+
 	c.namespace = productInfo.Namespace
 	c.jobTaskSpec.ClusterID = productInfo.ClusterID
 

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
@@ -79,6 +79,12 @@ func (c *HelmDeployJobCtl) Run(ctx context.Context) {
 		logError(c.job, msg, c.logger)
 		return
 	}
+	if productInfo.IsSleeping() {
+		msg := fmt.Sprintf("Environment %s/%s is sleeping", productInfo.ProductName, productInfo.EnvName)
+		logError(c.job, msg, c.logger)
+		return
+	}
+
 	c.namespace = productInfo.Namespace
 	c.jobTaskSpec.ClusterID = productInfo.ClusterID
 

--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -2759,3 +2759,37 @@ func GetEnvAnalysisHistory(c *gin.Context) {
 	}
 	ctx.Err = err
 }
+
+type EnvSleepRequest struct {
+	IsEnable bool `json:"isEnable"`
+}
+
+// @Summary Environment Sleep
+// @Description Environment Sleep
+// @Tags 	environment
+// @Accept 	json
+// @Produce json
+// @Param 	name 				path		string						true	"env name"
+// @Param 	projectName			query		string						true	"project name"
+// @Param 	body 				body 		EnvSleepRequest				true 	"body"
+// @Success 200
+// @Router /api/aslan/environment/environments/{name}/sleep [post]
+func EnvSleep(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	envName := c.Param("name")
+	projectName := c.Query("projectName")
+	if projectName == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("projectName can't be empty!")
+		return
+	}
+
+	arg := new(EnvSleepRequest)
+	if err := c.ShouldBind(arg); err != nil {
+		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+
+	ctx.Err = service.EnvSleep(projectName, envName, arg.IsEnable, false, ctx.Logger)
+}

--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -2614,7 +2614,7 @@ func UpsertEnvAnalysisCron(c *gin.Context) {
 
 	data, err := c.GetRawData()
 	if err != nil {
-		log.Errorf("CreateEnvAnalysisCron c.GetRawData() err : %v", err)
+		log.Errorf("UpsertEnvAnalysisCron c.GetRawData() err : %v", err)
 	}
 	c.Request.Body = io.NopCloser(bytes.NewBuffer(data))
 	internalhandler.InsertOperationLog(c, ctx.UserName, projectName, "更新", "环境巡检-cron", envName, string(data), ctx.Logger)
@@ -2636,7 +2636,7 @@ func UpsertEnvAnalysisCron(c *gin.Context) {
 // @Produce json
 // @Param 	name 		path		string							true	"env name"
 // @Param 	projectName	query		string							true	"project name"
-// @Success 200 		{object}    EnvAnalysisCronArg
+// @Success 200 		{object}    service.EnvAnalysisCronArg
 // @Router /api/aslan/environment/environments/{name}/analysis/cron [get]
 func GetEnvAnalysisCron(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
@@ -2685,7 +2685,7 @@ func UpsertProductionEnvAnalysisCron(c *gin.Context) {
 
 	data, err := c.GetRawData()
 	if err != nil {
-		log.Errorf("CreateProductionEnvAnalysisCron c.GetRawData() err : %v", err)
+		log.Errorf("UpsertProductionEnvAnalysisCron c.GetRawData() err : %v", err)
 	}
 	c.Request.Body = io.NopCloser(bytes.NewBuffer(data))
 	internalhandler.InsertOperationLog(c, ctx.UserName, projectName, "更新", "环境巡检-cron", envName, string(data), ctx.Logger)
@@ -2707,7 +2707,7 @@ func UpsertProductionEnvAnalysisCron(c *gin.Context) {
 // @Produce json
 // @Param 	name 		path		string							true	"env name"
 // @Param 	projectName	query		string							true	"project name"
-// @Success 200 		{object}    EnvAnalysisCronArg
+// @Success 200 		{object}    service.EnvAnalysisCronArg
 // @Router /api/aslan/environment/production/environments/{name}/analysis/cron [get]
 func GetProductionEnvAnalysisCron(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
@@ -2760,10 +2760,6 @@ func GetEnvAnalysisHistory(c *gin.Context) {
 	ctx.Err = err
 }
 
-type EnvSleepRequest struct {
-	IsEnable bool `json:"isEnable"`
-}
-
 // @Summary Environment Sleep
 // @Description Environment Sleep
 // @Tags 	environment
@@ -2771,27 +2767,37 @@ type EnvSleepRequest struct {
 // @Produce json
 // @Param 	name 				path		string						true	"env name"
 // @Param 	projectName			query		string						true	"project name"
-// @Param 	body 				body 		EnvSleepRequest				true 	"body"
+// @Param 	action				query		string						true	"enable or disable"
 // @Success 200
 // @Router /api/aslan/environment/environments/{name}/sleep [post]
 func EnvSleep(c *gin.Context) {
-	ctx := internalhandler.NewContext(c)
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
 	envName := c.Param("name")
+	if envName == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("name can't be empty!")
+		return
+	}
 	projectName := c.Query("projectName")
 	if projectName == "" {
 		ctx.Err = e.ErrInvalidParam.AddDesc("projectName can't be empty!")
 		return
 	}
-
-	arg := new(EnvSleepRequest)
-	if err := c.ShouldBind(arg); err != nil {
-		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
+	action := c.Query("action")
+	if action == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("action can't be empty!")
 		return
 	}
 
-	ctx.Err = service.EnvSleep(projectName, envName, arg.IsEnable, false, ctx.Logger)
+	ctx.Err = service.EnvSleep(projectName, envName, action == "enable", false, ctx.Logger)
 }
 
 // @Summary Production Environment Sleep
@@ -2801,27 +2807,37 @@ func EnvSleep(c *gin.Context) {
 // @Produce json
 // @Param 	name 				path		string						true	"env name"
 // @Param 	projectName			query		string						true	"project name"
-// @Param 	body 				body 		EnvSleepRequest				true 	"body"
+// @Param 	action				query		string						true	"enable or disable"
 // @Success 200
 // @Router /api/aslan/environment/production/environments/{name}/sleep [post]
 func ProductionEnvSleep(c *gin.Context) {
-	ctx := internalhandler.NewContext(c)
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
 	envName := c.Param("name")
+	if envName == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("name can't be empty!")
+		return
+	}
 	projectName := c.Query("projectName")
 	if projectName == "" {
 		ctx.Err = e.ErrInvalidParam.AddDesc("projectName can't be empty!")
 		return
 	}
-
-	arg := new(EnvSleepRequest)
-	if err := c.ShouldBind(arg); err != nil {
-		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
+	action := c.Query("action")
+	if action == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("action can't be empty!")
 		return
 	}
 
-	ctx.Err = service.EnvSleep(projectName, envName, arg.IsEnable, true, ctx.Logger)
+	ctx.Err = service.EnvSleep(projectName, envName, action == "enable", true, ctx.Logger)
 }
 
 // @Summary Get Env Sleep Cron
@@ -2831,11 +2847,18 @@ func ProductionEnvSleep(c *gin.Context) {
 // @Produce json
 // @Param 	name 		path		string							true	"env name"
 // @Param 	projectName	query		string							true	"project name"
-// @Success 200 		{object}    EnvSleepCronArg
+// @Success 200 		{object}    service.EnvSleepCronArg
 // @Router /api/aslan/environment/environments/{name}/sleep/cron [get]
 func GetEnvSleepCron(c *gin.Context) {
-	ctx := internalhandler.NewContext(c)
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
 
 	projectName := c.Query("projectName")
 	if projectName == "" {
@@ -2850,4 +2873,139 @@ func GetEnvSleepCron(c *gin.Context) {
 	}
 
 	ctx.Resp, ctx.Err = service.GetEnvSleepCron(projectName, envName, boolptr.False(), ctx.Logger)
+}
+
+// @Summary Get Production Env Sleep Cron
+// @Description Get Production Env Sleep Cron
+// @Tags 	environment
+// @Accept 	json
+// @Produce json
+// @Param 	name 		path		string							true	"env name"
+// @Param 	projectName	query		string							true	"project name"
+// @Success 200 		{object}    service.EnvSleepCronArg
+// @Router /api/aslan/environment/production/environments/{name}/sleep/cron [get]
+func GetProductionEnvSleepCron(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	projectName := c.Query("projectName")
+	if projectName == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("productName can not be null!")
+		return
+	}
+
+	envName := c.Param("name")
+	if envName == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("name can not be null!")
+		return
+	}
+
+	ctx.Resp, ctx.Err = service.GetEnvSleepCron(projectName, envName, boolptr.True(), ctx.Logger)
+}
+
+// @Summary Upsert Env Sleep Cron
+// @Description Upsert Env Sleep Cron
+// @Tags 	environment
+// @Accept 	json
+// @Produce json
+// @Param 	name 		path		string							true	"env name"
+// @Param 	projectName	query		string							true	"project name"
+// @Param 	body 		body 		service.EnvSleepCronArg 		true 	"body"
+// @Success 200
+// @Router /api/aslan/environment/environments/{name}/sleep/cron [put]
+func UpsertEnvSleepCron(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	projectName := c.Query("projectName")
+	if projectName == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("productName can not be null!")
+		return
+	}
+
+	envName := c.Param("name")
+	if envName == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("name can not be null!")
+		return
+	}
+
+	data, err := c.GetRawData()
+	if err != nil {
+		log.Errorf("UpsertEnvSleepCron c.GetRawData() err : %v", err)
+	}
+	c.Request.Body = io.NopCloser(bytes.NewBuffer(data))
+	internalhandler.InsertOperationLog(c, ctx.UserName, projectName, "更新", "环境睡眠-cron", envName, string(data), ctx.Logger)
+
+	arg := new(service.EnvSleepCronArg)
+	err = c.BindJSON(arg)
+	if err != nil {
+		ctx.Err = e.ErrInvalidParam.AddErr(err)
+		return
+	}
+
+	ctx.Err = service.UpsertEnvSleepCron(projectName, envName, boolptr.False(), arg, ctx.Logger)
+}
+
+// @Summary Upsert Production Env Sleep Cron
+// @Description Upsert Production Env Sleep Cron
+// @Tags 	environment
+// @Accept 	json
+// @Produce json
+// @Param 	name 		path		string							true	"env name"
+// @Param 	projectName	query		string							true	"project name"
+// @Param 	body 		body 		service.EnvSleepCronArg 		true 	"body"
+// @Success 200
+// @Router /api/aslan/environment/production/environments/{name}/sleep/cron [put]
+func UpsertProductionEnvSleepCron(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	projectName := c.Query("projectName")
+	if projectName == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("productName can not be null!")
+		return
+	}
+
+	envName := c.Param("name")
+	if envName == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("name can not be null!")
+		return
+	}
+
+	data, err := c.GetRawData()
+	if err != nil {
+		log.Errorf("UpsertEnvSleepCron c.GetRawData() err : %v", err)
+	}
+	c.Request.Body = io.NopCloser(bytes.NewBuffer(data))
+	internalhandler.InsertOperationLog(c, ctx.UserName, projectName, "更新", "环境睡眠-cron", envName, string(data), ctx.Logger)
+
+	arg := new(service.EnvSleepCronArg)
+	err = c.BindJSON(arg)
+	if err != nil {
+		ctx.Err = e.ErrInvalidParam.AddErr(err)
+		return
+	}
+
+	ctx.Err = service.UpsertEnvSleepCron(projectName, envName, boolptr.True(), arg, ctx.Logger)
 }

--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -2636,7 +2636,7 @@ func UpsertEnvAnalysisCron(c *gin.Context) {
 // @Produce json
 // @Param 	name 		path		string							true	"env name"
 // @Param 	projectName	query		string							true	"project name"
-// @Success 200
+// @Success 200 		{object}    EnvAnalysisCronArg
 // @Router /api/aslan/environment/environments/{name}/analysis/cron [get]
 func GetEnvAnalysisCron(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
@@ -2707,7 +2707,7 @@ func UpsertProductionEnvAnalysisCron(c *gin.Context) {
 // @Produce json
 // @Param 	name 		path		string							true	"env name"
 // @Param 	projectName	query		string							true	"project name"
-// @Success 200
+// @Success 200 		{object}    EnvAnalysisCronArg
 // @Router /api/aslan/environment/production/environments/{name}/analysis/cron [get]
 func GetProductionEnvAnalysisCron(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
@@ -2792,4 +2792,62 @@ func EnvSleep(c *gin.Context) {
 	}
 
 	ctx.Err = service.EnvSleep(projectName, envName, arg.IsEnable, false, ctx.Logger)
+}
+
+// @Summary Production Environment Sleep
+// @Description Production Environment Sleep
+// @Tags 	environment
+// @Accept 	json
+// @Produce json
+// @Param 	name 				path		string						true	"env name"
+// @Param 	projectName			query		string						true	"project name"
+// @Param 	body 				body 		EnvSleepRequest				true 	"body"
+// @Success 200
+// @Router /api/aslan/environment/production/environments/{name}/sleep [post]
+func ProductionEnvSleep(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	envName := c.Param("name")
+	projectName := c.Query("projectName")
+	if projectName == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("projectName can't be empty!")
+		return
+	}
+
+	arg := new(EnvSleepRequest)
+	if err := c.ShouldBind(arg); err != nil {
+		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+
+	ctx.Err = service.EnvSleep(projectName, envName, arg.IsEnable, true, ctx.Logger)
+}
+
+// @Summary Get Env Sleep Cron
+// @Description Get Env Sleep Cron
+// @Tags 	environment
+// @Accept 	json
+// @Produce json
+// @Param 	name 		path		string							true	"env name"
+// @Param 	projectName	query		string							true	"project name"
+// @Success 200 		{object}    EnvSleepCronArg
+// @Router /api/aslan/environment/environments/{name}/sleep/cron [get]
+func GetEnvSleepCron(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	projectName := c.Query("projectName")
+	if projectName == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("productName can not be null!")
+		return
+	}
+
+	envName := c.Param("name")
+	if envName == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("name can not be null!")
+		return
+	}
+
+	ctx.Resp, ctx.Err = service.GetEnvSleepCron(projectName, envName, boolptr.False(), ctx.Logger)
 }

--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -2797,6 +2797,12 @@ func EnvSleep(c *gin.Context) {
 		return
 	}
 
+	method := "睡眠"
+	if action != "enable" {
+		method = "唤醒"
+	}
+	internalhandler.InsertDetailedOperationLog(c, ctx.UserName, projectName, setting.OperationSceneEnv, method, "环境", envName, "", ctx.Logger, envName)
+
 	if !ctx.Resources.IsSystemAdmin {
 		if _, ok := ctx.Resources.ProjectAuthInfo[projectName]; !ok {
 			ctx.UnAuthorized = true
@@ -2849,6 +2855,12 @@ func ProductionEnvSleep(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam.AddDesc("action can't be empty!")
 		return
 	}
+
+	method := "睡眠"
+	if action != "enable" {
+		method = "唤醒"
+	}
+	internalhandler.InsertDetailedOperationLog(c, ctx.UserName, projectName, setting.OperationSceneEnv, method, "生产环境", envName, "", ctx.Logger, envName)
 
 	if !ctx.Resources.IsSystemAdmin {
 		if _, ok := ctx.Resources.ProjectAuthInfo[projectName]; !ok {
@@ -3013,7 +3025,7 @@ func UpsertEnvSleepCron(c *gin.Context) {
 		log.Errorf("UpsertEnvSleepCron c.GetRawData() err : %v", err)
 	}
 	c.Request.Body = io.NopCloser(bytes.NewBuffer(data))
-	internalhandler.InsertOperationLog(c, ctx.UserName, projectName, "更新", "环境睡眠-cron", envName, string(data), ctx.Logger)
+	internalhandler.InsertDetailedOperationLog(c, ctx.UserName, projectName, setting.OperationSceneEnv, "更新", "环境定时睡眠与唤醒", envName, string(data), ctx.Logger, envName)
 
 	arg := new(service.EnvSleepCronArg)
 	err = c.BindJSON(arg)
@@ -3063,7 +3075,7 @@ func UpsertProductionEnvSleepCron(c *gin.Context) {
 		log.Errorf("UpsertEnvSleepCron c.GetRawData() err : %v", err)
 	}
 	c.Request.Body = io.NopCloser(bytes.NewBuffer(data))
-	internalhandler.InsertOperationLog(c, ctx.UserName, projectName, "更新", "环境睡眠-cron", envName, string(data), ctx.Logger)
+	internalhandler.InsertDetailedOperationLog(c, ctx.UserName, projectName, setting.OperationSceneEnv, "更新", "生产环境定时睡眠与唤醒", envName, string(data), ctx.Logger, envName)
 
 	arg := new(service.EnvSleepCronArg)
 	err = c.BindJSON(arg)

--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -2797,6 +2797,19 @@ func EnvSleep(c *gin.Context) {
 		return
 	}
 
+	if !ctx.Resources.IsSystemAdmin {
+		if _, ok := ctx.Resources.ProjectAuthInfo[projectName]; !ok {
+			ctx.UnAuthorized = true
+			return
+		}
+
+		if !ctx.Resources.ProjectAuthInfo[projectName].IsProjectAdmin &&
+			!ctx.Resources.ProjectAuthInfo[projectName].Env.EditConfig {
+			ctx.UnAuthorized = true
+			return
+		}
+	}
+
 	ctx.Err = service.EnvSleep(projectName, envName, action == "enable", false, ctx.Logger)
 }
 
@@ -2837,6 +2850,19 @@ func ProductionEnvSleep(c *gin.Context) {
 		return
 	}
 
+	if !ctx.Resources.IsSystemAdmin {
+		if _, ok := ctx.Resources.ProjectAuthInfo[projectName]; !ok {
+			ctx.UnAuthorized = true
+			return
+		}
+
+		if !ctx.Resources.ProjectAuthInfo[projectName].IsProjectAdmin &&
+			!ctx.Resources.ProjectAuthInfo[projectName].ProductionEnv.EditConfig {
+			ctx.UnAuthorized = true
+			return
+		}
+	}
+
 	ctx.Err = service.EnvSleep(projectName, envName, action == "enable", true, ctx.Logger)
 }
 
@@ -2870,6 +2896,19 @@ func GetEnvSleepCron(c *gin.Context) {
 	if envName == "" {
 		ctx.Err = e.ErrInvalidParam.AddDesc("name can not be null!")
 		return
+	}
+
+	if !ctx.Resources.IsSystemAdmin {
+		if _, ok := ctx.Resources.ProjectAuthInfo[projectName]; !ok {
+			ctx.UnAuthorized = true
+			return
+		}
+
+		if !ctx.Resources.ProjectAuthInfo[projectName].IsProjectAdmin &&
+			!ctx.Resources.ProjectAuthInfo[projectName].Env.View {
+			ctx.UnAuthorized = true
+			return
+		}
 	}
 
 	ctx.Resp, ctx.Err = service.GetEnvSleepCron(projectName, envName, boolptr.False(), ctx.Logger)
@@ -2907,6 +2946,19 @@ func GetProductionEnvSleepCron(c *gin.Context) {
 		return
 	}
 
+	if !ctx.Resources.IsSystemAdmin {
+		if _, ok := ctx.Resources.ProjectAuthInfo[projectName]; !ok {
+			ctx.UnAuthorized = true
+			return
+		}
+
+		if !ctx.Resources.ProjectAuthInfo[projectName].IsProjectAdmin &&
+			!ctx.Resources.ProjectAuthInfo[projectName].ProductionEnv.View {
+			ctx.UnAuthorized = true
+			return
+		}
+	}
+
 	ctx.Resp, ctx.Err = service.GetEnvSleepCron(projectName, envName, boolptr.True(), ctx.Logger)
 }
 
@@ -2941,6 +2993,19 @@ func UpsertEnvSleepCron(c *gin.Context) {
 	if envName == "" {
 		ctx.Err = e.ErrInvalidParam.AddDesc("name can not be null!")
 		return
+	}
+
+	if !ctx.Resources.IsSystemAdmin {
+		if _, ok := ctx.Resources.ProjectAuthInfo[projectName]; !ok {
+			ctx.UnAuthorized = true
+			return
+		}
+
+		if !ctx.Resources.ProjectAuthInfo[projectName].IsProjectAdmin &&
+			!ctx.Resources.ProjectAuthInfo[projectName].Env.EditConfig {
+			ctx.UnAuthorized = true
+			return
+		}
 	}
 
 	data, err := c.GetRawData()
@@ -3005,6 +3070,19 @@ func UpsertProductionEnvSleepCron(c *gin.Context) {
 	if err != nil {
 		ctx.Err = e.ErrInvalidParam.AddErr(err)
 		return
+	}
+
+	if !ctx.Resources.IsSystemAdmin {
+		if _, ok := ctx.Resources.ProjectAuthInfo[projectName]; !ok {
+			ctx.UnAuthorized = true
+			return
+		}
+
+		if !ctx.Resources.ProjectAuthInfo[projectName].IsProjectAdmin &&
+			!ctx.Resources.ProjectAuthInfo[projectName].ProductionEnv.EditConfig {
+			ctx.UnAuthorized = true
+			return
+		}
 	}
 
 	ctx.Err = service.UpsertEnvSleepCron(projectName, envName, boolptr.True(), arg, ctx.Logger)

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -204,8 +204,8 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		production.DELETE("/envcfgs/:name/cfg/:objectName", DeleteProductionCommonEnvCfg)
 
 		production.POST("/environments/:name/sleep", ProductionEnvSleep)
-		production.GET("/:name/sleep/cron", GetProductionEnvSleepCron)
-		production.PUT("/:name/sleep/cron", UpsertProductionEnvSleepCron)
+		production.GET("/environments/:name/sleep/cron", GetProductionEnvSleepCron)
+		production.PUT("/environments/:name/sleep/cron", UpsertProductionEnvSleepCron)
 	}
 
 	// ---------------------------------------------------------------------------------------

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -147,7 +147,6 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		production.GET("/environments/:name", GetProductionEnv)
 		production.PUT("/environments/:name/registry", UpdateProductionProductRegistry)
 		production.GET("/environments/:name/groups", ListProductionGroups)
-		production.POST("/environments/:name/sleep", ProductionEnvSleep)
 
 		// used for production deploy workflows
 		production.GET("/environmentsForUpdate", ListProductionEnvs)
@@ -203,6 +202,10 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		production.PUT("/envcfgs/:name", UpdateProductionCommonEnvCfg)
 		production.POST("/envcfgs/:name", CreateProductionCommonEnvCfg)
 		production.DELETE("/envcfgs/:name/cfg/:objectName", DeleteProductionCommonEnvCfg)
+
+		production.POST("/environments/:name/sleep", ProductionEnvSleep)
+		production.GET("/:name/sleep/cron", GetProductionEnvSleepCron)
+		production.PUT("/:name/sleep/cron", UpsertProductionEnvSleepCron)
 	}
 
 	// ---------------------------------------------------------------------------------------
@@ -222,7 +225,6 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		environments.POST("/:name/affectedservices", AffectedServices)
 		environments.POST("/:name/estimated-values", EstimatedValues)
 		environments.PUT("/:name/renderset", UpdateHelmProductRenderset)
-		environments.POST("/:name/sleep", EnvSleep)
 
 		environments.PUT("/:name/helm/default-values", UpdateHelmProductDefaultValues)
 		environments.POST("/:name/helm/default-values/preview", PreviewHelmProductDefaultValues)
@@ -274,8 +276,9 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		environments.PUT("/:name/analysis/cron", UpsertEnvAnalysisCron)
 		environments.GET("/analysis/history", GetEnvAnalysisHistory)
 
-		environments.GET("/:name/sleep/cron", GetEnvAnalysisCron)
-		environments.PUT("/:name/sleep/cron", UpsertEnvAnalysisCron)
+		environments.POST("/:name/sleep", EnvSleep)
+		environments.GET("/:name/sleep/cron", GetEnvSleepCron)
+		environments.PUT("/:name/sleep/cron", UpsertEnvSleepCron)
 	}
 
 	// ---------------------------------------------------------------------------------------

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -147,6 +147,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		production.GET("/environments/:name", GetProductionEnv)
 		production.PUT("/environments/:name/registry", UpdateProductionProductRegistry)
 		production.GET("/environments/:name/groups", ListProductionGroups)
+		production.POST("/environments/:name/sleep", ProductionEnvSleep)
 
 		// used for production deploy workflows
 		production.GET("/environmentsForUpdate", ListProductionEnvs)
@@ -272,6 +273,9 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		environments.GET("/:name/analysis/cron", GetEnvAnalysisCron)
 		environments.PUT("/:name/analysis/cron", UpsertEnvAnalysisCron)
 		environments.GET("/analysis/history", GetEnvAnalysisHistory)
+
+		environments.GET("/:name/sleep/cron", GetEnvAnalysisCron)
+		environments.PUT("/:name/sleep/cron", UpsertEnvAnalysisCron)
 	}
 
 	// ---------------------------------------------------------------------------------------

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -221,6 +221,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		environments.POST("/:name/affectedservices", AffectedServices)
 		environments.POST("/:name/estimated-values", EstimatedValues)
 		environments.PUT("/:name/renderset", UpdateHelmProductRenderset)
+		environments.POST("/:name/sleep", EnvSleep)
 
 		environments.PUT("/:name/helm/default-values", UpdateHelmProductDefaultValues)
 		environments.POST("/:name/helm/default-values/preview", PreviewHelmProductDefaultValues)

--- a/pkg/microservice/aslan/core/environment/handler/service.go
+++ b/pkg/microservice/aslan/core/environment/handler/service.go
@@ -120,7 +120,7 @@ func GetService(c *gin.Context) {
 		}
 	}
 
-	ctx.Resp, ctx.Err = service.GetService(envName, projectKey, serviceName, false, workLoadType, false, ctx.Logger)
+	ctx.Resp, ctx.Err = service.GetService(envName, projectKey, serviceName, false, workLoadType, ctx.Logger)
 }
 
 // @Summary Get Production Service
@@ -149,7 +149,6 @@ func GetProductionService(c *gin.Context) {
 	envName := c.Param("name")
 	projectKey := c.Query("projectName")
 	serviceName := c.Param("serviceName")
-	isHelmChartDeploy := c.Query("isHelmChartDeploy")
 	workLoadType := c.Query("workLoadType")
 
 	// TODO: Authorization leak
@@ -184,7 +183,7 @@ func GetProductionService(c *gin.Context) {
 		return
 	}
 
-	ctx.Resp, ctx.Err = service.GetService(envName, projectKey, serviceName, true, workLoadType, isHelmChartDeploy == "true", ctx.Logger)
+	ctx.Resp, ctx.Err = service.GetService(envName, projectKey, serviceName, true, workLoadType, ctx.Logger)
 }
 
 func RestartService(c *gin.Context) {

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -4569,13 +4569,34 @@ func EnvSleep(productName, envName string, isEnable, isProduction bool, log *zap
 					if workLoad, ok := scaleMap[u.GetName()]; ok {
 						workLoad.ServiceName = svc.ServiceName
 						workLoad.DeployedFromZadig = true
+						newScaleNumMap[workLoad.Name] = int(workLoad.Replicas)
 					}
 				case setting.CronJob:
 					if workLoad, ok := cronjobMap[u.GetName()]; ok {
 						workLoad.ServiceName = svc.ServiceName
 						workLoad.DeployedFromZadig = true
+						newScaleNumMap[workLoad.Name] = int(workLoad.Replicas)
 					}
 				}
+			}
+		}
+	} else if templateProduct.IsHostProduct() {
+		svcTmpls, err := repository.ListMaxRevisionsServices(productName, prod.Production)
+		if err != nil {
+			err = fmt.Errorf("failed to list services, productName: %s, isProduction: %v, err: %s", productName, prod.Production, err)
+			log.Error(err)
+			return e.ErrEnvSleep.AddErr(err)
+		}
+		for _, svcTmpl := range svcTmpls {
+			if workLoad, ok := scaleMap[svcTmpl.ServiceName]; ok {
+				workLoad.ServiceName = svcTmpl.ServiceName
+				workLoad.DeployedFromZadig = true
+				newScaleNumMap[workLoad.Name] = int(workLoad.Replicas)
+			}
+			if workLoad, ok := cronjobMap[svcTmpl.ServiceName]; ok {
+				workLoad.ServiceName = svcTmpl.ServiceName
+				workLoad.DeployedFromZadig = true
+				newScaleNumMap[workLoad.Name] = int(workLoad.Replicas)
 			}
 		}
 	} else if templateProduct.IsHelmProduct() {

--- a/pkg/microservice/aslan/core/environment/service/environment_group.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_group.go
@@ -164,7 +164,6 @@ func ListGroups(serviceName, envName, productName string, perPage, page int, pro
 			if err != nil {
 				return resp, count, e.ErrListGroups.AddErr(errors.Wrapf(err, "list zadigx %s release services", releaseType))
 			}
-			log.Debugf("%s release services num: %d", releaseType, len(releaseService))
 			for _, serviceResp := range releaseService {
 				if svc, ok := respMap[serviceResp.ServiceName]; !ok {
 					resp = append(resp, serviceResp)

--- a/pkg/microservice/aslan/core/environment/service/ide.go
+++ b/pkg/microservice/aslan/core/environment/service/ide.go
@@ -49,6 +49,10 @@ func PatchWorkload(ctx context.Context, projectName, envName, serviceName, devIm
 	if err != nil {
 		return nil, fmt.Errorf("failed to query env %q of project %q: %s", envName, projectName, err)
 	}
+	if project.IsSleeping() {
+		return nil, fmt.Errorf("environment is sleeping")
+	}
+
 	ns := project.Namespace
 	clusterID := project.ClusterID
 
@@ -80,6 +84,10 @@ func RecoverWorkload(ctx context.Context, projectName, envName, serviceName stri
 	if err != nil {
 		return fmt.Errorf("failed to query env %q of project %q: %s", envName, projectName, err)
 	}
+	if project.IsSleeping() {
+		return fmt.Errorf("environment is sleeping")
+	}
+
 	ns := project.Namespace
 	clusterID := project.ClusterID
 

--- a/pkg/microservice/aslan/core/environment/service/k8s.go
+++ b/pkg/microservice/aslan/core/environment/service/k8s.go
@@ -111,6 +111,9 @@ func (k *K8sService) updateService(args *SvcOptArgs) error {
 		k.log.Error(err)
 		return errors.New(e.UpsertServiceErrMsg)
 	}
+	if exitedProd.IsSleeping() {
+		return e.ErrUpdateEnv.AddErr(fmt.Errorf("Environment is sleeping"))
+	}
 
 	currentProductSvc := exitedProd.GetServiceMap()[svc.ServiceName]
 	if currentProductSvc == nil {

--- a/pkg/microservice/aslan/core/environment/service/product.go
+++ b/pkg/microservice/aslan/core/environment/service/product.go
@@ -326,6 +326,10 @@ func buildProductResp(envName string, prod *commonmodels.Product, log *zap.Sugar
 		prodResp.Status = setting.PodDeleting
 		return prodResp, nil
 	}
+	if prod.Status == setting.ProductStatusSleeping {
+		prodResp.Status = setting.ProductStatusSleeping
+		return prodResp, nil
+	}
 	if prod.Status == setting.ProductStatusUnknown {
 		prodResp.Status = setting.ClusterUnknown
 		return prodResp, nil

--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -25,9 +25,6 @@ import (
 	"go.uber.org/zap"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	versionedclient "istio.io/client-go/pkg/clientset/versioned"
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -154,7 +151,7 @@ func RestartScale(args *RestartScaleArgs, _ *zap.SugaredLogger) error {
 	return nil
 }
 
-func GetService(envName, productName, serviceName string, production bool, workLoadType string, isHelmChartDeploy bool, log *zap.SugaredLogger) (ret *SvcResp, err error) {
+func GetService(envName, productName, serviceName string, production bool, workLoadType string, log *zap.SugaredLogger) (ret *commonservice.SvcResp, err error) {
 	opt := &commonrepo.ProductFindOptions{Name: productName, EnvName: envName, Production: util.GetBoolPointer(production)}
 	env, err := commonrepo.NewProductColl().Find(opt)
 	if err != nil {
@@ -193,7 +190,7 @@ func GetService(envName, productName, serviceName string, production bool, workL
 			if err != nil {
 				return nil, e.ErrGetService.AddErr(fmt.Errorf("failed to find template service %s in product %s", serviceName, productName))
 			}
-			ret, err = GetServiceImpl(serviceName, serviceTmpl, workLoadType, env, clientset, inf, log)
+			ret, err = commonservice.GetServiceImpl(serviceName, serviceTmpl, workLoadType, env, clientset, inf, log)
 			if err != nil {
 				return nil, e.ErrGetService.AddErr(err)
 			}
@@ -201,7 +198,7 @@ func GetService(envName, productName, serviceName string, production bool, workL
 		// when not found service in product, we should find it as a fake service of ZadigxReleaseResource
 		// if raw service resources not found will be nil , we should create it
 		if ret == nil {
-			ret = &SvcResp{
+			ret = &commonservice.SvcResp{
 				ServiceName: serviceName,
 				EnvName:     envName,
 				ProductName: productName,
@@ -224,39 +221,13 @@ func GetService(envName, productName, serviceName string, production bool, workL
 		ret.Workloads = nil
 		ret.Namespace = env.Namespace
 	} else {
-		ret, err = GetServiceImpl(serviceName, serviceTmpl, workLoadType, env, clientset, inf, log)
+		ret, err = commonservice.GetServiceImpl(serviceName, serviceTmpl, workLoadType, env, clientset, inf, log)
 		if err != nil {
 			return nil, e.ErrGetService.AddErr(err)
 		}
-		ret.Workloads = nil
-		ret.Namespace = env.Namespace
 	}
 
 	return ret, nil
-}
-
-func toDeploymentWorkload(v *appsv1.Deployment) *commonservice.Workload {
-	workload := &commonservice.Workload{
-		Name:       v.Name,
-		Spec:       v.Spec.Template,
-		Type:       setting.Deployment,
-		Images:     wrapper.Deployment(v).ImageInfos(),
-		Ready:      wrapper.Deployment(v).Ready(),
-		Annotation: v.Annotations,
-	}
-	return workload
-}
-
-func toStsWorkload(v *appsv1.StatefulSet) *commonservice.Workload {
-	workload := &commonservice.Workload{
-		Name:       v.Name,
-		Spec:       v.Spec.Template,
-		Type:       setting.StatefulSet,
-		Images:     wrapper.StatefulSet(v).ImageInfos(),
-		Ready:      wrapper.StatefulSet(v).Ready(),
-		Annotation: v.Annotations,
-	}
-	return workload
 }
 
 func GetServiceWorkloads(svcTmpl *commonmodels.Service, env *commonmodels.Product, inf informers.SharedInformerFactory, log *zap.SugaredLogger) ([]*commonservice.Workload, error) {
@@ -328,188 +299,9 @@ func GetServiceWorkloads(svcTmpl *commonmodels.Service, env *commonmodels.Produc
 	return ret, nil
 }
 
-func GetServiceImpl(serviceName string, serviceTmpl *commonmodels.Service, workLoadType string, env *commonmodels.Product, clientset *kubernetes.Clientset, inf informers.SharedInformerFactory, log *zap.SugaredLogger) (ret *SvcResp, err error) {
+func GetZadigReleaseServiceImpl(releaseType, serviceName string, workLoadType string, env *commonmodels.Product, kubeClient client.Client, clientset *kubernetes.Clientset, inf informers.SharedInformerFactory, log *zap.SugaredLogger) (ret *commonservice.SvcResp, err error) {
 	envName, productName := env.EnvName, env.ProductName
-	ret = &SvcResp{
-		ServiceName: serviceName,
-		EnvName:     envName,
-		ProductName: productName,
-		Services:    make([]*internalresource.Service, 0),
-		Ingress:     make([]*internalresource.Ingress, 0),
-		Scales:      make([]*internalresource.Workload, 0),
-		CronJobs:    make([]*internalresource.CronJob, 0),
-	}
-	err = nil
-
-	namespace := env.Namespace
-	switch env.Source {
-	case setting.SourceFromExternal, setting.SourceFromHelm:
-		if env.Source == setting.SourceFromExternal {
-			svcOpt := &commonrepo.ServiceFindOption{ProductName: productName, ServiceName: serviceName, Type: setting.K8SDeployType}
-			modelSvc, err := commonrepo.NewServiceColl().Find(svcOpt)
-			if err != nil {
-				return nil, e.ErrGetService.AddErr(err)
-			}
-			workLoadType = modelSvc.WorkloadType
-		}
-		k8sServices, _ := getter.ListServicesWithCache(nil, inf)
-		switch workLoadType {
-		case setting.StatefulSet:
-			statefulSet, err := getter.GetStatefulSetByNameWWithCache(serviceName, namespace, inf)
-			if err != nil {
-				return nil, e.ErrGetService.AddDesc(fmt.Sprintf("service %s not found", serviceName))
-			}
-			scale := getStatefulSetWorkloadResource(statefulSet, inf, log)
-			ret.Scales = append(ret.Scales, scale)
-			ret.Workloads = append(ret.Workloads, toStsWorkload(statefulSet))
-			podLabels := labels.Set(statefulSet.Spec.Template.GetLabels())
-			for _, svc := range k8sServices {
-				if labels.SelectorFromValidatedSet(svc.Spec.Selector).Matches(podLabels) {
-					ret.Services = append(ret.Services, wrapper.Service(svc).Resource())
-					break
-				}
-			}
-		case setting.Deployment:
-			deploy, err := getter.GetDeploymentByNameWithCache(serviceName, namespace, inf)
-			if err != nil {
-				return nil, e.ErrGetService.AddDesc(fmt.Sprintf("service %s not found, err: %s", serviceName, err.Error()))
-			}
-			scale := getDeploymentWorkloadResource(deploy, inf, log)
-			ret.Workloads = append(ret.Workloads, toDeploymentWorkload(deploy))
-			ret.Scales = append(ret.Scales, scale)
-			podLabels := labels.Set(deploy.Spec.Template.GetLabels())
-			for _, svc := range k8sServices {
-				if labels.SelectorFromValidatedSet(svc.Spec.Selector).Matches(podLabels) {
-					ret.Services = append(ret.Services, wrapper.Service(svc).Resource())
-					break
-				}
-			}
-		case setting.CronJob:
-			version, err := clientset.Discovery().ServerVersion()
-			if err != nil {
-				log.Warnf("Failed to determine server version, error is: %s", err)
-				return ret, nil
-			}
-			cj, cjBeta, err := getter.GetCronJobByNameWithCache(serviceName, namespace, inf, kubeclient.VersionLessThan121(version))
-			if err != nil {
-				return ret, nil
-			}
-			ret.CronJobs = append(ret.CronJobs, getCronJobWorkLoadResource(cj, cjBeta, log))
-		default:
-			return nil, e.ErrGetService.AddDesc(fmt.Sprintf("service %s not found", serviceName))
-		}
-	default:
-		service := env.GetServiceMap()[serviceName]
-		if service == nil {
-			return nil, e.ErrGetService.AddDesc(fmt.Sprintf("failed to find service in environment: %s", envName))
-		}
-
-		env.EnsureRenderInfo()
-		renderSetFindOpt := &commonrepo.RenderSetFindOption{
-			Name:        env.Render.Name,
-			Revision:    env.Render.Revision,
-			ProductTmpl: env.ProductName,
-			EnvName:     envName,
-		}
-		rs, err := commonrepo.NewRenderSetColl().Find(renderSetFindOpt)
-		if err != nil {
-			log.Errorf("find renderset[%s] error: %v", env.Render.Name, err)
-			return nil, e.ErrGetService.AddDesc(fmt.Sprintf("未找到变量集: %s", env.Render.Name))
-		}
-
-		parsedYaml, err := kube.RenderServiceYaml(serviceTmpl.Yaml, productName, serviceTmpl.ServiceName, rs)
-		if err != nil {
-			log.Errorf("failed to render service yaml, err: %s", err)
-			return nil, err
-		}
-		// 渲染系统变量键值
-		parsedYaml = kube.ParseSysKeys(namespace, envName, productName, service.ServiceName, parsedYaml)
-
-		manifests := releaseutil.SplitManifests(parsedYaml)
-		for _, item := range manifests {
-			u, err := serializer.NewDecoder().YamlToUnstructured([]byte(item))
-			if err != nil {
-				log.Warnf("Failed to decode yaml to Unstructured, err: %s", err)
-				continue
-			}
-
-			switch u.GetKind() {
-			case setting.Deployment:
-				d, err := getter.GetDeploymentByNameWithCache(u.GetName(), namespace, inf)
-				if err != nil {
-					continue
-				}
-
-				ret.Scales = append(ret.Scales, getDeploymentWorkloadResource(d, inf, log))
-				ret.Workloads = append(ret.Workloads, toDeploymentWorkload(d))
-			case setting.StatefulSet:
-				sts, err := getter.GetStatefulSetByNameWWithCache(u.GetName(), namespace, inf)
-				if err != nil {
-					continue
-				}
-
-				ret.Scales = append(ret.Scales, getStatefulSetWorkloadResource(sts, inf, log))
-				ret.Workloads = append(ret.Workloads, toStsWorkload(sts))
-			case setting.CronJob:
-				version, err := clientset.Discovery().ServerVersion()
-				if err != nil {
-					log.Warnf("Failed to determine server version, error is: %s", err)
-					continue
-				}
-				cj, cjBeta, err := getter.GetCronJobByNameWithCache(u.GetName(), namespace, inf, kubeclient.VersionLessThan121(version))
-				if err != nil {
-					continue
-				}
-				ret.CronJobs = append(ret.CronJobs, getCronJobWorkLoadResource(cj, cjBeta, log))
-			case setting.Ingress:
-				version, err := clientset.Discovery().ServerVersion()
-				if err != nil {
-					log.Warnf("Failed to determine server version, error is: %s", err)
-					continue
-				}
-				if kubeclient.VersionLessThan122(version) {
-					ing, found, err := getter.GetExtensionsV1Beta1Ingress(namespace, u.GetName(), inf)
-					if err != nil || !found {
-						//log.Warnf("no ingress %s found in %s:%s %v", u.GetName(), service.ServiceName, namespace, err)
-						continue
-					}
-
-					ret.Ingress = append(ret.Ingress, wrapper.Ingress(ing).Resource())
-				} else {
-					ing, err := getter.GetNetworkingV1Ingress(namespace, u.GetName(), inf)
-					if err != nil {
-						//log.Warnf("no ingress %s found in %s:%s %v", u.GetName(), service.ServiceName, namespace, err)
-						continue
-					}
-
-					ingress := &internalresource.Ingress{
-						Name:     ing.Name,
-						Labels:   ing.Labels,
-						HostInfo: wrapper.GetIngressHostInfo(ing),
-						IPs:      []string{},
-						Age:      util.Age(ing.CreationTimestamp.Unix()),
-					}
-
-					ret.Ingress = append(ret.Ingress, ingress)
-				}
-
-			case setting.Service:
-				svc, err := getter.GetServiceByNameFromCache(u.GetName(), namespace, inf)
-				if err != nil {
-					//log.Warnf("no svc %s found in %s:%s %v", u.GetName(), service.ServiceName, namespace, err)
-					continue
-				}
-
-				ret.Services = append(ret.Services, wrapper.Service(svc).Resource())
-			}
-		}
-	}
-	return
-}
-
-func GetZadigReleaseServiceImpl(releaseType, serviceName string, workLoadType string, env *commonmodels.Product, kubeClient client.Client, clientset *kubernetes.Clientset, inf informers.SharedInformerFactory, log *zap.SugaredLogger) (ret *SvcResp, err error) {
-	envName, productName := env.EnvName, env.ProductName
-	ret = &SvcResp{
+	ret = &commonservice.SvcResp{
 		ServiceName: serviceName,
 		EnvName:     envName,
 		ProductName: productName,
@@ -534,10 +326,10 @@ func GetZadigReleaseServiceImpl(releaseType, serviceName string, workLoadType st
 			return nil, e.ErrGetService.AddDesc(fmt.Sprintf("failed to list deployments, service %s in %s: %v", serviceName, namespace, err))
 		}
 		for _, deployment := range deployments {
-			ret.Scales = append(ret.Scales, getDeploymentWorkloadResource(deployment, inf, log))
+			ret.Scales = append(ret.Scales, commonservice.GetDeploymentWorkloadResource(deployment, inf, log))
 			ret.Scales[len(ret.Scales)-1].ZadigXReleaseType = releaseType
 			ret.Scales[len(ret.Scales)-1].ZadigXReleaseTag = deployment.Labels[types.ZadigReleaseVersionLabelKey]
-			ret.Workloads = append(ret.Workloads, toDeploymentWorkload(deployment))
+			ret.Workloads = append(ret.Workloads, commonservice.ToDeploymentWorkload(deployment))
 		}
 		services, err := getter.ListServices(namespace, selector, kubeClient)
 		if err != nil {
@@ -784,7 +576,7 @@ func queryPodsStatus(productInfo *commonmodels.Product, serviceTmpl *commonmodel
 		return resp
 	}
 
-	svcResp, err := GetServiceImpl(serviceTmpl.ServiceName, serviceTmpl, "", productInfo, clientset, informer, log)
+	svcResp, err := commonservice.GetServiceImpl(serviceTmpl.ServiceName, serviceTmpl, "", productInfo, clientset, informer, log)
 	if err != nil {
 		return resp
 	}
@@ -904,26 +696,4 @@ func validateServiceContainer2(namespace, envName, productName, serviceName, con
 		EnvName:     envName,
 		ProductName: productName,
 	}
-}
-
-func getDeploymentWorkloadResource(d *appsv1.Deployment, informer informers.SharedInformerFactory, log *zap.SugaredLogger) *internalresource.Workload {
-	pods, err := getter.ListPodsWithCache(labels.SelectorFromValidatedSet(d.Spec.Selector.MatchLabels), informer)
-	if err != nil {
-		log.Warnf("Failed to get pods, err: %s", err)
-	}
-
-	return wrapper.Deployment(d).WorkloadResource(pods)
-}
-
-func getStatefulSetWorkloadResource(sts *appsv1.StatefulSet, informer informers.SharedInformerFactory, log *zap.SugaredLogger) *internalresource.Workload {
-	pods, err := getter.ListPodsWithCache(labels.SelectorFromValidatedSet(sts.Spec.Selector.MatchLabels), informer)
-	if err != nil {
-		log.Warnf("Failed to get pods, err: %s", err)
-	}
-
-	return wrapper.StatefulSet(sts).WorkloadResource(pods)
-}
-
-func getCronJobWorkLoadResource(cornJob *batchv1.CronJob, cronJobBeta *v1beta1.CronJob, log *zap.SugaredLogger) *internalresource.CronJob {
-	return wrapper.CronJob(cornJob, cronJobBeta).CronJobResource()
 }

--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -72,6 +72,9 @@ func Scale(args *ScaleArgs, logger *zap.SugaredLogger) error {
 	if err != nil {
 		return e.ErrScaleService.AddErr(err)
 	}
+	if prod.IsSleeping() {
+		return e.ErrScaleService.AddErr(fmt.Errorf("environment is sleeping"))
+	}
 
 	kubeClient, err := kubeclient.GetKubeClient(config.HubServerAddress(), prod.ClusterID)
 	if err != nil {
@@ -113,6 +116,9 @@ func RestartScale(args *RestartScaleArgs, _ *zap.SugaredLogger) error {
 	prod, err := commonrepo.NewProductColl().Find(opt)
 	if err != nil {
 		return err
+	}
+	if prod.IsSleeping() {
+		return e.ErrScaleService.AddErr(fmt.Errorf("environment is sleeping"))
 	}
 
 	kubeClient, err := kubeclient.GetKubeClient(config.HubServerAddress(), prod.ClusterID)
@@ -422,6 +428,10 @@ func RestartService(envName string, args *SvcOptArgs, log *zap.SugaredLogger) (e
 	if err != nil {
 		return err
 	}
+	if productObj.IsSleeping() {
+		return e.ErrScaleService.AddErr(fmt.Errorf("environment is sleeping"))
+	}
+
 	kubeClient, err := kubeclient.GetKubeClient(config.HubServerAddress(), productObj.ClusterID)
 	if err != nil {
 		return err

--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -231,6 +231,8 @@ func GetService(envName, productName, serviceName string, production bool, workL
 		if err != nil {
 			return nil, e.ErrGetService.AddErr(err)
 		}
+		ret.Workloads = nil
+		ret.Namespace = env.Namespace
 	}
 
 	return ret, nil

--- a/pkg/microservice/aslan/core/environment/service/share_env.go
+++ b/pkg/microservice/aslan/core/environment/service/share_env.go
@@ -87,6 +87,9 @@ func EnableBaseEnv(ctx context.Context, envName, productName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to query env `%s` in project `%s`: %s", envName, productName, err)
 	}
+	if prod.IsSleeping() {
+		return fmt.Errorf("Environment is sleeping")
+	}
 
 	ns := prod.Namespace
 	clusterID := prod.ClusterID
@@ -139,6 +142,9 @@ func DisableBaseEnv(ctx context.Context, envName, productName string) error {
 	prod, err := commonrepo.NewProductColl().Find(opt)
 	if err != nil {
 		return fmt.Errorf("failed to query env `%s` in project `%s`: %s", envName, productName, err)
+	}
+	if prod.IsSleeping() {
+		return fmt.Errorf("Environment is sleeping")
 	}
 
 	ns := prod.Namespace

--- a/pkg/microservice/aslan/core/environment/service/types.go
+++ b/pkg/microservice/aslan/core/environment/service/types.go
@@ -102,20 +102,6 @@ type ScaleArgs struct {
 	Number      int    `json:"number"`
 }
 
-// SvcResp struct 产品-服务详情页面Response
-type SvcResp struct {
-	ServiceName string                       `json:"service_name"`
-	Scales      []*internalresource.Workload `json:"scales"`
-	Ingress     []*internalresource.Ingress  `json:"ingress"`
-	Services    []*internalresource.Service  `json:"service_endpoints"`
-	CronJobs    []*internalresource.CronJob  `json:"cron_jobs"`
-	Namespace   string                       `json:"namespace"`
-	EnvName     string                       `json:"env_name"`
-	ProductName string                       `json:"product_name"`
-	GroupName   string                       `json:"group_name"`
-	Workloads   []*commonservice.Workload    `json:"-"`
-}
-
 func (pr *ProductRevision) GroupsUpdated() bool {
 	if pr.ServiceRevisions == nil || len(pr.ServiceRevisions) == 0 {
 		return false

--- a/pkg/microservice/aslan/server/rest/doc/docs.go
+++ b/pkg/microservice/aslan/server/rest/doc/docs.go
@@ -269,7 +269,10 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.EnvAnalysisCronArg"
+                        }
                     }
                 }
             },
@@ -762,12 +765,92 @@ const docTemplate = `{
                         "required": true
                     },
                     {
+                        "type": "string",
+                        "description": "enable or disable",
+                        "name": "action",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/aslan/environment/environments/{name}/sleep/cron": {
+            "get": {
+                "description": "Get Env Sleep Cron",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Get Env Sleep Cron",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.EnvSleepCronArg"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Upsert Env Sleep Cron",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Upsert Env Sleep Cron",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
                         "description": "body",
                         "name": "body",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handler.EnvSleepRequest"
+                            "$ref": "#/definitions/service.EnvSleepCronArg"
                         }
                     }
                 ],
@@ -1155,7 +1238,10 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.EnvAnalysisCronArg"
+                        }
                     }
                 }
             },
@@ -1455,6 +1541,131 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/service.ValuesResp"
                         }
+                    }
+                }
+            }
+        },
+        "/api/aslan/environment/production/environments/{name}/sleep": {
+            "post": {
+                "description": "Production Environment Sleep",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Production Environment Sleep",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "enable or disable",
+                        "name": "action",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/aslan/environment/production/environments/{name}/sleep/cron": {
+            "get": {
+                "description": "Get Production Env Sleep Cron",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Get Production Env Sleep Cron",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.EnvSleepCronArg"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Upsert Production Env Sleep Cron",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Upsert Production Env Sleep Cron",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/service.EnvSleepCronArg"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -2846,14 +3057,6 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
-                }
-            }
-        },
-        "handler.EnvSleepRequest": {
-            "type": "object",
-            "properties": {
-                "isEnable": {
-                    "type": "boolean"
                 }
             }
         },
@@ -4310,6 +4513,23 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/github_com_koderover_zadig_pkg_microservice_aslan_core_common_service.EnvService"
                     }
+                }
+            }
+        },
+        "service.EnvSleepCronArg": {
+            "type": "object",
+            "properties": {
+                "awake_cron": {
+                    "type": "string"
+                },
+                "awake_cron_enable": {
+                    "type": "boolean"
+                },
+                "sleep_cron": {
+                    "type": "string"
+                },
+                "sleep_cron_enable": {
+                    "type": "boolean"
                 }
             }
         },

--- a/pkg/microservice/aslan/server/rest/doc/docs.go
+++ b/pkg/microservice/aslan/server/rest/doc/docs.go
@@ -733,6 +733,51 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/aslan/environment/environments/{name}/sleep": {
+            "post": {
+                "description": "Environment Sleep",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Environment Sleep",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.EnvSleepRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/api/aslan/environment/init_info/{name}": {
             "get": {
                 "description": "Get init product",
@@ -2801,6 +2846,14 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "handler.EnvSleepRequest": {
+            "type": "object",
+            "properties": {
+                "isEnable": {
+                    "type": "boolean"
                 }
             }
         },

--- a/pkg/microservice/aslan/server/rest/doc/swagger.json
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.json
@@ -724,6 +724,51 @@
                 }
             }
         },
+        "/api/aslan/environment/environments/{name}/sleep": {
+            "post": {
+                "description": "Environment Sleep",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Environment Sleep",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.EnvSleepRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/api/aslan/environment/init_info/{name}": {
             "get": {
                 "description": "Get init product",
@@ -2792,6 +2837,14 @@
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "handler.EnvSleepRequest": {
+            "type": "object",
+            "properties": {
+                "isEnable": {
+                    "type": "boolean"
                 }
             }
         },

--- a/pkg/microservice/aslan/server/rest/doc/swagger.json
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.json
@@ -260,7 +260,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.EnvAnalysisCronArg"
+                        }
                     }
                 }
             },
@@ -753,12 +756,92 @@
                         "required": true
                     },
                     {
+                        "type": "string",
+                        "description": "enable or disable",
+                        "name": "action",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/aslan/environment/environments/{name}/sleep/cron": {
+            "get": {
+                "description": "Get Env Sleep Cron",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Get Env Sleep Cron",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.EnvSleepCronArg"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Upsert Env Sleep Cron",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Upsert Env Sleep Cron",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
                         "description": "body",
                         "name": "body",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handler.EnvSleepRequest"
+                            "$ref": "#/definitions/service.EnvSleepCronArg"
                         }
                     }
                 ],
@@ -1146,7 +1229,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.EnvAnalysisCronArg"
+                        }
                     }
                 }
             },
@@ -1446,6 +1532,131 @@
                         "schema": {
                             "$ref": "#/definitions/service.ValuesResp"
                         }
+                    }
+                }
+            }
+        },
+        "/api/aslan/environment/production/environments/{name}/sleep": {
+            "post": {
+                "description": "Production Environment Sleep",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Production Environment Sleep",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "enable or disable",
+                        "name": "action",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/aslan/environment/production/environments/{name}/sleep/cron": {
+            "get": {
+                "description": "Get Production Env Sleep Cron",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Get Production Env Sleep Cron",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.EnvSleepCronArg"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Upsert Production Env Sleep Cron",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Upsert Production Env Sleep Cron",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/service.EnvSleepCronArg"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -2837,14 +3048,6 @@
                     "items": {
                         "type": "string"
                     }
-                }
-            }
-        },
-        "handler.EnvSleepRequest": {
-            "type": "object",
-            "properties": {
-                "isEnable": {
-                    "type": "boolean"
                 }
             }
         },
@@ -4301,6 +4504,23 @@
                     "items": {
                         "$ref": "#/definitions/github_com_koderover_zadig_pkg_microservice_aslan_core_common_service.EnvService"
                     }
+                }
+            }
+        },
+        "service.EnvSleepCronArg": {
+            "type": "object",
+            "properties": {
+                "awake_cron": {
+                    "type": "string"
+                },
+                "awake_cron_enable": {
+                    "type": "boolean"
+                },
+                "sleep_cron": {
+                    "type": "string"
+                },
+                "sleep_cron_enable": {
+                    "type": "boolean"
                 }
             }
         },

--- a/pkg/microservice/aslan/server/rest/doc/swagger.yaml
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.yaml
@@ -160,11 +160,6 @@ definitions:
           type: string
         type: array
     type: object
-  handler.EnvSleepRequest:
-    properties:
-      isEnable:
-        type: boolean
-    type: object
   handler.ModuleAndImage:
     properties:
       image:
@@ -1140,6 +1135,17 @@ definitions:
           $ref: '#/definitions/github_com_koderover_zadig_pkg_microservice_aslan_core_common_service.EnvService'
         type: array
     type: object
+  service.EnvSleepCronArg:
+    properties:
+      awake_cron:
+        type: string
+      awake_cron_enable:
+        type: boolean
+      sleep_cron:
+        type: string
+      sleep_cron_enable:
+        type: boolean
+    type: object
   service.EstimateValuesArg:
     properties:
       chartName:
@@ -2106,6 +2112,8 @@ paths:
       responses:
         "200":
           description: OK
+          schema:
+            $ref: '#/definitions/service.EnvAnalysisCronArg'
       summary: Get Env Analysis Cron
       tags:
       - environment
@@ -2434,18 +2442,72 @@ paths:
         name: projectName
         required: true
         type: string
-      - description: body
-        in: body
-        name: body
+      - description: enable or disable
+        in: query
+        name: action
         required: true
-        schema:
-          $ref: '#/definitions/handler.EnvSleepRequest'
+        type: string
       produces:
       - application/json
       responses:
         "200":
           description: OK
       summary: Environment Sleep
+      tags:
+      - environment
+  /api/aslan/environment/environments/{name}/sleep/cron:
+    get:
+      consumes:
+      - application/json
+      description: Get Env Sleep Cron
+      parameters:
+      - description: env name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: project name
+        in: query
+        name: projectName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/service.EnvSleepCronArg'
+      summary: Get Env Sleep Cron
+      tags:
+      - environment
+    put:
+      consumes:
+      - application/json
+      description: Upsert Env Sleep Cron
+      parameters:
+      - description: env name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: project name
+        in: query
+        name: projectName
+        required: true
+        type: string
+      - description: body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/service.EnvSleepCronArg'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Upsert Env Sleep Cron
       tags:
       - environment
   /api/aslan/environment/init_info/{name}:
@@ -2700,6 +2762,8 @@ paths:
       responses:
         "200":
           description: OK
+          schema:
+            $ref: '#/definitions/service.EnvAnalysisCronArg'
       summary: Get Production Env Analysis Cron
       tags:
       - environment
@@ -2902,6 +2966,90 @@ paths:
           schema:
             $ref: '#/definitions/service.ValuesResp'
       summary: Get Production Chart Values
+      tags:
+      - environment
+  /api/aslan/environment/production/environments/{name}/sleep:
+    post:
+      consumes:
+      - application/json
+      description: Production Environment Sleep
+      parameters:
+      - description: env name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: project name
+        in: query
+        name: projectName
+        required: true
+        type: string
+      - description: enable or disable
+        in: query
+        name: action
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Production Environment Sleep
+      tags:
+      - environment
+  /api/aslan/environment/production/environments/{name}/sleep/cron:
+    get:
+      consumes:
+      - application/json
+      description: Get Production Env Sleep Cron
+      parameters:
+      - description: env name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: project name
+        in: query
+        name: projectName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/service.EnvSleepCronArg'
+      summary: Get Production Env Sleep Cron
+      tags:
+      - environment
+    put:
+      consumes:
+      - application/json
+      description: Upsert Production Env Sleep Cron
+      parameters:
+      - description: env name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: project name
+        in: query
+        name: projectName
+        required: true
+        type: string
+      - description: body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/service.EnvSleepCronArg'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Upsert Production Env Sleep Cron
       tags:
       - environment
   /api/aslan/environment/production/environments/{name}/workloads:

--- a/pkg/microservice/aslan/server/rest/doc/swagger.yaml
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.yaml
@@ -160,6 +160,11 @@ definitions:
           type: string
         type: array
     type: object
+  handler.EnvSleepRequest:
+    properties:
+      isEnable:
+        type: boolean
+    type: object
   handler.ModuleAndImage:
     properties:
       image:
@@ -2411,6 +2416,36 @@ paths:
           schema:
             $ref: '#/definitions/service.SvcDiffResult'
       summary: Preview service
+      tags:
+      - environment
+  /api/aslan/environment/environments/{name}/sleep:
+    post:
+      consumes:
+      - application/json
+      description: Environment Sleep
+      parameters:
+      - description: env name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: project name
+        in: query
+        name: projectName
+        required: true
+        type: string
+      - description: body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handler.EnvSleepRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Environment Sleep
       tags:
       - environment
   /api/aslan/environment/init_info/{name}:

--- a/pkg/microservice/cron/core/service/scheduler/cronjob_handler.go
+++ b/pkg/microservice/cron/core/service/scheduler/cronjob_handler.go
@@ -498,9 +498,6 @@ func (h *CronjobHandler) registerEnvSleepJob(name, schedule string, job *service
 			base = "environment/production/environments/"
 		}
 
-		log.Debugf("job: %+v", job)
-		log.Debugf("job.EnvArgs: %+v", job.EnvArgs)
-
 		url := ""
 		if job.EnvArgs.Name == util.GetEnvSleepCronName(job.EnvArgs.ProductName, job.EnvArgs.EnvName, true) {
 			url = base + fmt.Sprintf("%s/sleep?projectName=%s&action=enable", job.EnvArgs.EnvName, job.EnvArgs.ProductName)

--- a/pkg/microservice/cron/core/service/types.go
+++ b/pkg/microservice/cron/core/service/types.go
@@ -87,7 +87,8 @@ type Schedule struct {
 	WorkflowArgs    *WorkflowTaskArgs  `bson:"workflow_args,omitempty"       json:"workflow_args,omitempty"`
 	TestArgs        *TestTaskArgs      `bson:"test_args,omitempty"           json:"test_args,omitempty"`
 	WorkflowV4Args  *WorkflowV4        `bson:"workflow_v4_args"              json:"workflow_v4_args"`
-	EnvAnalysisArgs *EnvAnalysisArgs   `bson:"env_analysis_args,omitempty"   json:"env_analysis_args,omitempty"`
+	EnvAnalysisArgs *EnvArgs           `bson:"env_analysis_args,omitempty"   json:"env_analysis_args,omitempty"`
+	EnvArgs         *EnvArgs           `bson:"env_args,omitempty"            json:"env_args,omitempty"`
 	Type            ScheduleType       `bson:"type"                          json:"type"`
 	Cron            string             `bson:"cron"                          json:"cron"`
 	IsModified      bool               `bson:"-"                             json:"-"`
@@ -369,10 +370,11 @@ type TestTaskArgs struct {
 	RepoName       string `bson:"repo_name"        json:"repo_name"`
 }
 
-type EnvAnalysisArgs struct {
-	ProductName string `bson:"product_name"            json:"product_name"`
+type EnvArgs struct {
+	Name        string `bson:"name"                   json:"name"`
+	ProductName string `bson:"product_name"           json:"product_name"`
 	EnvName     string `bson:"env_name"               json:"env_name"`
-	Production  bool   `bson:"production"               json:"production"`
+	Production  bool   `bson:"production"             json:"production"`
 }
 
 type CreateBuildRequest struct {

--- a/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
@@ -173,6 +173,19 @@ func (p *DeployTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, _ *
 		return
 	}
 
+	productInfo, err := GetProductInfo(ctx, &EnvArgs{EnvName: p.Task.EnvName, ProductName: p.Task.ProductName})
+	if err != nil {
+		err = errors.WithMessagef(
+			err,
+			"failed to get product %s/%s",
+			p.Task.Namespace, p.Task.ServiceName)
+		return
+	}
+	if productInfo.IsSleeping() {
+		err = fmt.Errorf("product %s/%s is sleeping", p.Task.ProductName, p.Task.EnvName)
+		return
+	}
+
 	containerName := p.Task.ContainerName
 	containerName = strings.TrimSuffix(containerName, "_"+p.Task.ServiceName)
 

--- a/pkg/microservice/warpdrive/core/service/taskplugin/utils.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/utils.go
@@ -32,10 +32,13 @@ import (
 	"k8s.io/client-go/rest"
 	crClient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	configbase "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/config"
+	"github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/types"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/types/task"
 	"github.com/koderover/zadig/pkg/setting"
 	kubeclient "github.com/koderover/zadig/pkg/shared/kube/client"
+	"github.com/koderover/zadig/pkg/tool/httpclient"
 	"github.com/koderover/zadig/pkg/tool/kodo"
 )
 
@@ -310,4 +313,17 @@ func getReaperImage(reaperImage, buildOS, imageFrom string) string {
 		jobImage = buildOS
 	}
 	return jobImage
+}
+
+func GetProductInfo(ctx context.Context, args *EnvArgs) (*types.Product, error) {
+	httpClient := httpclient.New(
+		httpclient.SetHostURL(configbase.AslanServiceAddress()),
+	)
+	url := fmt.Sprintf("/api/environment/environments/%s/productInfo", args.EnvName)
+	prod := &types.Product{}
+	_, err := httpClient.Get(url, httpclient.SetResult(prod), httpclient.SetQueryParam("projectName", args.ProductName), httpclient.SetQueryParam("ifPassFilter", "true"))
+	if err != nil {
+		return nil, err
+	}
+	return prod, nil
 }

--- a/pkg/microservice/warpdrive/core/service/types/environment.go
+++ b/pkg/microservice/warpdrive/core/service/types/environment.go
@@ -20,6 +20,7 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/config"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/types/task"
+	"github.com/koderover/zadig/pkg/setting"
 )
 
 type Product struct {
@@ -115,4 +116,8 @@ func (p *Product) GetServiceMap() map[string]*Service {
 		}
 	}
 	return ret
+}
+
+func (p *Product) IsSleeping() bool {
+	return p.Status == setting.ProductStatusSleeping
 }

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -377,6 +377,7 @@ const (
 	ProductStatusCreating = "creating"
 	ProductStatusUpdating = "updating"
 	ProductStatusDeleting = "deleting"
+	ProductStatusSleeping = "sleeping"
 	ProductStatusUnknown  = "unknown"
 	ProductStatusUnstable = "Unstable"
 )

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -546,6 +546,7 @@ const (
 	WorkflowV4Cronjob  = "workflow_v4"
 	TestingCronjob     = "test"
 	EnvAnalysisCronjob = "env_analysis"
+	EnvSleepCronjob    = "env_sleep"
 
 	TopicProcess      = "task.process"
 	TopicCancel       = "task.cancel"

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -377,7 +377,7 @@ const (
 	ProductStatusCreating = "creating"
 	ProductStatusUpdating = "updating"
 	ProductStatusDeleting = "deleting"
-	ProductStatusSleeping = "sleeping"
+	ProductStatusSleeping = "Sleeping"
 	ProductStatusUnknown  = "unknown"
 	ProductStatusUnstable = "Unstable"
 )

--- a/pkg/tool/errors/http_errors.go
+++ b/pkg/tool/errors/http_errors.go
@@ -165,6 +165,8 @@ var (
 	ErrGetEnvConfigs = NewHTTPError(6078, "获取环境配置失败")
 	// TODO: max error code reached, sharing error code with update env
 	ErrUpdateEnvConfigs = NewHTTPError(6076, "更新环境配置失败")
+	// TODO: max error code reached, sharing error code with update env
+	ErrEnvSleep = NewHTTPError(6076, "环境睡眠失败")
 
 	//-----------------------------------------------------------------------------------------------
 	// Product Service APIs Range: 6080 - 6099 AND 6150 -6199

--- a/pkg/tool/kube/updater/cronjob.go
+++ b/pkg/tool/kube/updater/cronjob.go
@@ -71,3 +71,13 @@ func UpdateCronJobImage(ns, name, container, image string, cl client.Client, ver
 	patchBytes := []byte(fmt.Sprintf(`{"spec":{"jobTemplate":{"spec":{"template":{"spec":{"containers":[{"name":"%s","image":"%s"}]}}}}}}`, container, image))
 	return PatchCronJob(ns, name, patchBytes, cl, versionLessThan121)
 }
+
+func SuspendCronJob(ns, name string, cl client.Client, versionLessThan121 bool) error {
+	patchBytes := []byte(`{"spec":{"suspend":true}}`)
+	return PatchCronJob(ns, name, patchBytes, cl, versionLessThan121)
+}
+
+func ResumeCronJob(ns, name string, cl client.Client, versionLessThan121 bool) error {
+	patchBytes := []byte(`{"spec":{"suspend":false}}`)
+	return PatchCronJob(ns, name, patchBytes, cl, versionLessThan121)
+}

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -17,11 +17,13 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"unicode"
 
 	ref "github.com/containers/image/docker/reference"
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/mozillazg/go-pinyin"
 )
 
@@ -96,4 +98,12 @@ func GetPinyinFromChinese(han string) (string, string) {
 		}
 	}
 	return fullLetter, firstLetter
+}
+
+func GetEnvSleepCronName(projectName, envName string, isEnable bool) string {
+	suffix := "sleep"
+	if !isEnable {
+		suffix = "awake"
+	}
+	return fmt.Sprintf("%s-%s-%s-%s", envName, projectName, config.EnvSleepCronjob, suffix)
 }


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a982798</samp>

This pull request adds a new feature to the `aslan` microservice that allows users to put an environment to sleep or wake it up by scaling the workloads to zero or to the previous number of replicas. The pull request adds a new API, model, handler, service, and database field for this feature, as well as updates the documentation and the error handling. The pull request also adds some comments to other files for clarity.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a982798</samp>

*  Add a new feature to put an environment to sleep or wake it up by scaling the workloads to zero or to the previous number of replicas ([link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-a72d67ae0e860df489410fc2151dc45f9f615ef008b717b4c4c1ccb929114d7bL71-R77), [link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24R4422-R4583), [link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-e9d22162901df783d481a21459bff59cd789639ec450de043099bb498963846cR380))
  * Add a new field `PreSleepStatus` to the `Product` struct to store the previous number of replicas for each workload before the environment is put to sleep ([link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-a72d67ae0e860df489410fc2151dc45f9f615ef008b717b4c4c1ccb929114d7bL71-R77))
  * Add a new service function `EnvSleep` to implement the logic for scaling the workloads and updating the product status and the `PreSleepStatus` field ([link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24R4422-R4583))
  * Add a new constant `ProductStatusSleeping` to represent the status of a product when it is put to sleep ([link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-e9d22162901df783d481a21459bff59cd789639ec450de043099bb498963846cR380))
* Add a new handler function `EnvSleep` to handle the HTTP request for the sleep feature and return a JSON response ([link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eR1684-R1717), [link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-bc855cdae7fd5951f2dd616071a0a85b20273c7a89fc1725f032de2b17ff7bd7R224), [link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-754ac2982cab78c22f57f226133df3f1092fc72a6d1133a1331864479a935773R168-R169))
  * Add a new route `/api/aslan/environment/environments/:name/sleep` with the method `POST` and the handler `EnvSleep` ([link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-bc855cdae7fd5951f2dd616071a0a85b20273c7a89fc1725f032de2b17ff7bd7R224))
  * Add a new handler function `EnvSleep` to parse the path, query, and body parameters and call the service function `EnvSleep` with a logger ([link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eR1684-R1717))
  * Add a new error `ErrEnvSleep` to use when the service function `EnvSleep` fails ([link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-754ac2982cab78c22f57f226133df3f1092fc72a6d1133a1331864479a935773R168-R169))
* Add a new API definition and a new model definition to the documentation files ([link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62R736-R780), [link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62R2852-R2859), [link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216R727-R771), [link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216R2843-R2850), [link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2R163-R167), [link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2R2421-R2450))
  * Add a new API definition `/api/aslan/environment/environments/{name}/sleep` with the method `POST` and the same parameters and responses as the handler function `EnvSleep` ([link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62R736-R780), [link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216R727-R771), [link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2R2421-R2450))
  * Add a new model definition `handler.EnvSleepRequest` with a single property `isEnable` of type boolean to use as the schema for the body parameter of the API ([link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62R2852-R2859), [link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216R2843-R2850), [link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2R163-R167))
* Add comments to some functions to indicate their purposes ([link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-150810b9b9a9ae4e2d85ea333a4ca97a7ca4ca8c02b80ff11d17cc853f75ba14R372), [link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-43b4a5df02ef75087654902b8d4afc32745599d35053d171a5b950a94d012960R715), [link](https://github.com/koderover/zadig/pull/2925/files?diff=unified&w=0#diff-cadfbcfda6b8db490cf51fee5f15d40ed280356f899c4015c2e7c1b379bb03ddR568))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
