### PR TITLE
cp 2973

### DIFF
--- a/pkg/microservice/aslan/core/workflow/handler/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/handler/workflow_task_v4.go
@@ -66,8 +66,9 @@ func CreateWorkflowTaskV4(c *gin.Context) {
 
 	internalhandler.InsertOperationLog(c, ctx.UserName, args.Project, "新建", "自定义工作流任务", args.Name, data, ctx.Logger)
 	ctx.Resp, ctx.Err = workflow.CreateWorkflowTaskV4(&workflow.CreateWorkflowTaskV4Args{
-		Name:   ctx.UserName,
-		UserID: ctx.UserID,
+		Name:    ctx.UserName,
+		Account: ctx.Account,
+		UserID:  ctx.UserID,
 	}, args, ctx.Logger)
 }
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
@@ -442,12 +442,12 @@ func RemoveFixedValueMarks(workflow *commonmodels.WorkflowV4) error {
 	return json.Unmarshal([]byte(replacedString), &workflow)
 }
 
-func RenderGlobalVariables(workflow *commonmodels.WorkflowV4, taskID int64, creator string) error {
+func RenderGlobalVariables(workflow *commonmodels.WorkflowV4, taskID int64, creator, account string) error {
 	b, err := json.Marshal(workflow)
 	if err != nil {
 		return fmt.Errorf("marshal workflow error: %v", err)
 	}
-	params, err := getWorkflowDefaultParams(workflow, taskID, creator)
+	params, err := getWorkflowDefaultParams(workflow, taskID, creator, account)
 	if err != nil {
 		return fmt.Errorf("get workflow default params error: %v", err)
 	}
@@ -483,12 +483,13 @@ func renderMultiLineString(value, template string, inputs []*commonmodels.Param)
 	return value
 }
 
-func getWorkflowDefaultParams(workflow *commonmodels.WorkflowV4, taskID int64, creator string) ([]*commonmodels.Param, error) {
+func getWorkflowDefaultParams(workflow *commonmodels.WorkflowV4, taskID int64, creator, account string) ([]*commonmodels.Param, error) {
 	resp := []*commonmodels.Param{}
 	resp = append(resp, &commonmodels.Param{Name: "project", Value: workflow.Project, ParamsType: "string", IsCredential: false})
 	resp = append(resp, &commonmodels.Param{Name: "workflow.name", Value: workflow.Name, ParamsType: "string", IsCredential: false})
 	resp = append(resp, &commonmodels.Param{Name: "workflow.task.id", Value: fmt.Sprintf("%d", taskID), ParamsType: "string", IsCredential: false})
 	resp = append(resp, &commonmodels.Param{Name: "workflow.task.creator", Value: creator, ParamsType: "string", IsCredential: false})
+	resp = append(resp, &commonmodels.Param{Name: "workflow.task.creator.id", Value: account, ParamsType: "string", IsCredential: false})
 	resp = append(resp, &commonmodels.Param{Name: "workflow.task.timestamp", Value: fmt.Sprintf("%d", time.Now().Unix()), ParamsType: "string", IsCredential: false})
 	for _, param := range workflow.Params {
 		paramsKey := strings.Join([]string{"workflow", "params", param.Name}, ".")

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -1799,6 +1799,7 @@ func getDefaultVars(workflow *commonmodels.WorkflowV4, currentJobName string) []
 	vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, "project"))
 	vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, "workflow.name"))
 	vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, "workflow.task.creator"))
