### PR TITLE
fix other type ssh git integration

### DIFF
--- a/pkg/microservice/jobexecutor/core/service/step/step_git.go
+++ b/pkg/microservice/jobexecutor/core/service/step/step_git.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
@@ -294,6 +295,11 @@ func (s *GitStep) buildGitCommands(repo *types.Repository, hostNames sets.String
 		return cmds
 	}
 
+	sleepCmd := exec.Command(
+		"sleep",
+		"600",
+	)
+	cmds = append(cmds, &c.Command{Cmd: sleepCmd})
 	cmds = append(cmds, &c.Command{Cmd: c.Fetch(repo.RemoteName, ref)}, &c.Command{Cmd: c.CheckoutHead()})
 
 	// PR rebase branch 请求


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 34b7547</samp>

Added a temporary `sleep` command to the git step for testing purposes. This helps to check if the job executor can handle jobs that exceed the expected duration.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 34b7547</samp>

*  Added a `sleepCmd` to the `cmds` slice in `step_git.go` to test the timeout feature of the job executor ([link](https://github.com/koderover/zadig/pull/2963/files?diff=unified&w=0#diff-7856a64839d3a12d7f56dcb54ff0a9c37bb64251829b52bfb5bbf67818e8456bR27), [link](https://github.com/koderover/zadig/pull/2963/files?diff=unified&w=0#diff-7856a64839d3a12d7f56dcb54ff0a9c37bb64251829b52bfb5bbf67818e8456bR298-R302))
* Imported the `os/exec` package in `step_git.go` to use the `exec.Command` function to create the `sleepCmd` ([link](https://github.com/koderover/zadig/pull/2963/files?diff=unified&w=0#diff-7856a64839d3a12d7f56dcb54ff0a9c37bb64251829b52bfb5bbf67818e8456bR27))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
