### PR TITLE
remove useless log and add detailed log

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/render.go
+++ b/pkg/microservice/aslan/core/common/service/kube/render.go
@@ -574,7 +574,6 @@ func GenerateRenderedYaml(option *GeneSvcYamlOption) (string, int, []*WorkloadRe
 		return "", 0, nil, err
 	}
 	fullRenderedYaml = ParseSysKeys(productInfo.Namespace, productInfo.EnvName, option.ProductName, option.ServiceName, fullRenderedYaml)
-	log.Infof("fullRenderedYaml is: %s", fullRenderedYaml)
 
 	// service may not be deployed in environment, we need to extract containers again, since image related variables may be changed
 	latestSvcTemplate.KubeYamls = util.SplitYaml(fullRenderedYaml)

--- a/pkg/tool/nacos/client.go
+++ b/pkg/tool/nacos/client.go
@@ -69,7 +69,7 @@ const (
 func NewNacosClient(serverAddr, userName, password string) (*Client, error) {
 	host, err := url.Parse(serverAddr)
 	if err != nil {
-		return nil, errors.New("parse nacos server address failed")
+		return nil, errors.Wrap(err, "parse nacos server address failed")
 	}
 	// add default context path
 	if host.Path == "" {
@@ -82,7 +82,7 @@ func NewNacosClient(serverAddr, userName, password string) (*Client, error) {
 		SetResult(&result).
 		Post(loginURL)
 	if err != nil {
-		return nil, errors.New("login nacos failed")
+		return nil, errors.Wrap(err, "login nacos failed")
 	}
 	if !resp.IsSuccess() {
 		return nil, errors.New("login nacos failed")
@@ -120,7 +120,7 @@ func (c *Client) ListNamespaces() ([]*types.NacosNamespace, error) {
 	url := "/v1/console/namespaces"
 	res := &namespaceResp{}
 	if _, err := c.Client.Get(url, httpclient.SetResult(res)); err != nil {
-		return nil, errors.New("list nacos namespace failed")
+		return nil, errors.Wrap(err, "list nacos namespace failed")
 	}
 	resp := []*types.NacosNamespace{}
 	for _, namespace := range res.Data {
@@ -152,7 +152,7 @@ func (c *Client) ListConfigs(namespaceID string) ([]*types.NacosConfig, error) {
 			"tenant":   namespaceID,
 		})
 		if _, err := c.Client.Get(url, params, httpclient.SetResult(res)); err != nil {
-			return nil, errors.New("list nacos config failed")
+			return nil, errors.Wrap(err, "list nacos config failed")
 		}
 		for _, conf := range res.PageItems {
 			resp = append(resp, &types.NacosConfig{
@@ -181,7 +181,7 @@ func (c *Client) GetConfig(dataID, group, namespaceID string) (*types.NacosConfi
 		"show":   "all",
 	})
 	if _, err := c.Client.Get(url, params, httpclient.SetResult(res)); err != nil {
-		return nil, errors.New("get nacos config failed")
+		return nil, errors.Wrap(err, "get nacos config failed")
 	}
 	return &types.NacosConfig{
 		DataID:  res.DataID,
@@ -202,7 +202,7 @@ func (c *Client) UpdateConfig(dataID, group, namespaceID, content, format string
 		"type":    setFormat(format),
 	}
 	if _, err := c.Client.Post(path, httpclient.SetFormData(formValues)); err != nil {
-		return errors.New("update nacos config failed")
+		return errors.Wrap(err, "update nacos config failed")
 	}
 	return nil
 }


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 97ef5f1</samp>

This pull request improves the error handling of the `nacos` client and reduces the log output of the Kubernetes resource rendering.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 97ef5f1</samp>

*  Wrap original errors with more context for better error handling and debugging in nacos client (`[link](https://github.com/koderover/zadig/pull/2944/files?diff=unified&w=0#diff-7279b7b40b82887632605b22d3e6a571d1bb10fa5de646d09b3caafe1a37fb34L72-R72)`, `[link](https://github.com/koderover/zadig/pull/2944/files?diff=unified&w=0#diff-7279b7b40b82887632605b22d3e6a571d1bb10fa5de646d09b3caafe1a37fb34L85-R85)`, `[link](https://github.com/koderover/zadig/pull/2944/files?diff=unified&w=0#diff-7279b7b40b82887632605b22d3e6a571d1bb10fa5de646d09b3caafe1a37fb34L123-R123)`, `[link](https://github.com/koderover/zadig/pull/2944/files?diff=unified&w=0#diff-7279b7b40b82887632605b22d3e6a571d1bb10fa5de646d09b3caafe1a37fb34L155-R155)`, `[link](https://github.com/koderover/zadig/pull/2944/files?diff=unified&w=0#diff-7279b7b40b82887632605b22d3e6a571d1bb10fa5de646d09b3caafe1a37fb34L184-R184)`, `[link](https://github.com/koderover/zadig/pull/2944/files?diff=unified&w=0#diff-7279b7b40b82887632605b22d3e6a571d1bb10fa5de646d09b3caafe1a37fb34L205-R205)`) in file `pkg/tool/nacos/client.go`

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
