### PR TITLE
feat: add workflow param creator.id

### DIFF
--- a/pkg/microservice/aslan/core/workflow/handler/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/handler/workflow_task_v4.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+
 	"github.com/koderover/zadig/pkg/types"
 
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
@@ -94,8 +95,9 @@ func CreateWorkflowTaskV4(c *gin.Context) {
 	}
 
 	ctx.Resp, ctx.Err = workflow.CreateWorkflowTaskV4(&workflow.CreateWorkflowTaskV4Args{
-		Name:   ctx.UserName,
-		UserID: ctx.UserID,
+		Name:    ctx.UserName,
+		Account: ctx.Account,
+		UserID:  ctx.UserID,
 	}, args, ctx.Logger)
 }
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
@@ -442,12 +442,12 @@ func RemoveFixedValueMarks(workflow *commonmodels.WorkflowV4) error {
 	return json.Unmarshal([]byte(replacedString), &workflow)
 }
 
-func RenderGlobalVariables(workflow *commonmodels.WorkflowV4, taskID int64, creator string) error {
+func RenderGlobalVariables(workflow *commonmodels.WorkflowV4, taskID int64, creator, account string) error {
 	b, err := json.Marshal(workflow)
 	if err != nil {
 		return fmt.Errorf("marshal workflow error: %v", err)
 	}
-	params, err := getWorkflowDefaultParams(workflow, taskID, creator)
+	params, err := getWorkflowDefaultParams(workflow, taskID, creator, account)
 	if err != nil {
 		return fmt.Errorf("get workflow default params error: %v", err)
 	}
@@ -483,12 +483,13 @@ func renderMultiLineString(value, template string, inputs []*commonmodels.Param)
 	return value
 }
 
-func getWorkflowDefaultParams(workflow *commonmodels.WorkflowV4, taskID int64, creator string) ([]*commonmodels.Param, error) {
+func getWorkflowDefaultParams(workflow *commonmodels.WorkflowV4, taskID int64, creator, account string) ([]*commonmodels.Param, error) {
 	resp := []*commonmodels.Param{}
 	resp = append(resp, &commonmodels.Param{Name: "project", Value: workflow.Project, ParamsType: "string", IsCredential: false})
 	resp = append(resp, &commonmodels.Param{Name: "workflow.name", Value: workflow.Name, ParamsType: "string", IsCredential: false})
 	resp = append(resp, &commonmodels.Param{Name: "workflow.task.id", Value: fmt.Sprintf("%d", taskID), ParamsType: "string", IsCredential: false})
 	resp = append(resp, &commonmodels.Param{Name: "workflow.task.creator", Value: creator, ParamsType: "string", IsCredential: false})
+	resp = append(resp, &commonmodels.Param{Name: "workflow.task.creator.id", Value: account, ParamsType: "string", IsCredential: false})
 	resp = append(resp, &commonmodels.Param{Name: "workflow.task.timestamp", Value: fmt.Sprintf("%d", time.Now().Unix()), ParamsType: "string", IsCredential: false})
 	for _, param := range workflow.Params {
 		paramsKey := strings.Join([]string{"workflow", "params", param.Name}, ".")

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -24,12 +24,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/koderover/zadig/pkg/shared/client/user"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"gorm.io/gorm/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/koderover/zadig/pkg/shared/client/user"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
@@ -300,8 +301,9 @@ func CheckWorkflowV4ApprovalInitiator(workflowName, uid string, log *zap.Sugared
 }
 
 type CreateWorkflowTaskV4Args struct {
-	Name   string
-	UserID string
+	Name    string
+	Account string
+	UserID  string
 }
 
 func CreateWorkflowTaskV4ByBuildInTrigger(triggerName string, args *commonmodels.WorkflowV4, log *zap.SugaredLogger) (*CreateTaskV4Resp, error) {
@@ -330,6 +332,11 @@ func CreateWorkflowTaskV4(args *CreateWorkflowTaskV4Args, workflow *commonmodels
 	}
 	if err := LintWorkflowV4(workflow, log); err != nil {
 		return resp, err
+	}
+
+	// if account is not set, use name as account
+	if args.Account == "" {
+		args.Account = args.Name
 	}
 
 	dbWorkflow, err := commonrepo.NewWorkflowV4Coll().Find(workflow.Name)
@@ -378,7 +385,7 @@ func CreateWorkflowTaskV4(args *CreateWorkflowTaskV4Args, workflow *commonmodels
 		return resp, e.ErrCreateTask.AddDesc(err.Error())
 	}
 
-	if err := jobctl.RenderGlobalVariables(workflow, nextTaskID, args.Name); err != nil {
+	if err := jobctl.RenderGlobalVariables(workflow, nextTaskID, args.Name, args.Account); err != nil {
 		log.Errorf("RenderGlobalVariables error: %v", err)
 		return resp, e.ErrCreateTask.AddDesc(err.Error())
 	}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -1858,6 +1858,7 @@ func getDefaultVars(workflow *commonmodels.WorkflowV4, currentJobName string) []
 	vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, "project"))
 	vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, "workflow.name"))
 	vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, "workflow.task.creator"))
