### PR TITLE
add pods in resource view

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -532,7 +532,7 @@ func (c *DeployJobCtl) wait(ctx context.Context) {
 				for _, pod := range pods {
 					podResource := wrapper.Pod(pod).Resource()
 					if podResource.Status != setting.StatusRunning && podResource.Status != setting.StatusSucceeded {
-						for _, cs := range podResource.ContainerStatuses {
+						for _, cs := range podResource.Containers {
 							// message为空不认为是错误状态，有可能还在waiting
 							if cs.Message != "" {
 								msg = append(msg, fmt.Sprintf("Status: %s, Reason: %s, Message: %s", cs.Status, cs.Reason, cs.Message))

--- a/pkg/microservice/aslan/core/environment/handler/kube.go
+++ b/pkg/microservice/aslan/core/environment/handler/kube.go
@@ -158,6 +158,22 @@ func ListWorkloadsInfo(c *gin.Context) {
 	ctx.Resp, ctx.Err = service.ListWorkloadsInfo(c.Param("clusterID"), c.Param("namespace"), ctx.Logger)
 }
 
+// @Summary Get Pods Info
+// @Description Get Pods Info
+// @Tags 	environment
+// @Accept 	json
+// @Produce json
+// @Param 	clusterID 		path		string										true	"clusterID"
+// @Param 	namespace 		path		string										true	"namespace"
+// @Success 200 			{array} 	resource.Pod
+// @Router /api/aslan/environment/kube/pod/cluster/{clusterID}/namespace/{namespace} [get]
+func ListPodsInfo(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	ctx.Resp, ctx.Err = service.ListPodsInfo(c.Param("clusterID"), c.Param("namespace"), ctx.Logger)
+}
+
 func ListCustomWorkload(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()

--- a/pkg/microservice/aslan/core/environment/handler/kube.go
+++ b/pkg/microservice/aslan/core/environment/handler/kube.go
@@ -165,7 +165,7 @@ func ListWorkloadsInfo(c *gin.Context) {
 // @Produce json
 // @Param 	projectName 	query		string										true	"projectName"
 // @Param 	envName 		query		string										true	"envName"
-// @Success 200 			{array} 	resource.Pod
+// @Success 200 			{array} 	service.ListPodsInfoRespone
 // @Router /api/aslan/environment/kube/pods [get]
 func ListPodsInfo(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
@@ -179,6 +179,15 @@ func ListPodsInfo(c *gin.Context) {
 	}
 
 	projectKey := c.Query("projectName")
+	if projectKey == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("projectName can't be empty")
+		return
+	}
+	envName := c.Query("envName")
+	if envName == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("envName can't be empty")
+	}
+
 	// authorization checks
 	if !ctx.Resources.IsSystemAdmin {
 		if _, ok := ctx.Resources.ProjectAuthInfo[projectKey]; !ok {
@@ -192,7 +201,7 @@ func ListPodsInfo(c *gin.Context) {
 		}
 	}
 
-	ctx.Resp, ctx.Err = service.ListPodsInfo(projectKey, c.Query("envName"), ctx.Logger)
+	ctx.Resp, ctx.Err = service.ListPodsInfo(projectKey, envName, ctx.Logger)
 }
 
 // @Summary Get Pods Detail Info
@@ -217,6 +226,18 @@ func GetPodsDetailInfo(c *gin.Context) {
 	}
 
 	projectKey := c.Query("projectName")
+	if projectKey == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("projectName can't be empty")
+		return
+	}
+	envName := c.Query("envName")
+	if envName == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("envName can't be empty")
+	}
+	podName := c.Query("podName")
+	if podName == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("podName can't be empty")
+	}
 	// authorization checks
 	if !ctx.Resources.IsSystemAdmin {
 		if _, ok := ctx.Resources.ProjectAuthInfo[projectKey]; !ok {
@@ -230,7 +251,7 @@ func GetPodsDetailInfo(c *gin.Context) {
 		}
 	}
 
-	ctx.Resp, ctx.Err = service.GetPodDetailInfo(projectKey, c.Query("envName"), c.Param("podName"), ctx.Logger)
+	ctx.Resp, ctx.Err = service.GetPodDetailInfo(projectKey, envName, podName, ctx.Logger)
 }
 
 func ListCustomWorkload(c *gin.Context) {

--- a/pkg/microservice/aslan/core/environment/handler/kube.go
+++ b/pkg/microservice/aslan/core/environment/handler/kube.go
@@ -186,6 +186,7 @@ func ListPodsInfo(c *gin.Context) {
 	envName := c.Query("envName")
 	if envName == "" {
 		ctx.Err = e.ErrInvalidParam.AddDesc("envName can't be empty")
+		return
 	}
 
 	// authorization checks
@@ -233,10 +234,12 @@ func GetPodsDetailInfo(c *gin.Context) {
 	envName := c.Query("envName")
 	if envName == "" {
 		ctx.Err = e.ErrInvalidParam.AddDesc("envName can't be empty")
+		return
 	}
-	podName := c.Query("podName")
+	podName := c.Param("podName")
 	if podName == "" {
 		ctx.Err = e.ErrInvalidParam.AddDesc("podName can't be empty")
+		return
 	}
 	// authorization checks
 	if !ctx.Resources.IsSystemAdmin {

--- a/pkg/microservice/aslan/core/environment/handler/product.go
+++ b/pkg/microservice/aslan/core/environment/handler/product.go
@@ -57,7 +57,7 @@ type getInitProductResponse struct {
 // @Param 	envType 		query		string								true	"env type"
 // @Param 	isBaseEnv 		query		string								true	"is base env"
 // @Param 	baseEnv 		query		string								true	"base env"
-// @Success 200 			{object} 	getInitProductRespone
+// @Success 200 			{object} 	getInitProductResponse
 // @Router /api/aslan/environment/init_info/{name} [get]
 func GetInitProduct(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -109,6 +109,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		kube.GET("/workloads", ListWorkloads)
 		kube.GET("/nodes", ListNodes)
 		kube.GET("/pods", ListPodsInfo)
+		kube.GET("/pods/:podName", GetPodsDetailInfo)
 
 		kube.POST("/k8s/resources", GetResourceDeployStatus)
 		kube.POST("/helm/releases", GetReleaseDeployStatus)

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -119,6 +119,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		kube.GET("/namespace/cluster/:clusterID", ListNamespace)
 		kube.GET("/deployment/cluster/:clusterID/namespace/:namespace", ListDeploymentNames)
 		kube.GET("/workload/cluster/:clusterID/namespace/:namespace", ListWorkloadsInfo)
+		kube.GET("/pod/cluster/:clusterID/namespace/:namespace", ListPodsInfo)
 		kube.GET("/custom_workload/cluster/:clusterID/namespace/:namespace", ListCustomWorkload)
 		kube.GET("/canary_service/cluster/:clusterID/namespace/:namespace", ListCanaryDeploymentServiceInfo)
 		kube.GET("/resources/cluster/:clusterID/namespace/:namespace", ListAllK8sResourcesInNamespace)

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -108,6 +108,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		kube.GET("/pods/:podName/events", ListPodEvents)
 		kube.GET("/workloads", ListWorkloads)
 		kube.GET("/nodes", ListNodes)
+		kube.GET("/pods", ListPodsInfo)
 
 		kube.POST("/k8s/resources", GetResourceDeployStatus)
 		kube.POST("/helm/releases", GetReleaseDeployStatus)
@@ -119,7 +120,6 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		kube.GET("/namespace/cluster/:clusterID", ListNamespace)
 		kube.GET("/deployment/cluster/:clusterID/namespace/:namespace", ListDeploymentNames)
 		kube.GET("/workload/cluster/:clusterID/namespace/:namespace", ListWorkloadsInfo)
-		kube.GET("/pod/cluster/:clusterID/namespace/:namespace", ListPodsInfo)
 		kube.GET("/custom_workload/cluster/:clusterID/namespace/:namespace", ListCustomWorkload)
 		kube.GET("/canary_service/cluster/:clusterID/namespace/:namespace", ListCanaryDeploymentServiceInfo)
 		kube.GET("/resources/cluster/:clusterID/namespace/:namespace", ListAllK8sResourcesInNamespace)

--- a/pkg/microservice/aslan/core/environment/service/kube.go
+++ b/pkg/microservice/aslan/core/environment/service/kube.go
@@ -1343,24 +1343,24 @@ func GetPodDetailInfo(projectName, envName, podName string, log *zap.SugaredLogg
 		EnvName: envName,
 	})
 	if err != nil {
-		return nil, e.ErrListPod.AddErr(fmt.Errorf("failed to get product info, err: %s", err))
+		return nil, e.ErrGetPodDetail.AddErr(fmt.Errorf("failed to get product info, err: %s", err))
 	}
 
 	kubeClient, err := kubeclient.GetKubeClient(config.HubServerAddress(), productInfo.ClusterID)
 	if err != nil {
-		return nil, e.ErrListPod.AddErr(err)
+		return nil, e.ErrGetPodDetail.AddErr(err)
 	}
 
 	pod, found, err := getter.GetPod(productInfo.Namespace, podName, kubeClient)
 	if err != nil {
 		errMsg := fmt.Sprintf("[%s] GetPod error: %v", productInfo.Namespace, err)
 		log.Error(errMsg)
-		return nil, e.ErrListPod.AddDesc(errMsg)
+		return nil, e.ErrGetPodDetail.AddDesc(errMsg)
 	}
 	if !found {
-		errMsg := fmt.Sprintf("[%s] can't find pod", productInfo.Namespace)
+		errMsg := fmt.Sprintf("[%s] can't find pod %s", productInfo.Namespace, podName)
 		log.Error(errMsg)
-		return nil, e.ErrListPod.AddDesc(errMsg)
+		return nil, e.ErrGetPodDetail.AddDesc(errMsg)
 	}
 
 	res := wrapper.Pod(pod).Resource()

--- a/pkg/microservice/aslan/core/environment/service/kube.go
+++ b/pkg/microservice/aslan/core/environment/service/kube.go
@@ -1282,3 +1282,24 @@ func GetReleaseInstanceDeployStatus(productName string, request *HelmDeployStatu
 
 	return resp, err
 }
+
+func ListPodsInfo(clusterID, namespace string, log *zap.SugaredLogger) ([]*resource.Pod, error) {
+	res := make([]*resource.Pod, 0)
+
+	kubeClient, err := kubeclient.GetKubeClient(config.HubServerAddress(), clusterID)
+	if err != nil {
+		return res, e.ErrListPod.AddErr(err)
+	}
+
+	pods, err := getter.ListPods(namespace, labels.Everything(), kubeClient)
+	if err != nil {
+		errMsg := fmt.Sprintf("[%s] ListPods error: %v", namespace, err)
+		log.Error(errMsg)
+		return res, e.ErrListPod.AddDesc(errMsg)
+	}
+
+	for _, pod := range pods {
+		res = append(res, wrapper.Pod(pod).Resource())
+	}
+	return res, nil
+}

--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -620,7 +620,7 @@ func queryPodsStatus(productInfo *commonmodels.Product, serviceTmpl *commonmodel
 
 	imageSet := sets.String{}
 	for _, pod := range pods {
-		for _, container := range pod.ContainerStatuses {
+		for _, container := range pod.Containers {
 			imageSet.Insert(container.Image)
 		}
 	}

--- a/pkg/microservice/aslan/server/rest/doc/docs.go
+++ b/pkg/microservice/aslan/server/rest/doc/docs.go
@@ -908,7 +908,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handler.getInitProductRespone"
+                            "$ref": "#/definitions/handler.getInitProductResponse"
                         }
                     }
                 }
@@ -996,6 +996,48 @@ const docTemplate = `{
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/service.ServiceDeployStatus"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/aslan/environment/kube/pod/cluster/{clusterID}/namespace/{namespace}": {
+            "get": {
+                "description": "Get Pods Info",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Get Pods Info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "clusterID",
+                        "name": "clusterID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/resource.Pod"
                             }
                         }
                     }
@@ -3182,7 +3224,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handler.getInitProductRespone": {
+        "handler.getInitProductResponse": {
             "type": "object",
             "properties": {
                 "chart_infos": {
@@ -4468,7 +4510,7 @@ const docTemplate = `{
                 "cluster_name": {
                     "type": "string"
                 },
-                "env_name": {
+                "env_key": {
                     "type": "string"
                 },
                 "namespace": {

--- a/pkg/microservice/aslan/server/rest/doc/docs.go
+++ b/pkg/microservice/aslan/server/rest/doc/docs.go
@@ -1037,7 +1037,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/resource.Pod"
+                                "$ref": "#/definitions/service.ListPodsInfoRespone"
                             }
                         }
                     }
@@ -4901,6 +4901,29 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "value": {}
+            }
+        },
+        "service.ListPodsInfoRespone": {
+            "type": "object",
+            "properties": {
+                "create_time": {
+                    "type": "integer"
+                },
+                "images": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "ready": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
             }
         },
         "service.LoadServiceFromYamlTemplateReq": {

--- a/pkg/microservice/aslan/server/rest/doc/docs.go
+++ b/pkg/microservice/aslan/server/rest/doc/docs.go
@@ -1002,7 +1002,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/aslan/environment/kube/pod/cluster/{clusterID}/namespace/{namespace}": {
+        "/api/aslan/environment/kube/pods": {
             "get": {
                 "description": "Get Pods Info",
                 "consumes": [
@@ -1018,16 +1018,16 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "clusterID",
-                        "name": "clusterID",
-                        "in": "path",
+                        "description": "projectName",
+                        "name": "projectName",
+                        "in": "query",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "namespace",
-                        "name": "namespace",
-                        "in": "path",
+                        "description": "envName",
+                        "name": "envName",
+                        "in": "query",
                         "required": true
                     }
                 ],
@@ -4069,6 +4069,12 @@ const docTemplate = `{
                 "name": {
                     "type": "string"
                 },
+                "ports": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/resource.ContainerPort"
+                    }
+                },
                 "ready": {
                     "type": "boolean"
                 },
@@ -4099,6 +4105,35 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
+                }
+            }
+        },
+        "resource.ContainerPort": {
+            "type": "object",
+            "properties": {
+                "containerPort": {
+                    "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 \u003c x \u003c 65536.",
+                    "type": "integer"
+                },
+                "hostIP": {
+                    "description": "What host IP to bind the external port to.\n+optional",
+                    "type": "string"
+                },
+                "hostPort": {
+                    "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 \u003c x \u003c 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.\n+optional",
+                    "type": "integer"
+                },
+                "name": {
+                    "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.\n+optional",
+                    "type": "string"
+                },
+                "protocol": {
+                    "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".\n+optional\n+default=\"TCP\"",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/resource.Protocol"
+                        }
+                    ]
                 }
             }
         },
@@ -4232,6 +4267,19 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "resource.Protocol": {
+            "type": "string",
+            "enum": [
+                "TCP",
+                "UDP",
+                "SCTP"
+            ],
+            "x-enum-varnames": [
+                "ProtocolTCP",
+                "ProtocolUDP",
+                "ProtocolSCTP"
+            ]
         },
         "resource.Service": {
             "type": "object",

--- a/pkg/microservice/aslan/server/rest/doc/docs.go
+++ b/pkg/microservice/aslan/server/rest/doc/docs.go
@@ -1044,6 +1044,52 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/aslan/environment/kube/pods/{podName}": {
+            "get": {
+                "description": "Get Pods Detail Info",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Get Pods Detail Info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "projectName",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "envName",
+                        "name": "envName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "podName",
+                        "name": "podName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/resource.Pod"
+                        }
+                    }
+                }
+            }
+        },
         "/api/aslan/environment/production/environments": {
             "put": {
                 "description": "Update Multi production products",

--- a/pkg/microservice/aslan/server/rest/doc/swagger.json
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.json
@@ -993,7 +993,7 @@
                 }
             }
         },
-        "/api/aslan/environment/kube/pod/cluster/{clusterID}/namespace/{namespace}": {
+        "/api/aslan/environment/kube/pods": {
             "get": {
                 "description": "Get Pods Info",
                 "consumes": [
@@ -1009,16 +1009,16 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "clusterID",
-                        "name": "clusterID",
-                        "in": "path",
+                        "description": "projectName",
+                        "name": "projectName",
+                        "in": "query",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "namespace",
-                        "name": "namespace",
-                        "in": "path",
+                        "description": "envName",
+                        "name": "envName",
+                        "in": "query",
                         "required": true
                     }
                 ],
@@ -4060,6 +4060,12 @@
                 "name": {
                     "type": "string"
                 },
+                "ports": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/resource.ContainerPort"
+                    }
+                },
                 "ready": {
                     "type": "boolean"
                 },
@@ -4090,6 +4096,35 @@
                 },
                 "name": {
                     "type": "string"
+                }
+            }
+        },
+        "resource.ContainerPort": {
+            "type": "object",
+            "properties": {
+                "containerPort": {
+                    "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 \u003c x \u003c 65536.",
+                    "type": "integer"
+                },
+                "hostIP": {
+                    "description": "What host IP to bind the external port to.\n+optional",
+                    "type": "string"
+                },
+                "hostPort": {
+                    "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 \u003c x \u003c 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.\n+optional",
+                    "type": "integer"
+                },
+                "name": {
+                    "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.\n+optional",
+                    "type": "string"
+                },
+                "protocol": {
+                    "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".\n+optional\n+default=\"TCP\"",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/resource.Protocol"
+                        }
+                    ]
                 }
             }
         },
@@ -4223,6 +4258,19 @@
                     "type": "string"
                 }
             }
+        },
+        "resource.Protocol": {
+            "type": "string",
+            "enum": [
+                "TCP",
+                "UDP",
+                "SCTP"
+            ],
+            "x-enum-varnames": [
+                "ProtocolTCP",
+                "ProtocolUDP",
+                "ProtocolSCTP"
+            ]
         },
         "resource.Service": {
             "type": "object",

--- a/pkg/microservice/aslan/server/rest/doc/swagger.json
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.json
@@ -1028,7 +1028,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/resource.Pod"
+                                "$ref": "#/definitions/service.ListPodsInfoRespone"
                             }
                         }
                     }
@@ -4892,6 +4892,29 @@
                     "type": "string"
                 },
                 "value": {}
+            }
+        },
+        "service.ListPodsInfoRespone": {
+            "type": "object",
+            "properties": {
+                "create_time": {
+                    "type": "integer"
+                },
+                "images": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "ready": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
             }
         },
         "service.LoadServiceFromYamlTemplateReq": {

--- a/pkg/microservice/aslan/server/rest/doc/swagger.json
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.json
@@ -1035,6 +1035,52 @@
                 }
             }
         },
+        "/api/aslan/environment/kube/pods/{podName}": {
+            "get": {
+                "description": "Get Pods Detail Info",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Get Pods Detail Info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "projectName",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "envName",
+                        "name": "envName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "podName",
+                        "name": "podName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/resource.Pod"
+                        }
+                    }
+                }
+            }
+        },
         "/api/aslan/environment/production/environments": {
             "put": {
                 "description": "Update Multi production products",

--- a/pkg/microservice/aslan/server/rest/doc/swagger.json
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.json
@@ -899,7 +899,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handler.getInitProductRespone"
+                            "$ref": "#/definitions/handler.getInitProductResponse"
                         }
                     }
                 }
@@ -987,6 +987,48 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/service.ServiceDeployStatus"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/aslan/environment/kube/pod/cluster/{clusterID}/namespace/{namespace}": {
+            "get": {
+                "description": "Get Pods Info",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Get Pods Info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "clusterID",
+                        "name": "clusterID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/resource.Pod"
                             }
                         }
                     }
@@ -3173,7 +3215,7 @@
                 }
             }
         },
-        "handler.getInitProductRespone": {
+        "handler.getInitProductResponse": {
             "type": "object",
             "properties": {
                 "chart_infos": {
@@ -4459,7 +4501,7 @@
                 "cluster_name": {
                     "type": "string"
                 },
-                "env_name": {
+                "env_key": {
                     "type": "string"
                 },
                 "namespace": {

--- a/pkg/microservice/aslan/server/rest/doc/swagger.yaml
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.yaml
@@ -241,7 +241,7 @@ definitions:
       variable_yaml:
         type: string
     type: object
-  handler.getInitProductRespone:
+  handler.getInitProductResponse:
     properties:
       chart_infos:
         items:
@@ -1104,7 +1104,7 @@ definitions:
     properties:
       cluster_name:
         type: string
-      env_name:
+      env_key:
         type: string
       namespace:
         type: string
@@ -2542,7 +2542,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handler.getInitProductRespone'
+            $ref: '#/definitions/handler.getInitProductResponse'
       summary: Get init product
       tags:
       - environment
@@ -2602,6 +2602,34 @@ paths:
               $ref: '#/definitions/service.ServiceDeployStatus'
             type: array
       summary: Get Resource Deploy Status
+      tags:
+      - environment
+  /api/aslan/environment/kube/pod/cluster/{clusterID}/namespace/{namespace}:
+    get:
+      consumes:
+      - application/json
+      description: Get Pods Info
+      parameters:
+      - description: clusterID
+        in: path
+        name: clusterID
+        required: true
+        type: string
+      - description: namespace
+        in: path
+        name: namespace
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/resource.Pod'
+            type: array
+      summary: Get Pods Info
       tags:
       - environment
   /api/aslan/environment/production/environments:

--- a/pkg/microservice/aslan/server/rest/doc/swagger.yaml
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.yaml
@@ -812,6 +812,10 @@ definitions:
         type: string
       name:
         type: string
+      ports:
+        items:
+          $ref: '#/definitions/resource.ContainerPort'
+        type: array
       ready:
         type: boolean
       reason:
@@ -833,6 +837,42 @@ definitions:
         type: string
       name:
         type: string
+    type: object
+  resource.ContainerPort:
+    properties:
+      containerPort:
+        description: |-
+          Number of port to expose on the pod's IP address.
+          This must be a valid port number, 0 < x < 65536.
+        type: integer
+      hostIP:
+        description: |-
+          What host IP to bind the external port to.
+          +optional
+        type: string
+      hostPort:
+        description: |-
+          Number of port to expose on the host.
+          If specified, this must be a valid port number, 0 < x < 65536.
+          If HostNetwork is specified, this must match ContainerPort.
+          Most containers do not need this.
+          +optional
+        type: integer
+      name:
+        description: |-
+          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+          named port in a pod must have a unique name. Name for the port that can be
+          referred to by services.
+          +optional
+        type: string
+      protocol:
+        allOf:
+        - $ref: '#/definitions/resource.Protocol'
+        description: |-
+          Protocol for port. Must be UDP, TCP, or SCTP.
+          Defaults to "TCP".
+          +optional
+          +default="TCP"
     type: object
   resource.CronJob:
     properties:
@@ -920,6 +960,16 @@ definitions:
       status:
         type: string
     type: object
+  resource.Protocol:
+    enum:
+    - TCP
+    - UDP
+    - SCTP
+    type: string
+    x-enum-varnames:
+    - ProtocolTCP
+    - ProtocolUDP
+    - ProtocolSCTP
   resource.Service:
     properties:
       age:
@@ -2604,20 +2654,20 @@ paths:
       summary: Get Resource Deploy Status
       tags:
       - environment
-  /api/aslan/environment/kube/pod/cluster/{clusterID}/namespace/{namespace}:
+  /api/aslan/environment/kube/pods:
     get:
       consumes:
       - application/json
       description: Get Pods Info
       parameters:
-      - description: clusterID
-        in: path
-        name: clusterID
+      - description: projectName
+        in: query
+        name: projectName
         required: true
         type: string
-      - description: namespace
-        in: path
-        name: namespace
+      - description: envName
+        in: query
+        name: envName
         required: true
         type: string
       produces:

--- a/pkg/microservice/aslan/server/rest/doc/swagger.yaml
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.yaml
@@ -2682,6 +2682,37 @@ paths:
       summary: Get Pods Info
       tags:
       - environment
+  /api/aslan/environment/kube/pods/{podName}:
+    get:
+      consumes:
+      - application/json
+      description: Get Pods Detail Info
+      parameters:
+      - description: projectName
+        in: query
+        name: projectName
+        required: true
+        type: string
+      - description: envName
+        in: query
+        name: envName
+        required: true
+        type: string
+      - description: podName
+        in: path
+        name: podName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/resource.Pod'
+      summary: Get Pods Detail Info
+      tags:
+      - environment
   /api/aslan/environment/production/environments:
     put:
       consumes:

--- a/pkg/microservice/aslan/server/rest/doc/swagger.yaml
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.yaml
@@ -1349,6 +1349,21 @@ definitions:
         type: string
       value: {}
     type: object
+  service.ListPodsInfoRespone:
+    properties:
+      create_time:
+        type: integer
+      images:
+        items:
+          type: string
+        type: array
+      name:
+        type: string
+      ready:
+        type: string
+      status:
+        type: string
+    type: object
   service.LoadServiceFromYamlTemplateReq:
     properties:
       auto_sync:
@@ -2677,7 +2692,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/resource.Pod'
+              $ref: '#/definitions/service.ListPodsInfoRespone'
             type: array
       summary: Get Pods Info
       tags:

--- a/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
@@ -585,7 +585,7 @@ func (p *DeployTaskPlugin) Wait(ctx context.Context) {
 				for _, pod := range pods {
 					podResource := wrapper.Pod(pod).Resource()
 					if podResource.Status != setting.StatusRunning && podResource.Status != setting.StatusSucceeded {
-						for _, cs := range podResource.ContainerStatuses {
+						for _, cs := range podResource.Containers {
 							// message为空不认为是错误状态，有可能还在waiting
 							if cs.Message != "" {
 								msg = append(msg, fmt.Sprintf("Status: %s, Reason: %s, Message: %s", cs.Status, cs.Reason, cs.Message))

--- a/pkg/shared/kube/resource/pod.go
+++ b/pkg/shared/kube/resource/pod.go
@@ -24,7 +24,7 @@ type Pod struct {
 	CreateTime           int64             `json:"createtime"`
 	IP                   string            `json:"ip"`
 	Labels               map[string]string `json:"labels"`
-	ContainerStatuses    []Container       `json:"containers"`
+	Containers           []Container       `json:"containers"`
 	NodeName             string            `json:"node_name"`
 	HostIP               string            `json:"host_ip"`
 	EnableDebugContainer bool              `json:"enable_debug_container"`
@@ -36,11 +36,12 @@ type Pod struct {
 }
 
 type Container struct {
-	Name         string `json:"name"`
-	Image        string `json:"image"`
-	RestartCount int32  `json:"restart_count"`
-	Status       string `json:"status"`
-	Ready        bool   `json:"ready"`
+	Name         string          `json:"name"`
+	Image        string          `json:"image"`
+	RestartCount int32           `json:"restart_count"`
+	Status       string          `json:"status"`
+	Ready        bool            `json:"ready"`
+	Ports        []ContainerPort `json:"ports"`
 	// Message regarding the last termination of the container
 	Message string `json:"message"`
 	// reason from the last termination of the container
@@ -50,3 +51,39 @@ type Container struct {
 	// Time at which the container last terminated
 	FinishedAt int64 `json:"finished_at,omitempty"`
 }
+
+type ContainerPort struct {
+	// If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+	// named port in a pod must have a unique name. Name for the port that can be
+	// referred to by services.
+	// +optional
+	Name string `json:"name,omitempty"`
+	// Number of port to expose on the host.
+	// If specified, this must be a valid port number, 0 < x < 65536.
+	// If HostNetwork is specified, this must match ContainerPort.
+	// Most containers do not need this.
+	// +optional
+	HostPort int32 `json:"hostPort,omitempty"`
+	// Number of port to expose on the pod's IP address.
+	// This must be a valid port number, 0 < x < 65536.
+	ContainerPort int32 `json:"containerPort"`
+	// Protocol for port. Must be UDP, TCP, or SCTP.
+	// Defaults to "TCP".
+	// +optional
+	// +default="TCP"
+	Protocol Protocol `json:"protocol,omitempty"`
+	// What host IP to bind the external port to.
+	// +optional
+	HostIP string `json:"hostIP,omitempty"`
+}
+
+type Protocol string
+
+const (
+	// ProtocolTCP is the TCP protocol.
+	ProtocolTCP Protocol = "TCP"
+	// ProtocolUDP is the UDP protocol.
+	ProtocolUDP Protocol = "UDP"
+	// ProtocolSCTP is the SCTP protocol.
+	ProtocolSCTP Protocol = "SCTP"
+)

--- a/pkg/tool/errors/http_errors.go
+++ b/pkg/tool/errors/http_errors.go
@@ -216,6 +216,7 @@ var (
 	ErrDeleteSvcHasSvcsInSubEnv = NewHTTPError(6094, "删除服务失败，待删除服务存在于子环境中")
 	ErrPreviewYaml              = NewHTTPError(6150, "预览Yaml失败")
 	ErrAnalysisEnvResource      = NewHTTPError(6151, "AI环境巡检失败")
+	ErrListPod                  = NewHTTPError(6152, "列出Pod失败")
 
 	//-----------------------------------------------------------------------------------------------
 	// it report APIs Range: 6100 - 6149

--- a/pkg/tool/errors/http_errors.go
+++ b/pkg/tool/errors/http_errors.go
@@ -217,6 +217,7 @@ var (
 	ErrPreviewYaml              = NewHTTPError(6150, "预览Yaml失败")
 	ErrAnalysisEnvResource      = NewHTTPError(6151, "AI环境巡检失败")
 	ErrListPod                  = NewHTTPError(6152, "列出Pod失败")
+	ErrGetPodDetail             = NewHTTPError(6153, "获取Pod详情失败")
 
 	//-----------------------------------------------------------------------------------------------
 	// it report APIs Range: 6100 - 6149


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eadd559</samp>

This pull request adds a new API endpoint for listing pods in a cluster and namespace, updates the pod and container resource types to include port information, and fixes some typos and renames some types and fields in the swagger documentation and the code. The main files affected are `pkg/microservice/aslan/server/rest/doc/docs.go`, `pkg/microservice/aslan/core/environment/handler/kube.go`, `pkg/microservice/aslan/core/environment/service/kube.go`, and `pkg/shared/kube/resource/pod.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eadd559</samp>

*  Rename `ContainerStatuses` field to `Containers` in `resource.Pod` type and add `Ports` field to `resource.Container` type to include port and protocol information of pod containers ([link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-628ed659c43743c48f2e289f3667210a2da86d8200e44afae69ad37bc6fffeb7L27-R27),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-628ed659c43743c48f2e289f3667210a2da86d8200e44afae69ad37bc6fffeb7L39-R44),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-628ed659c43743c48f2e289f3667210a2da86d8200e44afae69ad37bc6fffeb7R54-R89))
* Update `Resource` function in `wrapper.Pod` to convert `corev1.ContainerPort` types to `resource.ContainerPort` types and assign them to the `Ports` field of the `resource.Container` types ([link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-736e993aacc2ab5029b8f76b94e7e8069c373b08ba6f77b60a29a0bf65d395fdL146-R146),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-736e993aacc2ab5029b8f76b94e7e8069c373b08ba6f77b60a29a0bf65d395fdR156-R160),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-736e993aacc2ab5029b8f76b94e7e8069c373b08ba6f77b60a29a0bf65d395fdR175),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-736e993aacc2ab5029b8f76b94e7e8069c373b08ba6f77b60a29a0bf65d395fdL214-R234),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-736e993aacc2ab5029b8f76b94e7e8069c373b08ba6f77b60a29a0bf65d395fdL229-R249),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-736e993aacc2ab5029b8f76b94e7e8069c373b08ba6f77b60a29a0bf65d395fdL238-R258))
* Update `wait` function in `job_deploy.go` and `Wait` function in `deploy.go` to check the status and message of the `Containers` field instead of the `ContainerStatuses` field of the `resource.Pod` type ([link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-12dc0db8a7f7896ce61906a83153d616f1197e33e17ea94802488a33fa600831L535-R535),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-9b8d72a57eca69a24c890acc2d09faa9e330ee0157337dd88e4d63a189805227L588-R588))
* Update `queryPodsStatus` function in `service.go` to query the status and image of the `Containers` field instead of the `ContainerStatuses` field of the `resource.Pod` type ([link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-06d37031b76a99e605f5abab3018e3a09695d7723162586b7dcaec04a6c23864L625-R625))
* Add `ListPodsInfo` function to `service` package and `handler` package to handle GET request to `/api/aslan/environment/kube/pod/cluster/{clusterID}/namespace/{namespace}` and return a list of pods in the specified cluster and namespace ([link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-a5cea4826aa345a878ca29c2d24b4c6777b2656c91c9e150efba27388e4d08edR161-R176),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-911246577caa021c865066caebafafc4a263bfd1fa3cac432a1ce75d598df345R1285-R1305))
* Register `/api/aslan/environment/kube/pod/cluster/{clusterID}/namespace/{namespace}` route to the `kube` group of the gin router in `router.go` ([link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-bc855cdae7fd5951f2dd616071a0a85b20273c7a89fc1725f032de2b17ff7bd7R122))
* Add swagger documentation for `/api/aslan/environment/kube/pod/cluster/{clusterID}/namespace/{namespace}` endpoint to `docs.go`, `swagger.json`, and `swagger.yaml` files ([link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62R1005-R1046),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216R996-R1037),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2R2607-R2634))
* Add `ErrListPod` error to `http_errors.go` to indicate failure in listing pods from the kube client ([link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-754ac2982cab78c22f57f226133df3f1092fc72a6d1133a1331864479a935773R219))
* Rename `getInitProductRespone` type to `getInitProductResponse` to fix typo in `product.go`, `docs.go`, `swagger.json`, and `swagger.yaml` files ([link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-71ab717e1094267e313ebdbd610fe982f7b3f54a609c5c880a1617667c5167deL60-R60),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62L911-R911),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62L3185-R3227),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216L902-R902),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216L3176-R3218),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2L244-R244),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2L2545-R2545))
* Rename `env_name` property to `env_key` in `service.Service` type and update swagger documentation accordingly in `docs.go`, `swagger.json`, and `swagger.yaml` files ([link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62L4471-R4513),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216L4462-R4504),[link](https://github.com/koderover/zadig/pull/2987/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2L1107-R1107))

### Does this PR introduce a user-facing change?

- [X] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
