### PR TITLE
add service name lower case check when load from template

### DIFF
--- a/pkg/microservice/aslan/core/service/service/helm.go
+++ b/pkg/microservice/aslan/core/service/service/helm.go
@@ -677,6 +677,10 @@ func CreateOrUpdateHelmServiceFromChartTemplate(projectName string, args *HelmSe
 		return nil, fmt.Errorf("invalid argument")
 	}
 
+	if strings.ToLower(args.Name) != args.Name {
+		return nil, fmt.Errorf("service name should be lowercase")
+	}
+
 	templateChartInfo, err := prepareChartTemplateData(templateArgs.TemplateName, logger)
 	if err != nil {
 		return nil, err
@@ -1260,6 +1264,7 @@ func handleSingleService(projectName string, repoConfig *commonservice.RepoConfi
 	serviceName := filepath.Base(path)
 	serviceName = strings.TrimSuffix(serviceName, filepath.Ext(serviceName))
 	serviceName = strings.TrimSpace(serviceName)
+	serviceName = strings.ToLower(serviceName)
 
 	to := filepath.Join(config.LocalTestServicePath(projectName, serviceName), serviceName)
 	// remove old files

--- a/pkg/microservice/aslan/core/service/service/template.go
+++ b/pkg/microservice/aslan/core/service/service/template.go
@@ -53,6 +53,11 @@ func geneCreateFromDetail(templateId string, variableYaml string) *commonmodels.
 
 func LoadServiceFromYamlTemplate(username string, req *LoadServiceFromYamlTemplateReq, force bool, logger *zap.SugaredLogger) error {
 	projectName, serviceName, templateID, autoSync := req.ProjectName, req.ServiceName, req.TemplateID, req.AutoSync
+	// check if serviceName has upper case
+	if strings.ToLower(serviceName) != serviceName {
+		return fmt.Errorf("service name should be lowercase")
+	}
+
 	template, err := commonrepo.NewYamlTemplateColl().GetById(templateID)
 	if err != nil {
 		logger.Errorf("Failed to find template of ID: %s, the error is: %s", templateID, err)
@@ -88,6 +93,11 @@ func LoadServiceFromYamlTemplate(username string, req *LoadServiceFromYamlTempla
 
 func LoadProductionServiceFromYamlTemplate(username string, req *LoadServiceFromYamlTemplateReq, force bool, logger *zap.SugaredLogger) error {
 	projectName, serviceName, templateID, autoSync := req.ProjectName, req.ServiceName, req.TemplateID, req.AutoSync
+	// check if serviceName has upper case
+	if strings.ToLower(serviceName) != serviceName {
+		return fmt.Errorf("service name should be lowercase")
+	}
+
 	template, err := commonrepo.NewYamlTemplateColl().GetById(templateID)
 	if err != nil {
 		logger.Errorf("Failed to find template of ID: %s, the error is: %s", templateID, err)


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 973c943</samp>

Enforce lowercase service names for helm services in Zadig. This pull request adds validation and conversion logic in `helm.go` and `template.go` to prevent helm or kubernetes errors caused by uppercase service names.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 973c943</samp>

*  Validate that service names are lowercase in helm and yaml template functions ([link](https://github.com/koderover/zadig/pull/2959/files?diff=unified&w=0#diff-d300863490f9d35da5aa75718b2a04d9e149f408ae9fb6e8caca2032ca53664dR680-R683), [link](https://github.com/koderover/zadig/pull/2959/files?diff=unified&w=0#diff-554da713e5f60d36b3b19c7bbe6074a0d56c106fbd5d730227a194e7743e716cR56-R60), [link](https://github.com/koderover/zadig/pull/2959/files?diff=unified&w=0#diff-554da713e5f60d36b3b19c7bbe6074a0d56c106fbd5d730227a194e7743e716cR96-R100))
*  Convert service names to lowercase in `handleSingleService` function ([link](https://github.com/koderover/zadig/pull/2959/files?diff=unified&w=0#diff-d300863490f9d35da5aa75718b2a04d9e149f408ae9fb6e8caca2032ca53664dR1267))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
