### PR TITLE
cherry pick #2813 to ee-1.5.1

### DIFF
--- a/pkg/microservice/aslan/core/collaboration/handler/collaboration_mode.go
+++ b/pkg/microservice/aslan/core/collaboration/handler/collaboration_mode.go
@@ -18,15 +18,21 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/collaboration/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/collaboration/service"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/collaboration"
+	"github.com/koderover/zadig/pkg/microservice/user/core/service/user"
 	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 	"github.com/koderover/zadig/pkg/tool/log"
+	"github.com/koderover/zadig/pkg/types"
 )
 
 func GetCollaborationMode(c *gin.Context) {
@@ -57,7 +63,13 @@ func CreateCollaborationMode(c *gin.Context) {
 		return
 	}
 
-	internalhandler.InsertOperationLog(c, ctx.Account, args.ProjectName, "新增", "协作模式", args.Name, string(data), ctx.Logger)
+	detail, err := generateCollaborationDetailLog(ctx.Account, args, ctx.Logger)
+	if err != nil {
+		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+
+	internalhandler.InsertOperationLog(c, ctx.Account, args.ProjectName, "新增", "协作模式", detail, string(data), ctx.Logger)
 
 	ctx.Err = service.CreateCollaborationMode(ctx.Account, args, ctx.Logger)
 }
@@ -79,7 +91,13 @@ func UpdateCollaborationMode(c *gin.Context) {
 		return
 	}
 
-	internalhandler.InsertOperationLog(c, ctx.Account, args.ProjectName, "更新", "协作模式", args.Name, string(data), ctx.Logger)
+	detail, err := generateCollaborationDetailLog(ctx.Account, args, ctx.Logger)
+	if err != nil {
+		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+
+	internalhandler.InsertOperationLog(c, ctx.Account, args.ProjectName, "更新", "协作模式", detail, string(data), ctx.Logger)
 
 	ctx.Err = service.UpdateCollaborationMode(ctx.Account, args, ctx.Logger)
 }
@@ -97,4 +115,255 @@ func DeleteCollaborationMode(c *gin.Context) {
 	internalhandler.InsertOperationLog(c, ctx.Account, projectName, "删除", "协作模式", name, "", ctx.Logger)
 
 	ctx.Err = service.DeleteCollaborationMode(ctx.Account, projectName, name, ctx.Logger)
+}
+
+func generateCollaborationDetailLog(username string, args *commonmodels.CollaborationMode, logger *zap.SugaredLogger) (string, error) {
+	collaborationWorkflowVerbTranslateMap := map[string]string{
+		"get_workflow":   "查看",
+		"edit_workflow":  "编辑",
+		"run_workflow":   "执行",
+		"debug_workflow": "调试",
+	}
+
+	collaborationProductVerbTranslateMap := map[string]string{
+		"get_environment":             "查看",
+		"config_environment":          "配置",
+		"manage_environment":          "管理服务实例",
+		"debug_pod":                   "服务调试",
+		"get_production_environment":  "查看",
+		"edit_production_environment": "编辑",
+		"production_debug_pod":        "服务调试",
+	}
+
+	collaborationTypeTranslateMap := map[string]string{
+		"new":   "独享",
+		"share": "共享",
+	}
+
+	currMode, exists, err := service.GetCollaborationMode(username, args.ProjectName, args.Name, logger)
+	if err != nil {
+		return "", fmt.Errorf("can't get current collaboration mode, projectName: %v, name: %v err: %v", args.ProjectName, args.Name, err)
+	}
+	if !exists {
+		currMode = &commonmodels.CollaborationMode{
+			Name:      args.Name,
+			Members:   []string{},
+			Workflows: []commonmodels.WorkflowCMItem{},
+			Products:  []commonmodels.ProductCMItem{},
+		}
+	}
+
+	currUserIDSet := sets.NewString(currMode.Members...)
+	argsUserIDSet := sets.NewString(args.Members...)
+	addedUserIDSet := argsUserIDSet.Difference(currUserIDSet)
+	deletedUserIDSet := currUserIDSet.Difference(argsUserIDSet)
+
+	allUserIDSet := sets.NewString(args.Members...)
+	allUserIDSet.Insert(currMode.Members...)
+
+	detail := "协作模式名称：" + args.Name + "\n\n"
+
+	// user part
+	userResp, err := user.SearchUsersByUIDs(allUserIDSet.List(), logger)
+	if err != nil {
+		return "", fmt.Errorf("failed to search users by uids(%v), err: %v", args.Members, err)
+	}
+	userInfoMap := make(map[string]types.UserInfo)
+	for _, user := range userResp.Users {
+		userInfoMap[user.Uid] = user
+	}
+
+	if deletedUserIDSet.Len() != 0 {
+		detail += "删除用户："
+		for _, userid := range deletedUserIDSet.List() {
+			detail += userInfoMap[userid].Name + "，"
+		}
+		detail = strings.Trim(detail, "，")
+		detail += "\n\n"
+	}
+
+	if addedUserIDSet.Len() != 0 {
+		detail += "新增用户："
+		for _, userid := range addedUserIDSet.List() {
+			detail += userInfoMap[userid].Name + "，"
+		}
+		detail = strings.Trim(detail, "，")
+		detail += "\n"
+
+		for _, workflow := range args.Workflows {
+			detail += "工作流名称：" + workflow.Name + "，类型：" + collaborationTypeTranslateMap[string(workflow.CollaborationType)] + "，"
+			detail += "权限："
+			for _, verb := range workflow.Verbs {
+				detail += collaborationWorkflowVerbTranslateMap[verb] + "，"
+			}
+			detail = strings.TrimSuffix(detail, "，")
+			detail += "\n"
+		}
+
+		for _, env := range args.Products {
+			detail += "环境名称：" + env.Name + "，类型：" + collaborationTypeTranslateMap[string(env.CollaborationType)] + "，权限："
+			for _, verb := range env.Verbs {
+				detail += collaborationProductVerbTranslateMap[verb] + "，"
+			}
+
+			detail = strings.TrimSuffix(detail, "，")
+			detail += "\n"
+		}
+
+		detail += "\n"
+	}
+
+	// workflow part
+	currWorklowMap := make(map[string]commonmodels.WorkflowCMItem)
+	argWorklowMap := make(map[string]commonmodels.WorkflowCMItem)
+	currWorklowSet := sets.NewString()
+	argWorklowSet := sets.NewString()
+
+	for _, workflow := range currMode.Workflows {
+		currWorklowSet.Insert(workflow.Name)
+		currWorklowMap[workflow.Name] = workflow
+	}
+	for _, workflow := range args.Workflows {
+		argWorklowSet.Insert(workflow.Name)
+		argWorklowMap[workflow.Name] = workflow
+	}
+
+	addedWorkflowSet := argWorklowSet.Difference(currWorklowSet)
+	deletedWorkflowSet := currWorklowSet.Difference(argWorklowSet)
+	intersectionWorkflowSet := argWorklowSet.Intersection(currWorklowSet)
+
+	detail += "权限变更：\n"
+	for _, name := range addedWorkflowSet.List() {
+		workflow := argWorklowMap[name]
+		detail += "工作流名称：" + workflow.Name + "，类型：" + collaborationTypeTranslateMap[string(workflow.CollaborationType)] + "，"
+		detail += "增加权限："
+		for _, verb := range workflow.Verbs {
+			detail += collaborationWorkflowVerbTranslateMap[verb] + "，"
+		}
+		detail = strings.TrimSuffix(detail, "，")
+		detail += "\n"
+	}
+	for _, name := range deletedWorkflowSet.List() {
+		workflow := currWorklowMap[name]
+		detail += "工作流名称：" + workflow.Name + "，类型：" + collaborationTypeTranslateMap[string(workflow.CollaborationType)] + "，"
+		detail += "移除权限："
+		for _, verb := range workflow.Verbs {
+			detail += collaborationWorkflowVerbTranslateMap[verb] + "，"
+		}
+		detail = strings.TrimSuffix(detail, "，")
+		detail += "\n"
+	}
+	for _, name := range intersectionWorkflowSet.List() {
+		workflow := argWorklowMap[name]
+		currWorkflow := currWorklowMap[name]
+
+		currVerbSet := sets.NewString(currWorkflow.Verbs...)
+		argVerbSet := sets.NewString(workflow.Verbs...)
+		addedVerbSet := argVerbSet.Difference(currVerbSet)
+		deletedVerbSet := currVerbSet.Difference(argVerbSet)
+
+		if addedVerbSet.Len() == 0 && deletedVerbSet.Len() == 0 {
+			continue
+		}
+
+		detail += "工作流名称：" + workflow.Name + "，类型：" + collaborationTypeTranslateMap[string(workflow.CollaborationType)] + "，"
+		if addedVerbSet.Len() != 0 {
+			detail += "增加权限："
+			for _, verb := range addedVerbSet.List() {
+				detail += collaborationWorkflowVerbTranslateMap[verb] + "，"
+			}
+		}
+		if deletedVerbSet.Len() != 0 {
+			detail += "移除权限："
+			for _, verb := range deletedVerbSet.List() {
+				detail += collaborationWorkflowVerbTranslateMap[verb] + "，"
+			}
+		}
+		detail = strings.TrimSuffix(detail, "，")
+		detail += "\n"
+	}
+
+	// product part
+	currProductMap := make(map[string]commonmodels.ProductCMItem)
+	argProductMap := make(map[string]commonmodels.ProductCMItem)
+	currProductSet := sets.NewString()
+	argProductSet := sets.NewString()
+
+	for _, product := range currMode.Products {
+		currProductSet.Insert(product.Name)
+		currProductMap[product.Name] = product
+	}
+	for _, product := range args.Products {
+		argProductSet.Insert(product.Name)
+		argProductMap[product.Name] = product
+	}
+
+	addedProductSet := argProductSet.Difference(currProductSet)
+	deletedProductSet := currProductSet.Difference(argProductSet)
+	intersectionProductSet := argProductSet.Intersection(currProductSet)
+
+	for _, envName := range addedProductSet.List() {
+		env := argProductMap[envName]
+		detail += "环境名称：" + env.Name + "，类型：" + collaborationTypeTranslateMap[string(env.CollaborationType)] + "，新增权限："
+		for _, verb := range env.Verbs {
+			detail += collaborationProductVerbTranslateMap[verb] + "，"
+		}
+
+		detail = strings.TrimSuffix(detail, "，")
+		detail += "\n"
+	}
+	for _, envName := range deletedProductSet.List() {
+		env := currProductMap[envName]
+		detail += "环境名称：" + env.Name + "，类型：" + collaborationTypeTranslateMap[string(env.CollaborationType)] + "，移除权限："
+		for _, verb := range env.Verbs {
+			detail += collaborationProductVerbTranslateMap[verb] + "，"
+		}
+
+		detail = strings.TrimSuffix(detail, "，")
+		detail += "\n"
+	}
+	for _, envName := range intersectionProductSet.List() {
+		argProduct := argProductMap[envName]
+		currProduct := currProductMap[envName]
+
+		currVerbSet := sets.NewString(currProduct.Verbs...)
+		argVerbSet := sets.NewString(argProduct.Verbs...)
+		addedVerbSet := argVerbSet.Difference(currVerbSet)
+		deletedVerbSet := currVerbSet.Difference(argVerbSet)
+
+		if addedVerbSet.Len() == 0 && deletedVerbSet.Len() == 0 {
+			continue
+		}
+
+		detail += "环境名称：" + argProduct.Name + "，类型：" + collaborationTypeTranslateMap[string(argProduct.CollaborationType)] + "，"
+
+		if addedVerbSet.Len() != 0 {
+			detail += "增加权限："
+			for _, verb := range addedVerbSet.List() {
+				detail += collaborationProductVerbTranslateMap[verb] + "，"
+			}
+		}
+		if deletedVerbSet.Len() != 0 {
+			detail += "移除权限："
+			for _, verb := range deletedVerbSet.List() {
+				detail += collaborationProductVerbTranslateMap[verb] + "，"
+			}
+		}
+
+		detail = strings.TrimSuffix(detail, "，")
+		detail += "\n"
+	}
+
+	if strings.LastIndex(detail, "权限变更：\n") == len(detail)-len("权限变更：\n") {
+		detail = strings.TrimSuffix(detail, "权限变更：\n")
+		return detail, nil
+	}
+
+	detail += "影响用户："
+	for _, userID := range allUserIDSet.List() {
+		detail += userInfoMap[userID].Name + "，"
+	}
+	detail = strings.TrimSuffix(detail, "，")
+
+	return detail, nil
 }

--- a/pkg/microservice/aslan/core/collaboration/service/collaboration_mode.go
+++ b/pkg/microservice/aslan/core/collaboration/service/collaboration_mode.go
@@ -17,6 +17,7 @@ limitations under the License.
 package service
 
 import (
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.uber.org/zap"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/collaboration/repository/models"
@@ -48,4 +49,21 @@ func DeleteCollaborationMode(username, projectName, name string, logger *zap.Sug
 		return err
 	}
 	return mongodb.NewCollaborationInstanceColl().ResetRevision(name, projectName)
+}
+
+func GetCollaborationMode(username, projectName, name string, logger *zap.SugaredLogger) (*models.CollaborationMode, bool, error) {
+	opt := &mongodb.CollaborationModeFindOptions{
+		ProjectName: projectName,
+		Name:        name,
+	}
+	resp, err := mongodb.NewCollaborationModeColl().Find(opt)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, false, nil
+		}
+
+		logger.Errorf("UpdateCollaborationMode error, err msg:%s", err)
+		return nil, false, err
+	}
+	return resp, true, nil
 }

