### PR TITLE
initialization function

### DIFF
--- a/pkg/microservice/aslan/core/system/handler/initialization.go
+++ b/pkg/microservice/aslan/core/system/handler/initialization.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2023 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/system/service"
+	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
+	e "github.com/koderover/zadig/pkg/tool/errors"
+)
+
+func GetSystemInitializationStatus(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	ctx.Resp, ctx.Err = service.GetSystemInitializationStatus(ctx.Logger)
+}
+
+type InitializeUserReq struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Company  string `json:"company"`
+	Email    string `json:"email"`
+	Phone    int64  `json:"phone"`
+	Reason   string `json:"reason"`
+	Address  string `json:"address"`
+}
+
+func (req *InitializeUserReq) Validate() error {
+	if len(req.Username) == 0 {
+		return fmt.Errorf("username cannot be empty")
+	}
+
+	if len(req.Password) == 0 {
+		return fmt.Errorf("password cannot be empty")
+	}
+
+	if len(req.Company) == 0 {
+		return fmt.Errorf("company cannot be empty")
+	}
+
+	if len(req.Email) == 0 {
+		return fmt.Errorf("email cannot be empty")
+	}
+
+	if len(req.Reason) > 500 {
+		return fmt.Errorf("reason is too long")
+	}
+
+	if len(req.Address) > 100 {
+		return fmt.Errorf("address is too long")
+	}
+	return nil
+}
+
+func InitializeUser(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	req := new(InitializeUserReq)
+	if err := c.BindJSON(req); err != nil {
+		ctx.Err = e.ErrInvalidParam.AddDesc("invalid user initialization config")
+		return
+	}
+
+	if err := req.Validate(); err != nil {
+		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+
+	ctx.Err = service.InitializeUser(req.Username, req.Password, req.Company, req.Email, req.Phone, req.Reason, req.Address, ctx.Logger)
+}

--- a/pkg/microservice/aslan/core/system/handler/router.go
+++ b/pkg/microservice/aslan/core/system/handler/router.go
@@ -312,6 +312,13 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		dashboard.GET("/environment/:name", GetMyEnvironment)
 	}
 