+	vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, "workflow.task.creator.id"))
 	vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, "workflow.task.timestamp"))
 	vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, "workflow.task.id"))
 	for _, param := range workflow.Params {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3aec4db</samp>

This pull request adds the ability to use the user account who creates or approves a workflow task as a global variable in the workflow steps. It modifies the `workflow` and `workflow_task_v4` services to pass and set the `account` parameter and the `workflow.task.creator.id` variable. It also updates the `workflow_task_v4` handler to accept the `account` field in the request.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3aec4db</samp>

*  Import `user` package and add `Account` field to `CreateWorkflowTaskV4Args` struct in `handler` package to get and pass user account information ([link](https://github.com/koderover/zadig/pull/2973/files?diff=unified&w=0#diff-82f7f396429fe004e5daddf6b2ad94e2b949e798defe27d7fe5f561443527507R28), [link](https://github.com/koderover/zadig/pull/2973/files?diff=unified&w=0#diff-82f7f396429fe004e5daddf6b2ad94e2b949e798defe27d7fe5f561443527507L97-R100))
* Add `account` parameter and append `workflow.task.creator.id` variable to `RenderGlobalVariables` and `getWorkflowDefaultParams` functions in `job` package to set and use user account as a global variable for workflow task ([link](https://github.com/koderover/zadig/pull/2973/files?diff=unified&w=0#diff-cd667032e3bf01aed408f869322d63aed342d028916369c057cf2a090257e6a4L445-R450), [link](https://github.com/koderover/zadig/pull/2973/files?diff=unified&w=0#diff-cd667032e3bf01aed408f869322d63aed342d028916369c057cf2a090257e6a4L486-R486), [link](https://github.com/koderover/zadig/pull/2973/files?diff=unified&w=0#diff-cd667032e3bf01aed408f869322d63aed342d028916369c057cf2a090257e6a4R492))
* Remove `user` package and add `Account` field to `CreateWorkflowTaskV4Args` struct in `workflow` package to receive user account information from `handler` package ([link](https://github.com/koderover/zadig/pull/2973/files?diff=unified&w=0#diff-5a9b5157a24d6d74d66a54b3d6b2a961d0b468af078c53b04301e590ab97e165L27), [link](https://github.com/koderover/zadig/pull/2973/files?diff=unified&w=0#diff-5a9b5157a24d6d74d66a54b3d6b2a961d0b468af078c53b04301e590ab97e165L303-R306))
* Add `user` package and check if account is set or use name as fallback in `CheckWorkflowV4ApprovalInitiator` function in `workflow` package to verify approval requester ([link](https://github.com/koderover/zadig/pull/2973/files?diff=unified&w=0#diff-5a9b5157a24d6d74d66a54b3d6b2a961d0b468af078c53b04301e590ab97e165R33-R34), [link](https://github.com/koderover/zadig/pull/2973/files?diff=unified&w=0#diff-5a9b5157a24d6d74d66a54b3d6b2a961d0b468af078c53b04301e590ab97e165R337-R341))
* Pass account to `RenderGlobalVariables` function in `workflow` package to render global variables for workflow task ([link](https://github.com/koderover/zadig/pull/2973/files?diff=unified&w=0#diff-5a9b5157a24d6d74d66a54b3d6b2a961d0b468af078c53b04301e590ab97e165L381-R388))
* Append `workflow.task.creator.id` variable to default variables in `workflow_v4.go` to render workflow steps ([link](https://github.com/koderover/zadig/pull/2973/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R1861))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
