### PR TITLE
feat: Release Plan

### DIFF
--- a/pkg/microservice/aslan/config/consts.go
+++ b/pkg/microservice/aslan/config/consts.go
@@ -499,6 +499,7 @@ const (
 	StatusCancel         ReleasePlanStatus = "cancel"
 )
 
+// ReleasePlanStatusMap is a map of status and its available next status
 var ReleasePlanStatusMap = map[ReleasePlanStatus][]ReleasePlanStatus{
 	StatusPlanning:       {StatusWaitForApprove, StatusExecuting},
 	StatusWaitForApprove: {StatusPlanning, StatusExecuting},

--- a/pkg/microservice/aslan/config/consts.go
+++ b/pkg/microservice/aslan/config/consts.go
@@ -498,6 +498,6 @@ const (
 type ReleasePlanJobType string
 
 const (
-	JobTypeText     = "text"
-	JobTypeWorkflow = "workflow"
+	JobText     ReleasePlanJobType = "text"
+	JobWorkflow ReleasePlanJobType = "workflow"
 )

--- a/pkg/microservice/aslan/config/consts.go
+++ b/pkg/microservice/aslan/config/consts.go
@@ -484,3 +484,20 @@ const (
 const (
 	CUSTOME_THEME = "custom"
 )
+
+type ReleasePlanStatus string
+
+const (
+	StatusPlanning       ReleasePlanStatus = "planning"
+	StatusWaitForApprove ReleasePlanStatus = "waitforapprove"
+	StatusExecuting      ReleasePlanStatus = "executing"
+	StatusSuccess        ReleasePlanStatus = "success"
+	StatusCancel         ReleasePlanStatus = "cancel"
+)
+
+type ReleasePlanJobType string
+
+const (
+	JobTypeText     = "text"
+	JobTypeWorkflow = "workflow"
+)

--- a/pkg/microservice/aslan/config/consts.go
+++ b/pkg/microservice/aslan/config/consts.go
@@ -495,6 +495,12 @@ const (
 	StatusCancel         ReleasePlanStatus = "cancel"
 )
 
+var ReleasePlanStatusMap = map[ReleasePlanStatus][]ReleasePlanStatus{
+	StatusPlanning:       {StatusWaitForApprove, StatusExecuting},
+	StatusWaitForApprove: {StatusPlanning, StatusExecuting},
+	StatusExecuting:      {StatusPlanning, StatusSuccess, StatusCancel},
+}
+
 type ReleasePlanJobType string
 
 const (

--- a/pkg/microservice/aslan/config/consts.go
+++ b/pkg/microservice/aslan/config/consts.go
@@ -121,6 +121,10 @@ const (
 	StatusDebugAfter     Status = "debug_after"
 )
 
+func FailedStatus() []Status {
+	return []Status{StatusFailed, StatusTimeout, StatusCancelled, StatusReject}
+}
+
 func InCompletedStatus() []Status {
 	return []Status{StatusCreated, StatusRunning, StatusWaiting, StatusQueued, StatusBlocked, QueueItemPending, StatusPrepare, StatusWaitingApprove}
 }
@@ -511,8 +515,8 @@ const (
 type ReleasePlanJobStatus string
 
 const (
-	ReleasePlanJobStatusTodo ReleasePlanJobStatus = "todo"
-	ReleasePlanJobStatusDone ReleasePlanJobStatus = "done"
-	//ReleasePlanJobStatusFailed  ReleasePlanJobStatus = "failed"
+	ReleasePlanJobStatusTodo    ReleasePlanJobStatus = "todo"
+	ReleasePlanJobStatusDone    ReleasePlanJobStatus = "done"
+	ReleasePlanJobStatusFailed  ReleasePlanJobStatus = "failed"
 	ReleasePlanJobStatusRunning ReleasePlanJobStatus = "running"
 )

--- a/pkg/microservice/aslan/config/consts.go
+++ b/pkg/microservice/aslan/config/consts.go
@@ -507,3 +507,12 @@ const (
 	JobText     ReleasePlanJobType = "text"
 	JobWorkflow ReleasePlanJobType = "workflow"
 )
+
+type ReleasePlanJobStatus string
+
+const (
+	ReleasePlanJobStatusTodo ReleasePlanJobStatus = "todo"
+	ReleasePlanJobStatusDone ReleasePlanJobStatus = "done"
+	//ReleasePlanJobStatusFailed  ReleasePlanJobStatus = "failed"
+	ReleasePlanJobStatusRunning ReleasePlanJobStatus = "running"
+)

--- a/pkg/microservice/aslan/core/common/repository/models/im_app.go
+++ b/pkg/microservice/aslan/core/common/repository/models/im_app.go
@@ -32,6 +32,9 @@ type IMApp struct {
 	LarkDefaultApprovalCode string `json:"-" bson:"lark_default_approval_code"`
 	// LarkApprovalCodeList is a json string save all approval definition code
 	LarkApprovalCodeList map[string]string `json:"-" bson:"lark_approval_code_list"`
+	// LarkApprovalCodeListCommon is used for any source approval
+	// because LarkApprovalCodeList title is fixed "Zadig 工作流", so we need a common approval code list
+	LarkApprovalCodeListCommon map[string]string `json:"-" bson:"lark_approval_code_list_common"`
 
 	// DingTalk fields
 	DingTalkAppKey                  string `json:"dingtalk_app_key" bson:"dingtalk_app_key"`

--- a/pkg/microservice/aslan/core/common/repository/models/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/models/release_plan.go
@@ -82,8 +82,9 @@ type WorkflowReleaseJobSpec struct {
 
 type ReleasePlanLog struct {
 	Username   string      `bson:"username"                    json:"username"`
+	Account    string      `bson:"account"                     json:"account"`
 	Action     string      `bson:"action"                      json:"action"`
-	Target     string      `bson:"target"                      json:"target"`
+	TargetName string      `bson:"target_name"                 json:"target_name"`
 	TargetType string      `bson:"target_type"                 json:"target_type"`
 	Before     interface{} `bson:"before"                      json:"before"`
 	After      interface{} `bson:"after"                       json:"after"`

--- a/pkg/microservice/aslan/core/common/repository/models/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/models/release_plan.go
@@ -41,9 +41,9 @@ type ReleasePlan struct {
 
 	Jobs []*ReleaseJob `bson:"jobs"       yaml:"jobs"                   json:"jobs"`
 
-	Logs     []*ReleasePlanLog        `bson:"logs"       yaml:"logs"                   json:"logs"`
-	Status   config.ReleasePlanStatus `bson:"status"       yaml:"status"                   json:"status"`
-	Revision int                      `bson:"revision"       yaml:"revision"                   json:"revision"`
+	Logs   []*ReleasePlanLog        `bson:"logs"       yaml:"logs"                   json:"logs"`
+	Status config.ReleasePlanStatus `bson:"status"       yaml:"status"                   json:"status"`
+	//Revision int                      `bson:"revision"       yaml:"revision"                   json:"revision"`
 }
 
 func (ReleasePlan) TableName() string {

--- a/pkg/microservice/aslan/core/common/repository/models/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/models/release_plan.go
@@ -60,7 +60,9 @@ type ReleaseJob struct {
 	// So we need to record the last status of the release job
 	LastStatus config.Status `bson:"last_status"       yaml:"last_status"                   json:"last_status"`
 	// Updated is used to indicate whether the release job has been updated
-	Updated bool `bson:"updated"       yaml:"updated"                   json:"updated"`
+	Updated      bool   `bson:"updated"       yaml:"updated"                   json:"updated"`
+	ExecutorBy   string `bson:"executor_by"       yaml:"executor_by"                   json:"executor_by"`
+	ExecutorTime int64  `bson:"executor_time"       yaml:"executor_time"                   json:"executor_time"`
 }
 
 type TextReleaseJobSpec struct {
@@ -75,10 +77,11 @@ type WorkflowReleaseJobSpec struct {
 }
 
 type ReleasePlanLog struct {
-	Username  string      `bson:"username"                    json:"username"`
-	Action    string      `bson:"action"                      json:"action"`
-	Target    string      `bson:"target"                      json:"target"`
-	Before    interface{} `bson:"before"                      json:"before"`
-	After     interface{} `bson:"after"                       json:"after"`
-	CreatedAt int64       `bson:"created_at"                  json:"created_at"`
+	Username   string      `bson:"username"                    json:"username"`
+	Action     string      `bson:"action"                      json:"action"`
+	Target     string      `bson:"target"                      json:"target"`
+	TargetType string      `bson:"target_type"                 json:"target_type"`
+	Before     interface{} `bson:"before"                      json:"before"`
+	After      interface{} `bson:"after"                       json:"after"`
+	CreatedAt  int64       `bson:"created_at"                  json:"created_at"`
 }

--- a/pkg/microservice/aslan/core/common/repository/models/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/models/release_plan.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 The KodeRover Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import (
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+)
+
+type ReleasePlan struct {
+	ID        primitive.ObjectID `bson:"_id,omitempty"       yaml:"-"                   json:"id"`
+	Index     int                `bson:"index"       yaml:"index"                   json:"index"`
+	Name      string             `bson:"name"       yaml:"name"                   json:"name"`
+	Principal string             `bson:"principal"       yaml:"principal"                   json:"principal"`
+	// PrincipalID is the user id of the principal
+	PrincipalID string `bson:"principal_id"       yaml:"principal_id"                   json:"principal_id"`
+	StartTime   int64  `bson:"start_time"       yaml:"start_time"                   json:"start_time"`
+	EndTime     int64  `bson:"end_time"       yaml:"end_time"                   json:"end_time"`
+	Description string `bson:"description"       yaml:"description"                   json:"description"`
+	CreatedBy   string `bson:"created_by"       yaml:"created_by"                   json:"created_by"`
+	CreateTime  int64  `bson:"create_time"       yaml:"create_time"                   json:"create_time"`
+	UpdatedBy   string `bson:"updated_by"       yaml:"updated_by"                   json:"updated_by"`
+	UpdateTime  int64  `bson:"update_time"       yaml:"update_time"                   json:"update_time"`
+
+	Status config.ReleasePlanStatus `bson:"status"       yaml:"status"                   json:"status"`
+}
+
+type ReleaseJob struct {
+	Name   string        `bson:"name"       yaml:"name"                   json:"name"`
+	Type   string        `bson:"type"       yaml:"type"                   json:"type"`
+	Status config.Status `bson:"status"       yaml:"status"                   json:"status"`
+	Spec   interface{}   `bson:"spec"       yaml:"spec"                   json:"spec"`
+}
+
+type TextReleaseJobSpec struct {
+	Content string `bson:"content"       yaml:"content"                   json:"content"`
+}
+
+type WorkflowReleaseJobSpec struct {
+	ProjectName  string `bson:"project_name"       yaml:"project_name"                   json:"project_name"`
+	WorkflowName string `bson:"workflow_name"       yaml:"workflow_name"                   json:"workflow_name"`
+}

--- a/pkg/microservice/aslan/core/common/repository/models/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/models/release_plan.go
@@ -24,7 +24,7 @@ import (
 
 type ReleasePlan struct {
 	ID        primitive.ObjectID `bson:"_id,omitempty"       yaml:"-"                   json:"id"`
-	Index     int                `bson:"index"       yaml:"index"                   json:"index"`
+	Index     int64              `bson:"index"       yaml:"index"                   json:"index"`
 	Name      string             `bson:"name"       yaml:"name"                   json:"name"`
 	Principal string             `bson:"principal"       yaml:"principal"                   json:"principal"`
 	// PrincipalID is the user id of the principal
@@ -39,23 +39,46 @@ type ReleasePlan struct {
 
 	Approval *Approval `bson:"approval"       yaml:"approval"                   json:"approval"`
 
+	Jobs []*ReleaseJob `bson:"jobs"       yaml:"jobs"                   json:"jobs"`
+
+	Logs   []*ReleasePlanLog        `bson:"logs"       yaml:"logs"                   json:"logs"`
 	Status config.ReleasePlanStatus `bson:"status"       yaml:"status"                   json:"status"`
 }
 
+func (ReleasePlan) TableName() string {
+	return "release_plan"
+}
+
 type ReleaseJob struct {
+	UUID   string        `bson:"uuid"       yaml:"uuid"                   json:"uuid"`
 	Name   string        `bson:"name"       yaml:"name"                   json:"name"`
 	Type   string        `bson:"type"       yaml:"type"                   json:"type"`
-	Status config.Status `bson:"status"       yaml:"status"                   json:"status"`
+	Status config.Status `bson:"status"     yaml:"status"                 json:"status"`
 	Spec   interface{}   `bson:"spec"       yaml:"spec"                   json:"spec"`
+
+	// ReleasePlan can return to PlanningStatus when some release jobs have been executed
+	// So we need to record the last status of the release job
+	LastStatus config.Status `bson:"last_status"       yaml:"last_status"                   json:"last_status"`
+	// Updated is used to indicate whether the release job has been updated
+	Updated bool `bson:"updated"       yaml:"updated"                   json:"updated"`
 }
 
 type TextReleaseJobSpec struct {
-	Content string `bson:"content"       yaml:"content"                   json:"content"`
-	Remark  string `bson:"remark"       yaml:"remark"                   json:"remark"`
+	Content       string `bson:"content"       yaml:"content"                   json:"content"`
+	ReleaseRemark string `bson:"remark"       yaml:"remark"                   json:"remark"`
 }
 
 type WorkflowReleaseJobSpec struct {
-	ProjectName  string      `bson:"project_name"       yaml:"project_name"                   json:"project_name"`
-	WorkflowName string      `bson:"workflow_name"       yaml:"workflow_name"                   json:"workflow_name"`
-	Workflow     *WorkflowV4 `bson:"workflow"       yaml:"workflow"                   json:"workflow"`
+	//ProjectName  string      `bson:"project_name"       yaml:"project_name"                   json:"project_name"`
+	//WorkflowName string      `bson:"workflow_name"       yaml:"workflow_name"                   json:"workflow_name"`
+	Workflow *WorkflowV4 `bson:"workflow"       yaml:"workflow"                   json:"workflow"`
+}
+
+type ReleasePlanLog struct {
+	Username  string      `bson:"username"                    json:"username"`
+	Action    string      `bson:"action"                      json:"action"`
+	Target    string      `bson:"target"                      json:"target"`
+	Before    interface{} `bson:"before"                      json:"before"`
+	After     interface{} `bson:"after"                       json:"after"`
+	CreatedAt int64       `bson:"created_at"                  json:"created_at"`
 }

--- a/pkg/microservice/aslan/core/common/repository/models/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/models/release_plan.go
@@ -23,12 +23,12 @@ import (
 )
 
 type ReleasePlan struct {
-	ID        primitive.ObjectID `bson:"_id,omitempty"       yaml:"-"                   json:"id"`
-	Index     int64              `bson:"index"       yaml:"index"                   json:"index"`
-	Name      string             `bson:"name"       yaml:"name"                   json:"name"`
-	Principal string             `bson:"principal"       yaml:"principal"                   json:"principal"`
-	// PrincipalID is the user id of the principal
-	PrincipalID string `bson:"principal_id"       yaml:"principal_id"                   json:"principal_id"`
+	ID      primitive.ObjectID `bson:"_id,omitempty"       yaml:"-"                   json:"id"`
+	Index   int64              `bson:"index"       yaml:"index"                   json:"index"`
+	Name    string             `bson:"name"       yaml:"name"                   json:"name"`
+	Manager string             `bson:"manager"       yaml:"manager"                   json:"manager"`
+	// ManagerID is the user id of the manager
+	ManagerID   string `bson:"manager_id"       yaml:"manager_id"                   json:"manager_id"`
 	StartTime   int64  `bson:"start_time"       yaml:"start_time"                   json:"start_time"`
 	EndTime     int64  `bson:"end_time"       yaml:"end_time"                   json:"end_time"`
 	Description string `bson:"description"       yaml:"description"                   json:"description"`
@@ -50,12 +50,16 @@ func (ReleasePlan) TableName() string {
 }
 
 type ReleaseJob struct {
-	UUID   string        `bson:"uuid"       yaml:"uuid"                   json:"uuid"`
-	Name   string        `bson:"name"       yaml:"name"                   json:"name"`
-	Type   string        `bson:"type"       yaml:"type"                   json:"type"`
-	Status config.Status `bson:"status"     yaml:"status"                 json:"status"`
-	Spec   interface{}   `bson:"spec"       yaml:"spec"                   json:"spec"`
+	ID   string      `bson:"id"       yaml:"id"                   json:"id"`
+	Name string      `bson:"name"       yaml:"name"                   json:"name"`
+	Type string      `bson:"type"       yaml:"type"                   json:"type"`
+	Spec interface{} `bson:"spec"       yaml:"spec"                   json:"spec"`
 
+	ReleaseJobRuntime `bson:",inline" yaml:",inline" json:",inline"`
+}
+
+type ReleaseJobRuntime struct {
+	Status config.Status `bson:"status"     yaml:"status"                 json:"status"`
 	// ReleasePlan can return to PlanningStatus when some release jobs have been executed
 	// So we need to record the last status of the release job
 	LastStatus config.Status `bson:"last_status"       yaml:"last_status"                   json:"last_status"`

--- a/pkg/microservice/aslan/core/common/repository/models/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/models/release_plan.go
@@ -43,7 +43,11 @@ type ReleasePlan struct {
 
 	Logs   []*ReleasePlanLog        `bson:"logs"       yaml:"logs"                   json:"logs"`
 	Status config.ReleasePlanStatus `bson:"status"       yaml:"status"                   json:"status"`
-	//Revision int                      `bson:"revision"       yaml:"revision"                   json:"revision"`
+
+	PlanningTime  int64 `bson:"planning_time"       yaml:"planning_time"                   json:"planning_time"`
+	ApprovalTime  int64 `bson:"approval_time"       yaml:"approval_time"                   json:"approval_time"`
+	ExecutingTime int64 `bson:"executing_time"       yaml:"executing_time"                   json:"executing_time"`
+	SuccessTime   int64 `bson:"success_time"       yaml:"success_time"                   json:"success_time"`
 }
 
 func (ReleasePlan) TableName() string {

--- a/pkg/microservice/aslan/core/common/repository/models/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/models/release_plan.go
@@ -60,25 +60,25 @@ type ReleaseJob struct {
 }
 
 type ReleaseJobRuntime struct {
-	Status config.Status `bson:"status"     yaml:"status"                 json:"status"`
+	Status config.ReleasePlanJobStatus `bson:"status"     yaml:"status"                 json:"status"`
 	// ReleasePlan can return to PlanningStatus when some release jobs have been executed
 	// So we need to record the last status of the release job
-	LastStatus config.Status `bson:"last_status"       yaml:"last_status"                   json:"last_status"`
+	LastStatus config.ReleasePlanJobStatus `bson:"last_status"       yaml:"last_status"                   json:"last_status"`
 	// Updated is used to indicate whether the release job has been updated
 	Updated      bool   `bson:"updated"       yaml:"updated"                   json:"updated"`
-	ExecutorBy   string `bson:"executor_by"       yaml:"executor_by"                   json:"executor_by"`
-	ExecutorTime int64  `bson:"executor_time"       yaml:"executor_time"                   json:"executor_time"`
+	ExecutedBy   string `bson:"executed_by"       yaml:"executed_by"                   json:"executed_by"`
+	ExecutedTime int64  `bson:"executed_time"       yaml:"executed_time"                   json:"executed_time"`
 }
 
 type TextReleaseJobSpec struct {
-	Content       string `bson:"content"       yaml:"content"                   json:"content"`
-	ReleaseRemark string `bson:"remark"       yaml:"remark"                   json:"remark"`
+	Content string `bson:"content"       yaml:"content"                   json:"content"`
+	Remark  string `bson:"remark"       yaml:"remark"                   json:"remark"`
 }
 
 type WorkflowReleaseJobSpec struct {
-	//ProjectName  string      `bson:"project_name"       yaml:"project_name"                   json:"project_name"`
-	//WorkflowName string      `bson:"workflow_name"       yaml:"workflow_name"                   json:"workflow_name"`
-	Workflow *WorkflowV4 `bson:"workflow"       yaml:"workflow"                   json:"workflow"`
+	Workflow *WorkflowV4   `bson:"workflow"       yaml:"workflow"                   json:"workflow"`
+	Status   config.Status `bson:"status"       yaml:"status"                   json:"status"`
+	TaskID   int64         `bson:"task_id"       yaml:"task_id"                   json:"task_id"`
 }
 
 type ReleasePlanLog struct {

--- a/pkg/microservice/aslan/core/common/repository/models/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/models/release_plan.go
@@ -37,12 +37,13 @@ type ReleasePlan struct {
 	UpdatedBy   string `bson:"updated_by"       yaml:"updated_by"                   json:"updated_by"`
 	UpdateTime  int64  `bson:"update_time"       yaml:"update_time"                   json:"update_time"`
 
-	Approval *Approval `bson:"approval"       yaml:"approval"                   json:"approval"`
+	Approval *Approval `bson:"approval"       yaml:"approval"                   json:"approval,omitempty"`
 
 	Jobs []*ReleaseJob `bson:"jobs"       yaml:"jobs"                   json:"jobs"`
 
-	Logs   []*ReleasePlanLog        `bson:"logs"       yaml:"logs"                   json:"logs"`
-	Status config.ReleasePlanStatus `bson:"status"       yaml:"status"                   json:"status"`
+	Logs     []*ReleasePlanLog        `bson:"logs"       yaml:"logs"                   json:"logs"`
+	Status   config.ReleasePlanStatus `bson:"status"       yaml:"status"                   json:"status"`
+	Revision int                      `bson:"revision"       yaml:"revision"                   json:"revision"`
 }
 
 func (ReleasePlan) TableName() string {
@@ -83,7 +84,7 @@ type WorkflowReleaseJobSpec struct {
 type ReleasePlanLog struct {
 	Username   string      `bson:"username"                    json:"username"`
 	Account    string      `bson:"account"                     json:"account"`
-	Action     string      `bson:"action"                      json:"action"`
+	Verb       string      `bson:"verb"                        json:"verb"`
 	TargetName string      `bson:"target_name"                 json:"target_name"`
 	TargetType string      `bson:"target_type"                 json:"target_type"`
 	Before     interface{} `bson:"before"                      json:"before"`

--- a/pkg/microservice/aslan/core/common/repository/models/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/models/release_plan.go
@@ -51,10 +51,10 @@ func (ReleasePlan) TableName() string {
 }
 
 type ReleaseJob struct {
-	ID   string      `bson:"id"       yaml:"id"                   json:"id"`
-	Name string      `bson:"name"       yaml:"name"                   json:"name"`
-	Type string      `bson:"type"       yaml:"type"                   json:"type"`
-	Spec interface{} `bson:"spec"       yaml:"spec"                   json:"spec"`
+	ID   string                    `bson:"id"       yaml:"id"                   json:"id"`
+	Name string                    `bson:"name"       yaml:"name"                   json:"name"`
+	Type config.ReleasePlanJobType `bson:"type"       yaml:"type"                   json:"type"`
+	Spec interface{}               `bson:"spec"       yaml:"spec"                   json:"spec"`
 
 	ReleaseJobRuntime `bson:",inline" yaml:",inline" json:",inline"`
 }
@@ -89,5 +89,6 @@ type ReleasePlanLog struct {
 	TargetType string      `bson:"target_type"                 json:"target_type"`
 	Before     interface{} `bson:"before"                      json:"before"`
 	After      interface{} `bson:"after"                       json:"after"`
+	Detail     string      `bson:"detail"                      json:"detail"`
 	CreatedAt  int64       `bson:"created_at"                  json:"created_at"`
 }

--- a/pkg/microservice/aslan/core/common/repository/models/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/models/release_plan.go
@@ -37,6 +37,8 @@ type ReleasePlan struct {
 	UpdatedBy   string `bson:"updated_by"       yaml:"updated_by"                   json:"updated_by"`
 	UpdateTime  int64  `bson:"update_time"       yaml:"update_time"                   json:"update_time"`
 
+	Approval *Approval `bson:"approval"       yaml:"approval"                   json:"approval"`
+
 	Status config.ReleasePlanStatus `bson:"status"       yaml:"status"                   json:"status"`
 }
 
@@ -49,9 +51,11 @@ type ReleaseJob struct {
 
 type TextReleaseJobSpec struct {
 	Content string `bson:"content"       yaml:"content"                   json:"content"`
+	Remark  string `bson:"remark"       yaml:"remark"                   json:"remark"`
 }
 
 type WorkflowReleaseJobSpec struct {
-	ProjectName  string `bson:"project_name"       yaml:"project_name"                   json:"project_name"`
-	WorkflowName string `bson:"workflow_name"       yaml:"workflow_name"                   json:"workflow_name"`
+	ProjectName  string      `bson:"project_name"       yaml:"project_name"                   json:"project_name"`
+	WorkflowName string      `bson:"workflow_name"       yaml:"workflow_name"                   json:"workflow_name"`
+	Workflow     *WorkflowV4 `bson:"workflow"       yaml:"workflow"                   json:"workflow"`
 }

--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -122,6 +122,7 @@ type DingTalkApproval struct {
 	// DefaultApprovalInitiator if not set, use workflow task creator as approval initiator
 	DefaultApprovalInitiator *DingTalkApprovalUser   `bson:"default_approval_initiator" yaml:"default_approval_initiator" json:"default_approval_initiator"`
 	ApprovalNodes            []*DingTalkApprovalNode `bson:"approval_nodes"             yaml:"approval_nodes"             json:"approval_nodes"`
+	InstanceCode             string                  `bson:"instance_code"              yaml:"instance_code"              json:"instance_code"`
 }
 
 type DingTalkApprovalNode struct {
@@ -148,6 +149,8 @@ type LarkApproval struct {
 	// Deprecated: use ApprovalNodes instead
 	ApproveUsers  []*LarkApprovalUser `bson:"approve_users"               yaml:"approve_users"              json:"approve_users"`
 	ApprovalNodes []*LarkApprovalNode `bson:"approval_nodes"               yaml:"approval_nodes"              json:"approval_nodes"`
+	// InstanceCode: lark approval instance code
+	InstanceCode string `bson:"instance_code"               yaml:"instance_code"              json:"instance_code"`
 }
 
 // GetNodeTypeKey get node type key for deduplication

--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -113,7 +113,8 @@ type NativeApproval struct {
 	ApproveUsers    []*User                `bson:"approve_users"               yaml:"approve_users"              json:"approve_users"`
 	NeededApprovers int                    `bson:"needed_approvers"            yaml:"needed_approvers"           json:"needed_approvers"`
 	RejectOrApprove config.ApproveOrReject `bson:"reject_or_approve"           yaml:"-"                          json:"reject_or_approve"`
-	InstanceCode    string                 `bson:"instance_code"               yaml:"instance_code"              json:"instance_code"`
+	// InstanceCode: native approval instance code, save for working after restart aslan
+	InstanceCode string `bson:"instance_code"               yaml:"instance_code"              json:"instance_code"`
 }
 
 type DingTalkApproval struct {
@@ -123,7 +124,8 @@ type DingTalkApproval struct {
 	// DefaultApprovalInitiator if not set, use workflow task creator as approval initiator
 	DefaultApprovalInitiator *DingTalkApprovalUser   `bson:"default_approval_initiator" yaml:"default_approval_initiator" json:"default_approval_initiator"`
 	ApprovalNodes            []*DingTalkApprovalNode `bson:"approval_nodes"             yaml:"approval_nodes"             json:"approval_nodes"`
-	InstanceCode             string                  `bson:"instance_code"              yaml:"instance_code"              json:"instance_code"`
+	// InstanceCode: dingtalk approval instance code
+	InstanceCode string `bson:"instance_code"              yaml:"instance_code"              json:"instance_code"`
 }
 
 type DingTalkApprovalNode struct {

--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -113,6 +113,7 @@ type NativeApproval struct {
 	ApproveUsers    []*User                `bson:"approve_users"               yaml:"approve_users"              json:"approve_users"`
 	NeededApprovers int                    `bson:"needed_approvers"            yaml:"needed_approvers"           json:"needed_approvers"`
 	RejectOrApprove config.ApproveOrReject `bson:"reject_or_approve"           yaml:"-"                          json:"reject_or_approve"`
+	InstanceCode    string                 `bson:"instance_code"               yaml:"instance_code"              json:"instance_code"`
 }
 
 type DingTalkApproval struct {

--- a/pkg/microservice/aslan/core/common/repository/mongodb/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/release_plan.go
@@ -105,6 +105,7 @@ type ListReleasePlanOption struct {
 	PageSize       int64
 	IsSort         bool
 	ExcludedFields []string
+	Status         config.ReleasePlanStatus
 }
 
 func (c *ReleasePlanColl) ListByOptions(opt *ListReleasePlanOption) ([]*models.ReleasePlan, int64, error) {
@@ -123,6 +124,9 @@ func (c *ReleasePlanColl) ListByOptions(opt *ListReleasePlanOption) ([]*models.R
 	if opt.PageNum > 0 && opt.PageSize > 0 {
 		opts.SetSkip((opt.PageNum - 1) * opt.PageSize)
 		opts.SetLimit(opt.PageSize)
+	}
+	if opt.Status != "" {
+		query["status"] = opt.Status
 	}
 	if len(opt.ExcludedFields) > 0 {
 		projection := bson.M{}

--- a/pkg/microservice/aslan/core/common/repository/mongodb/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/release_plan.go
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2023 The KodeRover Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongodb
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
+)
+
+type ReleasePlanColl struct {
+	*mongo.Collection
+
+	coll string
+}
+
+func NewReleasePlanColl() *ReleasePlanColl {
+	name := models.ReleasePlan{}.TableName()
+	return &ReleasePlanColl{
+		Collection: mongotool.Database(config.MongoDatabase()).Collection(name),
+		coll:       name,
+	}
+}
+
+func (c *ReleasePlanColl) GetCollectionName() string {
+	return c.coll
+}
+
+func (c *ReleasePlanColl) EnsureIndex(ctx context.Context) error {
+	return nil
+}
+
+func (c *ReleasePlanColl) Create(args *models.ReleasePlan) error {
+	if args == nil {
+		return errors.New("nil ReleasePlan")
+	}
+
+	_, err := c.InsertOne(context.Background(), args)
+	return err
+}
+
+func (c *ReleasePlanColl) GetByID(idString string) (*models.ReleasePlan, error) {
+	id, err := primitive.ObjectIDFromHex(idString)
+	if err != nil {
+		return nil, err
+	}
+
+	query := bson.M{"_id": id}
+	result := new(models.ReleasePlan)
+	err = c.FindOne(context.Background(), query).Decode(result)
+	return result, err
+}
+
+func (c *ReleasePlanColl) DeleteByID(idString string) error {
+	id, err := primitive.ObjectIDFromHex(idString)
+	if err != nil {
+		return err
+	}
+
+	query := bson.M{"_id": id}
+	_, err = c.DeleteOne(context.Background(), query)
+	return err
+}
+
+type ListReleasePlanOption struct {
+	PageNum  int64
+	PageSize int64
+	IsSort   bool
+}
+
+func (c *ReleasePlanColl) ListByOptions(opt *ListReleasePlanOption) ([]*models.ReleasePlan, int64, error) {
+	if opt == nil {
+		return nil, 0, errors.New("nil ListOption")
+	}
+
+	query := bson.M{}
+
+	var resp []*models.ReleasePlan
+	ctx := context.Background()
+	opts := options.Find()
+	if opt.IsSort {
+		opts.SetSort(bson.D{{"index", -1}})
+	}
+	if opt.PageNum > 0 && opt.PageSize > 0 {
+		opts.SetSkip((opt.PageNum - 1) * opt.PageSize)
+		opts.SetLimit(opt.PageSize)
+	}
+	opts.SetProjection(bson.M{
+		"jobs":     0,
+		"approval": 0,
+		"logs":     0,
+	})
+
+	count, err := c.Collection.CountDocuments(ctx, query)
+	if err != nil {
+		return nil, 0, err
+	}
+	cursor, err := c.Collection.Find(ctx, query, opts)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	err = cursor.All(ctx, &resp)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return resp, count, nil
+}

--- a/pkg/microservice/aslan/core/common/service/approval/approval.go
+++ b/pkg/microservice/aslan/core/common/service/approval/approval.go
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2023 The KodeRover Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package approval
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+)
+
+type ApproveMap struct {
+	m map[string]*ApproveWithLock
+	sync.RWMutex
+}
+
+type ApproveWithLock struct {
+	Approval *commonmodels.NativeApproval
+	sync.RWMutex
+}
+
+var GlobalApproveMap ApproveMap
+
+func init() {
+	GlobalApproveMap.m = make(map[string]*ApproveWithLock, 0)
+}
+
+func (c *ApproveMap) SetApproval(key string, value *ApproveWithLock) {
+	c.Lock()
+	defer c.Unlock()
+	c.m[key] = value
+}
+
+func (c *ApproveMap) GetApproval(key string) (*ApproveWithLock, bool) {
+	c.RLock()
+	defer c.RUnlock()
+	v, existed := c.m[key]
+	return v, existed
+}
+func (c *ApproveMap) DeleteApproval(key string) {
+	c.Lock()
+	defer c.Unlock()
+	delete(c.m, key)
+}
+
+func (c *ApproveWithLock) IsApproval() (bool, int, error) {
+	c.Lock()
+	defer c.Unlock()
+	ApproveCount := 0
+	for _, user := range c.Approval.ApproveUsers {
+		if user.RejectOrApprove == config.Reject {
+			c.Approval.RejectOrApprove = config.Reject
+			return false, ApproveCount, fmt.Errorf("%s reject this task", user.UserName)
+		}
+		if user.RejectOrApprove == config.Approve {
+			ApproveCount++
+		}
+	}
+	if ApproveCount >= c.Approval.NeededApprovers {
+		c.Approval.RejectOrApprove = config.Approve
+		return true, ApproveCount, nil
+	}
+	return false, ApproveCount, nil
+}
+
+func (c *ApproveWithLock) DoApproval(userName, userID, comment string, appvove bool) error {
+	c.Lock()
+	defer c.Unlock()
+	for _, user := range c.Approval.ApproveUsers {
+		if user.UserID != userID {
+			continue
+		}
+		if user.RejectOrApprove != "" {
+			return fmt.Errorf("%s have %s already", userName, user.RejectOrApprove)
+		}
+		user.Comment = comment
+		user.OperationTime = time.Now().Unix()
+		if appvove {
+			user.RejectOrApprove = config.Approve
+			return nil
+		} else {
+			user.RejectOrApprove = config.Reject
+			return nil
+		}
+	}
+	return fmt.Errorf("user %s has no authority to Approve", userName)
+}

--- a/pkg/microservice/aslan/core/common/service/lark/webhook.go
+++ b/pkg/microservice/aslan/core/common/service/lark/webhook.go
@@ -88,9 +88,9 @@ func EventHandler(appID, sign, ts, nonce, body string) (*EventHandlerResponse, e
 	if err != nil {
 		return nil, errors.Wrap(err, "decrypt body")
 	}
-
 	// handle lark open platform webhook URL check request, which only need reply the challenge field.
 	if sign == "" {
+		log.Infof("LarkEventHandler: challenge request received, challenge: %s", gjson.Get(raw, "challenge").String())
 		return &EventHandlerResponse{Challenge: gjson.Get(raw, "challenge").String()}, nil
 	}
 
@@ -115,7 +115,7 @@ func EventHandler(appID, sign, ts, nonce, body string) (*EventHandlerResponse, e
 		log.Errorf("unmarshal callback event failed: %v", err)
 		return nil, errors.Wrap(err, "unmarshal")
 	}
-	log.Infof("LarkEventHandler: new request approval ID %s, request ID %s, ts: %s", larkAppInfoID, callback.UUID, callback.Ts)
+	log.Infof("LarkEventHandler: new request approval ID %s, request UUID %s, ts: %s", larkAppInfoID, callback.UUID, callback.Ts)
 	manager := GetLarkApprovalInstanceManager(event.InstanceCode)
 	if !manager.CheckAndUpdateUUID(callback.UUID) {
 		log.Infof("check existed request uuid %s, ignored", callback.UUID)

--- a/pkg/microservice/aslan/core/common/service/lark/webhook.go
+++ b/pkg/microservice/aslan/core/common/service/lark/webhook.go
@@ -115,7 +115,7 @@ func EventHandler(appID, sign, ts, nonce, body string) (*EventHandlerResponse, e
 		log.Errorf("unmarshal callback event failed: %v", err)
 		return nil, errors.Wrap(err, "unmarshal")
 	}
-	log.Infof("LarkEventHandler: new request approval ID %s, request UUID %s, ts: %s", larkAppInfoID, callback.UUID, callback.Ts)
+	log.Infof("LarkEventHandler: new request approval ID %s, request ID %s, ts: %s", larkAppInfoID, callback.UUID, callback.Ts)
 	manager := GetLarkApprovalInstanceManager(event.InstanceCode)
 	if !manager.CheckAndUpdateUUID(callback.UUID) {
 		log.Infof("check existed request uuid %s, ignored", callback.UUID)

--- a/pkg/microservice/aslan/core/common/service/lark/webhook.go
+++ b/pkg/microservice/aslan/core/common/service/lark/webhook.go
@@ -78,6 +78,7 @@ func EventHandler(appID, sign, ts, nonce, body string) (*EventHandlerResponse, e
 	log.Infof("LarkEventHandler: new request approval received")
 	larkAppInfo, err := mongodb.NewIMAppColl().GetLarkByAppID(context.Background(), appID)
 	if err != nil {
+		log.Errorf("get lark app info failed: %v", err)
 		return nil, errors.Wrap(err, "get approval by appID")
 	}
 	key := larkAppInfo.EncryptKey
@@ -86,6 +87,7 @@ func EventHandler(appID, sign, ts, nonce, body string) (*EventHandlerResponse, e
 
 	raw, err := larkDecrypt(gjson.Get(body, "encrypt").String(), key)
 	if err != nil {
+		log.Errorf("decrypt body failed: %v", err)
 		return nil, errors.Wrap(err, "decrypt body")
 	}
 	// handle lark open platform webhook URL check request, which only need reply the challenge field.
@@ -95,6 +97,7 @@ func EventHandler(appID, sign, ts, nonce, body string) (*EventHandlerResponse, e
 	}
 
 	if sign != larkCalculateSignature(ts, nonce, key, body) {
+		log.Errorf("check sign failed")
 		return nil, errors.New("check sign failed")
 	}
 

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/stage.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/stage.go
@@ -38,22 +38,6 @@ import (
 	"github.com/koderover/zadig/pkg/tool/log"
 )
 
-//type approveMap struct {
-//	m map[string]*approveWithLock
-//	sync.RWMutex
-//}
-//
-//type approveWithLock struct {
-//	approval *commonmodels.NativeApproval
-//	sync.RWMutex
-//}
-//
-//var globalApproveMap approveMap
-
-//func init() {
-//	globalApproveMap.m = make(map[string]*approveWithLock, 0)
-//}
-
 type StageCtl interface {
 	Run(ctx context.Context, concurrency int)
 }
@@ -607,64 +591,3 @@ func updateStageStatus(stage *commonmodels.StageTask) {
 	}
 	stage.Status = stageStatus
 }
-
-//func (c *approveMap) setApproval(key string, value *approveWithLock) {
-//	c.Lock()
-//	defer c.Unlock()
-//	c.m[key] = value
-//}
-//
-//func (c *approveMap) getApproval(key string) (*approveWithLock, bool) {
-//	c.RLock()
-//	defer c.RUnlock()
-//	v, existed := c.m[key]
-//	return v, existed
-//}
-//func (c *approveMap) deleteApproval(key string) {
-//	c.Lock()
-//	defer c.Unlock()
-//	delete(c.m, key)
-//}
-//
-//func (c *approveWithLock) isApproval() (bool, int, error) {
-//	c.Lock()
-//	defer c.Unlock()
-//	approveCount := 0
-//	for _, user := range c.approval.ApproveUsers {
-//		if user.RejectOrApprove == config.Reject {
-//			c.approval.RejectOrApprove = config.Reject
-//			return false, approveCount, fmt.Errorf("%s reject this task", user.UserName)
-//		}
-//		if user.RejectOrApprove == config.Approve {
-//			approveCount++
-//		}
-//	}
-//	if approveCount >= c.approval.NeededApprovers {
-//		c.approval.RejectOrApprove = config.Approve
-//		return true, approveCount, nil
-//	}
-//	return false, approveCount, nil
-//}
-//
-//func (c *approveWithLock) doApproval(userName, userID, comment string, appvove bool) error {
-//	c.Lock()
-//	defer c.Unlock()
-//	for _, user := range c.approval.ApproveUsers {
-//		if user.UserID != userID {
-//			continue
-//		}
-//		if user.RejectOrApprove != "" {
-//			return fmt.Errorf("%s have %s already", userName, user.RejectOrApprove)
-//		}
-//		user.Comment = comment
-//		user.OperationTime = time.Now().Unix()
-//		if appvove {
-//			user.RejectOrApprove = config.Approve
-//			return nil
-//		} else {
-//			user.RejectOrApprove = config.Reject
-//			return nil
-//		}
-//	}
-//	return fmt.Errorf("user %s has no authority to approve", userName)
-//}

--- a/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
@@ -174,12 +174,6 @@ func UpdateReleaseJobStatus(c *gin.Context) {
 		return
 	}
 
-	req := new(service.ExecuteReleaseJobArgs)
-	if err := c.ShouldBindJSON(req); err != nil {
-		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
-		return
-	}
-
 	// only release plan manager can execute release job
 	// so no need to check authorization there
 	ctx.Err = service.UpdateReleasePlanStatus(ctx, c.Param("id"), c.Param("status"))

--- a/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
@@ -43,10 +43,10 @@ func ListReleasePlans(c *gin.Context) {
 		return
 	}
 
-	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.View {
-		ctx.UnAuthorized = true
-		return
-	}
+	//if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.View {
+	//	ctx.UnAuthorized = true
+	//	return
+	//}
 
 	opt := new(ListReleasePlanOption)
 	if err := c.ShouldBindQuery(&opt); err != nil {
@@ -68,10 +68,10 @@ func GetReleasePlan(c *gin.Context) {
 		return
 	}
 
-	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.View {
-		ctx.UnAuthorized = true
-		return
-	}
+	//if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.View {
+	//	ctx.UnAuthorized = true
+	//	return
+	//}
 
 	ctx.Resp, ctx.Err = service.GetReleasePlan(c.Param("id"))
 }
@@ -87,10 +87,10 @@ func CreateReleasePlan(c *gin.Context) {
 		return
 	}
 
-	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.Create {
-		ctx.UnAuthorized = true
-		return
-	}
+	//if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.Create {
+	//	ctx.UnAuthorized = true
+	//	return
+	//}
 
 	req := new(models.ReleasePlan)
 	if err := c.ShouldBindJSON(req); err != nil {
@@ -111,10 +111,10 @@ func UpdateReleasePlan(c *gin.Context) {
 		return
 	}
 
-	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.Edit {
-		ctx.UnAuthorized = true
-		return
-	}
+	//if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.Edit {
+	//	ctx.UnAuthorized = true
+	//	return
+	//}
 
 	req := new(service.UpdateReleasePlanArgs)
 	if err := c.ShouldBindJSON(req); err != nil {
@@ -135,10 +135,10 @@ func DeleteReleasePlan(c *gin.Context) {
 		return
 	}
 
-	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.Delete {
-		ctx.UnAuthorized = true
-		return
-	}
+	//if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.Delete {
+	//	ctx.UnAuthorized = true
+	//	return
+	//}
 
 	ctx.Err = service.DeleteReleasePlan(ctx.UserName, c.Param("id"))
 }

--- a/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
@@ -142,3 +142,45 @@ func DeleteReleasePlan(c *gin.Context) {
 
 	ctx.Err = service.DeleteReleasePlan(ctx.UserName, c.Param("id"))
 }
+
+func ExecuteReleaseJob(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	req := new(service.ExecuteReleaseJobArgs)
+	if err := c.ShouldBindJSON(req); err != nil {
+		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+
+	// only release plan manager can execute release job
+	// so no need to check authorization there
+	ctx.Err = service.ExecuteReleaseJob(ctx, c.Param("id"), req)
+}
+
+func UpdateReleaseJobStatus(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	req := new(service.ExecuteReleaseJobArgs)
+	if err := c.ShouldBindJSON(req); err != nil {
+		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+
+	// only release plan manager can execute release job
+	// so no need to check authorization there
+	ctx.Err = service.UpdateReleasePlanStatus(ctx, c.Param("id"), c.Param("status"))
+}

--- a/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
@@ -121,7 +121,7 @@ func UpdateReleasePlan(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
 		return
 	}
-	ctx.Err = service.UpdateReleasePlan(c.Param("id"), ctx.UserName, req)
+	ctx.Err = service.UpdateReleasePlan(ctx, c.Param("id"), req)
 }
 
 func DeleteReleasePlan(c *gin.Context) {
@@ -140,5 +140,5 @@ func DeleteReleasePlan(c *gin.Context) {
 		return
 	}
 
-	ctx.Err = service.DeleteReleasePlan(c.Param("id"))
+	ctx.Err = service.DeleteReleasePlan(ctx.UserName, c.Param("id"))
 }

--- a/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
@@ -105,5 +105,20 @@ func UpdateReleasePlan(c *gin.Context) {
 }
 
 func DeleteReleasePlan(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.Delete {
+		ctx.UnAuthorized = true
+		return
+	}
+	
+	ctx.Err = service.DeleteReleasePlan(c.Param("id"))
 }

--- a/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 The KodeRover Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package handler
+
+import "github.com/gin-gonic/gin"
+
+func ListReleasePlans(c *gin.Context) {
+
+}
+
+func GetReleasePlan(c *gin.Context) {
+
+}
+
+func CreateReleasePlan(c *gin.Context) {
+
+}
+
+func UpdateReleasePlan(c *gin.Context) {
+
+}

--- a/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
@@ -16,20 +16,94 @@
 
 package handler
 
-import "github.com/gin-gonic/gin"
+import (
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/release_plan/service"
+	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
+	e "github.com/koderover/zadig/pkg/tool/errors"
+)
+
+type ListReleasePlanOption struct {
+	PageNum  int64 `form:"pageNum" binding:"required"`
+	PageSize int64 `form:"pageSize" binding:"required"`
+}
 
 func ListReleasePlans(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.View {
+		ctx.UnAuthorized = true
+		return
+	}
+
+	opt := new(ListReleasePlanOption)
+	if err := c.ShouldBindQuery(&opt); err != nil {
+		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+
+	ctx.Resp, ctx.Err = service.ListReleasePlans(opt.PageNum, opt.PageSize)
 }
 
 func GetReleasePlan(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.View {
+		ctx.UnAuthorized = true
+		return
+	}
+
+	ctx.Resp, ctx.Err = service.GetReleasePlan(c.Param("id"))
 }
 
 func CreateReleasePlan(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.Create {
+		ctx.UnAuthorized = true
+		return
+	}
+
+	req := new(models.ReleasePlan)
+	if err := c.ShouldBindJSON(req); err != nil {
+		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+	ctx.Err = service.CreateReleasePlan(ctx.UserName, req)
 }
 
 func UpdateReleasePlan(c *gin.Context) {
+
+}
+
+func DeleteReleasePlan(c *gin.Context) {
 
 }

--- a/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
@@ -178,3 +178,22 @@ func UpdateReleaseJobStatus(c *gin.Context) {
 	// so no need to check authorization there
 	ctx.Err = service.UpdateReleasePlanStatus(ctx, c.Param("id"), c.Param("status"))
 }
+
+func ApproveReleasePlan(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	req := new(service.ApproveRequest)
+	if err := c.ShouldBindJSON(req); err != nil {
+		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+
+	ctx.Err = service.ApproveReleasePlan(ctx, c.Param("id"), req)
+}

--- a/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
@@ -140,7 +140,7 @@ func DeleteReleasePlan(c *gin.Context) {
 	//	return
 	//}
 
-	ctx.Err = service.DeleteReleasePlan(ctx.UserName, c.Param("id"))
+	ctx.Err = service.DeleteReleasePlan(c, ctx.UserName, c.Param("id"))
 }
 
 func ExecuteReleaseJob(c *gin.Context) {

--- a/pkg/microservice/aslan/core/release_plan/handler/router.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/router.go
@@ -28,5 +28,8 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		v1.GET("/:id", GetReleasePlan)
 		v1.PUT("/:id", UpdateReleasePlan)
 		v1.DELETE("/:id", DeleteReleasePlan)
+
+		v1.POST("/:id/execute", ExecuteReleaseJob)
+		v1.POST("/:id/status/:status", UpdateReleaseJobStatus)
 	}
 }

--- a/pkg/microservice/aslan/core/release_plan/handler/router.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/router.go
@@ -23,6 +23,10 @@ type Router struct{}
 func (*Router) Inject(router *gin.RouterGroup) {
 	v1 := router.Group("v1")
 	{
-		v1.GET("/")
+		v1.GET("", ListReleasePlans)
+		v1.POST("", CreateReleasePlan)
+		v1.GET("/:id", GetReleasePlan)
+		v1.PUT("/:id", UpdateReleasePlan)
+		v1.DELETE("/:id", DeleteReleasePlan)
 	}
 }

--- a/pkg/microservice/aslan/core/release_plan/handler/router.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/router.go
@@ -31,5 +31,6 @@ func (*Router) Inject(router *gin.RouterGroup) {
 
 		v1.POST("/:id/execute", ExecuteReleaseJob)
 		v1.POST("/:id/status/:status", UpdateReleaseJobStatus)
+		v1.POST("/:id/approve", ApproveReleasePlan)
 	}
 }

--- a/pkg/microservice/aslan/core/release_plan/handler/router.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/router.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 The KodeRover Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package handler
+
+import "github.com/gin-gonic/gin"
+
+type Router struct{}
+
+func (*Router) Inject(router *gin.RouterGroup) {
+	v1 := router.Group("v1")
+	{
+		v1.GET("/")
+	}
+}

--- a/pkg/microservice/aslan/core/release_plan/service/approval.go
+++ b/pkg/microservice/aslan/core/release_plan/service/approval.go
@@ -54,8 +54,8 @@ func createApprovalInstance(plan *models.ReleasePlan, phone string) error {
 		detailURL)
 
 	switch plan.Approval.Type {
-	case config.NativeApproval:
-		return createNativeApproval(ctx, stage, workflowCtx, logger, ack)
+	//case config.NativeApproval:
+	//	return createNativeApproval(ctx, stage, workflowCtx, logger, ack)
 	case config.LarkApproval:
 		return createLarkApproval(plan.Approval.LarkApproval, plan.Manager, phone, formContent)
 	case config.DingTalkApproval:
@@ -199,12 +199,75 @@ func updateDingTalkApproval(ctx context.Context, approvalInfo *models.Approval) 
 			return errors.Wrap(err, "get unexpected instance final info")
 		}
 	}
-
+	return nil
 }
 
-func createNativeApproval() error {
+//func createNativeApproval(approval *models.LarkApproval) error {
+//	approval := stage.Approval.NativeApproval
+//	if approval == nil {
+//		return errors.New("waitForApprove: native approval data not found")
+//	}
+//
+//	if approval.Timeout == 0 {
+//		approval.Timeout = 60
+//	}
+//	approveKey := fmt.Sprintf("%s-%d-%s", workflowCtx.WorkflowName, workflowCtx.TaskID, stage.Name)
+//	approveWithL := &approveWithLock{approval: approval}
+//	globalApproveMap.setApproval(approveKey, approveWithL)
+//	defer func() {
+//		globalApproveMap.deleteApproval(approveKey)
+//		ack()
+//	}()
+//}
 
-}
+//func updateNativeApproval() error {
+//	approval := stage.Approval.NativeApproval
+//	if approval == nil {
+//		return errors.New("waitForApprove: native approval data not found")
+//	}
+//
+//	if approval.Timeout == 0 {
+//		approval.Timeout = 60
+//	}
+//	approveKey := fmt.Sprintf("%s-%d-%s", workflowCtx.WorkflowName, workflowCtx.TaskID, stage.Name)
+//	approveWithL := &approveWithLock{approval: approval}
+//	globalApproveMap.setApproval(approveKey, approveWithL)
+//	defer func() {
+//		globalApproveMap.deleteApproval(approveKey)
+//		ack()
+//	}()
+//	if err := instantmessage.NewWeChatClient().SendWorkflowTaskAproveNotifications(workflowCtx.WorkflowName, workflowCtx.TaskID); err != nil {
+//		logger.Errorf("send approve notification failed, error: %v", err)
+//	}
+//
+//	timeout := time.After(time.Duration(approval.Timeout) * time.Minute)
+//	latestApproveCount := 0
+//	for {
+//		time.Sleep(1 * time.Second)
+//		select {
+//		case <-ctx.Done():
+//			stage.Status = config.StatusCancelled
+//			return fmt.Errorf("workflow was canceled")
+//
+//		case <-timeout:
+//			stage.Status = config.StatusTimeout
+//			return fmt.Errorf("workflow timeout")
+//		default:
+//			approved, approveCount, err := approveWithL.isApproval()
+//			if err != nil {
+//				stage.Status = config.StatusReject
+//				return err
+//			}
+//			if approved {
+//				return nil
+//			}
+//			if approveCount > latestApproveCount {
+//				ack()
+//				latestApproveCount = approveCount
+//			}
+//		}
+//	}
+//}
 
 func createLarkApproval(approval *models.LarkApproval, manager, phone, content string) error {
 	if approval == nil {
@@ -243,6 +306,7 @@ func createLarkApproval(approval *models.LarkApproval, manager, phone, content s
 		return errors.Wrap(err, "create approval instance")
 	}
 	approval.InstanceCode = instance
+	return nil
 }
 
 func updateLarkApproval(ctx context.Context, approval *models.Approval) error {

--- a/pkg/microservice/aslan/core/release_plan/service/approval.go
+++ b/pkg/microservice/aslan/core/release_plan/service/approval.go
@@ -35,9 +35,8 @@ import (
 	approvalservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/approval"
 	dingservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/dingtalk"
 	larkservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/lark"
-	"github.com/koderover/zadig/pkg/microservice/user/core/repository"
-	"github.com/koderover/zadig/pkg/microservice/user/core/repository/orm"
 	"github.com/koderover/zadig/pkg/shared/client/systemconfig"
+	"github.com/koderover/zadig/pkg/shared/client/user"
 	"github.com/koderover/zadig/pkg/tool/dingtalk"
 	"github.com/koderover/zadig/pkg/tool/lark"
 	"github.com/koderover/zadig/pkg/tool/log"
@@ -247,8 +246,8 @@ func createNativeApproval(plan *models.ReleasePlan, url string) error {
 			log.Errorf("CreateNativeApproval template execute error, error msg:%s", err)
 			return
 		}
-		for _, user := range approval.ApproveUsers {
-			info, err := orm.GetUserByUid(user.UserID, repository.DB)
+		for _, u := range approval.ApproveUsers {
+			info, err := user.New().GetUserByID(u.UserID)
 			if err != nil {
 				log.Warnf("CreateNativeApproval GetUserByUid error, error msg:%s", err)
 				continue

--- a/pkg/microservice/aslan/core/release_plan/service/approval.go
+++ b/pkg/microservice/aslan/core/release_plan/service/approval.go
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2023 The KodeRover Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+
+	configbase "github.com/koderover/zadig/pkg/config"
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
+	dingservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/dingtalk"
+	larkservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/lark"
+	"github.com/koderover/zadig/pkg/tool/dingtalk"
+	"github.com/koderover/zadig/pkg/tool/lark"
+	"github.com/koderover/zadig/pkg/tool/log"
+)
+
+func createApprovalInstance(plan *models.ReleasePlan, phone string) error {
+	if plan.Approval == nil {
+		return errors.New("createApprovalInstance: approval data not found")
+	}
+
+	// todo
+	detailURL := fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d?display_name=%s",
+		configbase.SystemAddress(),
+		//workflowCtx.ProjectName,
+		//workflowCtx.WorkflowName,
+		//workflowCtx.TaskID,
+		//url.QueryEscape(workflowCtx.WorkflowDisplayName),
+	)
+
+	formContent := fmt.Sprintf("发布计划名称: %s\n发布负责人: %s\n发布窗口期: %s\n\n更多详见: %s",
+		plan.Name, plan.Manager,
+		time.Unix(plan.StartTime, 0).Format("2006-01-02 15:04:05")+"-"+time.Unix(plan.EndTime, 0).Format("2006-01-02 15:04:05"),
+		detailURL)
+
+	switch plan.Approval.Type {
+	case config.NativeApproval:
+		return createNativeApproval(ctx, stage, workflowCtx, logger, ack)
+	case config.LarkApproval:
+		return createLarkApproval(plan.Approval.LarkApproval, plan.Manager, phone, formContent)
+	case config.DingTalkApproval:
+		return createDingTalkApproval(plan.Approval.DingTalkApproval, plan.Manager, phone, formContent)
+	default:
+		return errors.New("invalid approval type")
+	}
+}
+
+func createDingTalkApproval(approval *models.DingTalkApproval, manager, phone, content string) error {
+	if approval == nil {
+		return errors.New("waitForApprove: dingtalk approval data not found")
+	}
+
+	data, err := mongodb.NewIMAppColl().GetByID(context.Background(), approval.ID)
+	if err != nil {
+		return errors.Wrap(err, "get dingtalk im data")
+	}
+
+	client := dingtalk.NewClient(data.DingTalkAppKey, data.DingTalkAppSecret)
+
+	var userID string
+	if approval.DefaultApprovalInitiator == nil {
+		userIDResp, err := client.GetUserIDByMobile(phone)
+		if err != nil {
+			return errors.Wrapf(err, "get user dingtalk id by mobile-%s", phone)
+		}
+		userID = userIDResp.UserID
+	} else {
+		userID = approval.DefaultApprovalInitiator.ID
+		content = fmt.Sprintf("审批发起人: %s\n%s", manager, content)
+	}
+
+	instanceResp, err := client.CreateApprovalInstance(&dingtalk.CreateApprovalInstanceArgs{
+		ProcessCode:      data.DingTalkDefaultApprovalFormCode,
+		OriginatorUserID: userID,
+		ApproverNodeList: func() (nodeList []*dingtalk.ApprovalNode) {
+			for _, node := range approval.ApprovalNodes {
+				var userIDList []string
+				for _, user := range node.ApproveUsers {
+					userIDList = append(userIDList, user.ID)
+				}
+				nodeList = append(nodeList, &dingtalk.ApprovalNode{
+					UserIDs:    userIDList,
+					ActionType: node.Type,
+				})
+			}
+			return
+		}(),
+		FormContent: content,
+	})
+	if err != nil {
+		return errors.Wrap(err, "create approval instance")
+	}
+
+	approval.InstanceCode = instanceResp.InstanceID
+	return nil
+}
+
+func updateDingTalkApproval(ctx context.Context, approvalInfo *models.Approval) error {
+	if approvalInfo == nil || approvalInfo.DingTalkApproval == nil {
+		return errors.New("updateDingTalkApproval: approval data not found")
+	}
+	approval := approvalInfo.DingTalkApproval
+	instanceID := approval.InstanceCode
+	if instanceID == "" {
+		return errors.New("updateDingTalkApproval: instance id not found")
+	}
+
+	data, err := mongodb.NewIMAppColl().GetByID(context.Background(), approval.ID)
+	if err != nil {
+		return errors.Wrap(err, "get dingtalk im data")
+	}
+	client := dingtalk.NewClient(data.DingTalkAppKey, data.DingTalkAppSecret)
+
+	resultMap := map[string]config.ApproveOrReject{
+		"agree":  config.Approve,
+		"refuse": config.Reject,
+	}
+
+	checkNodeStatus := func(node *models.DingTalkApprovalNode) (config.ApproveOrReject, error) {
+		users := node.ApproveUsers
+		switch node.Type {
+		case "AND":
+			result := config.Approve
+			for _, user := range users {
+				if user.RejectOrApprove == "" {
+					result = ""
+				}
+				if user.RejectOrApprove == config.Reject {
+					return config.Reject, nil
+				}
+			}
+			return result, nil
+		case "OR":
+			for _, user := range users {
+				if user.RejectOrApprove != "" {
+					return user.RejectOrApprove, nil
+				}
+			}
+			return "", nil
+		default:
+			return "", errors.Errorf("unknown node type %s", node.Type)
+		}
+	}
+
+	userApprovalResult := dingservice.GetDingTalkApprovalManager(instanceID).GetAllUserApprovalResults()
+	for _, node := range approval.ApprovalNodes {
+		if node.RejectOrApprove != "" {
+			continue
+		}
+		for _, user := range node.ApproveUsers {
+			if result := userApprovalResult[user.ID]; result != nil && user.RejectOrApprove == "" {
+				user.RejectOrApprove = resultMap[result.Result]
+				user.Comment = result.Remark
+				user.OperationTime = result.OperationTime
+			}
+		}
+		node.RejectOrApprove, err = checkNodeStatus(node)
+		if err != nil {
+			return errors.Wrap(err, "check node")
+		}
+		switch node.RejectOrApprove {
+		case config.Approve:
+		case config.Reject:
+			approvalInfo.Status = config.StatusReject
+			return nil
+		}
+		break
+	}
+	if approval.ApprovalNodes[len(approval.ApprovalNodes)-1].RejectOrApprove == config.Approve {
+		instanceInfo, err := client.GetApprovalInstance(instanceID)
+		if err != nil {
+			return errors.Wrap(err, "get instance final info")
+		}
+		if instanceInfo.Status == "COMPLETED" && instanceInfo.Result == "agree" {
+			approvalInfo.Status = config.StatusPassed
+			return nil
+		} else {
+			log.Errorf("Unexpect instance final status is %s, result is %s", instanceInfo.Status, instanceInfo.Result)
+			return errors.Wrap(err, "get unexpected instance final info")
+		}
+	}
+
+}
+
+func createNativeApproval() error {
+
+}
+
+func createLarkApproval(approval *models.LarkApproval, manager, phone, content string) error {
+	if approval == nil {
+		return errors.New("waitForApprove: lark approval data not found")
+	}
+
+	data, err := mongodb.NewIMAppColl().GetByID(context.Background(), approval.ID)
+	if err != nil {
+		return errors.Wrap(err, "get lark im app data")
+	}
+	approvalCode := data.LarkApprovalCodeListCommon[approval.GetNodeTypeKey()]
+	if approvalCode == "" {
+		return errors.Errorf("failed to find approval code for node type %s", approval.GetNodeTypeKey())
+	}
+
+	client := lark.NewClient(data.AppID, data.AppSecret)
+
+	var userID string
+	if approval.DefaultApprovalInitiator == nil {
+		userID, err = client.GetUserOpenIDByEmailOrMobile(lark.QueryTypeMobile, phone)
+		if err != nil {
+			return errors.Wrapf(err, "get user lark id by mobile-%s", phone)
+		}
+	} else {
+		userID = approval.DefaultApprovalInitiator.ID
+		content = fmt.Sprintf("审批发起人: %s\n%s", manager, content)
+	}
+
+	instance, err := client.CreateApprovalInstance(&lark.CreateApprovalInstanceArgs{
+		ApprovalCode: approvalCode,
+		UserOpenID:   userID,
+		Nodes:        approval.GetLarkApprovalNode(),
+		FormContent:  content,
+	})
+	if err != nil {
+		return errors.Wrap(err, "create approval instance")
+	}
+	approval.InstanceCode = instance
+}
+
+func updateLarkApproval(ctx context.Context, approval *models.Approval) error {
+	if approval == nil || approval.LarkApproval == nil {
+		return errors.New("updateLarkApproval: lark approval data not found")
+	}
+	larkApproval := approval.LarkApproval
+	instance := larkApproval.InstanceCode
+	if instance == "" {
+		return errors.New("updateLarkApproval: lark approval instance code not found")
+	}
+
+	data, err := mongodb.NewIMAppColl().GetByID(ctx, larkApproval.ID)
+	if err != nil {
+		return errors.Wrap(err, "get lark im app data")
+	}
+	client := lark.NewClient(data.AppID, data.AppSecret)
+
+	checkNodeStatus := func(node *models.LarkApprovalNode) (config.ApproveOrReject, error) {
+		switch node.Type {
+		case "AND":
+			result := config.Approve
+			for _, user := range node.ApproveUsers {
+				if user.RejectOrApprove == "" {
+					result = ""
+				}
+				if user.RejectOrApprove == config.Reject {
+					return config.Reject, nil
+				}
+			}
+			return result, nil
+		case "OR":
+			for _, user := range node.ApproveUsers {
+				if user.RejectOrApprove != "" {
+					return user.RejectOrApprove, nil
+				}
+			}
+			return "", nil
+		default:
+			return "", errors.Errorf("unknown node type %s", node.Type)
+		}
+	}
+
+	// approvalUpdate is used to update the larkApproval status
+	approvalUpdate := func(larkApproval *models.LarkApproval) (done, isApprove bool, err error) {
+		// userUpdated represents whether the user status has been updated
+		userUpdated := false
+		for i, node := range larkApproval.ApprovalNodes {
+			if node.RejectOrApprove != "" {
+				continue
+			}
+			resultMap := larkservice.GetLarkApprovalInstanceManager(instance).GetNodeUserApprovalResults(lark.ApprovalNodeIDKey(i))
+			for _, user := range node.ApproveUsers {
+				if result, ok := resultMap[user.ID]; ok && user.RejectOrApprove == "" {
+					instanceData, err := client.GetApprovalInstance(&lark.GetApprovalInstanceArgs{InstanceID: instance})
+					if err != nil {
+						return false, false, errors.Wrap(err, "get larkApproval instance")
+					}
+
+					comment := ""
+					// nodeKeyMap is used to get the node key from the custom node key
+					nodeKeyMap := larkservice.GetLarkApprovalInstanceManager(instance).GetNodeKeyMap()
+					if nodeData, ok := instanceData.ApproverInfoWithNode[nodeKeyMap[lark.ApprovalNodeIDKey(i)]]; ok {
+						if userData, ok := nodeData[user.ID]; ok {
+							comment = userData.Comment
+						}
+					}
+					user.Comment = comment
+					user.RejectOrApprove = result.ApproveOrReject
+					user.OperationTime = result.OperationTime
+					userUpdated = true
+				}
+			}
+			node.RejectOrApprove, err = checkNodeStatus(node)
+			if err != nil {
+				return false, false, err
+			}
+			if node.RejectOrApprove == config.Approve {
+				break
+			}
+			if node.RejectOrApprove == config.Reject {
+				return true, false, nil
+			}
+			if userUpdated {
+				break
+			}
+		}
+
+		finalResult := larkApproval.ApprovalNodes[len(larkApproval.ApprovalNodes)-1].RejectOrApprove
+		return finalResult != "", finalResult == config.Approve, nil
+	}
+
+	done, isApprove, err := approvalUpdate(larkApproval)
+	if err != nil {
+		return errors.Wrap(err, "check larkApproval status")
+	}
+	if done {
+		finalInstance, err := client.GetApprovalInstance(&lark.GetApprovalInstanceArgs{InstanceID: instance})
+		if err != nil {
+			return errors.Wrap(err, "get larkApproval final instance")
+		}
+		if finalInstance.ApproveOrReject == config.Approve && isApprove {
+			approval.Status = config.StatusPassed
+			return nil
+		}
+		if finalInstance.ApproveOrReject == config.Reject && !isApprove {
+			approval.Status = config.StatusReject
+			return errors.New("Approval has been rejected")
+		}
+		return errors.New("check final larkApproval status failed")
+	}
+	return nil
+}

--- a/pkg/microservice/aslan/core/release_plan/service/approval.go
+++ b/pkg/microservice/aslan/core/release_plan/service/approval.go
@@ -288,6 +288,7 @@ func updateNativeApproval(ctx context.Context, approval *models.Approval) error 
 
 	approveWithL, ok := approvalservice.GlobalApproveMap.GetApproval(approval.NativeApproval.InstanceCode)
 	if !ok {
+		log.Infof("updateNativeApproval: approval instance code %s not found, set it", approval.NativeApproval.InstanceCode)
 		approvalservice.GlobalApproveMap.SetApproval(approval.NativeApproval.InstanceCode, &approvalservice.ApproveWithLock{Approval: approval.NativeApproval})
 	}
 

--- a/pkg/microservice/aslan/core/release_plan/service/approval.go
+++ b/pkg/microservice/aslan/core/release_plan/service/approval.go
@@ -291,6 +291,7 @@ func updateNativeApproval(ctx context.Context, approval *models.Approval) error 
 		approvalservice.GlobalApproveMap.SetApproval(approval.NativeApproval.InstanceCode, &approvalservice.ApproveWithLock{Approval: approval.NativeApproval})
 	}
 
+	approval.NativeApproval = approveWithL.Approval
 	approved, _, err := approveWithL.IsApproval()
 	if err != nil {
 		approval.Status = config.StatusReject

--- a/pkg/microservice/aslan/core/release_plan/service/approval.html
+++ b/pkg/microservice/aslan/core/release_plan/service/approval.html
@@ -1,0 +1,41 @@
+<head>
+  <meta charset="UTF-8">
+</head>
+<div>
+    <div>
+        <table style="width:100%; max-width: 1024px;">
+            <tbody>
+            <tr>
+                <td style="font-weight: 300; font-size: 18px; text-align:left; border-bottom: 1px solid #f0f0f0;">您好</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div>
+    <div style="margin-bottom: 5px; ">
+        <h3 style="font-size:18px;font-weight: 300;text-align:left; ">发布计划 <b>{{.PlanName}}</b> 需要您审批，基本信息如下:</h3>
+    </div>
+    <div class="card-body">
+        <table style="width:100%; max-width: 1024px;">
+            <tbody>
+            <tr>
+                <td style="font-weight: 300; font-size: 18px; text-align:left; "><a href="{{.Url}}" target="_blank">立即审批</a></td>
+            </tr>
+            <tr>
+              <ul>
+                <li>发布负责人: {{.Manager}}</li>
+                <li>发布窗口期: {{.TimeRange}}</li>
+                <li>需求关联:<br> {{.Description}}</li>
+              </ul>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div style="margin: 20px auto;font-size:90%">
+    <p style="text-align: left">本邮件由 Zadig 系统自动发出，请勿直接回复。</p>
+    <p style="text-align: left">Made By Zadig Team ♥ Happy Coding.</p>
+</div>

--- a/pkg/microservice/aslan/core/release_plan/service/execute.go
+++ b/pkg/microservice/aslan/core/release_plan/service/execute.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 The KodeRover Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+const ()
+
+type ReleaseJobExecutor interface {
+	Execute(args *ExecuteReleaseJobArgs) error
+}
+
+func NewReleaseJobExecutor(args *ExecuteReleaseJobArgs) (ReleaseJobExecutor, error) {
+	switch args.
+}

--- a/pkg/microservice/aslan/core/release_plan/service/execute.go
+++ b/pkg/microservice/aslan/core/release_plan/service/execute.go
@@ -25,8 +25,6 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 )
 
-const ()
-
 type ReleaseJobExecutor interface {
 	Execute(plan *models.ReleasePlan) error
 }

--- a/pkg/microservice/aslan/core/release_plan/service/execute.go
+++ b/pkg/microservice/aslan/core/release_plan/service/execute.go
@@ -16,12 +16,110 @@
 
 package service
 
+import (
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+)
+
 const ()
 
 type ReleaseJobExecutor interface {
-	Execute(args *ExecuteReleaseJobArgs) error
+	Execute(plan *models.ReleasePlan) error
 }
 
-func NewReleaseJobExecutor(args *ExecuteReleaseJobArgs) (ReleaseJobExecutor, error) {
-	switch args.
+func NewReleaseJobExecutor(username string, args *ExecuteReleaseJobArgs) (ReleaseJobExecutor, error) {
+	switch config.ReleasePlanJobType(args.Type) {
+	case config.JobText:
+		return NewTextReleaseJobExecutor(username, args)
+	case config.JobWorkflow:
+		return NewWorkflowReleaseJobExecutor(username, args)
+	default:
+		return nil, errors.Errorf("invalid release job type: %s", args.Type)
+	}
+}
+
+type TextReleaseJobExecutor struct {
+	ID         string
+	ExecutedBy string
+	Spec       TextReleaseJobSpec
+}
+
+type TextReleaseJobSpec struct {
+	Remark string `json:"remark"`
+}
+
+func NewTextReleaseJobExecutor(username string, args *ExecuteReleaseJobArgs) (ReleaseJobExecutor, error) {
+	var executor TextReleaseJobExecutor
+	if err := models.IToi(args.Spec, &executor.Spec); err != nil {
+		return nil, errors.Wrap(err, "invalid spec")
+	}
+	executor.ID = args.ID
+	executor.ExecutedBy = username
+	return &executor, nil
+}
+
+func (e *TextReleaseJobExecutor) Execute(plan *models.ReleasePlan) error {
+	spec := new(models.TextReleaseJobSpec)
+	for _, job := range plan.Jobs {
+		if job.ID != e.ID {
+			continue
+		}
+		if err := models.IToi(job.Spec, spec); err != nil {
+			return errors.Wrap(err, "invalid spec")
+		}
+		if job.Status != config.ReleasePlanJobStatusTodo {
+			return errors.Errorf("job %s status is not todo", e.ID)
+		}
+		spec.Remark = e.Spec.Remark
+		job.Spec = spec
+		job.Status = config.ReleasePlanJobStatusDone
+		job.ExecutedBy = e.ExecutedBy
+		job.ExecutedTime = time.Now().Unix()
+		return nil
+	}
+	return errors.Errorf("job %s not found", e.ID)
+}
+
+type WorkflowReleaseJobExecutor struct {
+	ID         string
+	ExecutedBy string
+	Spec       WorkflowReleaseJobSpec
+}
+
+type WorkflowReleaseJobSpec struct {
+	TaskID int64 `json:"task_id"`
+}
+
+func NewWorkflowReleaseJobExecutor(username string, args *ExecuteReleaseJobArgs) (ReleaseJobExecutor, error) {
+	var executor WorkflowReleaseJobExecutor
+	if err := models.IToi(args.Spec, &executor.Spec); err != nil {
+		return nil, errors.Wrap(err, "invalid spec")
+	}
+	executor.ID = args.ID
+	executor.ExecutedBy = username
+	return &executor, nil
+}
+
+func (e *WorkflowReleaseJobExecutor) Execute(plan *models.ReleasePlan) error {
+	spec := new(models.WorkflowReleaseJobSpec)
+	for _, job := range plan.Jobs {
+		if job.ID != e.ID {
+			continue
+		}
+		if err := models.IToi(job.Spec, spec); err != nil {
+			return errors.Wrap(err, "invalid spec")
+		}
+		if job.Status != config.ReleasePlanJobStatusTodo {
+			return errors.Errorf("job %s status is not todo", e.ID)
+		}
+		spec.TaskID = e.Spec.TaskID
+		job.Spec = spec
+		job.Status = config.ReleasePlanJobStatusRunning
+		return nil
+	}
+	return errors.Errorf("job %s not found", e.ID)
 }

--- a/pkg/microservice/aslan/core/release_plan/service/lint.go
+++ b/pkg/microservice/aslan/core/release_plan/service/lint.go
@@ -51,7 +51,12 @@ func lintWorkflow(workflow *models.WorkflowV4) error {
 	if workflow == nil {
 		return fmt.Errorf("workflow cannot be empty")
 	}
-	for _, stage := range workflow.Stages {
+	// ToJobs will change raw workflow data, so we need to copy it
+	tmp := new(models.WorkflowV4)
+	if err := models.IToi(workflow, tmp); err != nil {
+		return fmt.Errorf("IToi tmp workflow error: %v", err)
+	}
+	for _, stage := range tmp.Stages {
 		for _, job := range stage.Jobs {
 			if jobctl.JobSkiped(job) {
 				continue

--- a/pkg/microservice/aslan/core/release_plan/service/lint.go
+++ b/pkg/microservice/aslan/core/release_plan/service/lint.go
@@ -61,9 +61,13 @@ func lintWorkflow(workflow *models.WorkflowV4) error {
 			if jobctl.JobSkiped(job) {
 				continue
 			}
-			_, err := jobctl.ToJobs(job, workflow, 0)
+			err := jobctl.LintJob(job, workflow)
 			if err != nil {
-				return fmt.Errorf("invalid job-%s, err: %v", job.Name, err)
+				return fmt.Errorf("lint job-%s err: %v", job.Name, err)
+			}
+			_, err = jobctl.ToJobs(job, workflow, 0)
+			if err != nil {
+				return fmt.Errorf("lint job-%s runtime err: %v", job.Name, err)
 			}
 		}
 	}

--- a/pkg/microservice/aslan/core/release_plan/service/lint.go
+++ b/pkg/microservice/aslan/core/release_plan/service/lint.go
@@ -28,8 +28,8 @@ import (
 	jobctl "github.com/koderover/zadig/pkg/microservice/aslan/core/workflow/service/workflow/job"
 )
 
-func lintReleaseJob(_type string, spec interface{}) error {
-	switch config.ReleasePlanJobType(_type) {
+func lintReleaseJob(_type config.ReleasePlanJobType, spec interface{}) error {
+	switch _type {
 	case config.JobText:
 		t := new(models.TextReleaseJobSpec)
 		if err := models.IToi(spec, t); err != nil {

--- a/pkg/microservice/aslan/core/release_plan/service/lint.go
+++ b/pkg/microservice/aslan/core/release_plan/service/lint.go
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2023 The KodeRover Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	jobctl "github.com/koderover/zadig/pkg/microservice/aslan/core/workflow/service/workflow/job"
+)
+
+func lintReleaseJob(_type string, spec interface{}) error {
+	switch config.ReleasePlanJobType(_type) {
+	case config.JobText:
+		t := new(models.TextReleaseJobSpec)
+		if err := models.IToi(spec, t); err != nil {
+			return fmt.Errorf("invalid text spec: %v", err)
+		}
+		return nil
+	case config.JobWorkflow:
+		w := new(models.WorkflowReleaseJobSpec)
+		if err := models.IToi(spec, w); err != nil {
+			return fmt.Errorf("invalid workflow spec: %v", err)
+		}
+		return lintWorkflow(w.Workflow)
+	default:
+		return fmt.Errorf("invalid release job type: %s", _type)
+	}
+}
+
+func lintWorkflow(workflow *models.WorkflowV4) error {
+	if workflow == nil {
+		return fmt.Errorf("workflow cannot be empty")
+	}
+	for _, stage := range workflow.Stages {
+		for _, job := range stage.Jobs {
+			if jobctl.JobSkiped(job) {
+				continue
+			}
+			_, err := jobctl.ToJobs(job, workflow, 0)
+			if err != nil {
+				return fmt.Errorf("invalid job-%s, err: %v", job.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func lintApproval(approval *models.Approval) error {
+	if approval == nil {
+		return nil
+	}
+	if !approval.Enabled {
+		return nil
+	}
+	switch approval.Type {
+	case config.NativeApproval:
+		if approval.NativeApproval == nil {
+			return errors.New("approval not found")
+		}
+		if len(approval.NativeApproval.ApproveUsers) < approval.NativeApproval.NeededApprovers {
+			return errors.New("all approve users should not less than needed approvers")
+		}
+	case config.LarkApproval:
+		if approval.LarkApproval == nil {
+			return errors.New("approval not found")
+		}
+		if len(approval.LarkApproval.ApprovalNodes) == 0 {
+			return errors.New("num of approval-node is 0")
+		}
+		for i, node := range approval.LarkApproval.ApprovalNodes {
+			if len(node.ApproveUsers) == 0 {
+				return errors.Errorf("num of approval-node %d approver is 0", i)
+			}
+			if !lo.Contains([]string{"AND", "OR"}, string(node.Type)) {
+				return errors.Errorf("approval-node %d type should be AND or OR", i)
+			}
+		}
+	case config.DingTalkApproval:
+		if approval.DingTalkApproval == nil {
+			return errors.New("approval not found")
+		}
+		userIDSets := sets.NewString()
+		if len(approval.DingTalkApproval.ApprovalNodes) > 20 {
+			return errors.New("num of approval-node should not exceed 20")
+		}
+		if len(approval.DingTalkApproval.ApprovalNodes) == 0 {
+			return errors.New("num of approval-node is 0")
+		}
+		for i, node := range approval.DingTalkApproval.ApprovalNodes {
+			if len(node.ApproveUsers) == 0 {
+				return errors.Errorf("num of approval-node %d approver is 0", i)
+			}
+			for _, user := range node.ApproveUsers {
+				if userIDSets.Has(user.ID) {
+					return errors.Errorf("Duplicate approvers %s should not appear in a complete approval process", user.Name)
+				}
+				userIDSets.Insert(user.ID)
+			}
+			if !lo.Contains([]string{"AND", "OR"}, string(node.Type)) {
+				return errors.Errorf("approval-node %d type should be AND or OR", i)
+			}
+		}
+	default:
+		return errors.Errorf("invalid approval type %s", approval.Type)
+	}
+
+	return nil
+}

--- a/pkg/microservice/aslan/core/release_plan/service/lock.go
+++ b/pkg/microservice/aslan/core/release_plan/service/lock.go
@@ -19,14 +19,17 @@ package service
 import "sync"
 
 var (
-	globalLockMap = make(map[string]sync.RWMutex)
+	globalLockMap = make(map[string]*sync.RWMutex)
+	globalLock    = sync.RWMutex{}
 )
 
-func GetLock(key string) sync.RWMutex {
-	if lock, ok := globalLockMap[key]; ok {
-		return lock
+func getLock(key string) *sync.RWMutex {
+	globalLock.Lock()
+	defer globalLock.Unlock()
+	if mu, ok := globalLockMap[key]; ok {
+		return mu
 	}
-	lock := sync.RWMutex{}
-	globalLockMap[key] = lock
-	return lock
+	mu := &sync.RWMutex{}
+	globalLockMap[key] = mu
+	return mu
 }

--- a/pkg/microservice/aslan/core/release_plan/service/lock.go
+++ b/pkg/microservice/aslan/core/release_plan/service/lock.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 The KodeRover Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import "sync"
+
+var (
+	globalLockMap = make(map[string]sync.RWMutex)
+)
+
+func GetLock(key string) sync.RWMutex {
+	if lock, ok := globalLockMap[key]; ok {
+		return lock
+	}
+	lock := sync.RWMutex{}
+	globalLockMap[key] = lock
+	return lock
+}

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2023 The KodeRover Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
@@ -122,12 +123,12 @@ func GetReleasePlan(id string) (*models.ReleasePlan, error) {
 	return mongodb.NewReleasePlanColl().GetByID(context.Background(), id)
 }
 
-func DeleteReleasePlan(username, id string) error {
+func DeleteReleasePlan(c *gin.Context, username, id string) error {
 	info, err := mongodb.NewReleasePlanColl().GetByID(context.Background(), id)
 	if err != nil {
 		return errors.Wrap(err, "get plan")
 	}
-	internalhandler.InsertOperationLog(nil, username, "", "删除", "发布计划", info.Name, "", log.SugaredLogger())
+	internalhandler.InsertOperationLog(c, username, "", "删除", "发布计划", info.Name, "", log.SugaredLogger())
 	return mongodb.NewReleasePlanColl().DeleteByID(context.Background(), id)
 }
 

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -368,8 +368,8 @@ func ApproveReleasePlan(c *handler.Context, id string, req *ApproveRequest) erro
 	switch plan.Approval.Status {
 	case config.StatusPassed:
 		plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
-			Verb:       VerbUpdate,
-			TargetName: plan.Name,
+			Verb: VerbUpdate,
+			//TargetName: plan.Name,
 			TargetType: TargetTypeReleasePlanStatus,
 			Detail:     "审批通过",
 			CreatedAt:  time.Now().Unix(),
@@ -379,8 +379,8 @@ func ApproveReleasePlan(c *handler.Context, id string, req *ApproveRequest) erro
 		setReleaseJobsForExecuting(plan)
 	case config.StatusReject:
 		plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
-			Verb:       VerbUpdate,
-			TargetName: plan.Name,
+			Verb: VerbUpdate,
+			//TargetName: plan.Name,
 			TargetType: TargetTypeReleasePlanStatus,
 			Detail:     "审批拒绝",
 			CreatedAt:  time.Now().Unix(),

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -55,6 +55,13 @@ func CreateReleasePlan(creator string, args *models.ReleasePlan) error {
 		job.ID = uuid.New().String()
 	}
 
+	if args.Approval != nil {
+		// todo create approval
+		if err := lintApproval(args.Approval); err != nil {
+			return errors.Errorf("lintApproval error: %v", err)
+		}
+	}
+
 	nextID, err := mongodb.NewCounterColl().GetNextSeq(setting.WorkflowTaskV4Fmt)
 	if err != nil {
 		log.Errorf("CreateReleasePlan.GetNextSeq error: %v", err)

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -15,3 +15,69 @@
  */
 
 package service
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
+	"github.com/koderover/zadig/pkg/setting"
+	e "github.com/koderover/zadig/pkg/tool/errors"
+	"github.com/koderover/zadig/pkg/tool/log"
+)
+
+//type CreateReleasePlanResp struct {
+//	ID string `json:"id"`
+//}
+
+func CreateReleasePlan(creator string, args *models.ReleasePlan) error {
+	if args.Name == "" || args.PrincipalID == "" {
+		return errors.New("Required parameters are missing")
+	}
+	if args.StartTime > args.EndTime || args.EndTime < time.Now().Unix() {
+		return errors.New("Invalid release time range")
+	}
+
+	nextID, err := mongodb.NewCounterColl().GetNextSeq(setting.WorkflowTaskV4Fmt)
+	if err != nil {
+		log.Errorf("CreateReleasePlan.GetNextSeq error: %v", err)
+		return e.ErrGetCounter.AddDesc(err.Error())
+	}
+	args.Index = nextID
+	args.CreatedBy = creator
+	args.UpdatedBy = creator
+	args.CreateTime = time.Now().Unix()
+	args.UpdateTime = time.Now().Unix()
+
+	return mongodb.NewReleasePlanColl().Create(args)
+}
+
+type ListReleasePlanResp struct {
+	List  []*models.ReleasePlan `json:"list"`
+	Total int64
+}
+
+func ListReleasePlans(pageNum, pageSize int64) (*ListReleasePlanResp, error) {
+	list, total, err := mongodb.NewReleasePlanColl().ListByOptions(&mongodb.ListReleasePlanOption{
+		PageNum:  pageNum,
+		PageSize: pageSize,
+		IsSort:   true,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "ListReleasePlans")
+	}
+	return &ListReleasePlanResp{
+		List:  list,
+		Total: total,
+	}, nil
+}
+
+func GetReleasePlan(id string) (*models.ReleasePlan, error) {
+	return mongodb.NewReleasePlanColl().GetByID(id)
+}
+
+func UpdateReleasePlan(id string) error {
+
+}

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -349,7 +349,8 @@ func ApproveReleasePlan(c *handler.Context, id string, req *ApproveRequest) erro
 	if !ok {
 		// restore data after restart aslan
 		log.Infof("updateNativeApproval: approval instance code %s not found, set it", plan.Approval.NativeApproval.InstanceCode)
-		approvalservice.GlobalApproveMap.SetApproval(plan.Approval.NativeApproval.InstanceCode, &approvalservice.ApproveWithLock{Approval: plan.Approval.NativeApproval})
+		approveWithL = &approvalservice.ApproveWithLock{Approval: plan.Approval.NativeApproval}
+		approvalservice.GlobalApproveMap.SetApproval(plan.Approval.NativeApproval.InstanceCode, approveWithL)
 	}
 	if err = approveWithL.DoApproval(c.UserName, c.UserID, req.Comment, req.Approve); err != nil {
 		return errors.Wrap(err, "do approval")

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -276,7 +276,7 @@ func UpdateReleasePlanStatus(c *handler.Context, id, status string) error {
 	case config.StatusPlanning:
 		for _, job := range plan.Jobs {
 			job.LastStatus = job.Status
-			job.Status = ""
+			job.Status = config.ReleasePlanJobStatusTodo
 			job.Updated = false
 		}
 	case config.StatusExecuting:

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -312,6 +312,7 @@ func UpdateReleasePlanStatus(c *handler.Context, id, status string) error {
 		Detail:     detail,
 		Before:     plan.Status,
 		After:      status,
+		CreatedAt:  time.Now().Unix(),
 	})
 	plan.Status = config.ReleasePlanStatus(status)
 

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -368,8 +368,7 @@ func ApproveReleasePlan(c *handler.Context, id string, req *ApproveRequest) erro
 	switch plan.Approval.Status {
 	case config.StatusPassed:
 		plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
-			Verb: VerbUpdate,
-			//TargetName: plan.Name,
+			Verb:       VerbUpdate,
 			TargetType: TargetTypeReleasePlanStatus,
 			Detail:     "审批通过",
 			CreatedAt:  time.Now().Unix(),
@@ -379,8 +378,7 @@ func ApproveReleasePlan(c *handler.Context, id string, req *ApproveRequest) erro
 		setReleaseJobsForExecuting(plan)
 	case config.StatusReject:
 		plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
-			Verb: VerbUpdate,
-			//TargetName: plan.Name,
+			Verb:       VerbUpdate,
 			TargetType: TargetTypeReleasePlanStatus,
 			Detail:     "审批拒绝",
 			CreatedAt:  time.Now().Unix(),

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -64,7 +64,6 @@ func CreateReleasePlan(c *handler.Context, args *models.ReleasePlan) error {
 	}
 
 	if args.Approval != nil {
-		// todo create approval
 		if err := lintApproval(args.Approval); err != nil {
 			return errors.Errorf("lintApproval error: %v", err)
 		}
@@ -75,7 +74,7 @@ func CreateReleasePlan(c *handler.Context, args *models.ReleasePlan) error {
 		}
 	}
 
-	nextID, err := mongodb.NewCounterColl().GetNextSeq(setting.WorkflowTaskV4Fmt)
+	nextID, err := mongodb.NewCounterColl().GetNextSeq(setting.ReleasePlanFmt)
 	if err != nil {
 		log.Errorf("CreateReleasePlan.GetNextSeq error: %v", err)
 		return e.ErrGetCounter.AddDesc(err.Error())
@@ -92,8 +91,6 @@ func CreateReleasePlan(c *handler.Context, args *models.ReleasePlan) error {
 		Verb:       VerbCreate,
 		TargetName: args.Name,
 		TargetType: TargetTypeReleasePlan,
-		Before:     nil,
-		After:      nil,
 		CreatedAt:  time.Now().Unix(),
 	})
 

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -269,7 +269,7 @@ func UpdateReleasePlanStatus(c *handler.Context, id, status string) error {
 		return errors.Wrap(err, "get user")
 	}
 
-	targetName := plan.Name + "状态"
+	//targetName := plan.Name + "状态"
 	detail := ""
 
 	// target status check and update
@@ -304,10 +304,10 @@ func UpdateReleasePlanStatus(c *handler.Context, id, status string) error {
 		plan.PlanningTime = time.Now().Unix()
 	}
 	plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
-		Username:   c.UserName,
-		Account:    c.Account,
-		Verb:       VerbUpdate,
-		TargetName: targetName,
+		Username: c.UserName,
+		Account:  c.Account,
+		Verb:     VerbUpdate,
+		//TargetName: targetName,
 		TargetType: TargetTypeReleasePlanStatus,
 		Detail:     detail,
 		Before:     plan.Status,
@@ -376,6 +376,7 @@ func ApproveReleasePlan(c *handler.Context, id string, req *ApproveRequest) erro
 		})
 		plan.Status = config.StatusExecuting
 		plan.ApprovalTime = time.Now().Unix()
+		setReleaseJobsForExecuting(plan)
 	case config.StatusReject:
 		plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
 			Verb:       VerbUpdate,

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -272,6 +272,7 @@ func UpdateReleasePlanStatus(c *handler.Context, id, status string) error {
 	targetName := plan.Name + "状态"
 	detail := ""
 
+	// target status check and update
 	switch config.ReleasePlanStatus(status) {
 	case config.StatusPlanning:
 		for _, job := range plan.Jobs {
@@ -293,10 +294,14 @@ func UpdateReleasePlanStatus(c *handler.Context, id, status string) error {
 		}
 	}
 
+	// original status check and update
 	switch plan.Status {
+	// other status will not be done by this function
 	case config.StatusPlanning:
+		if len(plan.Jobs) == 0 {
+			return errors.Errorf("plan must not have no jobs")
+		}
 		plan.PlanningTime = time.Now().Unix()
-		// other status will not be done by this function
 	}
 	plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
 		Username:   c.UserName,

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -28,9 +28,8 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
-	"github.com/koderover/zadig/pkg/microservice/user/core/repository"
-	"github.com/koderover/zadig/pkg/microservice/user/core/repository/orm"
 	"github.com/koderover/zadig/pkg/setting"
+	"github.com/koderover/zadig/pkg/shared/client/user"
 	"github.com/koderover/zadig/pkg/shared/handler"
 	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
 	e "github.com/koderover/zadig/pkg/tool/errors"
@@ -48,12 +47,12 @@ func CreateReleasePlan(c *handler.Context, args *models.ReleasePlan) error {
 	if args.StartTime > args.EndTime || args.EndTime < time.Now().Unix() {
 		return errors.New("Invalid release time range")
 	}
-	user, err := orm.GetUserByUid(args.ManagerID, repository.DB)
-	if err != nil || user == nil {
+	userInfo, err := user.New().GetUserByID(args.ManagerID)
+	if err != nil {
 		return errors.Errorf("Failed to get user by id %s, error: %v", args.ManagerID, err)
 	}
-	if args.Manager != user.Name {
-		return errors.Errorf("Manager %s is not consistent with the user name %s", args.Manager, user.Name)
+	if args.Manager != userInfo.Name {
+		return errors.Errorf("Manager %s is not consistent with the user name %s", args.Manager, userInfo.Name)
 	}
 
 	for _, job := range args.Jobs {
@@ -262,7 +261,7 @@ func UpdateReleasePlanStatus(c *handler.Context, id, status string) error {
 		return errors.Errorf("can't convert plan status %s to %s", plan.Status, status)
 	}
 
-	userInfo, err := orm.GetUserByUid(c.UserID, repository.DB)
+	userInfo, err := user.New().GetUserByID(c.UserID)
 	if err != nil {
 		return errors.Wrap(err, "get user")
 	}

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -347,7 +347,9 @@ func ApproveReleasePlan(c *handler.Context, id string, req *ApproveRequest) erro
 
 	approveWithL, ok := approvalservice.GlobalApproveMap.GetApproval(plan.Approval.NativeApproval.InstanceCode)
 	if !ok {
-		return errors.Errorf("can not find native approval instance %s", plan.Approval.NativeApproval.InstanceCode)
+		// restore data after restart aslan
+		log.Infof("updateNativeApproval: approval instance code %s not found, set it", plan.Approval.NativeApproval.InstanceCode)
+		approvalservice.GlobalApproveMap.SetApproval(plan.Approval.NativeApproval.InstanceCode, &approvalservice.ApproveWithLock{Approval: plan.Approval.NativeApproval})
 	}
 	if err = approveWithL.DoApproval(c.UserName, c.UserID, req.Comment, req.Approve); err != nil {
 		return errors.Wrap(err, "do approval")

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -107,7 +107,7 @@ func ListReleasePlans(pageNum, pageSize int64) (*ListReleasePlanResp, error) {
 		PageNum:        pageNum,
 		PageSize:       pageSize,
 		IsSort:         true,
-		ExcludedFields: []string{"jobs", "approval", "logs"},
+		ExcludedFields: []string{"jobs", "logs"},
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "ListReleasePlans")

--- a/pkg/microservice/aslan/core/release_plan/service/update.go
+++ b/pkg/microservice/aslan/core/release_plan/service/update.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	VerbUpdateName      = "update_name"
-	VerbUpdateDesc      = "update_desc"
+	VerbUpdateDesc      = "update_description"
 	VerbUpdateTimeRange = "update_time_range"
 	VerbUpdateManager   = "update_manager"
 

--- a/pkg/microservice/aslan/core/release_plan/service/update.go
+++ b/pkg/microservice/aslan/core/release_plan/service/update.go
@@ -28,8 +28,7 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	larkservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/lark"
-	"github.com/koderover/zadig/pkg/microservice/user/core/repository"
-	"github.com/koderover/zadig/pkg/microservice/user/core/repository/orm"
+	"github.com/koderover/zadig/pkg/shared/client/user"
 	"github.com/koderover/zadig/pkg/tool/lark"
 	"github.com/koderover/zadig/pkg/tool/log"
 )
@@ -237,11 +236,11 @@ func (u *ManagerUpdater) Lint() error {
 	if u.ManagerID == "" {
 		return fmt.Errorf("manager_id cannot be empty")
 	}
-	user, err := orm.GetUserByUid(u.ManagerID, repository.DB)
-	if err != nil || user == nil {
+	userInfo, err := user.New().GetUserByID(u.ManagerID)
+	if err != nil {
 		return fmt.Errorf("user not found")
 	}
-	if u.Name != user.Name {
+	if u.Name != userInfo.Name {
 		return fmt.Errorf("name not match")
 	}
 	return nil

--- a/pkg/microservice/aslan/core/release_plan/service/update.go
+++ b/pkg/microservice/aslan/core/release_plan/service/update.go
@@ -42,7 +42,8 @@ const (
 )
 
 type PlanUpdater interface {
-	Update(plan *models.ReleasePlan) error
+	// Update returns the old data and the updated data
+	Update(plan *models.ReleasePlan) (before interface{}, after interface{}, err error)
 	Lint() error
 }
 
@@ -81,9 +82,10 @@ func NewNameUpdater(args *UpdateReleasePlanArgs) (*NameUpdater, error) {
 	return &updater, nil
 }
 
-func (u *NameUpdater) Update(plan *models.ReleasePlan) error {
+func (u *NameUpdater) Update(plan *models.ReleasePlan) (before interface{}, after interface{}, err error) {
+	before, after = plan.Name, u.Name
 	plan.Name = u.Name
-	return nil
+	return
 }
 
 func (u *NameUpdater) Lint() error {
@@ -105,9 +107,10 @@ func NewDescUpdater(args *UpdateReleasePlanArgs) (*DescUpdater, error) {
 	return &updater, nil
 }
 
-func (u *DescUpdater) Update(plan *models.ReleasePlan) error {
+func (u *DescUpdater) Update(plan *models.ReleasePlan) (before interface{}, after interface{}, err error) {
+	before, after = plan.Description, u.Description
 	plan.Description = u.Description
-	return nil
+	return
 }
 
 func (u *DescUpdater) Lint() error {
@@ -127,7 +130,9 @@ func NewTimeRangeUpdater(args *UpdateReleasePlanArgs) (*TimeRangeUpdater, error)
 	return &updater, nil
 }
 
-func (u *TimeRangeUpdater) Update(plan *models.ReleasePlan) error {
+func (u *TimeRangeUpdater) Update(plan *models.ReleasePlan) (before interface{}, after interface{}, err error) {
+
+	before, after = fmt.Sprintf("%s-%s", time.Unix(plan.StartTime, 0).Format("2006-01-02 15:04:05"), plan.EndTime), fmt.Sprintf("%d-%d", u.StartTime, u.EndTime
 	plan.StartTime = u.StartTime
 	plan.EndTime = u.EndTime
 	return nil
@@ -159,7 +164,7 @@ func NewManagerUpdater(args *UpdateReleasePlanArgs) (*ManagerUpdater, error) {
 	return &updater, nil
 }
 
-func (u *ManagerUpdater) Update(plan *models.ReleasePlan) error {
+func (u *ManagerUpdater) Update(plan *models.ReleasePlan) (before interface{}, after interface{}, err error) {
 	plan.ManagerID = u.ManagerID
 	plan.Manager = u.Name
 	return nil
@@ -193,7 +198,7 @@ func NewCreateReleaseJobUpdater(args *UpdateReleasePlanArgs) (*CreateReleaseJobU
 	return &updater, nil
 }
 
-func (u *CreateReleaseJobUpdater) Update(plan *models.ReleasePlan) error {
+func (u *CreateReleaseJobUpdater) Update(plan *models.ReleasePlan) (before interface{}, after interface{}, err error) {
 	job := &models.ReleaseJob{
 		ID:   uuid.New().String(),
 		Name: u.Name,
@@ -227,7 +232,7 @@ func NewUpdateReleaseJobUpdater(args *UpdateReleasePlanArgs) (*UpdateReleaseJobU
 	return &updater, nil
 }
 
-func (u *UpdateReleaseJobUpdater) Update(plan *models.ReleasePlan) error {
+func (u *UpdateReleaseJobUpdater) Update(plan *models.ReleasePlan) (before interface{}, after interface{}, err error) {
 	for _, job := range plan.Jobs {
 		if job.ID == u.ID {
 			if job.Type != u.Type {
@@ -263,7 +268,7 @@ func NewDeleteReleaseJobUpdater(args *UpdateReleasePlanArgs) (*DeleteReleaseJobU
 	return &updater, nil
 }
 
-func (u *DeleteReleaseJobUpdater) Update(plan *models.ReleasePlan) error {
+func (u *DeleteReleaseJobUpdater) Update(plan *models.ReleasePlan) (before interface{}, after interface{}, err error) {
 	for i, job := range plan.Jobs {
 		if job.ID == u.ID {
 			plan.Jobs = append(plan.Jobs[:i], plan.Jobs[i+1:]...)
@@ -292,7 +297,7 @@ func NewUpdateApprovalUpdater(args *UpdateReleasePlanArgs) (*UpdateApprovalUpdat
 	return &updater, nil
 }
 
-func (u *UpdateApprovalUpdater) Update(plan *models.ReleasePlan) error {
+func (u *UpdateApprovalUpdater) Update(plan *models.ReleasePlan) (before interface{}, after interface{}, err error) {
 	plan.Approval = u.Approval
 	return nil
 }

--- a/pkg/microservice/aslan/core/release_plan/service/update.go
+++ b/pkg/microservice/aslan/core/release_plan/service/update.go
@@ -51,6 +51,7 @@ const (
 	TargetTypeMetadata          = "元数据"
 	TargetTypeReleaseJob        = "发布任务"
 	TargetTypeApproval          = "审批"
+	TargetTypeDescription       = "需求关联"
 
 	VerbCreate  = "新建"
 	VerbUpdate  = "更新"
@@ -156,7 +157,7 @@ func (u *DescUpdater) TargetName() string {
 }
 
 func (u *DescUpdater) TargetType() string {
-	return TargetTypeMetadata
+	return TargetTypeDescription
 }
 
 func (u *DescUpdater) Verb() string {

--- a/pkg/microservice/aslan/core/release_plan/service/update.go
+++ b/pkg/microservice/aslan/core/release_plan/service/update.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 The KodeRover Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+)
+
+const (
+	VerbUpdateName      = "update_name"
+	VerbUpdateDesc      = "update_desc"
+	VerbUpdateTimeRange = "update_time_range"
+	VerbUpdatePrincipal = "update_principal"
+)
+
+type PlanUpdater interface {
+	Update(plan *models.ReleasePlan) error
+	Lint() error
+}
+
+func NewPlanUpdater(args *UpdateReleasePlanArgs) (PlanUpdater, error) {
+	switch args.Verb {
+	case VerbUpdateName:
+		return NewNameUpdater(args)
+	case VerbUpdateDesc:
+		return NewDescUpdater(args)
+	case VerbUpdateTimeRange:
+		return NewTimeRangeUpdater(args)
+	case VerbUpdatePrincipal:
+		return NewPrincipalUpdater(args)
+	default:
+		return nil, fmt.Errorf("invalid verb: %s", args.Verb)
+	}
+}
+
+type NameUpdater struct {
+	Name string `json:"name"`
+}
+
+func NewNameUpdater(args *UpdateReleasePlanArgs) (*NameUpdater, error) {
+	var updater NameUpdater
+	if err := models.IToi(args.Spec, &updater); err != nil {
+		return nil, errors.Wrap(err, "invalid spec")
+	}
+	return &updater, nil
+}
+
+func (u *NameUpdater) Update(plan *models.ReleasePlan) error {
+	plan.Name = u.Name
+	return nil
+}
+
+func (u *NameUpdater) Lint() error {
+	if u.Name == "" {
+		return fmt.Errorf("name cannot be empty")
+	}
+	return nil
+}

--- a/pkg/microservice/aslan/core/release_plan/service/update.go
+++ b/pkg/microservice/aslan/core/release_plan/service/update.go
@@ -18,17 +18,27 @@ package service
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/pkg/microservice/user/core/repository"
+	"github.com/koderover/zadig/pkg/microservice/user/core/repository/orm"
 )
 
 const (
 	VerbUpdateName      = "update_name"
 	VerbUpdateDesc      = "update_desc"
 	VerbUpdateTimeRange = "update_time_range"
-	VerbUpdatePrincipal = "update_principal"
+	VerbUpdateManager   = "update_manager"
+
+	VerbCreateReleaseJob = "create_release_job"
+	VerbUpdateReleaseJob = "update_release_job"
+	VerbDeleteReleaseJob = "delete_release_job"
+
+	VerbUpdateApproval = "update_approval"
 )
 
 type PlanUpdater interface {
@@ -44,8 +54,16 @@ func NewPlanUpdater(args *UpdateReleasePlanArgs) (PlanUpdater, error) {
 		return NewDescUpdater(args)
 	case VerbUpdateTimeRange:
 		return NewTimeRangeUpdater(args)
-	case VerbUpdatePrincipal:
-		return NewPrincipalUpdater(args)
+	case VerbUpdateManager:
+		return NewManagerUpdater(args)
+	case VerbCreateReleaseJob:
+		return NewCreateReleaseJobUpdater(args)
+	case VerbUpdateReleaseJob:
+		return NewUpdateReleaseJobUpdater(args)
+	case VerbDeleteReleaseJob:
+		return NewDeleteReleaseJobUpdater(args)
+	case VerbUpdateApproval:
+		return NewUpdateApprovalUpdater(args)
 	default:
 		return nil, fmt.Errorf("invalid verb: %s", args.Verb)
 	}
@@ -73,4 +91,215 @@ func (u *NameUpdater) Lint() error {
 		return fmt.Errorf("name cannot be empty")
 	}
 	return nil
+}
+
+type DescUpdater struct {
+	Description string `json:"description"`
+}
+
+func NewDescUpdater(args *UpdateReleasePlanArgs) (*DescUpdater, error) {
+	var updater DescUpdater
+	if err := models.IToi(args.Spec, &updater); err != nil {
+		return nil, errors.Wrap(err, "invalid spec")
+	}
+	return &updater, nil
+}
+
+func (u *DescUpdater) Update(plan *models.ReleasePlan) error {
+	plan.Description = u.Description
+	return nil
+}
+
+func (u *DescUpdater) Lint() error {
+	return nil
+}
+
+type TimeRangeUpdater struct {
+	StartTime int64 `json:"start_time"`
+	EndTime   int64 `json:"end_time"`
+}
+
+func NewTimeRangeUpdater(args *UpdateReleasePlanArgs) (*TimeRangeUpdater, error) {
+	var updater TimeRangeUpdater
+	if err := models.IToi(args.Spec, &updater); err != nil {
+		return nil, errors.Wrap(err, "invalid spec")
+	}
+	return &updater, nil
+}
+
+func (u *TimeRangeUpdater) Update(plan *models.ReleasePlan) error {
+	plan.StartTime = u.StartTime
+	plan.EndTime = u.EndTime
+	return nil
+}
+
+func (u *TimeRangeUpdater) Lint() error {
+	if u.StartTime == 0 || u.EndTime == 0 {
+		return fmt.Errorf("start_time and end_time cannot be empty")
+	}
+	if u.StartTime >= u.EndTime {
+		return fmt.Errorf("start_time must be less than end_time")
+	}
+	if u.EndTime < time.Now().Unix() {
+		return fmt.Errorf("end_time must be greater than now")
+	}
+	return nil
+}
+
+type ManagerUpdater struct {
+	ManagerID string `json:"manager_id"`
+	Name      string `json:"name"`
+}
+
+func NewManagerUpdater(args *UpdateReleasePlanArgs) (*ManagerUpdater, error) {
+	var updater ManagerUpdater
+	if err := models.IToi(args.Spec, &updater); err != nil {
+		return nil, errors.Wrap(err, "invalid spec")
+	}
+	return &updater, nil
+}
+
+func (u *ManagerUpdater) Update(plan *models.ReleasePlan) error {
+	plan.ManagerID = u.ManagerID
+	plan.Manager = u.Name
+	return nil
+}
+
+func (u *ManagerUpdater) Lint() error {
+	if u.ManagerID == "" {
+		return fmt.Errorf("manager_id cannot be empty")
+	}
+	user, err := orm.GetUserByUid(u.ManagerID, repository.DB)
+	if err != nil || user == nil {
+		return fmt.Errorf("user not found")
+	}
+	if u.Name != user.Name {
+		return fmt.Errorf("name not match")
+	}
+	return nil
+}
+
+type CreateReleaseJobUpdater struct {
+	Name string      `json:"name"`
+	Type string      `json:"type"`
+	Spec interface{} `json:"spec"`
+}
+
+func NewCreateReleaseJobUpdater(args *UpdateReleasePlanArgs) (*CreateReleaseJobUpdater, error) {
+	var updater CreateReleaseJobUpdater
+	if err := models.IToi(args.Spec, &updater); err != nil {
+		return nil, errors.Wrap(err, "invalid spec")
+	}
+	return &updater, nil
+}
+
+func (u *CreateReleaseJobUpdater) Update(plan *models.ReleasePlan) error {
+	job := &models.ReleaseJob{
+		ID:   uuid.New().String(),
+		Name: u.Name,
+		Type: u.Type,
+		Spec: u.Spec,
+	}
+	plan.Jobs = append(plan.Jobs, job)
+	return nil
+}
+
+func (u *CreateReleaseJobUpdater) Lint() error {
+	if u.Name == "" {
+		return fmt.Errorf("name cannot be empty")
+	}
+
+	return lintReleaseJob(u.Type, u.Spec)
+}
+
+type UpdateReleaseJobUpdater struct {
+	ID   string      `json:"id"`
+	Name string      `json:"name"`
+	Type string      `json:"type"`
+	Spec interface{} `json:"spec"`
+}
+
+func NewUpdateReleaseJobUpdater(args *UpdateReleasePlanArgs) (*UpdateReleaseJobUpdater, error) {
+	var updater UpdateReleaseJobUpdater
+	if err := models.IToi(args.Spec, &updater); err != nil {
+		return nil, errors.Wrap(err, "invalid spec")
+	}
+	return &updater, nil
+}
+
+func (u *UpdateReleaseJobUpdater) Update(plan *models.ReleasePlan) error {
+	for _, job := range plan.Jobs {
+		if job.ID == u.ID {
+			if job.Type != u.Type {
+				return fmt.Errorf("job type cannot be changed")
+			}
+			job.Name = u.Name
+			job.Spec = u.Spec
+			return nil
+		}
+	}
+	return fmt.Errorf("job %s-%s not found", u.Name, u.ID)
+}
+
+func (u *UpdateReleaseJobUpdater) Lint() error {
+	if u.ID == "" {
+		return fmt.Errorf("id cannot be empty")
+	}
+	if u.Name == "" {
+		return fmt.Errorf("name cannot be empty")
+	}
+	return lintReleaseJob(u.Type, u.Spec)
+}
+
+type DeleteReleaseJobUpdater struct {
+	ID string `json:"id"`
+}
+
+func NewDeleteReleaseJobUpdater(args *UpdateReleasePlanArgs) (*DeleteReleaseJobUpdater, error) {
+	var updater DeleteReleaseJobUpdater
+	if err := models.IToi(args.Spec, &updater); err != nil {
+		return nil, errors.Wrap(err, "invalid spec")
+	}
+	return &updater, nil
+}
+
+func (u *DeleteReleaseJobUpdater) Update(plan *models.ReleasePlan) error {
+	for i, job := range plan.Jobs {
+		if job.ID == u.ID {
+			plan.Jobs = append(plan.Jobs[:i], plan.Jobs[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("job %s not found", u.ID)
+}
+
+func (u *DeleteReleaseJobUpdater) Lint() error {
+	if u.ID == "" {
+		return fmt.Errorf("id cannot be empty")
+	}
+	return nil
+}
+
+type UpdateApprovalUpdater struct {
+	Approval *models.Approval `json:"approval"`
+}
+
+func NewUpdateApprovalUpdater(args *UpdateReleasePlanArgs) (*UpdateApprovalUpdater, error) {
+	var updater UpdateApprovalUpdater
+	if err := models.IToi(args.Spec, &updater); err != nil {
+		return nil, errors.Wrap(err, "invalid spec")
+	}
+	return &updater, nil
+}
+
+func (u *UpdateApprovalUpdater) Update(plan *models.ReleasePlan) error {
+	plan.Approval = u.Approval
+	return nil
+}
+
+func (u *UpdateApprovalUpdater) Lint() error {
+	if u.Approval == nil {
+		return fmt.Errorf("approval cannot be empty")
+	}
+	return lintApproval(u.Approval)
 }

--- a/pkg/microservice/aslan/core/release_plan/service/update.go
+++ b/pkg/microservice/aslan/core/release_plan/service/update.go
@@ -413,6 +413,9 @@ func NewUpdateApprovalUpdater(args *UpdateReleasePlanArgs) (*UpdateApprovalUpdat
 }
 
 func (u *UpdateApprovalUpdater) Update(plan *models.ReleasePlan) (before interface{}, after interface{}, err error) {
+	if err := clearApprovalData(u.Approval); err != nil {
+		return nil, nil, errors.Wrap(err, "clear approval data")
+	}
 	before, after = plan.Approval, u.Approval
 	plan.Approval = u.Approval
 	return

--- a/pkg/microservice/aslan/core/release_plan/service/update.go
+++ b/pkg/microservice/aslan/core/release_plan/service/update.go
@@ -214,7 +214,7 @@ func (u *TimeRangeUpdater) Verb() string {
 
 type ManagerUpdater struct {
 	ManagerID string `json:"manager_id"`
-	Name      string `json:"name"`
+	Manager   string `json:"manager"`
 }
 
 func NewManagerUpdater(args *UpdateReleasePlanArgs) (*ManagerUpdater, error) {
@@ -226,9 +226,9 @@ func NewManagerUpdater(args *UpdateReleasePlanArgs) (*ManagerUpdater, error) {
 }
 
 func (u *ManagerUpdater) Update(plan *models.ReleasePlan) (before interface{}, after interface{}, err error) {
-	before, after = plan.Manager, u.Name
+	before, after = plan.Manager, u.Manager
 	plan.ManagerID = u.ManagerID
-	plan.Manager = u.Name
+	plan.Manager = u.Manager
 	return
 }
 
@@ -240,7 +240,7 @@ func (u *ManagerUpdater) Lint() error {
 	if err != nil {
 		return fmt.Errorf("user not found")
 	}
-	if u.Name != userInfo.Name {
+	if u.Manager != userInfo.Name {
 		return fmt.Errorf("name not match")
 	}
 	return nil

--- a/pkg/microservice/aslan/core/release_plan/service/watcher.go
+++ b/pkg/microservice/aslan/core/release_plan/service/watcher.go
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 The KodeRover Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+func

--- a/pkg/microservice/aslan/core/release_plan/service/watcher.go
+++ b/pkg/microservice/aslan/core/release_plan/service/watcher.go
@@ -141,8 +141,8 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 		err = updateLarkApproval(ctx, plan.Approval)
 	case config.DingTalkApproval:
 		err = updateDingTalkApproval(ctx, plan.Approval)
+		// NativeApproval is update when approve
 	case config.NativeApproval:
-		//err = updateNativeApproval(ctx, plan.Approval)
 	default:
 		err = errors.Errorf("unknown approval type %s", plan.Approval.Type)
 	}
@@ -152,8 +152,7 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 	switch plan.Approval.Status {
 	case config.StatusPassed:
 		plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
-			Verb: VerbUpdate,
-			//TargetName: plan.Name,
+			Verb:       VerbUpdate,
 			TargetType: TargetTypeReleasePlanStatus,
 			Detail:     "审批通过",
 			CreatedAt:  time.Now().Unix(),
@@ -163,8 +162,7 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 		setReleaseJobsForExecuting(plan)
 	case config.StatusReject:
 		plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
-			Verb: VerbUpdate,
-			//TargetName: plan.Name,
+			Verb:       VerbUpdate,
 			TargetType: TargetTypeReleasePlanStatus,
 			Detail:     "审批拒绝",
 			CreatedAt:  time.Now().Unix(),

--- a/pkg/microservice/aslan/core/release_plan/service/watcher.go
+++ b/pkg/microservice/aslan/core/release_plan/service/watcher.go
@@ -86,6 +86,8 @@ func updatePlanWorkflowReleaseJob(plan *models.ReleasePlan, log *zap.SugaredLogg
 				job.Status = config.ReleasePlanJobStatusDone
 			}
 			if checkReleasePlanJobsAllDone(plan) {
+				plan.ExecutingTime = time.Now().Unix()
+				plan.SuccessTime = time.Now().Unix()
 				plan.Status = config.StatusSuccess
 			}
 		}
@@ -157,6 +159,7 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 			CreatedAt:  time.Now().Unix(),
 		})
 		plan.Status = config.StatusExecuting
+		plan.ApprovalTime = time.Now().Unix()
 	case config.StatusReject:
 		plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
 			Verb:       VerbUpdate,

--- a/pkg/microservice/aslan/core/release_plan/service/watcher.go
+++ b/pkg/microservice/aslan/core/release_plan/service/watcher.go
@@ -140,6 +140,7 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 	case config.DingTalkApproval:
 		err = updateDingTalkApproval(ctx, plan.Approval)
 	case config.NativeApproval:
+		err = updateNativeApproval(ctx, plan.Approval)
 	default:
 		err = errors.Errorf("unknown approval type %s", plan.Approval.Type)
 	}

--- a/pkg/microservice/aslan/core/release_plan/service/watcher.go
+++ b/pkg/microservice/aslan/core/release_plan/service/watcher.go
@@ -142,7 +142,7 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 	case config.DingTalkApproval:
 		err = updateDingTalkApproval(ctx, plan.Approval)
 	case config.NativeApproval:
-		err = updateNativeApproval(ctx, plan.Approval)
+		//err = updateNativeApproval(ctx, plan.Approval)
 	default:
 		err = errors.Errorf("unknown approval type %s", plan.Approval.Type)
 	}

--- a/pkg/microservice/aslan/core/release_plan/service/watcher.go
+++ b/pkg/microservice/aslan/core/release_plan/service/watcher.go
@@ -16,4 +16,159 @@
 
 package service
 
-func
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/samber/lo"
+	"go.uber.org/zap"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
+	"github.com/koderover/zadig/pkg/tool/log"
+)
+
+func WatchExecutingWorkflow() {
+	log := log.SugaredLogger().With("service", "WatchExecutingWorkflow")
+	for {
+		time.Sleep(time.Second * 3)
+		t := time.Now()
+		list, _, err := mongodb.NewReleasePlanColl().ListByOptions(&mongodb.ListReleasePlanOption{
+			Status: config.StatusExecuting,
+		})
+		if err != nil {
+			log.Errorf("list executing workflow error: %v", err)
+			continue
+		}
+		for _, plan := range list {
+			updatePlanWorkflowReleaseJob(plan, log)
+		}
+		if time.Since(t) > time.Millisecond*200 {
+			log.Warnf("watch executing workflow cost %s", time.Since(t))
+		}
+	}
+}
+
+func updatePlanWorkflowReleaseJob(plan *models.ReleasePlan, log *zap.SugaredLogger) {
+	getLock(plan.ID.Hex()).Lock()
+	defer getLock(plan.ID.Hex()).Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	plan, err := mongodb.NewReleasePlanColl().GetByID(ctx, plan.ID.Hex())
+	if err != nil {
+		log.Errorf("get plan %s error: %v", plan.ID.Hex(), err)
+		return
+	}
+	// plan status maybe changed during no lock time
+	if plan.Status != config.StatusExecuting {
+		return
+	}
+	for _, job := range plan.Jobs {
+		if job.Status == config.ReleasePlanJobStatusRunning && job.Type == config.JobWorkflow {
+			spec := new(models.WorkflowReleaseJobSpec)
+			if err := models.IToi(job.Spec, spec); err != nil {
+				log.Errorf("convert spec error: %v", err)
+				continue
+			}
+			task, err := mongodb.NewworkflowTaskv4Coll().Find(spec.Workflow.Name, spec.TaskID)
+			if err != nil {
+				log.Errorf("find task %s-%d error: %v", spec.Workflow.Name, spec.TaskID, err)
+				continue
+			}
+			spec.Status = task.Status
+			if lo.Contains(config.FailedStatus(), task.Status) {
+				job.Status = config.ReleasePlanJobStatusFailed
+			}
+			if task.Status == config.StatusPassed {
+				job.Status = config.ReleasePlanJobStatusDone
+			}
+			if checkReleasePlanJobsAllDone(plan) {
+				plan.Status = config.StatusSuccess
+			}
+		}
+	}
+	if err := mongodb.NewReleasePlanColl().UpdateByID(ctx, plan.ID.Hex(), plan); err != nil {
+		log.Errorf("update plan %s error: %v", plan.ID.Hex(), err)
+	}
+	return
+}
+
+func WatchApproval() {
+	log := log.SugaredLogger().With("service", "WatchApproval")
+	for {
+		time.Sleep(time.Second * 3)
+		t := time.Now()
+		list, _, err := mongodb.NewReleasePlanColl().ListByOptions(&mongodb.ListReleasePlanOption{
+			Status: config.StatusWaitForApprove,
+		})
+		if err != nil {
+			log.Errorf("list approval workflow error: %v", err)
+			continue
+		}
+		for _, plan := range list {
+			if err := updatePlanApproval(plan); err != nil {
+				log.Errorf("update plan %s approval error: %v", plan.Name, err)
+			}
+		}
+		if time.Since(t) > time.Millisecond*200 {
+			log.Warnf("watch approval workflow cost %s", time.Since(t))
+		}
+	}
+}
+
+func updatePlanApproval(plan *models.ReleasePlan) error {
+	getLock(plan.ID.Hex()).Lock()
+	defer getLock(plan.ID.Hex()).Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	plan, err := mongodb.NewReleasePlanColl().GetByID(ctx, plan.ID.Hex())
+	if err != nil {
+		return errors.Errorf("get plan %s error: %v", plan.ID.Hex(), err)
+	}
+	// plan status maybe changed during no lock time
+	if plan.Status != config.StatusWaitForApprove {
+		return nil
+	}
+
+	switch plan.Approval.Type {
+	case config.LarkApproval:
+		err = updateLarkApproval(ctx, plan.Approval)
+	case config.DingTalkApproval:
+		err = updateDingTalkApproval(ctx, plan.Approval)
+	case config.NativeApproval:
+	default:
+		err = errors.Errorf("unknown approval type %s", plan.Approval.Type)
+	}
+	if err != nil {
+		return errors.Errorf("update plan %s approval error: %v", plan.Name, err)
+	}
+	switch plan.Approval.Status {
+	case config.StatusPassed:
+		plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
+			Verb:       VerbUpdate,
+			TargetName: plan.Name,
+			TargetType: TargetTypeReleasePlanStatus,
+			Detail:     "审批通过",
+			CreatedAt:  time.Now().Unix(),
+		})
+		plan.Status = config.StatusExecuting
+		// TODO
+	case config.StatusReject:
+		plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
+			Verb:       VerbUpdate,
+			TargetName: plan.Name,
+			TargetType: TargetTypeReleasePlanStatus,
+			Detail:     "审批拒绝",
+			CreatedAt:  time.Now().Unix(),
+		})
+	}
+
+	if err := mongodb.NewReleasePlanColl().UpdateByID(ctx, plan.ID.Hex(), plan); err != nil {
+		return errors.Errorf("update plan %s error: %v", plan.ID.Hex(), err)
+	}
+	return nil
+}

--- a/pkg/microservice/aslan/core/release_plan/service/watcher.go
+++ b/pkg/microservice/aslan/core/release_plan/service/watcher.go
@@ -139,8 +139,8 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 		err = updateLarkApproval(ctx, plan.Approval)
 	case config.DingTalkApproval:
 		err = updateDingTalkApproval(ctx, plan.Approval)
-	case config.NativeApproval:
-		err = updateNativeApproval(ctx, plan.Approval)
+	//case config.NativeApproval:
+	//	err = updateNativeApproval(ctx, plan.Approval)
 	default:
 		err = errors.Errorf("unknown approval type %s", plan.Approval.Type)
 	}

--- a/pkg/microservice/aslan/core/release_plan/service/watcher.go
+++ b/pkg/microservice/aslan/core/release_plan/service/watcher.go
@@ -139,8 +139,8 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 		err = updateLarkApproval(ctx, plan.Approval)
 	case config.DingTalkApproval:
 		err = updateDingTalkApproval(ctx, plan.Approval)
-	//case config.NativeApproval:
-	//	err = updateNativeApproval(ctx, plan.Approval)
+	case config.NativeApproval:
+		err = updateNativeApproval(ctx, plan.Approval)
 	default:
 		err = errors.Errorf("unknown approval type %s", plan.Approval.Type)
 	}

--- a/pkg/microservice/aslan/core/release_plan/service/watcher.go
+++ b/pkg/microservice/aslan/core/release_plan/service/watcher.go
@@ -160,6 +160,7 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 		})
 		plan.Status = config.StatusExecuting
 		plan.ApprovalTime = time.Now().Unix()
+		setReleaseJobsForExecuting(plan)
 	case config.StatusReject:
 		plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
 			Verb:       VerbUpdate,

--- a/pkg/microservice/aslan/core/release_plan/service/watcher.go
+++ b/pkg/microservice/aslan/core/release_plan/service/watcher.go
@@ -157,7 +157,6 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 			CreatedAt:  time.Now().Unix(),
 		})
 		plan.Status = config.StatusExecuting
-		// TODO
 	case config.StatusReject:
 		plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
 			Verb:       VerbUpdate,

--- a/pkg/microservice/aslan/core/release_plan/service/watcher.go
+++ b/pkg/microservice/aslan/core/release_plan/service/watcher.go
@@ -152,8 +152,8 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 	switch plan.Approval.Status {
 	case config.StatusPassed:
 		plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
-			Verb:       VerbUpdate,
-			TargetName: plan.Name,
+			Verb: VerbUpdate,
+			//TargetName: plan.Name,
 			TargetType: TargetTypeReleasePlanStatus,
 			Detail:     "审批通过",
 			CreatedAt:  time.Now().Unix(),
@@ -163,8 +163,8 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 		setReleaseJobsForExecuting(plan)
 	case config.StatusReject:
 		plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
-			Verb:       VerbUpdate,
-			TargetName: plan.Name,
+			Verb: VerbUpdate,
+			//TargetName: plan.Name,
 			TargetType: TargetTypeReleasePlanStatus,
 			Detail:     "审批拒绝",
 			CreatedAt:  time.Now().Unix(),

--- a/pkg/microservice/aslan/core/service.go
+++ b/pkg/microservice/aslan/core/service.go
@@ -47,6 +47,7 @@ import (
 	labelMongodb "github.com/koderover/zadig/pkg/microservice/aslan/core/label/repository/mongodb"
 	multiclusterservice "github.com/koderover/zadig/pkg/microservice/aslan/core/multicluster/service"
 	policyservice "github.com/koderover/zadig/pkg/microservice/aslan/core/policy/service"
+	releaseplanservice "github.com/koderover/zadig/pkg/microservice/aslan/core/release_plan/service"
 	systemrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/system/repository/mongodb"
 	systemservice "github.com/koderover/zadig/pkg/microservice/aslan/core/system/service"
 	templateservice "github.com/koderover/zadig/pkg/microservice/aslan/core/templatestore/service"
@@ -143,6 +144,7 @@ func Start(ctx context.Context) {
 
 	initDatabase()
 	initKlock()
+	initReleasePlanWatcher()
 
 	initService()
 	initDinD()
@@ -334,6 +336,11 @@ func initDinD() {
 
 func initKlock() {
 	_ = klock.Init(config.Namespace())
+}
+
+func initReleasePlanWatcher() {
+	go releaseplanservice.WatchExecutingWorkflow()
+	go releaseplanservice.WatchApproval()
 }
 
 func initDatabase() {

--- a/pkg/microservice/aslan/core/service.go
+++ b/pkg/microservice/aslan/core/service.go
@@ -338,6 +338,8 @@ func initKlock() {
 	_ = klock.Init(config.Namespace())
 }
 
+// initReleasePlanWatcher watch release plan status and update release plan status
+// for working after aslan restart
 func initReleasePlanWatcher() {
 	go releaseplanservice.WatchExecutingWorkflow()
 	go releaseplanservice.WatchApproval()

--- a/pkg/microservice/aslan/core/service.go
+++ b/pkg/microservice/aslan/core/service.go
@@ -442,6 +442,7 @@ func initDatabase() {
 		commonrepo.NewProjectManagementColl(),
 		commonrepo.NewImageTagsCollColl(),
 		commonrepo.NewLLMIntegrationColl(),
+		commonrepo.NewReleasePlanColl(),
 
 		// msg queue
 		commonrepo.NewMsgQueueCommonColl(),

--- a/pkg/microservice/aslan/core/workflow/handler/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/handler/workflow_v4.go
@@ -23,8 +23,9 @@ import (
 	"io"
 
 	"github.com/gin-gonic/gin"
-	"github.com/koderover/zadig/pkg/types"
 	"gopkg.in/yaml.v3"
+
+	"github.com/koderover/zadig/pkg/types"
 
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/workflow/service/workflow"

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -24,12 +24,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/koderover/zadig/pkg/shared/client/user"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"gorm.io/gorm/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/koderover/zadig/pkg/shared/client/user"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
@@ -231,6 +232,7 @@ func GetWorkflowv4Preset(encryptedKey, workflowName, uid, username string, log *
 	if err := ensureWorkflowV4Resp(encryptedKey, workflow, log); err != nil {
 		return workflow, err
 	}
+	clearWorkflowV4Triggers(workflow)
 	return workflow, nil
 }
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -695,6 +695,13 @@ func getRecentTaskV4Info(workflow *Workflow, tasks []*commonmodels.WorkflowTask)
 	}
 }
 
+func clearWorkflowV4Triggers(workflow *commonmodels.WorkflowV4) {
+	workflow.HookCtls = nil
+	workflow.MeegoHookCtls = nil
+	workflow.GeneralHookCtls = nil
+	workflow.JiraHookCtls = nil
+}
+
 func ensureWorkflowV4Resp(encryptedKey string, workflow *commonmodels.WorkflowV4, logger *zap.SugaredLogger) error {
 	for _, stage := range workflow.Stages {
 		for _, job := range stage.Jobs {

--- a/pkg/microservice/aslan/server/rest/router.go
+++ b/pkg/microservice/aslan/server/rest/router.go
@@ -36,6 +36,7 @@ import (
 	loghandler "github.com/koderover/zadig/pkg/microservice/aslan/core/log/handler"
 	multiclusterhandler "github.com/koderover/zadig/pkg/microservice/aslan/core/multicluster/handler"
 	projecthandler "github.com/koderover/zadig/pkg/microservice/aslan/core/project/handler"
+	releaseplanhandler "github.com/koderover/zadig/pkg/microservice/aslan/core/release_plan/handler"
 	servicehandler "github.com/koderover/zadig/pkg/microservice/aslan/core/service/handler"
 	stathandler "github.com/koderover/zadig/pkg/microservice/aslan/core/stat/handler"
 	systemhandler "github.com/koderover/zadig/pkg/microservice/aslan/core/system/handler"
@@ -122,6 +123,7 @@ func (s *engine) injectRouterGroup(router *gin.RouterGroup) {
 		"/api/environment":   new(environmenthandler.Router),
 		"/api/cron":          new(cronhandler.Router),
 		"/api/workflow":      new(workflowhandler.Router),
+		"/api/release_plan":  new(releaseplanhandler.Router),
 		"/api/build":         new(buildhandler.Router),
 		"/api/delivery":      new(deliveryhandler.Router),
 		"/api/logs":          new(loghandler.Router),

--- a/pkg/microservice/policy/core/service/policy_meta_registration.go
+++ b/pkg/microservice/policy/core/service/policy_meta_registration.go
@@ -67,7 +67,7 @@ var projectDefinitionMap = map[string]int{
 func GetPolicyRegistrationDefinitions(scope, envType string, logger *zap.SugaredLogger) ([]*PolicyDefinition, error) {
 	policyMetas := yamlconfig.DefaultPolicyMetasConfig().Policies()
 
-	systemScopeSet := sets.NewString("Project", "Template", "TestCenter", "ReleaseCenter", "DeliveryCenter", "DataCenter")
+	systemScopeSet := sets.NewString("Project", "Template", "TestCenter", "ReleaseCenter", "DeliveryCenter", "DataCenter", "ReleasePlan")
 	projectScopeSet := sets.NewString("Workflow", "Environment", "ProductionEnvironment", "Test", "Delivery", "Build", "Service", "ProductionService", "Scan")
 	systemPolicyMetas, projectPolicyMetas, filteredPolicyMetas := []*types.PolicyMeta{}, []*types.PolicyMeta{}, []*types.PolicyMeta{}
 	for _, v := range policyMetas {

--- a/pkg/microservice/policy/core/yamlconfig/metas.yaml
+++ b/pkg/microservice/policy/core/yamlconfig/metas.yaml
@@ -335,6 +335,18 @@ metas:
             endpoint: /api/v1/users/search
           - method: GET
             endpoint: /api/aslan/cluster/clusters
+  - resource: ReleasePlan
+    alias: 发布计划
+    description: ""
+    rules:
+      - action: get_release_plan
+        alias: 查看
+      - action: create_release_plan
+        alias: 新建
+      - action: edit_release_plan
+        alias: 编辑
+      - action: delete_release_plan
+        alias: 删除
   - resource: TestCenter
     alias: 测试中心
     description: ""

--- a/pkg/microservice/user/core/service/user/authz.go
+++ b/pkg/microservice/user/core/service/user/authz.go
@@ -19,12 +19,13 @@ package user
 import (
 	"fmt"
 
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/koderover/zadig/pkg/microservice/user/core/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/user/core/repository/mongodb"
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/types"
-	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func GetUserAuthInfo(uid string, logger *zap.SugaredLogger) (*AuthorizedResources, error) {
@@ -613,5 +614,13 @@ func modifySystemAction(systemActions *SystemActions, verb string) {
 		systemActions.DataCenter.ViewInsight = true
 	case VerbEditDataCenterInsightConfig:
 		systemActions.DataCenter.EditInsightConfig = true
+	case VerbCreateReleasePlan:
+		systemActions.ReleasePlan.Create = true
+	case VerbEditReleasePlan:
+		systemActions.ReleasePlan.Edit = true
+	case VerbDeleteReleasePlan:
+		systemActions.ReleasePlan.Delete = true
+	case VerbGetReleasePlan:
+		systemActions.ReleasePlan.View = true
 	}
 }

--- a/pkg/microservice/user/core/service/user/types.go
+++ b/pkg/microservice/user/core/service/user/types.go
@@ -102,6 +102,11 @@ const (
 	VerbGetDataCenterOverview       = "data_over"
 	VerbGetDataCenterInsight        = "efficiency_over"
 	VerbEditDataCenterInsightConfig = "edit_dashboard_config"
+	// release plan
+	VerbGetReleasePlan    = "get_release_plan"
+	VerbCreateReleasePlan = "create_release_plan"
+	VerbEditReleasePlan   = "edit_release_plan"
+	VerbDeleteReleasePlan = "delete_release_plan"
 )
 
 type AuthorizedResources struct {
@@ -130,6 +135,7 @@ type SystemActions struct {
 	ReleaseCenter  *ReleaseCenterActions  `json:"release_center"`
 	DeliveryCenter *DeliveryCenterActions `json:"delivery_center"`
 	DataCenter     *DataCenterActions     `json:"data_center"`
+	ReleasePlan    *ReleasePlanActions    `json:"release_plan"`
 }
 
 type WorkflowActions struct {
@@ -237,4 +243,11 @@ type DataCenterActions struct {
 	ViewOverView      bool
 	ViewInsight       bool
 	EditInsightConfig bool
+}
+
+type ReleasePlanActions struct {
+	Create bool
+	View   bool
+	Edit   bool
+	Delete bool
 }

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -368,6 +368,7 @@ const (
 	TestTaskFmt       = "TestTask:%s"
 	ServiceTaskFmt    = "ServiceTask:%s"
 	ScanningTaskFmt   = "ScanningTask:%s"
+	ReleasePlanFmt    = "ReleasePlan"
 )
 
 // Product Status

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -368,7 +368,7 @@ const (
 	TestTaskFmt       = "TestTask:%s"
 	ServiceTaskFmt    = "ServiceTask:%s"
 	ScanningTaskFmt   = "ScanningTask:%s"
-	ReleasePlanFmt    = "ReleasePlan"
+	ReleasePlanFmt    = "ReleasePlan:default"
 )
 
 // Product Status

--- a/pkg/shared/client/user/user_auth.go
+++ b/pkg/shared/client/user/user_auth.go
@@ -33,6 +33,7 @@ type SystemActions struct {
 	ReleaseCenter  *ReleaseCenterActions  `json:"release_center"`
 	DeliveryCenter *DeliveryCenterActions `json:"delivery_center"`
 	DataCenter     *DataCenterActions     `json:"data_center"`
+	ReleasePlan    *ReleasePlanActions    `json:"release_plan"`
 }
 
 type WorkflowActions struct {
@@ -140,6 +141,13 @@ type DataCenterActions struct {
 	ViewOverView      bool
 	ViewInsight       bool
 	EditInsightConfig bool
+}
+
+type ReleasePlanActions struct {
+	Create bool
+	View   bool
+	Edit   bool
+	Delete bool
 }
 
 func (c *Client) GetUserAuthInfo(uid string) (*AuthorizedResources, error) {

--- a/pkg/shared/handler/base.go
+++ b/pkg/shared/handler/base.go
@@ -246,9 +246,7 @@ func InsertOperationLog(c *gin.Context, username, productName, method, function,
 	if err != nil {
 		logger.Errorf("InsertOperation err:%v", err)
 	}
-	if c != nil {
-		c.Set("operationLogID", req.ID.Hex())
-	}
+	c.Set("operationLogID", req.ID.Hex())
 }
 
 func InsertDetailedOperationLog(c *gin.Context, username, productName, scene, method, function, detail, requestBody string, logger *zap.SugaredLogger, targets ...string) {

--- a/pkg/shared/handler/base.go
+++ b/pkg/shared/handler/base.go
@@ -28,13 +28,14 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt"
+	"go.uber.org/zap"
+
 	systemmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/system/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/system/repository/mongodb"
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/shared/client/user"
 	"github.com/koderover/zadig/pkg/types"
 	"github.com/koderover/zadig/pkg/util/ginzap"
-	"go.uber.org/zap"
 )
 
 // Context struct
@@ -245,7 +246,9 @@ func InsertOperationLog(c *gin.Context, username, productName, method, function,
 	if err != nil {
 		logger.Errorf("InsertOperation err:%v", err)
 	}
-	c.Set("operationLogID", req.ID.Hex())
+	if c != nil {
+		c.Set("operationLogID", req.ID.Hex())
+	}
 }
 
 func InsertDetailedOperationLog(c *gin.Context, username, productName, scene, method, function, detail, requestBody string, logger *zap.SugaredLogger, targets ...string) {


### PR DESCRIPTION
Signed-off-by: M-Cosmosss <yuzhou@koderover.com>### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8f498e1</samp>

This pull request adds the release plan feature to the Zadig project, which allows users to create and manage release plans for their projects. It defines the data models, database operations, service functions, API handlers, and policy metas for the release plan resource. It also updates some existing files to support the release plan feature, such as adding the release plan actions to the user authorization system and clearing the hook controls of a workflow before returning the preset response.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8f498e1</samp>

*  Add data models, constants, and indexes for the release plan feature ([link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-b75a929528a6cc3d65392ca838a5f63796ed0a4ec0f239f69a4e8c4bf61ba04cR487-R503), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-d8635583436a02bda02f03d481624721e703adea0d4cf781c09567771344e92aR1-R87), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-1a311a15ce8e53b0e42903ec48ea2dda5ddcd8d390fdeef511d74729c5bdbe2fR1-R150), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-a74fa9c9aa31979c0e1634097c1a6b3e84ea13e0686ad037178b5d1208e9f9deR445), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-e9d22162901df783d481a21459bff59cd789639ec450de043099bb498963846cR371))
*  Add service functions and update logic for the release plan feature ([link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cR1-R122), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-7947730bf8903869386d417e33f7417d9e44be012e368c73723a8cd1298c0659R1-R76))
*  Add RESTful API handlers and router for the release plan feature ([link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R1-R124), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-35aa675932bf6312a17e222c3b61023210d89cece6f0e6d895b4c47baf6ad797R1-R32), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-30e4f93858e028bb4bcaa7da5e4914049b2fb708bc0f6cfffb34e8f043b54cd4R39), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-30e4f93858e028bb4bcaa7da5e4914049b2fb708bc0f6cfffb34e8f043b54cd4R126))
*  Add policy meta and system actions for the release plan resource ([link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-79e9e5f47018d1fde4fa8a8f5ae32e07b41ae503218d5707f1287717f06935e3L70-R70), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-7db6a3a936fa7dc732a132d391062ab100f89d839196764063ee199abb63a287R338-R349), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-24bc50eab08b400dc370e3f6e3e2efff21071e953c9515f76dd1f8524ceec221R617-R624), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-9699d594e4a8dac5527e9400f6235c9643bf8f6502b87ba5c7c9ba162eb0eea7R105-R109), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-9699d594e4a8dac5527e9400f6235c9643bf8f6502b87ba5c7c9ba162eb0eea7R138), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-9699d594e4a8dac5527e9400f6235c9643bf8f6502b87ba5c7c9ba162eb0eea7R247-R253), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-79c17691e4482250d5c5b5572a5fa45508f1952af9f46ba3beccac6a94597144R36), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-79c17691e4482250d5c5b5572a5fa45508f1952af9f46ba3beccac6a94597144R146-R152))
*  Clear hook controls of workflow in the preset response for the release plan feature ([link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-5a9b5157a24d6d74d66a54b3d6b2a961d0b468af078c53b04301e590ab97e165R235), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R698-R704))
*  Fix import order and unused import in some files ([link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-0f8a8ee855a0910d9a79938a5d3fe54e784aa806d54f11d14dcc7ec3968f32b2L26-R29), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-5a9b5157a24d6d74d66a54b3d6b2a961d0b468af078c53b04301e590ab97e165L27), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-5a9b5157a24d6d74d66a54b3d6b2a961d0b468af078c53b04301e590ab97e165R33-R34), [link](https://github.com/koderover/zadig/pull/2975/files?diff=unified&w=0#diff-24bc50eab08b400dc370e3f6e3e2efff21071e953c9515f76dd1f8524ceec221L22-R28))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
