### PR TITLE
fix share env func

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/product.go
+++ b/pkg/microservice/aslan/core/common/repository/models/product.go
@@ -184,7 +184,7 @@ func (Product) TableName() string {
 }
 
 // GetNamespace returns the default name of namespace created by zadig
-func (p *Product) GetNamespace() string {
+func (p *Product) GetDefaultNamespace() string {
 	return p.ProductName + "-env-" + p.EnvName
 }
 

--- a/pkg/microservice/aslan/core/common/service/delivery.go
+++ b/pkg/microservice/aslan/core/common/service/delivery.go
@@ -369,7 +369,7 @@ func getProductEnvInfo(pipelineTask *taskmodels.Task, log *zap.SugaredLogger) (*
 		Name:    product.ProductName,
 		EnvName: product.EnvName,
 	}); err != nil {
-		product.Namespace = product.GetNamespace()
+		product.Namespace = product.GetDefaultNamespace()
 	} else {
 		product.Namespace = productInfo.Namespace
 	}

--- a/pkg/microservice/aslan/core/common/service/product.go
+++ b/pkg/microservice/aslan/core/common/service/product.go
@@ -224,7 +224,7 @@ func GetProductEnvNamespace(envName, productName, namespace string) string {
 	})
 	if err != nil {
 		product = &commonmodels.Product{EnvName: envName, ProductName: productName}
-		return product.GetNamespace()
+		return product.GetDefaultNamespace()
 	}
 	return product.Namespace
 }

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -3925,7 +3925,7 @@ func EnvAnalysis(projectName, envName string, production *bool, triggerName stri
 		ctx,
 		config.HubServerAddress(), env.ClusterID,
 		llmClient,
-		filters, env.GetNamespace(),
+		filters, env.Namespace,
 		false, // noCache bool
 		true,  // explain bool
 		10,    // maxConcurrency int

--- a/pkg/microservice/aslan/core/environment/service/environment_creator.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_creator.go
@@ -162,7 +162,7 @@ func (creator *HelmProductCreator) Create(user, requestID string, args *models.P
 	}
 
 	//判断namespace是否存在
-	namespace := args.GetNamespace()
+	namespace := args.GetDefaultNamespace()
 	if args.Namespace == "" {
 		args.Namespace = namespace
 	}
@@ -352,7 +352,7 @@ func (creator *K8sYamlProductCreator) Create(user, requestID string, args *model
 		return fmt.Errorf("failed to new istio client: %s", err)
 	}
 
-	namespace := args.GetNamespace()
+	namespace := args.GetDefaultNamespace()
 	if args.Namespace == "" {
 		args.Namespace = namespace
 	}

--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -587,14 +587,6 @@ func queryPodsStatus(productInfo *commonmodels.Product, serviceTmpl *commonmodel
 		return resp
 	}
 
-	workloadImagesMap := make(map[string][]string)
-	for _, workload := range svcResp.Workloads {
-		workloadImagesMap[workload.Name] = workload.Images
-	}
-	if images, ok := workloadImagesMap[serviceTmpl.ServiceName]; ok {
-		resp.Images = images
-	}
-
 	resp.Ingress = svcResp.Ingress
 	resp.Workloads = svcResp.Workloads
 	if len(serviceTmpl.Containers) == 0 {
@@ -616,6 +608,12 @@ func queryPodsStatus(productInfo *commonmodels.Product, serviceTmpl *commonmodel
 	}
 
 	if len(pods) == 0 && len(svcResp.CronJobs) == 0 {
+		imageSet := sets.String{}
+		for _, workload := range svcResp.Workloads {
+			imageSet.Insert(workload.Images...)
+		}
+
+		resp.Images = imageSet.List()
 		resp.PodStatus, resp.Ready = setting.PodNonStarted, setting.PodNotReady
 		return resp
 	}

--- a/pkg/microservice/aslan/core/environment/service/share_env.go
+++ b/pkg/microservice/aslan/core/environment/service/share_env.go
@@ -17,14 +17,13 @@ limitations under the License.
 package service
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"time"
 
-	"github.com/gogo/protobuf/jsonpb"
 	types "github.com/golang/protobuf/ptypes/struct"
+	"google.golang.org/protobuf/encoding/protojson"
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
 	versionedclient "istio.io/client-go/pkg/clientset/versioned"
 	appsv1 "k8s.io/api/apps/v1"
@@ -797,9 +796,8 @@ func buildEnvoyPatchValue(data map[string]interface{}) (*types.Struct, error) {
 		return nil, fmt.Errorf("failed to marshal data: %s", err)
 	}
 
-	reader := bytes.NewReader(dataBytes)
 	val := &types.Struct{}
-	err = jsonpb.Unmarshal(reader, val)
+	err = protojson.Unmarshal(dataBytes, val)
 	return val, err
 }
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 946f45f</samp>

Update protobuf dependency and unmarshaling function in the service package. This improves compatibility and performance of the envoy patching feature in `share_env.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 946f45f</samp>

*  Migrate from gogo/protobuf to google.golang.org/protobuf for JSON encoding and decoding of Protocol Buffers messages ([link](https://github.com/koderover/zadig/pull/2978/files?diff=unified&w=0#diff-22190d4add8462b956413294f5d90b8d79a762060450aba68aca2311dc71ce1dL26-R26), [link](https://github.com/koderover/zadig/pull/2978/files?diff=unified&w=0#diff-22190d4add8462b956413294f5d90b8d79a762060450aba68aca2311dc71ce1dL800-R800))
* Remove unused `bytes` package from the import list of `share_env.go` ([link](https://github.com/koderover/zadig/pull/2978/files?diff=unified&w=0#diff-22190d4add8462b956413294f5d90b8d79a762060450aba68aca2311dc71ce1dL20))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
