### PR TITLE
fix nacos auth error

### DIFF
--- a/pkg/tool/nacos/client.go
+++ b/pkg/tool/nacos/client.go
@@ -144,12 +144,13 @@ func (c *Client) ListConfigs(namespaceID string) ([]*types.NacosConfig, error) {
 		numString := strconv.Itoa(pageNum)
 		sizeString := strconv.Itoa(pageSize)
 		params := httpclient.SetQueryParams(map[string]string{
-			"dataId":   "",
-			"group":    "",
-			"search":   "accurate",
-			"pageNo":   numString,
-			"pageSize": sizeString,
-			"tenant":   namespaceID,
+			"dataId":      "",
+			"group":       "",
+			"search":      "accurate",
+			"pageNo":      numString,
+			"pageSize":    sizeString,
+			"tenant":      namespaceID,
+			"accessToken": c.token,
 		})
 		if _, err := c.Client.Get(url, params, httpclient.SetResult(res)); err != nil {
 			return nil, errors.New("list nacos config failed")
@@ -175,10 +176,11 @@ func (c *Client) GetConfig(dataID, group, namespaceID string) (*types.NacosConfi
 	url := "/v1/cs/configs"
 	res := &config{}
 	params := httpclient.SetQueryParams(map[string]string{
-		"dataId": dataID,
-		"group":  group,
-		"tenant": namespaceID,
-		"show":   "all",
+		"dataId":      dataID,
+		"group":       group,
+		"tenant":      namespaceID,
+		"show":        "all",
+		"accessToken": c.token,
 	})
 	if _, err := c.Client.Get(url, params, httpclient.SetResult(res)); err != nil {
 		return nil, errors.New("get nacos config failed")
@@ -195,11 +197,12 @@ func (c *Client) UpdateConfig(dataID, group, namespaceID, content, format string
 	namespaceID = getNamespaceID(namespaceID)
 	path := "/v1/cs/configs"
 	formValues := map[string]string{
-		"dataId":  dataID,
-		"group":   group,
-		"tenant":  namespaceID,
-		"content": content,
-		"type":    setFormat(format),
+		"dataId":      dataID,
+		"group":       group,
+		"tenant":      namespaceID,
+		"content":     content,
+		"type":        setFormat(format),
+		"accessToken": c.token,
 	}
 	if _, err := c.Client.Post(path, httpclient.SetFormData(formValues)); err != nil {
 		return errors.New("update nacos config failed")


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 61449f5</samp>

Added authentication support for Nacos client in `pkg/tool/nacos/client.go`. This enables secure and authorized access to the Nacos server configuration.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 61449f5</samp>

*  Add `accessToken` parameter to Nacos API requests for authentication ([link](https://github.com/koderover/zadig/pull/2953/files?diff=unified&w=0#diff-7279b7b40b82887632605b22d3e6a571d1bb10fa5de646d09b3caafe1a37fb34L147-R153), [link](https://github.com/koderover/zadig/pull/2953/files?diff=unified&w=0#diff-7279b7b40b82887632605b22d3e6a571d1bb10fa5de646d09b3caafe1a37fb34L178-R183), [link](https://github.com/koderover/zadig/pull/2953/files?diff=unified&w=0#diff-7279b7b40b82887632605b22d3e6a571d1bb10fa5de646d09b3caafe1a37fb34L198-R205))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