+	vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, "workflow.task.creator.id"))
 	vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, "workflow.task.timestamp"))
 	vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, "workflow.task.id"))
 	for _, param := range workflow.Params {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dd0e7fd</samp>

Added support for passing the user's ID as a global variable and a default parameter for the workflow tasks. This allows the user's ID to be used in the workflow tasks for auditing or authorization purposes. Modified `job.go`, `workflow_task_v4.go`, `workflow_v4.go`, and `workflow_task_v4.go` to implement this feature.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dd0e7fd</samp>

*  Pass the user's ID as a global variable and a default parameter for the workflow tasks ([link](https://github.com/koderover/zadig/pull/2974/files?diff=unified&w=0#diff-82f7f396429fe004e5daddf6b2ad94e2b949e798defe27d7fe5f561443527507L69-R71), [link](https://github.com/koderover/zadig/pull/2974/files?diff=unified&w=0#diff-cd667032e3bf01aed408f869322d63aed342d028916369c057cf2a090257e6a4L445-R450), [link](https://github.com/koderover/zadig/pull/2974/files?diff=unified&w=0#diff-cd667032e3bf01aed408f869322d63aed342d028916369c057cf2a090257e6a4L486-R486), [link](https://github.com/koderover/zadig/pull/2974/files?diff=unified&w=0#diff-cd667032e3bf01aed408f869322d63aed342d028916369c057cf2a090257e6a4R492), [link](https://github.com/koderover/zadig/pull/2974/files?diff=unified&w=0#diff-5a9b5157a24d6d74d66a54b3d6b2a961d0b468af078c53b04301e590ab97e165L304-R308), [link](https://github.com/koderover/zadig/pull/2974/files?diff=unified&w=0#diff-5a9b5157a24d6d74d66a54b3d6b2a961d0b468af078c53b04301e590ab97e165L382-R390), [link](https://github.com/koderover/zadig/pull/2974/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R1802))
  - Modify the `CreateWorkflowTaskV4` function in `workflow_task_v4.go` to get the user's ID from the context and pass it to the `CreateWorkflowTaskV4Args` struct ([link](https://github.com/koderover/zadig/pull/2974/files?diff=unified&w=0#diff-82f7f396429fe004e5daddf6b2ad94e2b949e798defe27d7fe5f561443527507L69-R71), [link](https://github.com/koderover/zadig/pull/2974/files?diff=unified&w=0#diff-5a9b5157a24d6d74d66a54b3d6b2a961d0b468af078c53b04301e590ab97e165L304-R308))
  - Modify the `RenderGlobalVariables` function in `job.go` to accept the user's ID as a parameter and pass it as a global variable to the workflow tasks ([link](https://github.com/koderover/zadig/pull/2974/files?diff=unified&w=0#diff-cd667032e3bf01aed408f869322d63aed342d028916369c057cf2a090257e6a4L445-R450), [link](https://github.com/koderover/zadig/pull/2974/files?diff=unified&w=0#diff-5a9b5157a24d6d74d66a54b3d6b2a961d0b468af078c53b04301e590ab97e165L382-R390))
  - Modify the `getWorkflowDefaultParams` function in `job.go` to accept the user's ID as a parameter and append it as a default parameter with the name `workflow.task.creator.id` ([link](https://github.com/koderover/zadig/pull/2974/files?diff=unified&w=0#diff-cd667032e3bf01aed408f869322d63aed342d028916369c057cf2a090257e6a4L486-R486), [link](https://github.com/koderover/zadig/pull/2974/files?diff=unified&w=0#diff-cd667032e3bf01aed408f869322d63aed342d028916369c057cf2a090257e6a4R492))
  - Modify the `getDefaultVars` function in `workflow_v4.go` to append the `workflow.task.creator.id` variable to the list of default variables for the workflow tasks ([link](https://github.com/koderover/zadig/pull/2974/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R1802))
  - Add a fallback value for the user's ID in case it is not set by the caller in the `CreateWorkflowTaskV4` function in `workflow_task_v4.go` ([link](https://github.com/koderover/zadig/pull/2974/files?diff=unified&w=0#diff-5a9b5157a24d6d74d66a54b3d6b2a961d0b468af078c53b04301e590ab97e165R339-R343))
  - Import the `user` package in `workflow_task_v4.go` to use the `user.GetAccount` function to get the user's ID from the user service ([link](https://github.com/koderover/zadig/pull/2974/files?diff=unified&w=0#diff-5a9b5157a24d6d74d66a54b3d6b2a961d0b468af078c53b04301e590ab97e165R33-R34))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
