### PR TITLE
cp 2924

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_scanning.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_scanning.go
@@ -167,6 +167,7 @@ func (j *ScanningJob) ToJobs(taskID int64) ([]*commonmodels.JobTask, error) {
 			Key:   "SCANNING_NAME",
 			Value: scanning.Name,
 		}
+
 		scanningImage := basicImage.Value
 		if basicImage.ImageFrom == commonmodels.ImageFromKoderover {
 			scanningImage = strings.ReplaceAll(config.ReaperImage(), "${BuildOS}", basicImage.Value)
@@ -181,6 +182,13 @@ func (j *ScanningJob) ToJobs(taskID int64) ([]*commonmodels.JobTask, error) {
 			Envs:                []*commonmodels.KeyVal{scanningNameKV},
 			Registries:          registries,
 			ShareStorageDetails: getShareStorageDetail(j.workflow.ShareStorages, scanning.ShareStorageInfo, j.workflow.Name, taskID),
+		}
+
+		if len(scanning.Repos) > 0 {
+			jobTaskSpec.Properties.Envs = append(jobTaskSpec.Properties.Envs, &commonmodels.KeyVal{
+				Key:   "BRANCH",
+				Value: scanning.Repos[0].Branch,
+			})
 		}
 
 		// init tools install step

--- a/pkg/microservice/warpdrive/core/service/taskplugin/scanning.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/scanning.go
@@ -23,10 +23,9 @@ import (
 	"strings"
 	"time"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -148,12 +147,21 @@ func (p *ScanPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipelineC
 		repoList = append(repoList, repo)
 	}
 
+	envVars := make([]*task.KeyVal, 0)
+	if len(repoList) > 0 {
+		envVars = append(envVars, &task.KeyVal{
+			Key:   "BRANCH",
+			Value: repoList[0].Branch,
+		})
+	}
+
 	jobCtx := JobCtxBuilder{
 		JobName:     p.JobName,
 		PipelineCtx: pipelineCtx,
 		Installs:    p.Task.InstallCtx,
 		JobCtx: task.JobCtx{
-			Builds: repoList,
+			Builds:  repoList,
+			EnvVars: envVars,
 		},
 	}
 


### PR DESCRIPTION
### What this PR does / Why we need it:
cp https://github.com/koderover/zadig/pull/2924/files

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8972ba2</samp>

*  Pass the branch information of the scanned repository to the job task specification and the task context ([link](https://github.com/koderover/zadig/pull/2932/files?diff=unified&w=0#diff-8ce6648bcd34814704b4ce0fb5f896cccff5cfc80f48da92a359a5bac85ff2c3R187-R193), [link](https://github.com/koderover/zadig/pull/2932/files?diff=unified&w=0#diff-011710bf487b419f6cd001735c3d510d5e6b07037b3b5d80f716fb35f7aaba8fR150-R157), [link](https://github.com/koderover/zadig/pull/2932/files?diff=unified&w=0#diff-011710bf487b419f6cd001735c3d510d5e6b07037b3b5d80f716fb35f7aaba8fL156-R164))
  * In `job_scanning.go`, append a new environment variable with the key `BRANCH` and the value of the first element's branch to the `jobTaskSpec.Properties.Envs` slice if the `scanning.Repos` slice has any elements ([link](https://github.com/koderover/zadig/pull/2932/files?diff=unified&w=0#diff-8ce6648bcd34814704b4ce0fb5f896cccff5cfc80f48da92a359a5bac85ff2c3R187-R193))
  * In `scanning.go`, declare and assign a new variable `envVars` as a slice of pointers to `task.KeyVal` structs, which are key-value pairs for environment variables ([link](https://github.com/koderover/zadig/pull/2932/files?diff=unified&w=0#diff-011710bf487b419f6cd001735c3d510d5e6b07037b3b5d80f716fb35f7aaba8fR150-R157))
  * In `scanning.go`, append a new `task.KeyVal` with the key `BRANCH` and the value of the first element's branch to the `envVars` slice if the `repoList` slice has any elements ([link](https://github.com/koderover/zadig/pull/2932/files?diff=unified&w=0#diff-011710bf487b419f6cd001735c3d510d5e6b07037b3b5d80f716fb35f7aaba8fR150-R157))
  * In `scanning.go`, add the `envVars` slice as the value of the `EnvVars` field of the `JobCtx` struct in the assignment of the `JobCtx` field of the `taskCtx` variable ([link](https://github.com/koderover/zadig/pull/2932/files?diff=unified&w=0#diff-011710bf487b419f6cd001735c3d510d5e6b07037b3b5d80f716fb35f7aaba8fL156-R164))
* Reorder the import statements in the package `taskplugin` in `scanning.go` ([link](https://github.com/koderover/zadig/pull/2932/files?diff=unified&w=0#diff-011710bf487b419f6cd001735c3d510d5e6b07037b3b5d80f716fb35f7aaba8fL26-R28))
  * Move the `apierrors` alias to the third position and the `zap` package to the second position ([link](https://github.com/koderover/zadig/pull/2932/files?diff=unified&w=0#diff-011710bf487b419f6cd001735c3d510d5e6b07037b3b5d80f716fb35f7aaba8fL26-R28))
* Add an empty line to the package `job` in `job_scanning.go` ([link](https://github.com/koderover/zadig/pull/2932/files?diff=unified&w=0#diff-8ce6648bcd34814704b4ce0fb5f896cccff5cfc80f48da92a359a5bac85ff2c3R170))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