--- a/pkg/microservice/picket/core/filter/service/users.go
+++ b/pkg/microservice/picket/core/filter/service/users.go
@@ -33,10 +33,6 @@ type DeleteUserResp struct {
 }
 
 func DeleteUser(userID string, header http.Header, qs url.Values, _ *zap.SugaredLogger) ([]byte, error) {
-	_, err := user.New().DeleteUser(userID, header, qs)
-	if err != nil {
-		return []byte{}, err
-	}
 	return policy.New().DeleteRoleBindings(userID, header, qs)
 }
 

--- a/pkg/microservice/policy/core/handler/role_binding.go
+++ b/pkg/microservice/policy/core/handler/role_binding.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	picketuser "github.com/koderover/zadig/pkg/microservice/picket/client/user"
 	"github.com/koderover/zadig/pkg/microservice/policy/core/service"
 	"github.com/koderover/zadig/pkg/microservice/user/core/service/user"
 	"github.com/koderover/zadig/pkg/setting"
@@ -62,7 +63,11 @@ func UpdateRoleBinding(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam.AddErr(err)
 		return
 	}
-	detail := "用户：" + userInfo.Name + "，角色名称：" + args.Role
+	username := ""
+	if userInfo != nil {
+		username = userInfo.Name
+	}
+	detail := "用户：" + username + "，角色名称：" + args.Role
 	internalhandler.InsertDetailedOperationLog(c, ctx.UserName, projectName, setting.OperationSceneProject, "更新", "角色绑定", detail, string(data), ctx.Logger, args.Name)
 
 	ctx.Err = service.UpdateOrCreateRoleBinding(projectName, args, ctx.Logger)
