### PR TITLE
fix renderset query logic & remove some useless code

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/1180_vars.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/1180_vars.go
@@ -349,7 +349,7 @@ func migrateTestProductVariables() error {
 				continue
 			}
 			product.EnsureRenderInfo()
-			renderInfo, exists, err := mongodb.NewRenderSetColl().FindRenderSet(&mongodb.RenderSetFindOption{
+			renderInfo, err := mongodb.NewRenderSetColl().Find(&mongodb.RenderSetFindOption{
 				ProductTmpl: product.ProductName,
 				Name:        product.Render.Name,
 				Revision:    product.Render.Revision,
@@ -357,9 +357,6 @@ func migrateTestProductVariables() error {
 			})
 			if err != nil {
 				return errors.Wrapf(err, "get render info, product name: %s, render name: %s, revision: %d", product.ProductName, product.Render.Name, product.Render.Revision)
-			}
-			if !exists {
-				return fmt.Errorf("render set not found, product name: %s, render name: %s, revision: %d", product.ProductName, product.Render.Name, product.Render.Revision)
 			}
 
 			if len(renderInfo.GlobalVariables) > 0 {
@@ -559,7 +556,7 @@ func migrateProductionProductVariables() error {
 			}
 
 			product.EnsureRenderInfo()
-			renderInfo, exists, err := mongodb.NewRenderSetColl().FindRenderSet(&mongodb.RenderSetFindOption{
+			renderInfo, err := mongodb.NewRenderSetColl().Find(&mongodb.RenderSetFindOption{
 				ProductTmpl: product.ProductName,
 				Name:        product.Render.Name,
 				Revision:    product.Render.Revision,
@@ -567,9 +564,6 @@ func migrateProductionProductVariables() error {
 			})
 			if err != nil {
 				return errors.Wrapf(err, "get render info, product name: %s, render name: %s, revision: %d", product.ProductName, product.Render.Name, product.Render.Revision)
-			}
-			if !exists {
-				return fmt.Errorf("render set not found, product name: %s, render name: %s, revision: %d", product.ProductName, product.Render.Name, product.Render.Revision)
 			}
 
 			// change service variable yaml to kvs

--- a/pkg/microservice/aslan/core/collaboration/service/collaboration_instance.go
+++ b/pkg/microservice/aslan/core/collaboration/service/collaboration_instance.go
@@ -28,7 +28,6 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/collaboration/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/collaboration/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/collaboration/repository/mongodb"
-	models2 "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	templatemodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/template"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	commonservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service"
@@ -1396,33 +1395,6 @@ func GetCollaborationNew(projectName, uid, identityType, userName string, logger
 		return nil, nil
 	}
 	return getCollaborationNew(updateResp, projectName, identityType, userName, logger)
-}
-
-func getRenderSet(projectName string, envs []string) ([]models2.RenderSet, error) {
-	products, err := commonrepo.NewProductColl().List(&commonrepo.ProductListOptions{
-		InProjects: []string{projectName},
-		InEnvs:     envs,
-	})
-	if err != nil {
-		return nil, err
-	}
-	var findOpts []commonrepo.RenderSetFindOption
-	for _, product := range products {
-		findOpts = append(findOpts, commonrepo.RenderSetFindOption{
-			Revision:    product.Render.Revision,
-			ProductTmpl: projectName,
-			EnvName:     product.EnvName,
-			Name:        product.Namespace,
-		})
-	}
-	renderSets, err := commonrepo.NewRenderSetColl().ListByFindOpts(&commonrepo.RenderSetListOption{
-		ProductTmpl: projectName,
-		FindOpts:    findOpts,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return renderSets, nil
 }
 
 func getWorkflowDisplayName(workflowName, workflowType string) string {

--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -378,14 +378,16 @@ func GetSvcRenderArgs(productName, envName string, getSvcRendersArgs []*GetSvcRe
 		EnvName: envName,
 	})
 
+	if err == mongo.ErrNoDocuments {
+		return nil, nil, nil
+	}
+
 	if err != nil && err != mongo.ErrNoDocuments {
 		return nil, nil, err
 	}
 
-	if err == nil {
-		renderSetName = productInfo.Render.Name
-		renderRevision = productInfo.Render.Revision
-	}
+	renderSetName = productInfo.Render.Name
+	renderRevision = productInfo.Render.Revision
 
 	opt := &commonrepo.RenderSetFindOption{
 		ProductTmpl: productName,
@@ -393,13 +395,9 @@ func GetSvcRenderArgs(productName, envName string, getSvcRendersArgs []*GetSvcRe
 		Name:        renderSetName,
 		Revision:    renderRevision,
 	}
-	rendersetObj, existed, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
+	rendersetObj, err := commonrepo.NewRenderSetColl().Find(opt)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	if !existed {
-		return nil, nil, nil
 	}
 
 	svcChartRenderArgSet := sets.NewString()

--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -180,12 +180,9 @@ func GetK8sProductionSvcRenderArgs(productName, envName, serviceName string, log
 		Name:        productInfo.Render.Name,
 		Revision:    productInfo.Render.Revision,
 	}
-	rendersetObj, existed, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
+	rendersetObj, err := commonrepo.NewRenderSetColl().Find(opt)
 	if err != nil {
 		return nil, errors.Wrapf(err, fmt.Errorf("failed to find render set : %s/%s", productName, envName).Error())
-	}
-	if !existed {
-		return nil, fmt.Errorf("render set not found : %s/%s", productName, envName)
 	}
 
 	svcRender := rendersetObj.GetServiceRenderMap()[serviceName]
@@ -267,7 +264,7 @@ func GetK8sSvcRenderArgs(productName, envName, serviceName string, production bo
 			Name:        productInfo.Render.Name,
 			Revision:    productInfo.Render.Revision,
 		}
-		rendersetObj, _, err = commonrepo.NewRenderSetColl().FindRenderSet(opt)
+		rendersetObj, err = commonrepo.NewRenderSetColl().Find(opt)
 		if err == nil {
 			for _, svcRender := range rendersetObj.ServiceVariables {
 				if _, ok := svcRenders[svcRender.ServiceName]; ok {

--- a/pkg/microservice/aslan/core/common/service/render/renderset.go
+++ b/pkg/microservice/aslan/core/common/service/render/renderset.go
@@ -67,21 +67,6 @@ func GetRenderSetInfo(renderName string, revision int64) (*commonmodels.RenderSe
 	return resp, nil
 }
 
-// ValidateRenderSet 检查指定renderSet是否能覆盖产品所有需要渲染的值
-func ValidateRenderSet(productName, renderName, envName string, serviceInfo *templatemodels.ServiceInfo, log *zap.SugaredLogger) (*commonmodels.RenderSet, error) {
-	resp := &commonmodels.RenderSet{ProductTmpl: productName}
-	var err error
-	if renderName != "" {
-		opt := &commonrepo.RenderSetFindOption{Name: renderName, ProductTmpl: productName, EnvName: envName}
-		resp, err = commonrepo.NewRenderSetColl().Find(opt)
-		if err != nil {
-			log.Errorf("find renderset[%s] error: %v", renderName, err)
-			return resp, err
-		}
-	}
-	return resp, nil
-}
-
 func mergeServiceVariables(newVariables []*templatemodels.ServiceRender, oldVariables []*templatemodels.ServiceRender) []*templatemodels.ServiceRender {
 	allVarMap := make(map[string]*templatemodels.ServiceRender)
 	for _, sv := range oldVariables {

--- a/pkg/microservice/aslan/core/common/service/render/renderset.go
+++ b/pkg/microservice/aslan/core/common/service/render/renderset.go
@@ -34,7 +34,6 @@ import (
 )
 
 func GetRenderSet(renderName string, revision int64, isDefault bool, envName string, log *zap.SugaredLogger) (*commonmodels.RenderSet, error) {
-	// 未指定renderName返回空的renderSet
 	if renderName == "" {
 		return &commonmodels.RenderSet{}, nil
 	}

--- a/pkg/microservice/aslan/core/common/service/service.go
+++ b/pkg/microservice/aslan/core/common/service/service.go
@@ -1152,7 +1152,7 @@ func buildServiceInfoInEnv(productInfo *commonmodels.Product, templateSvcs []*co
 			mergedValues := ""
 			if newSvcKVsMap[svcName] == nil {
 				// config phase
-				mergedBs, err := util.OverrideValues([]byte(currentValues), []byte(latestValues), nil, false)
+				mergedBs, err := util.OverrideValues([]byte(currentValues), []byte(latestValues))
 				if err != nil {
 					return "", nil, errors.Wrapf(err, "failed to override values")
 				}

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -1270,11 +1270,9 @@ func UpdateProductDefaultValues(productName, envName, userName, requestID string
 		EnvName:     envName,
 		ProductTmpl: productName,
 	}
-	productRenderset, _, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
-	if err != nil || productRenderset == nil {
-		if err != nil {
-			log.Errorf("query renderset fail when updating helm product:%s render charts, err %s", productName, err.Error())
-		}
+	productRenderset, err := commonrepo.NewRenderSetColl().Find(opt)
+	if err != nil {
+		log.Errorf("query renderset fail when updating helm product:%s render charts, err %s", productName, err.Error())
 		return e.ErrUpdateEnv.AddDesc(fmt.Sprintf("failed to query renderset for environment: %s", envName))
 	}
 
@@ -1375,11 +1373,9 @@ func UpdateHelmProductCharts(productName, envName, userName, requestID string, a
 		EnvName:     envName,
 		ProductTmpl: productName,
 	}
-	productRenderset, _, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
-	if err != nil || productRenderset == nil {
-		if err != nil {
-			log.Errorf("query renderset fail when updating helm product:%s render charts, err %s", productName, err)
-		}
+	productRenderset, err := commonrepo.NewRenderSetColl().Find(opt)
+	if err != nil {
+		log.Errorf("query renderset fail when updating helm product:%s render charts, err %s", productName, err)
 		return e.ErrUpdateEnv.AddDesc(fmt.Sprintf("failed to query renderset for environment: %s", envName))
 	}
 
@@ -1553,11 +1549,9 @@ func UpdateHelmProductRenderset(productName, envName, userName, requestID string
 		EnvName:     envName,
 		ProductTmpl: productName,
 	}
-	productRenderset, _, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
+	productRenderset, err := commonrepo.NewRenderSetColl().Find(opt)
 	if err != nil || productRenderset == nil {
-		if err != nil {
-			log.Errorf("query renderset fail when updating helm product:%s render charts, err %s", productName, err.Error())
-		}
+		log.Errorf("query renderset fail when updating helm product:%s render charts, err %s", productName, err.Error())
 		return e.ErrUpdateEnv.AddDesc(fmt.Sprintf("failed to query renderset for environment: %s", envName))
 	}
 
@@ -2668,6 +2662,7 @@ func preCreateProduct(envName string, args *commonmodels.Product, kubeClient cli
 	if args.Render.Revision > 0 {
 		renderSetName = args.Render.Name
 	} else {
+		log.Infof("++++++++++++++ creating renderset in pre create product function: %s", renderSetName)
 		renderSet := &commonmodels.RenderSet{
 			Name:        renderSetName,
 			Revision:    0,
@@ -3436,11 +3431,9 @@ func PreviewProductGlobalVariables(productName, envName string, arg []*commontyp
 		ProductTmpl: product.Render.ProductTmpl,
 		Revision:    product.Render.Revision,
 	}
-	productRenderset, _, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
-	if err != nil || productRenderset == nil {
-		if err != nil {
-			log.Errorf("query renderset fail when updating helm product:%s render charts, err %s", productName, err.Error())
-		}
+	productRenderset, err := commonrepo.NewRenderSetColl().Find(opt)
+	if err != nil {
+		log.Errorf("query renderset fail when updating helm product:%s render charts, err %s", productName, err.Error())
 		return nil, e.ErrUpdateEnv.AddDesc(fmt.Sprintf("failed to query renderset for environment: %s", envName))
 	}
 	return PreviewProductGlobalVariablesWithRender(product, productRenderset, arg, log)
@@ -3477,11 +3470,9 @@ func PreviewHelmProductGlobalVariables(productName, envName, globalVariable stri
 		ProductTmpl: product.Render.ProductTmpl,
 		Revision:    product.Render.Revision,
 	}
-	productRenderset, _, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
-	if err != nil || productRenderset == nil {
-		if err != nil {
-			log.Errorf("query renderset fail when updating helm product:%s render charts, err %s", productName, err.Error())
-		}
+	productRenderset, err := commonrepo.NewRenderSetColl().Find(opt)
+	if err != nil {
+		log.Errorf("query renderset fail when updating helm product:%s render charts, err %s", productName, err.Error())
 		return nil, e.ErrUpdateEnv.AddDesc(fmt.Sprintf("failed to query renderset for environment: %s", envName))
 	}
 
@@ -3580,11 +3571,9 @@ func UpdateProductGlobalVariables(productName, envName, userName, requestID stri
 		ProductTmpl: product.Render.ProductTmpl,
 		Revision:    product.Render.Revision,
 	}
-	productRenderset, _, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
-	if err != nil || productRenderset == nil {
-		if err != nil {
-			log.Errorf("query renderset fail when updating helm product:%s render charts, err %s", productName, err.Error())
-		}
+	productRenderset, err := commonrepo.NewRenderSetColl().Find(opt)
+	if err != nil {
+		log.Errorf("query renderset fail when updating helm product:%s render charts, err %s", productName, err.Error())
 		return e.ErrUpdateEnv.AddDesc(fmt.Sprintf("failed to query renderset for environment: %s", envName))
 	}
 

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -1484,15 +1484,14 @@ func SyncHelmProductEnvironment(productName, envName, requestID string, log *zap
 		return err
 	}
 	opt := &commonrepo.RenderSetFindOption{
-		Name:        product.Namespace,
+		Name:        product.Render.Name,
+		Revision:    product.Render.Revision,
 		EnvName:     envName,
 		ProductTmpl: productName,
 	}
-	productRenderset, _, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
-	if err != nil || productRenderset == nil {
-		if err != nil {
-			log.Errorf("query renderset fail when updating helm product:%s render charts, err %s", productName, err.Error())
-		}
+	productRenderset, err := commonrepo.NewRenderSetColl().Find(opt)
+	if err != nil {
+		log.Errorf("query renderset fail when updating helm product:%s render charts, err %s", productName, err.Error())
 		return e.ErrUpdateEnv.AddDesc(fmt.Sprintf("failed to query renderset for environment: %s", envName))
 	}
 
@@ -1549,7 +1548,8 @@ func UpdateHelmProductRenderset(productName, envName, userName, requestID string
 		return err
 	}
 	opt := &commonrepo.RenderSetFindOption{
-		Name:        product.Namespace,
+		Name:        product.Render.Name,
+		Revision:    product.Render.Revision,
 		EnvName:     envName,
 		ProductTmpl: productName,
 	}
@@ -1632,33 +1632,26 @@ func UpdateProductVariable(productName, envName, username, requestID string, upd
 		}
 	}
 
+	createdRenderset := &commonmodels.RenderSet{
+		Name:             renderset.Name,
+		EnvName:          envName,
+		ProductTmpl:      productName,
+		UpdateBy:         username,
+		DefaultValues:    renderset.DefaultValues,
+		GlobalVariables:  renderset.GlobalVariables,
+		YamlData:         renderset.YamlData,
+		ChartInfos:       renderset.ChartInfos,
+		ServiceVariables: renderset.ServiceVariables,
+	}
+
 	// FIXME: best to render yaml before create renderset
-	if err = render.CreateK8sHelmRenderSet(
-		&commonmodels.RenderSet{
-			Name:             productResp.Namespace,
-			EnvName:          envName,
-			ProductTmpl:      productName,
-			UpdateBy:         username,
-			DefaultValues:    renderset.DefaultValues,
-			GlobalVariables:  renderset.GlobalVariables,
-			YamlData:         renderset.YamlData,
-			ChartInfos:       renderset.ChartInfos,
-			ServiceVariables: renderset.ServiceVariables,
-		},
-		log,
-	); err != nil {
+	if err = render.CreateK8sHelmRenderSet(createdRenderset, log); err != nil {
 		log.Errorf("[%s][P:%s] create renderset error: %v", envName, productName, err)
 		return e.ErrUpdateEnv.AddDesc(e.FindProductTmplErrMsg)
 	}
 
-	productResp.EnsureRenderInfo()
-	renderSet, err := FindProductRenderSet(productResp.ProductName, productResp.Render.Name, envName, log)
-	if err != nil {
-		log.Errorf("[%s][P:%s] find product renderset error: %s", productResp.EnvName, productResp.ProductName, err)
-		return e.ErrUpdateEnv.AddDesc(err.Error())
-	}
-	productResp.Render.Revision = renderSet.Revision
-	productResp.Render.Name = renderSet.Name
+	productResp.Render.Revision = createdRenderset.Revision
+	productResp.Render.Name = createdRenderset.Name
 
 	// update render used in product
 	err = commonrepo.NewProductColl().UpdateRender(envName, productResp.ProductName, productResp.Render)
@@ -1673,9 +1666,9 @@ func UpdateProductVariable(productName, envName, username, requestID string, upd
 	}
 
 	if deployType == setting.K8SDeployType {
-		return updateK8sProductVariable(productResp, renderSet, username, requestID, log)
+		return updateK8sProductVariable(productResp, createdRenderset, username, requestID, log)
 	} else {
-		return updateHelmProductVariable(productResp, renderSet, username, requestID, log)
+		return updateHelmProductVariable(productResp, createdRenderset, username, requestID, log)
 	}
 }
 
@@ -1775,18 +1768,6 @@ func UpdateMultipleHelmEnv(requestID, userName string, args *UpdateMultiHelmProd
 
 	// extract values.yaml and update renderset
 	for envName := range productMap {
-		renderSet, _, err := commonrepo.NewRenderSetColl().FindRenderSet(&commonrepo.RenderSetFindOption{
-			Name:        commonservice.GetProductEnvNamespace(envName, productName, ""),
-			EnvName:     envName,
-			ProductTmpl: productName,
-		})
-		if err != nil || renderSet == nil {
-			if err != nil {
-				log.Warnf("query renderset fail for product %s env: %s", productName, envName)
-			}
-			return envStatuses, e.ErrUpdateEnv.AddDesc(fmt.Sprintf("failed to query renderset for env: %s", envName))
-		}
-
 		err = updateHelmProduct(productName, envName, userName, requestID, args.ChartValues, args.DeletedServices, log)
 		if err != nil {
 			log.Errorf("UpdateMultiHelmProduct UpdateProductV2 err:%v", err)
@@ -1843,18 +1824,6 @@ func UpdateMultipleHelmChartEnv(requestID, userName string, args *UpdateMultiHel
 
 	// extract values.yaml and update renderset
 	for envName := range productMap {
-		renderSet, _, err := commonrepo.NewRenderSetColl().FindRenderSet(&commonrepo.RenderSetFindOption{
-			Name:        commonservice.GetProductEnvNamespace(envName, productName, ""),
-			EnvName:     envName,
-			ProductTmpl: productName,
-		})
-		if err != nil || renderSet == nil {
-			if err != nil {
-				log.Warnf("query renderset fail for product %s env: %s", productName, envName)
-			}
-			return envStatuses, e.ErrUpdateEnv.AddDesc(fmt.Sprintf("failed to query renderset for env: %s", envName))
-		}
-
 		err = updateHelmChartProduct(productName, envName, userName, requestID, args.ChartValues, args.DeletedServices, log)
 		if err != nil {
 			log.Errorf("UpdateMultiHelmProduct UpdateProductV2 err:%v", err)
@@ -2272,7 +2241,8 @@ func deleteK8sProductServices(productInfo *commonmodels.Product, serviceNames []
 
 	rs, err := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{
 		EnvName:     productInfo.EnvName,
-		Name:        productInfo.Namespace,
+		Name:        productInfo.Render.Name,
+		Revision:    productInfo.Render.Revision,
 		ProductTmpl: productInfo.ProductName,
 	})
 	if err != nil {
@@ -2694,40 +2664,29 @@ func preCreateProduct(envName string, args *commonmodels.Product, kubeClient cli
 		renderSetName       = commonservice.GetProductEnvNamespace(envName, args.ProductName, args.Namespace)
 		err                 error
 	)
-	if args.Render != nil && args.Render.Revision > 0 {
+	args.EnsureRenderInfo()
+	if args.Render.Revision > 0 {
 		renderSetName = args.Render.Name
 	} else {
-		switch args.Source {
-		case setting.HelmDeployType:
-			err = render.CreateK8sHelmRenderSet(
-				&commonmodels.RenderSet{
-					Name:        renderSetName,
-					Revision:    0,
-					EnvName:     envName,
-					ProductTmpl: args.ProductName,
-					UpdateBy:    args.UpdateBy,
-					ChartInfos:  args.ServiceRenders,
-				},
-				log,
-			)
-		default:
-			err = render.CreateRenderSet(
-				&commonmodels.RenderSet{
-					Name:             renderSetName,
-					Revision:         0,
-					EnvName:          envName,
-					ProductTmpl:      args.ProductName,
-					UpdateBy:         args.UpdateBy,
-					ServiceVariables: args.ServiceRenders,
-				},
-				log,
-			)
-
+		renderSet := &commonmodels.RenderSet{
+			Name:        renderSetName,
+			Revision:    0,
+			EnvName:     envName,
+			ProductTmpl: args.ProductName,
+			UpdateBy:    args.UpdateBy,
+			ChartInfos:  args.ServiceRenders,
 		}
+		if args.Source == setting.HelmDeployType {
+			renderSet.ChartInfos = args.ServiceRenders
+		} else {
+			renderSet.ServiceVariables = args.ServiceRenders
+		}
+		err = render.CreateRenderSet(renderSet, log)
 		if err != nil {
 			log.Errorf("[%s][P:%s] create renderset error: %v", envName, productTemplateName, err)
 			return e.ErrCreateEnv.AddDesc(e.FindProductTmplErrMsg)
 		}
+		args.Render.Revision = renderSet.Revision
 	}
 
 	var productTmpl *templatemodels.Product
@@ -2814,13 +2773,14 @@ func ensureKubeEnv(namespace, registryId string, customLabels map[string]string,
 	return nil
 }
 
-func FindProductRenderSet(productName, renderName, envName string, log *zap.SugaredLogger) (*commonmodels.RenderSet, error) {
+func FindProductRenderSet(productName, renderName, envName string, revision int64, log *zap.SugaredLogger) (*commonmodels.RenderSet, error) {
 	resp := &commonmodels.RenderSet{ProductTmpl: productName}
 	var err error
 	opt := &commonrepo.RenderSetFindOption{
 		Name:        renderName,
 		ProductTmpl: productName,
 		EnvName:     envName,
+		Revision:    revision,
 	}
 	resp, err = commonrepo.NewRenderSetColl().Find(opt)
 	if err != nil {
@@ -3079,7 +3039,7 @@ func updateHelmChartProductGroup(username, productName, envName string, productR
 		deletedRelease = append(deletedRelease, serviceName)
 	}
 
-	renderSet, err := diffRenderSetHelmChart(username, productName, envName, productResp, overrideCharts, deletedRelease, log)
+	renderSet, err := mergeRenderSetAndRenderChart(username, productName, envName, productResp, overrideCharts, deletedRelease, log)
 	if err != nil {
 		return e.ErrUpdateEnv.AddDesc("对比环境中的value.yaml和系统默认的value.yaml失败")
 	}
@@ -3183,7 +3143,6 @@ func diffRenderSet(username, productName, envName string, productResp *commonmod
 	// productResp is the product info in expected response
 	// productCur is the product info in current
 	serviceMap := productCur.GetServiceMap()
-	serviceRespMap := productResp.GetServiceMap()
 
 	// chart infos in product
 	currentChartInfoMap := make(map[string]*templatemodels.ServiceRender)
@@ -3222,43 +3181,8 @@ func diffRenderSet(username, productName, envName string, productResp *commonmod
 			continue
 		}
 
-		serviceInfoResp := serviceRespMap[serviceName]
-		serviceInfoCur := serviceMap[serviceName]
-		imageRelatedKey := sets.NewString()
-		if serviceInfoResp != nil && serviceInfoCur != nil {
-			curEnvService, err := repository.QueryTemplateService(&commonrepo.ServiceFindOption{
-				ServiceName: serviceName,
-				ProductName: productName,
-				Type:        setting.HelmDeployType,
-				Revision:    serviceInfoCur.Revision,
-			}, productCur.Production)
-			if err != nil {
-				log.Errorf("failed to query service, name %s, Revision %d,err %s", serviceName, serviceInfoCur.Revision, err)
-				return nil, fmt.Errorf("failed to query service, name %s,Revision %d,err %s", serviceName, serviceInfoCur.Revision, err)
-			}
-		L:
-			for _, curSvcContainers := range curEnvService.Containers {
-				if checkServiceImageUpdated(curSvcContainers, serviceInfoCur) {
-					for _, container := range serviceInfoResp.Containers {
-						if curSvcContainers.Name == container.Name && container.ImagePath != nil {
-							imageRelatedKey.Insert(container.ImagePath.Image, container.ImagePath.Repo, container.ImagePath.Tag)
-							continue L
-						}
-					}
-				}
-			}
-		}
-
 		// use the variables in current product when updating services
 		if okC {
-			// use the value of the key of the current values.yaml to replace the value of the same key of the values.yaml in the service
-			newValuesYaml, err := util.OverrideValues([]byte(currentChartInfo.ValuesYaml), []byte(latestChartInfo.ValuesYaml), imageRelatedKey, true)
-			if err != nil {
-				log.Errorf("Failed to override values for service %s, err: %s", serviceName, err)
-			} else {
-				latestChartInfo.ValuesYaml = string(newValuesYaml)
-			}
-
 			// user override value in cur environment
 			latestChartInfo.OverrideValues = currentChartInfo.OverrideValues
 			latestChartInfo.OverrideYaml = currentChartInfo.OverrideYaml
@@ -3274,31 +3198,22 @@ func diffRenderSet(username, productName, envName string, productResp *commonmod
 		newChartInfos = append(newChartInfos, chartInfo)
 	}
 
-	if err = render.CreateK8sHelmRenderSet(
-		&commonmodels.RenderSet{
-			Name:          productResp.Render.Name,
-			EnvName:       envName,
-			ProductTmpl:   productName,
-			ChartInfos:    newChartInfos,
-			DefaultValues: defaultValues,
-			YamlData:      yamlData,
-			UpdateBy:      username,
-		},
-		log,
-	); err != nil {
-		log.Errorf("[RenderSet.create] err: %v", err)
-		return nil, err
+	renderSet := &commonmodels.RenderSet{
+		Name:          productResp.Render.Name,
+		EnvName:       envName,
+		ProductTmpl:   productName,
+		ChartInfos:    newChartInfos,
+		DefaultValues: defaultValues,
+		YamlData:      yamlData,
+		UpdateBy:      username,
 	}
-
-	renderSet, err := FindProductRenderSet(productName, productResp.Render.Name, envName, log)
-	if err != nil {
-		log.Errorf("[RenderSet.find] err: %v", err)
+	if err = render.CreateK8sHelmRenderSet(renderSet, log); err != nil {
 		return nil, err
 	}
 	return renderSet, nil
 }
 
-func diffRenderSetHelmChart(username, productName, envName string, productResp *commonmodels.Product, overrideCharts []*commonservice.HelmSvcRenderArg, deletedReleases []string, log *zap.SugaredLogger) (*commonmodels.RenderSet, error) {
+func mergeRenderSetAndRenderChart(username, productName, envName string, productResp *commonmodels.Product, overrideCharts []*commonservice.HelmSvcRenderArg, deletedReleases []string, log *zap.SugaredLogger) (*commonmodels.RenderSet, error) {
 	renderSetOpt := &commonrepo.RenderSetFindOption{
 		Name:        productResp.Render.Name,
 		Revision:    productResp.Render.Revision,
@@ -3349,38 +3264,20 @@ func diffRenderSetHelmChart(username, productName, envName string, productResp *
 		newChartInfos = append(newChartInfos, chartInfo)
 	}
 
-	if err = render.CreateK8sHelmRenderSet(
-		&commonmodels.RenderSet{
-			Name:          productResp.Render.Name,
-			EnvName:       envName,
-			ProductTmpl:   productName,
-			ChartInfos:    newChartInfos,
-			DefaultValues: defaultValues,
-			YamlData:      yamlData,
-			UpdateBy:      username,
-		},
-		log,
-	); err != nil {
+	renderSet := &commonmodels.RenderSet{
+		Name:          productResp.Render.Name,
+		EnvName:       envName,
+		ProductTmpl:   productName,
+		ChartInfos:    newChartInfos,
+		DefaultValues: defaultValues,
+		YamlData:      yamlData,
+		UpdateBy:      username,
+	}
+	if err = render.CreateK8sHelmRenderSet(renderSet, log); err != nil {
 		log.Errorf("[RenderSet.create] err: %v", err)
 		return nil, err
 	}
-
-	renderSet, err := FindProductRenderSet(productName, productResp.Render.Name, envName, log)
-	if err != nil {
-		log.Errorf("[RenderSet.find] err: %v", err)
-		return nil, err
-	}
 	return renderSet, nil
-}
-
-// checkServiceImageUpdated If the service does not do any mirroring iterations on the platform, the latest YAML is used when updating the environment
-func checkServiceImageUpdated(curContainer *commonmodels.Container, serviceInfo *commonmodels.ProductService) bool {
-	for _, proContainer := range serviceInfo.Containers {
-		if curContainer.Name == proContainer.Name && curContainer.Image == proContainer.Image {
-			return false
-		}
-	}
-	return true
 }
 
 func findRenderChartFromList(svc *commonmodels.ProductService, renderCharts []*templatemodels.ServiceRender) *templatemodels.ServiceRender {

--- a/pkg/microservice/aslan/core/environment/service/environment_copy.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_copy.go
@@ -336,26 +336,5 @@ func copySingleHelmProduct(templateProduct *templatemodels.Product, productInfo 
 	if err != nil {
 		return err
 	}
-
-	// clear render info
-	productInfo.Render = nil
-
-	// insert renderset info into db
-	if len(productInfo.ServiceRenders) > 0 {
-		err := render.CreateK8sHelmRenderSet(&commonmodels.RenderSet{
-			Name:          commonservice.GetProductEnvNamespace(arg.EnvName, arg.ProductName, arg.Namespace),
-			EnvName:       arg.EnvName,
-			ProductTmpl:   arg.ProductName,
-			UpdateBy:      userName,
-			IsDefault:     false,
-			DefaultValues: arg.DefaultValues,
-			YamlData:      geneYamlData(arg.ValuesData),
-			ChartInfos:    productInfo.ServiceRenders,
-		}, log)
-		if err != nil {
-			log.Errorf("rennderset create fail when copy creating helm product, productName: %s,envname:%s,err:%s", arg.ProductName, arg.EnvName, err)
-			return e.ErrCreateEnv.AddDesc(fmt.Sprintf("failed to save chart values, productName: %s,envname:%s,err:%s", arg.ProductName, arg.EnvName, err))
-		}
-	}
 	return CreateProduct(userName, requestID, productInfo, log)
 }

--- a/pkg/microservice/aslan/core/environment/service/environment_copy.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_copy.go
@@ -23,7 +23,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
 
-	commonutil "github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	templatemodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/template"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
@@ -31,6 +30,7 @@ import (
 	commonservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/render"
 	commontypes "github.com/koderover/zadig/pkg/microservice/aslan/core/common/types"
+	commonutil "github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/pkg/setting"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 	"github.com/koderover/zadig/pkg/util"
@@ -309,7 +309,7 @@ func copySingleHelmProduct(templateProduct *templatemodels.Product, productInfo 
 	productInfo.EnvConfigs = arg.EnvConfigs
 
 	// merge chart infos, use chart info in product to override charts in template_project
-	sourceRenderSet, _, err := commonrepo.NewRenderSetColl().FindRenderSet(&commonrepo.RenderSetFindOption{
+	sourceRenderSet, err := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{
 		Name:        sourceRendersetName,
 		EnvName:     arg.BaseName,
 		ProductTmpl: arg.ProductName,

--- a/pkg/microservice/aslan/core/environment/service/environment_creation.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_creation.go
@@ -116,8 +116,7 @@ func prepareHelmProductCreation(templateProduct *templatemodels.Product, product
 	}
 	productObj.Services = serviceGroup
 
-	// insert renderset info into db
-	err = render.CreateK8sHelmRenderSet(&commonmodels.RenderSet{
+	renderset := &commonmodels.RenderSet{
 		Name:          commonservice.GetProductEnvNamespace(arg.EnvName, arg.ProductName, arg.Namespace),
 		EnvName:       arg.EnvName,
 		ProductTmpl:   arg.ProductName,
@@ -126,30 +125,20 @@ func prepareHelmProductCreation(templateProduct *templatemodels.Product, product
 		DefaultValues: arg.DefaultValues,
 		ChartInfos:    productObj.ServiceRenders,
 		YamlData:      geneYamlData(arg.ValuesData),
-	}, log)
-	if err != nil {
-		log.Errorf("rennderset create fail when copy creating helm product, productName: %s,envname:%s,err:%s", arg.ProductName, arg.EnvName, err)
-		return e.ErrCreateEnv.AddDesc(fmt.Sprintf("failed to save chart values, productName: %s,envname:%s,err:%s", arg.ProductName, arg.EnvName, err))
 	}
 
-	renderset, _, err := commonrepo.NewRenderSetColl().FindRenderSet(&commonrepo.RenderSetFindOption{
-		Name:        commonservice.GetProductEnvNamespace(arg.EnvName, arg.ProductName, arg.Namespace),
-		EnvName:     arg.EnvName,
-		IsDefault:   false,
+	// insert renderset info into db
+	err = render.CreateK8sHelmRenderSet(renderset, log)
+	if err != nil {
+		log.Errorf("rennderset create fail when creating helm product, productName: %s,envname:%s,err:%s", arg.ProductName, arg.EnvName, err)
+		return e.ErrCreateEnv.AddDesc(fmt.Sprintf("failed to create renderset, productName: %s,envname:%s,err:%s", arg.ProductName, arg.EnvName, err))
+	}
+
+	productObj.Render = &commonmodels.RenderInfo{
+		Name:        renderset.Name,
+		Revision:    renderset.Revision,
 		ProductTmpl: productObj.ProductName,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to find renderset of product: %s/%s, err: %s", arg.ProductName, arg.EnvName, err)
 	}
-
-	if renderset != nil {
-		productObj.Render = &commonmodels.RenderInfo{
-			Name:        renderset.Name,
-			Revision:    renderset.Revision,
-			ProductTmpl: productObj.ProductName,
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/microservice/aslan/core/environment/service/environment_creator.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_creator.go
@@ -174,7 +174,9 @@ func (creator *HelmProductCreator) Create(user, requestID string, args *models.P
 
 	// renderset may exist before product created, by setting values.yaml content
 	var renderSet *models.RenderSet
+	log.Infof("----------- helm creating renderset, envName:%s, productName:%s, namespace:%s", args.EnvName, args.ProductName, args.Namespace)
 	if args.Render == nil || args.Render.Revision == 0 {
+		log.Infof("----------- render info of product is not set")
 		renderSet, _, err = commonrepo.NewRenderSetColl().FindRenderSet(&commonrepo.RenderSetFindOption{
 			EnvName:     args.EnvName,
 			Name:        args.Namespace,
@@ -187,6 +189,7 @@ func (creator *HelmProductCreator) Create(user, requestID string, args *models.P
 		}
 		// if env renderset is predefined, set render info
 		if renderSet != nil {
+			log.Infof("----------- renderset info in env is predefined: %s, revision: %d", renderSet.Name, renderSet.Revision)
 			args.Render = &models.RenderInfo{
 				ProductTmpl: args.ProductName,
 				Name:        renderSet.Name,

--- a/pkg/microservice/aslan/core/environment/service/environment_creator.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_creator.go
@@ -250,7 +250,7 @@ func newPMProductCreator() *PMProductCreator {
 }
 
 func (creator *PMProductCreator) Create(user, requestID string, args *models.Product, log *zap.SugaredLogger) error {
-	// technically renderset is not used for pr projects, this logic is used for compatibility with previous logic
+	// technically renderset is not used for pm projects, this logic is used for compatibility with previous logic
 	renderSet := &commonmodels.RenderSet{
 		Name:        commonservice.GetProductEnvNamespace(args.EnvName, args.ProductName, ""),
 		Revision:    0,

--- a/pkg/microservice/aslan/core/environment/service/environment_creator.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_creator.go
@@ -213,7 +213,7 @@ func (creator *HelmProductCreator) Create(user, requestID string, args *models.P
 		return e.ErrCreateEnv.AddDesc(err.Error())
 	}
 
-	renderSet, err = FindProductRenderSet(args.ProductName, args.Render.Name, args.EnvName, log)
+	renderSet, err = FindProductRenderSet(args.ProductName, args.Render.Name, args.EnvName, args.Render.Revision, log)
 	if err != nil {
 		log.Errorf("[%s][P:%s] find product renderset error: %v", args.EnvName, args.ProductName, err)
 		return e.ErrCreateEnv.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/environment/service/environment_creator.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_creator.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/render"
+
 	"github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
 	versionedclient "istio.io/client-go/pkg/clientset/versioned"
@@ -30,7 +32,7 @@ import (
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
-	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/template"
+	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	commonservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/kube"
@@ -96,9 +98,6 @@ func (autoCreator *AutoCreator) Create(envName string) (string, error) {
 	productObject.UpdateBy = autoCreator.Param.UserName
 	productObject.EnvName = envName
 	productObject.RegistryID = autoCreator.Param.RegistryID
-	if autoCreator.Param.EnvType == setting.HelmDeployType {
-		productObject.Source = setting.SourceFromHelm
-	}
 
 	err = CreateProduct(autoCreator.Param.UserName, autoCreator.Param.RequestId, productObject, log)
 	if err != nil {
@@ -172,51 +171,12 @@ func (creator *HelmProductCreator) Create(user, requestID string, args *models.P
 		return e.ErrCreateEnv.AddErr(err)
 	}
 
-	// renderset may exist before product created, by setting values.yaml content
-	var renderSet *models.RenderSet
-	log.Infof("----------- helm creating renderset, envName:%s, productName:%s, namespace:%s", args.EnvName, args.ProductName, args.Namespace)
-	if args.Render == nil || args.Render.Revision == 0 {
-		log.Infof("----------- render info of product is not set")
-		renderSet, _, err = commonrepo.NewRenderSetColl().FindRenderSet(&commonrepo.RenderSetFindOption{
-			EnvName:     args.EnvName,
-			Name:        args.Namespace,
-			ProductTmpl: args.ProductName,
-		})
-
-		if err != nil {
-			log.Errorf("[%s][P:%s] find product renderset error: %v", args.EnvName, args.ProductName, err)
-			return e.ErrCreateEnv.AddDesc(err.Error())
-		}
-		// if env renderset is predefined, set render info
-		if renderSet != nil {
-			log.Infof("----------- renderset info in env is predefined: %s, revision: %d", renderSet.Name, renderSet.Revision)
-			args.Render = &models.RenderInfo{
-				ProductTmpl: args.ProductName,
-				Name:        renderSet.Name,
-				Revision:    renderSet.Revision,
-			}
-			// user renderchart from renderset
-			chartInfoMap := make(map[string]*template.ServiceRender)
-			for _, renderChart := range renderSet.ChartInfos {
-				chartInfoMap[renderChart.ServiceName] = renderChart
-			}
-
-			// use values.yaml content from predefined env renderset
-			for _, singleRenderChart := range args.ServiceRenders {
-				if renderInEnvRenderset, ok := chartInfoMap[singleRenderChart.ServiceName]; ok {
-					singleRenderChart.OverrideValues = renderInEnvRenderset.OverrideValues
-					singleRenderChart.OverrideYaml = renderInEnvRenderset.OverrideYaml
-				}
-			}
-		}
-	}
-
 	if err = preCreateProduct(args.EnvName, args, kubeClient, log); err != nil {
 		log.Errorf("CreateProduct preCreateProduct error: %v", err)
 		return e.ErrCreateEnv.AddDesc(err.Error())
 	}
 
-	renderSet, err = FindProductRenderSet(args.ProductName, args.Render.Name, args.EnvName, args.Render.Revision, log)
+	renderSet, err := FindProductRenderSet(args.ProductName, args.Render.Name, args.EnvName, args.Render.Revision, log)
 	if err != nil {
 		log.Errorf("[%s][P:%s] find product renderset error: %v", args.EnvName, args.ProductName, err)
 		return e.ErrCreateEnv.AddDesc(err.Error())
@@ -291,9 +251,26 @@ func newPMProductCreator() *PMProductCreator {
 }
 
 func (creator *PMProductCreator) Create(user, requestID string, args *models.Product, log *zap.SugaredLogger) error {
-	//创建角色环境之间的关联关系
-	//todo 创建环境暂时不指定角色
-	// 检查是否重复创建（TO BE FIXED）;检查k8s集群设置: Namespace/Secret .etc
+	// technically renderset is not used for pr projects, this logic is used for compatibility with previous logic
+	renderSet := &commonmodels.RenderSet{
+		Name:        commonservice.GetProductEnvNamespace(args.EnvName, args.ProductName, ""),
+		Revision:    0,
+		EnvName:     args.EnvName,
+		ProductTmpl: args.ProductName,
+		UpdateBy:    args.UpdateBy,
+		ChartInfos:  args.ServiceRenders,
+	}
+	err := render.CreateRenderSet(renderSet, log)
+	if err != nil {
+		log.Errorf("[%s][P:%s] create renderset error: %v", args.EnvName, args.ProductName, err)
+		return e.ErrCreateEnv.AddDesc(e.FindProductTmplErrMsg)
+	}
+	args.Render = &commonmodels.RenderInfo{
+		Name:        renderSet.EnvName,
+		Revision:    renderSet.Revision,
+		ProductTmpl: args.ProductName,
+	}
+
 	if err := preCreateProduct(args.EnvName, args, nil, log); err != nil {
 		log.Errorf("CreateProduct preCreateProduct error: %v", err)
 		return e.ErrCreateEnv.AddDesc(err.Error())
@@ -301,7 +278,7 @@ func (creator *PMProductCreator) Create(user, requestID string, args *models.Pro
 
 	args.Status = setting.ProductStatusCreating
 	args.RecycleDay = config.DefaultRecycleDay()
-	err := commonrepo.NewProductColl().Create(args)
+	err = commonrepo.NewProductColl().Create(args)
 	if err != nil {
 		log.Errorf("[%s][%s] create product record error: %v", args.EnvName, args.ProductName, err)
 		return e.ErrCreateEnv.AddDesc(err.Error())
@@ -360,28 +337,6 @@ func (creator *K8sYamlProductCreator) Create(user, requestID string, args *model
 		args.Namespace = namespace
 	}
 
-	var renderSet *models.RenderSet
-	if args.Render == nil || args.Render.Revision == 0 {
-		renderSet, _, err = commonrepo.NewRenderSetColl().FindRenderSet(&commonrepo.RenderSetFindOption{
-			EnvName:     args.EnvName,
-			Name:        args.Namespace,
-			ProductTmpl: args.ProductName,
-		})
-
-		if err != nil {
-			log.Errorf("[%s][P:%s] find product renderset error: %v", args.EnvName, args.ProductName, err)
-			return e.ErrCreateEnv.AddDesc(err.Error())
-		}
-		// if env renderset is predefined, set render info
-		if renderSet != nil {
-			args.Render = &models.RenderInfo{
-				ProductTmpl: args.ProductName,
-				Name:        renderSet.Name,
-				Revision:    renderSet.Revision,
-			}
-		}
-	}
-
 	//创建角色环境之间的关联关系
 	//todo 创建环境暂时不指定角色
 	// 检查是否重复创建（TO BE FIXED）;检查k8s集群设置: Namespace/Secret .etc
@@ -390,11 +345,12 @@ func (creator *K8sYamlProductCreator) Create(user, requestID string, args *model
 		return e.ErrCreateEnv.AddDesc(err.Error())
 	}
 
-	renderSet, _, err = commonrepo.NewRenderSetColl().FindRenderSet(&commonrepo.RenderSetFindOption{
-		EnvName:  args.EnvName,
-		Name:     args.Render.Name,
-		Revision: args.Render.Revision,
-	})
+	renderSet, err := FindProductRenderSet(args.ProductName, args.Render.Name, args.EnvName, args.Render.Revision, log)
+	if err != nil {
+		log.Errorf("[%s][P:%s] find product renderset error: %v", args.EnvName, args.ProductName, err)
+		return e.ErrCreateEnv.AddDesc(err.Error())
+	}
+
 	if err != nil {
 		return e.ErrCreateEnv.AddErr(fmt.Errorf("failed to find renderset: %v/%v", args.Render.Name, args.Render.Revision))
 	}

--- a/pkg/microservice/aslan/core/environment/service/environment_creator.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_creator.go
@@ -22,8 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/render"
-
 	"github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
 	versionedclient "istio.io/client-go/pkg/clientset/versioned"
@@ -36,6 +34,7 @@ import (
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	commonservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/kube"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/render"
 	"github.com/koderover/zadig/pkg/setting"
 	kubeclient "github.com/koderover/zadig/pkg/shared/kube/client"
 	e "github.com/koderover/zadig/pkg/tool/errors"

--- a/pkg/microservice/aslan/core/environment/service/environment_update.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_update.go
@@ -193,7 +193,7 @@ func updateK8sServiceInEnv(productInfo *commonmodels.Product, templateSvc *commo
 	svcRender := &templatemodels.ServiceRender{
 		ServiceName: templateSvc.ServiceName,
 	}
-	currentRenderset, err := FindProductRenderSet(productInfo.ProductName, productInfo.Render.Name, productInfo.EnvName, log.SugaredLogger())
+	currentRenderset, err := FindProductRenderSet(productInfo.ProductName, productInfo.Render.Name, productInfo.EnvName, productInfo.Render.Revision, log.SugaredLogger())
 	if err != nil {
 		return fmt.Errorf("failed to find renderset, err: %s", err)
 	}
@@ -544,16 +544,9 @@ func updateCVMProduct(exitedProd *commonmodels.Product, user, requestID string, 
 		serviceNames = svcNames
 	}
 
-	if exitedProd.Render == nil {
-		exitedProd.Render = &commonmodels.RenderInfo{ProductTmpl: exitedProd.ProductName}
-	}
-
-	// 检查renderset是否覆盖产品所有key
-	renderSet, err := render.ValidateRenderSet(exitedProd.ProductName, exitedProd.Render.Name, exitedProd.EnvName, nil, log)
-	if err != nil {
-		log.Errorf("[%s][P:%s] validate product renderset error: %v", envName, exitedProd.ProductName, err)
-		return e.ErrUpdateEnv.AddDesc(err.Error())
-	}
+	exitedProd.EnsureRenderInfo()
+	// renderset is not actually used in cvm projects, so we just create a dummy one
+	renderSet := &commonmodels.RenderSet{ProductTmpl: productName, Name: exitedProd.Render.Name, EnvName: envName, Revision: 1}
 
 	log.Infof("[%s][P:%s] updateProductImpl, services: %v", envName, productName, serviceNames)
 

--- a/pkg/microservice/aslan/core/environment/service/export.go
+++ b/pkg/microservice/aslan/core/environment/service/export.go
@@ -56,7 +56,7 @@ func ExportYaml(envName, productName, serviceName, source string, log *zap.Sugar
 		log.Errorf("failed to get clientset for cluster %s", env.ClusterID)
 		return res
 	}
-	cclusterVersion, err := clientSet.Discovery().ServerVersion()
+	clusterVersion, err := clientSet.Discovery().ServerVersion()
 	if err != nil {
 		log.Errorf("failed to get cluster version for cluster %s", env.ClusterID)
 		return res
@@ -74,7 +74,7 @@ func ExportYaml(envName, productName, serviceName, source string, log *zap.Sugar
 		yamls = append(yamls, deploys...)
 		stss := getStatefulSetYaml(kubeClient, namespace, selector, log)
 		yamls = append(yamls, stss...)
-		cronJobs := getCronJobYaml(kubeClient, namespace, selector, VersionLessThan121(cclusterVersion), log)
+		cronJobs := getCronJobYaml(kubeClient, namespace, selector, VersionLessThan121(clusterVersion), log)
 		yamls = append(yamls, cronJobs...)
 		if len(deploys) == 0 && len(stss) == 0 && len(cronJobs) == 0 {
 			if source == "wd" {
@@ -146,15 +146,6 @@ func getConfigMapYaml(kubeClient client.Client, namespace string, selector label
 	}
 
 	return resources
-}
-
-func getConfigMapYamlByName(kubeClient client.Client, namespace string, name string, log *zap.SugaredLogger) []byte {
-	resource, _, err := getter.GetDeploymentYaml(namespace, name, kubeClient)
-	if err != nil {
-		log.Errorf("getConfigMapYamlByName error: %v", err)
-		return nil
-	}
-	return resource
 }
 
 func getIngressYaml(kubeClient client.Client, namespace string, selector labels.Selector, log *zap.SugaredLogger) [][]byte {

--- a/pkg/microservice/aslan/core/environment/service/export.go
+++ b/pkg/microservice/aslan/core/environment/service/export.go
@@ -99,8 +99,8 @@ func ExportYaml(envName, productName, serviceName, source string, log *zap.Sugar
 			EnvName:     env.EnvName,
 			ProductTmpl: env.ProductName,
 		}
-		renderset, exists, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
-		if err != nil || !exists {
+		renderset, err := commonrepo.NewRenderSetColl().Find(opt)
+		if err != nil {
 			log.Errorf("failed to find renderset for env: %s, err: %v", envName, err)
 			return res
 		}

--- a/pkg/microservice/aslan/core/environment/service/helm.go
+++ b/pkg/microservice/aslan/core/environment/service/helm.go
@@ -428,7 +428,7 @@ func GetChartInfos(productName, envName, serviceName string, log *zap.SugaredLog
 	if err != nil {
 		return nil, e.ErrGetHelmCharts.AddErr(err)
 	}
-	renderSet, err := FindProductRenderSet(productName, prod.Render.Name, prod.EnvName, log)
+	renderSet, err := FindProductRenderSet(productName, prod.Render.Name, prod.EnvName, prod.Render.Revision, log)
 	if err != nil {
 		log.Errorf("[%s][P:%s] find product renderset error: %v", envName, productName, err)
 		return nil, e.ErrGetHelmCharts.AddErr(err)

--- a/pkg/microservice/aslan/core/environment/service/k8s.go
+++ b/pkg/microservice/aslan/core/environment/service/k8s.go
@@ -152,7 +152,7 @@ func (k *K8sService) updateService(args *SvcOptArgs) error {
 	}
 
 	exitedProd.EnsureRenderInfo()
-	curRenderset, _, err := commonrepo.NewRenderSetColl().FindRenderSet(&commonrepo.RenderSetFindOption{
+	curRenderset, err := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{
 		Name:     exitedProd.Render.Name,
 		EnvName:  exitedProd.EnvName,
 		Revision: exitedProd.Render.Revision,

--- a/pkg/microservice/aslan/core/environment/service/kube.go
+++ b/pkg/microservice/aslan/core/environment/service/kube.go
@@ -990,14 +990,14 @@ func GetResourceDeployStatus(productName string, request *K8sDeployStatusCheckRe
 
 	fakeRenderSet := &models.RenderSet{}
 	if err == nil && productInfo != nil {
-		renderset, _, err := commonrepo.NewRenderSetColl().FindRenderSet(&commonrepo.RenderSetFindOption{
+		renderset, err := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{
 			ProductTmpl: productName,
 			EnvName:     request.EnvName,
 			IsDefault:   false,
 			Revision:    productInfo.Render.Revision,
 			Name:        productInfo.Render.Name,
 		})
-		if err == nil && renderset != nil {
+		if err == nil {
 			fakeRenderSet.GlobalVariables = renderset.GlobalVariables
 		}
 	}

--- a/pkg/microservice/aslan/core/environment/service/openapi.go
+++ b/pkg/microservice/aslan/core/environment/service/openapi.go
@@ -424,11 +424,9 @@ func OpenAPIUpdateGlobalVariables(args *OpenAPIEnvGlobalVariables, userName, req
 		ProductTmpl: product.Render.ProductTmpl,
 		Revision:    product.Render.Revision,
 	}
-	productRenderset, _, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
-	if err != nil || productRenderset == nil {
-		if err != nil {
-			logger.Errorf("query renderset fail when updating helm product:%s render charts, err %s", projectName, err.Error())
-		}
+	productRenderset, err := commonrepo.NewRenderSetColl().Find(opt)
+	if err != nil {
+		logger.Errorf("query renderset fail when updating helm product:%s render charts, err %s", projectName, err.Error())
 		return e.ErrUpdateEnv.AddDesc(fmt.Sprintf("failed to query renderset for environment: %s", envName))
 	}
 

--- a/pkg/microservice/aslan/core/environment/service/product.go
+++ b/pkg/microservice/aslan/core/environment/service/product.go
@@ -219,16 +219,6 @@ func GetProduct(username, envName, productName string, log *zap.SugaredLogger) (
 	return buildProductResp(prod.EnvName, prod, log)
 }
 
-func normalStatus(status string) bool {
-	if status == setting.PodRunning || status == setting.PodSucceeded {
-		return true
-	}
-	if status == setting.ServiceStatusNoSuspended || status == setting.ServiceStatusAllSuspended || status == setting.ServiceStatusPartSuspended {
-		return true
-	}
-	return false
-}
-
 func buildProductResp(envName string, prod *commonmodels.Product, log *zap.SugaredLogger) (*ProductResp, error) {
 	prodResp := &ProductResp{
 		ID:              prod.ID.Hex(),

--- a/pkg/microservice/aslan/core/environment/service/production_environment.go
+++ b/pkg/microservice/aslan/core/environment/service/production_environment.go
@@ -79,8 +79,8 @@ func ExportProductionYaml(envName, productName, serviceName string, log *zap.Sug
 		EnvName:     env.EnvName,
 		ProductTmpl: env.ProductName,
 	}
-	renderset, exists, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
-	if err != nil || !exists {
+	renderset, err := commonrepo.NewRenderSetColl().Find(opt)
+	if err != nil {
 		log.Errorf("failed to find renderset for env: %s, err: %v", envName, err)
 		return res, errors.Wrapf(err, "failed to find renderset for env: %s", envName)
 	}

--- a/pkg/microservice/aslan/core/environment/service/renderset.go
+++ b/pkg/microservice/aslan/core/environment/service/renderset.go
@@ -152,13 +152,10 @@ func GetDefaultValues(productName, envName string, log *zap.SugaredLogger) (*Def
 		ProductTmpl: productName,
 		EnvName:     productInfo.EnvName,
 	}
-	rendersetObj, existed, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
+	rendersetObj, err := commonrepo.NewRenderSetColl().Find(opt)
 	if err != nil {
 		log.Errorf("failed to query renderset info, name %s err %s", productInfo.Render.Name, err)
 		return nil, err
-	}
-	if !existed {
-		return ret, nil
 	}
 	ret.DefaultVariable = rendersetObj.DefaultValues
 	err = service.FillGitNamespace(rendersetObj.YamlData)
@@ -272,14 +269,10 @@ func GetGlobalVariables(productName, envName string, log *zap.SugaredLogger) ([]
 		ProductTmpl: productName,
 		EnvName:     productInfo.EnvName,
 	}
-	rendersetObj, existed, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)
+	rendersetObj, err := commonrepo.NewRenderSetColl().Find(opt)
 	if err != nil {
 		log.Errorf("failed to query renderset info, name %s err %s", productInfo.Render.Name, err)
 		return nil, 0, err
 	}
-	if !existed {
-		return nil, 0, nil
-	}
-
 	return rendersetObj.GlobalVariables, rendersetObj.Revision, nil
 }

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -1292,12 +1292,6 @@ func DeleteServiceTemplate(serviceName, serviceType, productName, isEnvTemplate,
 	}
 
 	if serviceType == setting.HelmDeployType {
-		// 更新helm renderset
-		err = removeServiceFromRenderset(productName, productName, "", serviceName)
-		if err != nil {
-			log.Warnf("failed to update renderset: %s when deleting service: %s, err: %s", productName, serviceName, err.Error())
-		}
-
 		// 把该服务相关的s3的数据从仓库删除
 		if err = fs.DeleteArchivedFileFromS3([]string{serviceName}, configbase.ObjectStorageServicePath(productName, serviceName), log); err != nil {
 			log.Warnf("Failed to delete file %s, err: %s", serviceName, err)
@@ -1320,42 +1314,8 @@ func DeleteServiceTemplate(serviceName, serviceType, productName, isEnvTemplate,
 			log.Errorf("DeleteServiceTemplate Update %s error: %v", serviceName, err)
 			return e.ErrDeleteTemplate.AddDesc(err.Error())
 		}
-
-		// still onBoarding, need to delete service from renderset
-		if serviceType == setting.HelmDeployType && productTempl.OnboardingStatus != 0 {
-			envNames := []string{"dev", "qa"}
-			for _, envName := range envNames {
-				rendersetName := commonservice.GetProductEnvNamespace(envName, productName, "")
-				err := removeServiceFromRenderset(productName, rendersetName, envName, serviceName)
-				if err != nil {
-					log.Warnf("failed to update renderset: %s when deleting service: %s, err: %s", rendersetName, serviceName, err.Error())
-				}
-			}
-		}
 	}
-
 	commonservice.DeleteServiceWebhookByName(serviceName, productName, log)
-
-	return nil
-}
-
-// remove specific services from rendersets.chartinfos
-func removeServiceFromRenderset(productName, renderName, envName, serviceName string) error {
-	renderOpt := &commonrepo.RenderSetFindOption{Name: renderName, ProductTmpl: productName, EnvName: envName}
-	if rs, err := commonrepo.NewRenderSetColl().Find(renderOpt); err == nil {
-		chartInfos := make([]*templatemodels.ServiceRender, 0)
-		for _, chartInfo := range rs.ChartInfos {
-			if chartInfo.ServiceName == serviceName {
-				continue
-			}
-			chartInfos = append(chartInfos, chartInfo)
-		}
-		rs.ChartInfos = chartInfos
-		err = commonrepo.NewRenderSetColl().Update(rs)
-		if err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflow_task.go
@@ -704,9 +704,10 @@ func CreateEnvAndTaskByPR(workflowArgs *commonmodels.WorkflowTaskArgs, prID int,
 		return fmt.Errorf("CreateEnvAndTaskByPR Product Find err:%v", err)
 	}
 	baseRenderset, err := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{
-		Name:      baseProduct.Render.Name,
-		Revision:  baseProduct.Render.Revision,
-		IsDefault: false,
+		Name:        baseProduct.Render.Name,
+		Revision:    baseProduct.Render.Revision,
+		ProductTmpl: baseProduct.ProductName,
+		IsDefault:   false,
 	})
 	if err != nil {
 		return fmt.Errorf("CreateEnvAndTaskByPR renderset Find err:%v", err)
@@ -716,11 +717,6 @@ func CreateEnvAndTaskByPR(workflowArgs *commonmodels.WorkflowTaskArgs, prID int,
 	defer func() {
 		mutex.Unlock()
 	}()
-	//if baseProduct.Render != nil {
-	//	if renderSet, _ := commonrepo.NewRenderSetColl().Find(&commonrepo.RenderSetFindOption{Name: baseProduct.Render.Name, Revision: baseProduct.Render.Revision, ProductTmpl: baseProduct.ProductName}); renderSet != nil {
-	//		baseProduct.Vars = renderSet.KVs
-	//	}
-	//}
 
 	envName := fmt.Sprintf("%s-%d-%s%s", "pr", prID, util.GetRandomNumString(3), util.GetRandomString(3))
 	util.Clear(&baseProduct.ID)

--- a/pkg/util/helm.go
+++ b/pkg/util/helm.go
@@ -24,7 +24,6 @@ import (
 
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/helm/pkg/strvals"
 
 	"github.com/koderover/zadig/pkg/setting"
@@ -40,7 +39,7 @@ func GeneReleaseName(namingRule, projectName, namespace, envName, service string
 }
 
 // for keys exist in both yaml, current values will override the latest values
-func OverrideValues(currentValuesYaml, latestValuesYaml []byte, imageRelatedKey sets.String, onlyImages bool) ([]byte, error) {
+func OverrideValues(currentValuesYaml, latestValuesYaml []byte) ([]byte, error) {
 	currentValuesMap := map[string]interface{}{}
 	if err := yaml.Unmarshal(currentValuesYaml, &currentValuesMap); err != nil {
 		return nil, err
@@ -63,9 +62,6 @@ func OverrideValues(currentValuesYaml, latestValuesYaml []byte, imageRelatedKey 
 
 	replaceMap := make(map[string]interface{})
 	for key := range latestValuesFlatMap {
-		if onlyImages && !imageRelatedKey.Has(key) {
-			continue
-		}
 		if currentValue, ok := currentValuesFlatMap[key]; ok {
 			replaceMap[key] = currentValue
 		}


### PR DESCRIPTION
### What this PR does / Why we need it:
fix renderset query logic & remove some useless code

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 758ce7a</samp>

*  Remove unused imports, functions, and code related to renderset and service template operations in various packages ([link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-cef20e2415c4d69dd2be8ede0de0b2e97d00a0bc91cbec5b2e2cac44e0a3c578L31), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-cef20e2415c4d69dd2be8ede0de0b2e97d00a0bc91cbec5b2e2cac44e0a3c578L1401-L1427), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-835e78573fedb69b67a6300829204b8bbc35771d57aacb1279761d601d943235L22), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-835e78573fedb69b67a6300829204b8bbc35771d57aacb1279761d601d943235L92-L121), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-835e78573fedb69b67a6300829204b8bbc35771d57aacb1279761d601d943235L155-L197), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-3c405020d83cb2519d21479a186d8a5e60a64971718833bca15b68d3f60669b9L70-L84), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L1778-L1789), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L1846-L1857), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L3186), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L3352-R3282), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-c60ffbc0ba5fba85f414bdb2396843ecd498aa16f803cb40761685d65a234b94L151-L159), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-302ca81674abffb78036bdcdc23cf0696d0556c5dfbde67608636a407f92fe26L222-L231), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-fcfbf6b1c510bcc0aac99a96af3adfab8a03337a991e91e0b1a7f79b0faac5f0L1295-L1300), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-fcfbf6b1c510bcc0aac99a96af3adfab8a03337a991e91e0b1a7f79b0faac5f0L1323-R1321), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-9a9f8d26b928747ff3c5b2c3b49e587a740af9e07102c7f646788973063d8c99L719-L723), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-46e5c341c6a707108da3d135591c26620ef020884ac5ffc02339ac4768485e52L27), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-46e5c341c6a707108da3d135591c26620ef020884ac5ffc02339ac4768485e52L66-L68))
* Simplify the call to `util.OverrideValues` by removing the unused nil and false arguments in various packages ([link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-618d57a8566d51373f92b52b30ac5462a808b5cc1f1f06a8ad48e750fa986092L1155-R1155), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L3225-R3185))
* Modify the call to `FindProductRenderSet` to use the render revision field instead of the namespace field in various packages ([link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-62964acc3cc5b564cb53f5cb178c7505bae0aa6c6398448e3869d8dd166209c1L216-R216), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-32522f742768b025f50f0278e3483c42f49374f507116c80571b6fcb806b80d1L196-R196), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-f306c848ffa49dbbccdc498f8dfaae087caf2e8f8d0167589f72d3fb94404f8dL431-R431))
* Modify the call to `commonrepo.NewRenderSetColl().Find` to use the render name and revision fields instead of the namespace field in various packages ([link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L1487-R1494), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L1552-R1552), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L2275-R2245), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L2817-R2776), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24R2783), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-9a9f8d26b928747ff3c5b2c3b49e587a740af9e07102c7f646788973063d8c99L707-R710))
* Modify the call to `render.CreateRenderSet` to use the created renderset variable instead of creating a new struct in the `service` package ([link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L1635-R1654), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L3277-R3210))
* Modify the call to `updateK8sProductVariable` and `updateHelmProductVariable` to use the created renderset variable instead of the renderset variable in the `service` package ([link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L1676-R1671))
* Modify the call to `render.ValidateRenderSet` to use a dummy renderset instead of querying the renderset for the cvm project in the `service` package ([link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-32522f742768b025f50f0278e3483c42f49374f507116c80571b6fcb806b80d1L547-R550))
* Modify the call to `args.EnsureRenderInfo` to ensure the product has a valid render info before creating a renderset in the `service` package ([link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L2697-R2689))
* Rename the function `diffRenderSetHelmChart` to `mergeRenderSetAndRenderChart` to reflect its purpose better in the `service` package ([link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L3082-R3042), [link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L3301-R3216))
* Fix a typo in the variable name `cclusterVersion` to `clusterVersion` in the `service` package ([link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-c60ffbc0ba5fba85f414bdb2396843ecd498aa16f803cb40761685d65a234b94L59-R59))
* Modify the call to `VersionLessThan121` to use the `clusterVersion` variable instead of the `cclusterVersion` variable in the `service` package ([link](https://github.com/koderover/zadig/pull/2989/files?diff=unified&w=0#diff-c60ffbc0ba5fba85f414bdb2396843ecd498aa16f803cb40761685d65a234b94L77-R77))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
