### PR TITLE
fix list project unexpectedly lists all public project

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/template/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/template/product.go
@@ -138,18 +138,12 @@ type ProductListByFilterOpt struct {
 }
 
 func (c *ProductColl) PageListProjectByFilter(opt ProductListByFilterOpt) ([]*ProjectInfo, int, error) {
-	fullFindOptions := []bson.M{
-		{"public": true},
-	}
+	findOption := bson.M{}
 
 	if len(opt.Names) > 0 {
-		fullFindOptions = append(fullFindOptions, bson.M{"product_name": bson.M{"$in": opt.Names}})
+		findOption = bson.M{"product_name": bson.M{"$in": opt.Names}}
 	} else {
-		fullFindOptions = append(fullFindOptions, bson.M{"product_name": bson.M{"$ne": ""}})
-	}
-
-	findOption := bson.M{
-		"$or": fullFindOptions,
+		findOption = bson.M{"product_name": bson.M{"$ne": ""}}
 	}
 
 	finalSearchCondition := []bson.M{
@@ -259,25 +253,11 @@ func (c *ProductColl) ListProjectBriefs(inNames []string) ([]*ProjectInfo, error
 }
 
 func (c *ProductColl) listProjects(inNames []string, projection bson.M) ([]*ProjectInfo, error) {
-	filter := []bson.M{
-		{"public": true},
-	}
+	query := bson.M{}
 	if len(inNames) > 0 {
-		filter = append(filter, bson.M{
-			"product_name": bson.M{
-				"$in": inNames,
-			},
-		})
+		query["product_name"] = bson.M{"$in": inNames}
 	} else {
-		filter = append(filter, bson.M{
-			"product_name": bson.M{
-				"$ne": "",
-			},
-		})
-	}
-
-	query := bson.M{
-		"$or": filter,
+		query["product_name"] = bson.M{"$ne": ""}
 	}
 
 	pipeline := []bson.M{


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f0abea</samp>

Optimize MongoDB queries for project lists in `product.go`. Use simpler and more specific filters to improve performance and readability.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f0abea</samp>

*  Simplify query condition for `PageListProjectByFilter` function by removing redundant `public: true` condition and assigning `findOption` directly to `product_name` field ([link](https://github.com/koderover/zadig/pull/2943/files?diff=unified&w=0#diff-79dc64e07212428c7aa17d6a4a49f95d8793673562c71195ca6faa52dba016c8L141-R148))
*  Simplify query condition for `listProjects` function by removing redundant `public: true` condition and assigning `query` directly to `product_name` field ([link](https://github.com/koderover/zadig/pull/2943/files?diff=unified&w=0#diff-79dc64e07212428c7aa17d6a4a49f95d8793673562c71195ca6faa52dba016c8L262-R262))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