@@ -108,7 +113,11 @@ func CreateRoleBinding(c *gin.Context) {
 			ctx.Err = e.ErrInvalidParam.AddErr(err)
 			return
 		}
-		detail += "用户：" + userInfo.Name + "，角色名称：" + arg.Role + "\n"
+		username := ""
+		if userInfo != nil {
+			username = userInfo.Name
+		}
+		detail += "用户：" + username + "，角色名称：" + arg.Role + "\n"
 	}
 	internalhandler.InsertDetailedOperationLog(c, ctx.UserName, projectName, setting.OperationSceneProject, "创建", "角色绑定", detail, string(data), ctx.Logger, "")
 
@@ -162,13 +171,23 @@ func DeleteRoleBindings(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam.AddErr(err)
 		return
 	}
-	detail := "用户：" + userInfo.Name + "，角色名称："
+
+	username := ""
+	if userInfo != nil {
+		username = userInfo.Name
+	}
+	detail := "用户：" + username + "，角色名称："
 	for _, name := range args.Names {
 		detail += name + "，"
 	}
 	detail = strings.Trim(detail, "，")
 
 	internalhandler.InsertDetailedOperationLog(c, ctx.UserName, projectName, setting.OperationSceneProject, "删除", "角色绑定", projectName, detail, ctx.Logger, args.Names...)
