### PR TITLE
users api debug and edge case fix

### DIFF
--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -95,12 +95,12 @@ func ListProducts(c *gin.Context) {
 			projectInfo.Env.View {
 			hasPermission = true
 		}
-	} else {
-		permittedEnv, _ := internalhandler.ListCollaborationEnvironmentsPermission(ctx.UserID, projectName)
-		if permittedEnv != nil && len(permittedEnv.ReadEnvList) > 0 {
-			hasPermission = true
-			envFilter = permittedEnv.ReadEnvList
-		}
+	}
+
+	permittedEnv, _ := internalhandler.ListCollaborationEnvironmentsPermission(ctx.UserID, projectName)
+	if !hasPermission && permittedEnv != nil && len(permittedEnv.ReadEnvList) > 0 {
+		hasPermission = true
+		envFilter = permittedEnv.ReadEnvList
 	}
 
 	if !hasPermission {

--- a/pkg/shared/client/user/user.go
+++ b/pkg/shared/client/user/user.go
@@ -39,7 +39,9 @@ type usersResp struct {
 }
 
 type SearchArgs struct {
-	UIDs []string `json:"uids"`
+	UIDs    []string `json:"uids"`
+	PerPage int      `json:"per_page,omitempty"`
+	Page    int      `json:"page,omitempty"`
 }
 
 func (c *Client) ListUsers(args *SearchArgs) ([]*User, error) {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a7e1356</samp>

This pull request enhances the collaboration environment feature and the user search API in Zadig. It allows non-admin users to list products in collaboration environments, and adds pagination support to the user search API.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a7e1356</samp>

*  Support pagination in user search API by adding `PerPage` and `Page` fields to `SearchArgs` struct ([link](https://github.com/koderover/zadig/pull/2957/files?diff=unified&w=0#diff-cf1d9958f2968a8d069902a0143e7f0aaa30d52489bf81929405bf171c61cdf4L42-R44))
*  Allow users with collaboration environment permission to list products in those environments by moving the permission check outside of the project admin check ([link](https://github.com/koderover/zadig/pull/2957/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL98-R105))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
