### PR TITLE
ee admin user initialization

### DIFF
--- a/pkg/cli/initconfig/cmd/init.go
+++ b/pkg/cli/initconfig/cmd/init.go
@@ -75,6 +75,14 @@ func initSystemConfig() error {
 		return err
 	}
 
+	if config.Enterprise() {
+		// only initialize user for enterprise version
+		if err := initializeAdminUser(); err != nil {
+			log.Errorf("initialize admin user failed: email: %s, password: %s, err: %s", config.AdminEmail(), config.AdminPassword(), err)
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -101,4 +109,12 @@ func createLocalCluster() error {
 		return nil
 	}
 	return aslan.New(config.AslanServiceAddress()).AddLocalCluster()
+}
+
+func initializeAdminUser() error {
+	username := "admin"
+	password := config.AdminPassword()
+	email := config.AdminEmail()
+
+	return aslan.New(config.AslanServiceAddress()).InitializeUser(username, password, email)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -265,3 +265,11 @@ func RoleBindingNameFromUIDAndRole(uid string, role setting.RoleType, roleNamesp
 func BuildResourceKey(resourceType, projectName, labelBinding string) string {
 	return fmt.Sprintf("%s-%s-%s", resourceType, projectName, labelBinding)
 }
+
+func AdminPassword() string {
+	return viper.GetString(setting.ENVAdminPassword)
+}
+
+func AdminEmail() string {
+	return viper.GetString(setting.ENVAdminEmail)
+}

--- a/pkg/microservice/aslan/core/system/handler/initialization.go
+++ b/pkg/microservice/aslan/core/system/handler/initialization.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/gin-gonic/gin"
+	"github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/system/service"
 	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
 	e "github.com/koderover/zadig/pkg/tool/errors"
@@ -51,21 +52,24 @@ func (req *InitializeUserReq) Validate() error {
 		return fmt.Errorf("password cannot be empty")
 	}
 
-	if len(req.Company) == 0 {
-		return fmt.Errorf("company cannot be empty")
+	if !config.Enterprise() {
+		if len(req.Company) == 0 {
+			return fmt.Errorf("company cannot be empty")
+		}
+
+		if len(req.Email) == 0 {
+			return fmt.Errorf("email cannot be empty")
+		}
+
+		if len(req.Reason) > 500 {
+			return fmt.Errorf("reason is too long")
+		}
+
+		if len(req.Address) > 100 {
+			return fmt.Errorf("address is too long")
+		}
 	}
 
-	if len(req.Email) == 0 {
-		return fmt.Errorf("email cannot be empty")
-	}
-
-	if len(req.Reason) > 500 {
-		return fmt.Errorf("reason is too long")
-	}
-
-	if len(req.Address) > 100 {
-		return fmt.Errorf("address is too long")
-	}
 	return nil
 }
 

--- a/pkg/microservice/aslan/core/system/service/initialization.go
+++ b/pkg/microservice/aslan/core/system/service/initialization.go
@@ -98,21 +98,23 @@ func InitializeUser(username, password, company, email string, phone int64, reas
 		return fmt.Errorf("user initialization error: failed to create user, err: %s", err)
 	}
 
-	initializeInfo := &InitializeInfo{
-		CreatedAt: time.Now().Unix(),
-		Username:  username,
-		Phone:     phone,
-		Email:     email,
-		Company:   company,
-		Reason:    reason,
-		Address:   address,
-		Domain:    config.SystemAddress(),
-	}
+	if !config.Enterprise() {
+		initializeInfo := &InitializeInfo{
+			CreatedAt: time.Now().Unix(),
+			Username:  username,
+			Phone:     phone,
+			Email:     email,
+			Company:   company,
+			Reason:    reason,
+			Address:   address,
+			Domain:    config.SystemAddress(),
+		}
 
-	err = reportRegister(initializeInfo)
-	if err != nil {
-		// don't stop the whole initialization process if the upload fails
-		logger.Errorf("failed to upload initialization info, error: %s", err)
+		err = reportRegister(initializeInfo)
+		if err != nil {
+			// don't stop the whole initialization process if the upload fails
+			logger.Errorf("failed to upload initialization info, error: %s", err)
+		}
 	}
 
 	role, found, err := mongodb.NewRoleColl().Get("*", string(setting.SystemAdmin))

--- a/pkg/shared/client/aslan/system.go
+++ b/pkg/shared/client/aslan/system.go
@@ -17,6 +17,8 @@ limitations under the License.
 package aslan
 
 import (
+	"fmt"
+
 	"github.com/koderover/zadig/pkg/tool/httpclient"
 )
 
@@ -42,4 +44,26 @@ func (c *Client) DockerClean() error {
 	url := "/system/cleanCache/oneClick"
 	_, err := c.Post(url)
 	return err
+}
+
+type user struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Email    string `json:"email"`
+}
+
+func (c *Client) InitializeUser(username, password, email string) error {
+	url := "/system/initialization/user"
+	req := user{
+		Username: username,
+		Password: password,
+		Email:    email,
+	}
+
+	_, err := c.Post(url, httpclient.SetBody(req))
+	if err != nil {
+		return fmt.Errorf("failed to initialize user, error: %s", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc0279c</samp>

This pull request adds a feature to initialize an admin user for the enterprise version of Zadig. It modifies the `initSystemConfig` and `InitializeUser` functions and adds new functions and methods to the `cmd`, `handler`, `client`, and `config` packages. It also adds some environment variables and conditions to control the initialization logic.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cc0279c</samp>

*  Add a conditional block to check the config version and create an admin user if it is enterprise ([link](https://github.com/koderover/zadig/pull/2981/files?diff=unified&w=0#diff-c83b43a5532f2056a60d06a10b7f390061c552b030e72f082cdb1f079bde8908R78-R85))
*  Define a new function to initialize an admin user using the aslan client ([link](https://github.com/koderover/zadig/pull/2981/files?diff=unified&w=0#diff-c83b43a5532f2056a60d06a10b7f390061c552b030e72f082cdb1f079bde8908R113-R120))
*  Add new functions to get the admin password and email from the environment variables ([link](https://github.com/koderover/zadig/pull/2981/files?diff=unified&w=0#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5R268-R275))
*  Modify the validation function to skip some fields if the config is enterprise ([link](https://github.com/koderover/zadig/pull/2981/files?diff=unified&w=0#diff-28f76aae522352200e4bc81b3251edcbb9c2f8a9c7adf339c45ccb66edc5d0faR23), [link](https://github.com/koderover/zadig/pull/2981/files?diff=unified&w=0#diff-28f76aae522352200e4bc81b3251edcbb9c2f8a9c7adf339c45ccb66edc5d0faL54-R72))
*  Modify the user initialization function to skip reporting the info if the config is enterprise ([link](https://github.com/koderover/zadig/pull/2981/files?diff=unified&w=0#diff-7a9d786e7c5173e3a9d1eade27df592d3ed815e5261c863eeb147bea287e34beL101-R117))
*  Add a new method to the aslan client to send a request to the aslan service for user initialization ([link](https://github.com/koderover/zadig/pull/2981/files?diff=unified&w=0#diff-45452d70b589d2343fa2f71991aecec8938185f084ea966cdadf5d6ac25e06e8R20-R21), [link](https://github.com/koderover/zadig/pull/2981/files?diff=unified&w=0#diff-45452d70b589d2343fa2f71991aecec8938185f084ea966cdadf5d6ac25e06e8R48-R69))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