+	// initialization apis
+	init := router.Group("initialization")
+	{
+		init.GET("/status", GetSystemInitializationStatus)
+		init.POST("/user", InitializeUser)
+	}
+
 	// get nacos info
 	nacos := router.Group("nacos")
 	{

--- a/pkg/microservice/aslan/core/system/service/initialization.go
+++ b/pkg/microservice/aslan/core/system/service/initialization.go
@@ -1,0 +1,142 @@
+package service
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/koderover/zadig/pkg/config"
+	"github.com/koderover/zadig/pkg/microservice/policy/core/repository/models"
+	"github.com/koderover/zadig/pkg/microservice/policy/core/repository/mongodb"
+	"github.com/koderover/zadig/pkg/setting"
+	"github.com/koderover/zadig/pkg/shared/client/plutusvendor"
+	"github.com/koderover/zadig/pkg/shared/client/user"
+	"github.com/koderover/zadig/pkg/tool/httpclient"
+	"github.com/koderover/zadig/pkg/tool/log"
+	"github.com/koderover/zadig/pkg/tool/rsa"
+	"go.uber.org/zap"
+)
+
+type SystemInitializationStatus struct {
+	Initialized   bool   `json:"initialized"`
+	IsEnterprise  bool   `json:"is_enterprise"`
+	LicenseStatus string `json:"license_status"`
+	SystemID      string `json:"system_id"`
+}
+
+func GetSystemInitializationStatus(logger *zap.SugaredLogger) (*SystemInitializationStatus, error) {
+	// first check if the system is enterprise version
+	isEnterprise := config.Enterprise()
+
+	// then check if the user has been initialized
+	userCountInfo, err := user.New().CountUsers()
+	if err != nil {
+		logger.Errorf("failed to get user count, error: %s", err)
+		return nil, fmt.Errorf("failed to check if the user is initialized, error: %s", err)
+	}
+
+	resp := &SystemInitializationStatus{
+		IsEnterprise: isEnterprise,
+	}
+
+	if userCountInfo.TotalUser > 0 {
+		resp.Initialized = true
+	} else {
+		resp.Initialized = false
+	}
+
+	// if it is an enterprise system, check about the license information
+	if isEnterprise {
+		licenseInfo, err := plutusvendor.New().CheckZadigXLicenseStatus()
+		if err != nil {
+			logger.Errorf("failed to get enterprise license info, error: %s", err)
+			return nil, fmt.Errorf("failed to check enterprise license info, error: %s", err)
+		}
+		resp.LicenseStatus = licenseInfo.Status
+		resp.SystemID = licenseInfo.SystemID
+	}
+
+	return resp, nil
+}
+
+func InitializeUser(username, password, company, email string, phone int64, reason, address string, logger *zap.SugaredLogger) error {
+	userInfo, err := user.New().CreateUser(&user.CreateUserArgs{
+		Name:     username,
+		Password: password,
+		Email:    email,
+		Phone:    strconv.FormatInt(phone, 10),
+		Account:  username,
+	})
+
+	if err != nil {
+		logger.Errorf("failed to create user, error: %s", err)
+		return fmt.Errorf("user initialization error: failed to create user, err: %s", err)
+	}
+
+	initializeInfo := &InitializeInfo{
+		CreatedAt: time.Now().Unix(),
+		Username:  username,
+		Phone:     phone,
+		Email:     email,
+		Company:   company,
+		Reason:    reason,
+		Address:   address,
+		Domain:    config.SystemAddress(),
+	}
+
+	err = reportRegister(initializeInfo)
+	if err != nil {
+		// don't stop the whole initialization process if the upload fails
+		logger.Errorf("failed to upload initialization info, error: %s", err)
+	}
+
+	role, found, err := mongodb.NewRoleColl().Get("*", string(setting.SystemAdmin))
+	if err != nil {
+		logger.Errorf("Failed to get role %s in namespace %s, err: %s", string(setting.SystemAdmin), "*", err)
+		return err
+	} else if !found {
+		logger.Errorf("Role %s is not found in namespace %s", string(setting.SystemAdmin), "*")
+		return fmt.Errorf("role %s not found", string(setting.SystemAdmin))
+	}
+
+	args := &models.RoleBinding{
+		Name:      config.RoleBindingNameFromUIDAndRole(userInfo.Uid, setting.SystemAdmin, "*"),
+		Namespace: "*",
+		Subjects:  []*models.Subject{{Kind: models.UserKind, UID: userInfo.Uid}},
+		RoleRef: &models.RoleRef{
+			Name:      role.Name,
+			Namespace: role.Namespace,
+		},
+	}
+	return mongodb.NewRoleBindingColl().UpdateOrCreate(args)
+}
+
+type InitializeInfo struct {
+	CreatedAt int64  `json:"created_at"`
+	Username  string `json:"username"`
+	Phone     int64  `json:"phone,omitempty"`
+	Email     string `json:"email"`
+	Company   string `json:"company"`
+	Reason    string `json:"reason,omitempty"`
+	Address   string `json:"address,omitempty"`
+	Domain    string `json:"domain"`
+}
+
+type Operation struct {
+	Data string `json:"data"`
+}
+
+func reportRegister(info *InitializeInfo) error {
+	registerByte, _ := json.Marshal(info)
+	encrypt, err := rsa.EncryptByDefaultPublicKey(registerByte)
+	if err != nil {
+		log.Errorf("RSAEncrypt err: %s", err)
+		return err
+	}
+	encodeString := base64.StdEncoding.EncodeToString(encrypt)
+	reqBody := Operation{Data: encodeString}
+	_, err = httpclient.Post("https://api.koderover.com/api/operation/admin/user", httpclient.SetBody(reqBody))
+	return err
+}