+
+	_, err = picketuser.New().DeleteUser(userID, c.Request.Header, c.Request.URL.Query())
+	if err != nil {
+		return
+	}
 
 	ctx.Err = service.DeleteRoleBindings(args.Names, projectName, userID, ctx.Logger)
 }
@@ -206,7 +225,12 @@ func UpdateRoleBindings(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam.AddErr(err)
 		return
 	}
-	detail := "用户：" + userInfo.Name + "，角色名称："
+
+	username := ""
+	if userInfo != nil {
+		username = userInfo.Name
+	}
+	detail := "用户：" + username + "，角色名称："
 	for _, arg := range args {
 		detail += arg.Role + "，"
 	}
@@ -265,7 +289,12 @@ func UpdateSystemRoleBindings(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam.AddErr(err)
 		return
 	}
-	detail := "用户：" + userInfo.Name + "，角色名称："
+
+	username := ""
+	if userInfo != nil {
+		username = userInfo.Name
+	}
+	detail := "用户：" + username + "，角色名称："
 	for _, arg := range args {
 		detail += arg.Role + "，"
 	}
@@ -311,7 +340,12 @@ func CreateSystemRoleBinding(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam.AddErr(err)
 		return
 	}
-	detail := "用户：" + userInfo.Name + "，角色名称：" + args.Role
+
+	username := ""
+	if userInfo != nil {
+		username = userInfo.Name
+	}
+	detail := "用户：" + username + "，角色名称：" + args.Role
 	internalhandler.InsertDetailedOperationLog(c, ctx.UserName, "", setting.OperationSceneSystem, "创建", "系统角色绑定", detail, string(data), ctx.Logger, args.Name)
 
 	ctx.Err = service.CreateRoleBindings(service.SystemScope, []*service.RoleBinding{args}, ctx.Logger)
