### PR TITLE
cp 2934

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/apply.go
+++ b/pkg/microservice/aslan/core/common/service/kube/apply.go
@@ -530,7 +530,7 @@ func PrepareHelmServiceData(applyParam *ResourceApplyParam) (*commonmodels.Rende
 	productService := applyParam.ProductInfo.GetServiceMap()[applyParam.ServiceName]
 	if productService == nil {
 		if !applyParam.UpdateServiceRevision {
-			return nil, nil, nil, fmt.Errorf("First time online service %s needs to check the update service configuration", applyParam.ServiceName)
+			return nil, nil, nil, fmt.Errorf("first time online service %s needs to check the update service configuration", applyParam.ServiceName)
 		}
 
 		productService = &commonmodels.ProductService{

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2881,24 +2881,6 @@ func buildInstallParam(defaultValues string, productInfo *commonmodels.Product, 
 	return ret, nil
 }
 
-func buildChartInstallParam(namespace, envName, defaultValues string, renderChart *templatemodels.ServiceRender, serviceObj *commonmodels.Service, productSvc *commonmodels.ProductService) (*kube.ReleaseInstallParam, error) {
-	mergedValues, err := helmtool.MergeOverrideValues("", defaultValues, renderChart.GetOverrideYaml(), renderChart.OverrideValues, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to merge release %s: override yaml %s and values %s, err: %s", renderChart.ReleaseName, renderChart.GetOverrideYaml(), renderChart.OverrideValues, err)
-	}
-	ret := &kube.ReleaseInstallParam{
-		ProductName:    productSvc.ProductName,
-		Namespace:      namespace,
-		ReleaseName:    renderChart.ReleaseName,
-		MergedValues:   mergedValues,
-		RenderChart:    renderChart,
-		ServiceObj:     serviceObj,
-		Production:     true,
-		IsChartInstall: true,
-	}
-	return ret, nil
-}
-
 func installProductHelmCharts(user, requestID string, args *commonmodels.Product, renderset *commonmodels.RenderSet, eventStart int64, helmClient *helmtool.HelmClient,
 	kclient client.Client, istioClient versionedclient.Interface, log *zap.SugaredLogger) {
 	var (


### PR DESCRIPTION
### What this PR does / Why we need it:
cp https://github.com/koderover/zadig/pull/2934/files

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ce614e1</samp>

*  Fix a typo in the error message of `Apply` function ([link](https://github.com/koderover/zadig/pull/2939/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L533-R533))
*  Move and export `CalculateContainer` and `FetchCurrentServiceVariable` functions from `render.go` to `apply.go` ([link](https://github.com/koderover/zadig/pull/2939/files?diff=unified&w=0#diff-c638107a5f348cedbea18f66b5f3fb8cb4e440c7289c39be1817d16ce9b13c3eL269-R268), [link](https://github.com/koderover/zadig/pull/2939/files?diff=unified&w=0#diff-c638107a5f348cedbea18f66b5f3fb8cb4e440c7289c39be1817d16ce9b13c3eL316-R337), [link](https://github.com/koderover/zadig/pull/2939/files?diff=unified&w=0#diff-c638107a5f348cedbea18f66b5f3fb8cb4e440c7289c39be1817d16ce9b13c3eL41))
*  Add logic to query and merge template service for helm deploy job in `Run` function of `job_helm_deploy.go` ([link](https://github.com/koderover/zadig/pull/2939/files?diff=unified&w=0#diff-0db98f8df1b5910f183b6a80b83d0a7e287b00d927e8b28e81c79c8e663de011R36), [link](https://github.com/koderover/zadig/pull/2939/files?diff=unified&w=0#diff-0db98f8df1b5910f183b6a80b83d0a7e287b00d927e8b28e81c79c8e663de011R112-R118), [link](https://github.com/koderover/zadig/pull/2939/files?diff=unified&w=0#diff-0db98f8df1b5910f183b6a80b83d0a7e287b00d927e8b28e81c79c8e663de011R126-R152))
*  Add logic to query and merge template service for helm service yaml comparison in `CompareHelmServiceYamlInEnv` function of `workflow_v4.go` ([link](https://github.com/koderover/zadig/pull/2939/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R61), [link](https://github.com/koderover/zadig/pull/2939/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R2126-R2132), [link](https://github.com/koderover/zadig/pull/2939/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R2139-R2162))
*  Modify `MergeOverrideValues` function of `helmclient.go` to merge image values in helm -f option instead of --set option ([link](https://github.com/koderover/zadig/pull/2939/files?diff=unified&w=0#diff-43a9dce56755d1a350cdaddec8b11f9b7c4e7fa8fc7f7aa5204cbaddbb9c3869L180-R197), [link](https://github.com/koderover/zadig/pull/2939/files?diff=unified&w=0#diff-43a9dce56755d1a350cdaddec8b11f9b7c4e7fa8fc7f7aa5204cbaddbb9c3869L199-R219))
*  Remove unused `buildChartInstallParam` function from `environment.go` ([link](https://github.com/koderover/zadig/pull/2939/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L2884-L2901))
*  Remove and add back unused imports in `workflow_v4.go` ([link](https://github.com/koderover/zadig/pull/2939/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114L31-L32), [link](https://github.com/koderover/zadig/pull/2939/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R69-R70))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