--- a/pkg/microservice/policy/core/service/bundle/rego/authz.rego
+++ b/pkg/microservice/policy/core/service/bundle/rego/authz.rego
@@ -15,8 +15,8 @@ default response = {
 }
 
 response = r {
-    not is_authenticated
     not url_is_public
+    not is_authenticated
     r := {
       "allowed": false,
       "http_status": 401

--- a/pkg/microservice/policy/core/yamlconfig/urls.yaml
+++ b/pkg/microservice/policy/core/yamlconfig/urls.yaml
@@ -1,6 +1,12 @@
 description: "public urls: url not need to authentication ; system_admin urls: urls that only system admin has permission ; project_admin: urls that project admin has permission"
 exemption_urls:
   public:
+    - endpoint: /api/aslan/system/initialization/status
+      methods:
+        - GET
+    - endpoint: /api/aslan/system/initialization/user
+      methods:
+        - POST
     - endpoint: /api/debug/pprof/**
       methods:
         - GET

--- a/pkg/microservice/policy/core/yamlconfig/urls.yaml
+++ b/pkg/microservice/policy/core/yamlconfig/urls.yaml
@@ -1,10 +1,10 @@
 description: "public urls: url not need to authentication ; system_admin urls: urls that only system admin has permission ; project_admin: urls that project admin has permission"
 exemption_urls:
   public:
-    - endpoint: /api/aslan/system/initialization/status
+    - endpoint: api/aslan/system/initialization/status
       methods:
         - GET
-    - endpoint: /api/aslan/system/initialization/user
+    - endpoint: api/aslan/system/initialization/user
       methods:
         - POST
     - endpoint: /api/debug/pprof/**
@@ -449,7 +449,7 @@ exemption_urls:
     - endpoint: api/aslan/project/products
       methods:
         - PUT
-    - endpoint: /api/aslan/project/products/?*/type
+    - endpoint: api/aslan/project/products/?*/type
       methods:
         - PUT
     - endpoint: api/v1/picket/projects/?*

--- a/pkg/microservice/user/core/repository/orm/user.go
+++ b/pkg/microservice/user/core/repository/orm/user.go
@@ -45,19 +45,6 @@ func GetUser(account string, identityType string, db *gorm.DB) (*models.User, er
 	return &user, nil
 }
 
-func GetUserCount(db *gorm.DB) (int64, error) {
-	var count int64
-	err := db.Table("user").Count(&count).Error
-	if err != nil {
-		if err == gorm.ErrRecordNotFound {
-			return 0, nil
-		}
-		return 0, err
-	}
-
-	return count, nil
-}
-
 // GetUserByUid Get a user based on uid
 func GetUserByUid(uid string, db *gorm.DB) (*models.User, error) {
 	var user models.User

--- a/pkg/microservice/user/core/repository/orm/user_login.go
+++ b/pkg/microservice/user/core/repository/orm/user_login.go
@@ -82,9 +82,18 @@ func UpdateUserLogin(uid string, userLogin *models.UserLogin, db *gorm.DB) error
 	return nil
 }
 
-func CountUser(db *gorm.DB) (int64, error) {
+func CountActiveUser(db *gorm.DB) (int64, error) {
 	var count int64
 	err := db.Model(&models.UserLogin{}).Select("count(*)").Where("last_login_time > 0").Find(&count).Error
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func CountUser(db *gorm.DB) (int64, error) {
+	var count int64
+	err := db.Model(&models.UserLogin{}).Select("count(*)").Find(&count).Error
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/microservice/user/core/service.go
+++ b/pkg/microservice/user/core/service.go
@@ -27,7 +27,6 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/user/config"
 	"github.com/koderover/zadig/pkg/microservice/user/core/repository"
 	"github.com/koderover/zadig/pkg/microservice/user/core/repository/models"
-	"github.com/koderover/zadig/pkg/microservice/user/core/service/user"
 	"github.com/koderover/zadig/pkg/setting"
 	gormtool "github.com/koderover/zadig/pkg/tool/gorm"
 	"github.com/koderover/zadig/pkg/tool/log"
@@ -43,7 +42,6 @@ func Start(_ context.Context) {
 	})
 
 	initDatabase()
-	initUser()
 }
 
 func initDatabase() {
@@ -77,16 +75,6 @@ func initDatabase() {
 	mongotool.Init(ctx, configbase.MongoURI())
 	if err := mongotool.Ping(ctx); err != nil {
 		panic(fmt.Errorf("failed to connect to mongo, error: %s", err))
-	}
-}
-
-func initUser() {
-	//init default admin user
-	log.Infof("============================ start to init default admin user ============================")
-	err := user.InitializeAdmin()
-	if err != nil {
-		panic(fmt.Errorf("aslan preset system admin err:%s", err))
-		return
 	}
 }
 

--- a/pkg/microservice/user/core/service/login/local.go
+++ b/pkg/microservice/user/core/service/login/local.go
@@ -59,7 +59,7 @@ type CheckSignatureRes struct {
 }
 
 func CheckSignature(ifLoggedIn bool, logger *zap.SugaredLogger) error {
-	userNum, err := orm.CountUser(repository.DB)
+	userNum, err := orm.CountActiveUser(repository.DB)
 	if err != nil {
 		return err
 	}

--- a/pkg/shared/client/user/user.go
+++ b/pkg/shared/client/user/user.go
@@ -98,6 +98,13 @@ func (c *Client) SearchUser(args *SearchUserArgs) (*SearchUserResp, error) {
 	return resp, err
 }
 
+func (c *Client) CountUsers() (*types.UserStatistics, error) {
+	url := "/user/count"
+	resp := new(types.UserStatistics)
+	_, err := c.Get(url, httpclient.SetResult(resp))
+	return resp, err
+}
+
 func (c *Client) Healthz() error {
 	url := "/healthz"
 	_, err := c.Get(url)

--- a/pkg/types/user.go
+++ b/pkg/types/user.go
@@ -54,6 +54,7 @@ type UserCountByType struct {
 type UserStatistics struct {
 	UserByType []*UserCountByType `json:"user_info"`
 	ActiveUser int64              `json:"active_user"`
+	TotalUser  int64              `json:"total_user"`
 }
 
 type UserSetting struct {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 584e3c3</samp>

This pull request improves the system initialization and user statistics features. It adds new APIs and services for the system initialization in the `system` module, and fixes a bug in the project permission logic in the `policy` module. It also changes how active and total users are counted in the `user` module, and adds a new field to the `UserStatistics` type. It removes some unused code and imports from the `user` module.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 584e3c3</samp>

*  Add system initialization APIs and service logic to handle the system status, first user creation, and user input validation ([link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-28f76aae522352200e4bc81b3251edcbb9c2f8a9c7adf339c45ccb66edc5d0faR1-R88), [link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-a788b6154d88f1681af6dd9bb4b9504e74a014ea5e30ba254f38beb73d7bf5d7R315-R321), [link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-7a9d786e7c5173e3a9d1eade27df592d3ed815e5261c863eeb147bea287e34beR1-R142))
*  Fix a bug that the project admin role was not recognized correctly when the project is public by checking the public role binding in the permission service ([link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-31329186c596f7e21e9b582b999500ca2ea3dc08e461b62af28e92f79aac0bd5L82-R108))
*  Add a function to count the total number of users in the user repository and modify the functions to count the active users to align with the definition of active user in the system statistics ([link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-75c9f57ff419b19844268c60da57bfbe5d1b42fa78f9bab34dec02fc7e3f4dd7R93-R101), [link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-75c9f57ff419b19844268c60da57bfbe5d1b42fa78f9bab34dec02fc7e3f4dd7L85-R85), [link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-6edc8543c3f426bae078caf11911512ccec56b3c70e9e89d19db91b4d56eefc7L62-R62))
*  Remove the unused functions and imports related to the user initialization and register report from the user service, as they are now handled by the system initialization APIs ([link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-6cf85c03d168eef3a2e316e8be89480fe6efc1e9adc28a7ecd78fe36bdc9e287L48-L60), [link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-4677fe67ba966b984c329b4373dabd6094a92e5ed33568cd17502eb7f3c4be04L30), [link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-4677fe67ba966b984c329b4373dabd6094a92e5ed33568cd17502eb7f3c4be04L46), [link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-4677fe67ba966b984c329b4373dabd6094a92e5ed33568cd17502eb7f3c4be04L83-L92), [link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-a122d70189cd7678bf0b0e34711cb98db75b0397dd59aa334e216616a513e32aL21-L22), [link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-a122d70189cd7678bf0b0e34711cb98db75b0397dd59aa334e216616a513e32aL30), [link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-a122d70189cd7678bf0b0e34711cb98db75b0397dd59aa334e216616a513e32aL49-R47), [link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-a122d70189cd7678bf0b0e34711cb98db75b0397dd59aa334e216616a513e32aL172-L222), [link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-a122d70189cd7678bf0b0e34711cb98db75b0397dd59aa334e216616a513e32aL792-L821))
*  Add a function to get the user statistics, including the active user count and the total user count, from the user service to the user client, and add the total user count to the user statistics type ([link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-cf1d9958f2968a8d069902a0143e7f0aaa30d52489bf81929405bf171c61cdf4R101-R107), [link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-a122d70189cd7678bf0b0e34711cb98db75b0397dd59aa334e216616a513e32aL754-R710), [link](https://github.com/koderover/zadig/pull/2965/files?diff=unified&w=0#diff-e037ab649e62c2458337f02690fcdbe4b2fba9b511baafb9895c7e4957f388f3R57))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