@@ -342,7 +376,12 @@ func CreateOrUpdateSystemRoleBinding(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam.AddErr(err)
 		return
 	}
-	detail := "用户：" + userInfo.Name + "，角色名称：" + args.Role
+
+	username := ""
+	if userInfo != nil {
+		username = userInfo.Name
+	}
+	detail := "用户：" + username + "，角色名称：" + args.Role
 	internalhandler.InsertDetailedOperationLog(c, ctx.UserName, "", setting.OperationSceneSystem, "创建或更新", "系统角色绑定", detail, string(data), ctx.Logger, args.Name)
 
 	ctx.Err = service.CreateOrUpdateSystemRoleBinding(service.SystemScope, args, ctx.Logger)


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2fea2eb</samp>

This pull request adds detailed logging for collaboration mode operations, fixes a user inconsistency bug between the policy and picket services, and improves the error handling and robustness of the role binding functions. It modifies the files `collaboration_mode.go` in the `handler` and `service` packages of the `collaboration` module, and the files `role_binding.go` in the `handler` package of the `policy` module, and `users.go` in the `filter` package of the `picket` module.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2fea2eb</samp>

*  Add a new function `generateCollaborationDetailLog` to the handler package in `collaboration_mode.go` to provide detailed logs for the collaboration mode operations, such as the users, workflows and products involved, and their permissions ([link](https://github.com/koderover/zadig/pull/2986/files?diff=unified&w=0#diff-f29cd0ff5062a67ed7549e284c8218dc96602a3302d704a12b0c151119622a44L21-R35), [link](https://github.com/koderover/zadig/pull/2986/files?diff=unified&w=0#diff-f29cd0ff5062a67ed7549e284c8218dc96602a3302d704a12b0c151119622a44R119-R369))
*  Modify the `CreateCollaborationMode` and `UpdateCollaborationMode` functions in the handler package in `collaboration_mode.go` to call the `generateCollaborationDetailLog` function before inserting the operation log, to improve the auditability and traceability of the collaboration mode feature ([link](https://github.com/koderover/zadig/pull/2986/files?diff=unified&w=0#diff-f29cd0ff5062a67ed7549e284c8218dc96602a3302d704a12b0c151119622a44L60-R73), [link](https://github.com/koderover/zadig/pull/2986/files?diff=unified&w=0#diff-f29cd0ff5062a67ed7549e284c8218dc96602a3302d704a12b0c151119622a44L82-R101))
*  Add a new function `GetCollaborationMode` to the service package in `collaboration_mode.go` to query the collaboration mode from the MongoDB database by name, to enable the comparison of the current and the new collaboration mode in the `generateCollaborationDetailLog` function ([link](https://github.com/koderover/zadig/pull/2986/files?diff=unified&w=0#diff-b6f75bf07a628173cb59d30b7e1bbbd80aaffc4ae7b608f2dbe647c6cd43b49dR20), [link](https://github.com/koderover/zadig/pull/2986/files?diff=unified&w=0#diff-b6f75bf07a628173cb59d30b7e1bbbd80aaffc4ae7b608f2dbe647c6cd43b49dR53-R69))
*  Modify the `UpdateRoleBinding`, `CreateRoleBinding`, `DeleteRoleBindings`, `UpdateSystemRoleBindings`, `CreateSystemRoleBinding`, and `CreateOrUpdateSystemRoleBinding` functions in the handler package in `role_binding.go` to check if the `userInfo` is nil before using its `Name` field, to avoid a nil pointer dereference error when the user is not found by the `SearchUserByUID` function, and to improve the error handling and robustness of the functions ([link](https://github.com/koderover/zadig/pull/2986/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L65-R70), [link](https://github.com/koderover/zadig/pull/2986/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L111-R120), [link](https://github.com/koderover/zadig/pull/2986/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L165-R179), [link](https://github.com/koderover/zadig/pull/2986/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L209-R233), [link](https://github.com/koderover/zadig/pull/2986/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L268-R297), [link](https://github.com/koderover/zadig/pull/2986/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L314-R348), [link](https://github.com/koderover/zadig/pull/2986/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50L345-R384))
*  Modify the `DeleteRoleBindings` function in the handler package in `role_binding.go` to call the `DeleteUser` function from the `picketuser` package, to delete the user from the picket service when deleting the user from the policy service, and to ensure the consistency between the two services ([link](https://github.com/koderover/zadig/pull/2986/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50R26), [link](https://github.com/koderover/zadig/pull/2986/files?diff=unified&w=0#diff-ba7e55c6e2a80e13581095c29dc20cf73b7d3c4872ec7a5b0ed1ab955f980f50R187-R191))
*  Remove the call to the `DeleteUser` function from the `DeleteUserResp` type in the `filter` package in `users.go`, to avoid deleting the user from the picket service when deleting the user from the policy service, and to fix a bug that caused inconsistency and errors in other services that rely on the picket service for user information ([link](https://github.com/koderover/zadig/pull/2986/files?diff=unified&w=0#diff-08964597859f8341cdd472db331ab9db191fb0cdc9fb88c941c8bdbc84221a42L36-L39))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
