### PR TITLE
add system identity for jira/meego/apollo/nacos/sonar integration

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/1190.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/1190.go
@@ -25,7 +25,9 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/upgradepath"
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/kube"
 	"github.com/koderover/zadig/pkg/setting"
@@ -46,6 +48,12 @@ func V1180ToV1190() error {
 
 	log.Infof("-------- start migrate workflow template --------")
 	if err := migrateWorkflowTemplate(); err != nil {
+		log.Infof("migrateWorkflowTemplate err: %v", err)
+		return err
+	}
+
+	log.Infof("-------- start migrate project management system identity --------")
+	if err := migrateProjectManagementSystemIdentity(); err != nil {
 		log.Infof("migrateWorkflowTemplate err: %v", err)
 		return err
 	}
@@ -163,5 +171,119 @@ func migrateWorkflowTemplate() error {
 			return fmt.Errorf("udpate workflowV4s for merging custom and release workflow, error: %s", err)
 		}
 	}
+	return nil
+}
+
+func migrateProjectManagementSystemIdentity() error {
+	// project management system collection
+	pms, err := mongodb.NewProjectManagementColl().List()
+	if err != nil {
+		return fmt.Errorf("failed to list project management, err: %v", err)
+	}
+
+	jiraCount := 0
+	meegoCount := 0
+	for _, pm := range pms {
+		if pm.SystemIdentity != "" {
+			continue
+		}
+
+		systemIdentity := ""
+		if pm.Type == setting.PMJira {
+			jiraCount++
+			systemIdentity = fmt.Sprintf("jira-%d", jiraCount)
+		} else if pm.Type == setting.PMMeego {
+			meegoCount++
+			systemIdentity = fmt.Sprintf("meego-%d", meegoCount)
+		}
+		pm.SystemIdentity = systemIdentity
+		if err := mongodb.NewProjectManagementColl().UpdateByID(pm.ID.Hex(), pm); err != nil {
+			return fmt.Errorf("failed to update project management system, err: %v", err)
+		}
+	}
+
+	// workflow
+	jira, err := mongodb.NewProjectManagementColl().GetJira()
+	if err != nil {
+		return fmt.Errorf("failed to get jira info from project management, err: %v", err)
+	}
+	meego, err := mongodb.NewProjectManagementColl().GetMeego()
+	if err != nil {
+		return fmt.Errorf("failed to get meego info from project management, err: %v", err)
+	}
+	cursor, err := mongodb.NewWorkflowV4Coll().ListByCursor(&mongodb.ListWorkflowV4Option{
+		JobTypes: []config.JobType{config.JobJira, config.JobMeegoTransition},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list workflowV4 for project management by cursor, err: %v", err)
+	}
+	var ms []mongo.WriteModel
+	for cursor.Next(context.Background()) {
+		var workflow models.WorkflowV4
+		if err := cursor.Decode(&workflow); err != nil {
+			return err
+		}
+
+		for _, stage := range workflow.Stages {
+			for _, job := range stage.Jobs {
+				if job.JobType == config.JobJira {
+					spec := &commonmodels.JiraJobSpec{}
+					if err := commonmodels.IToiYaml(job.Spec, spec); err != nil {
+						return err
+					}
+
+					spec.JiraID = jira.ID.Hex()
+					spec.JiraSystemIdentity = jira.SystemIdentity
+					spec.JiraURL = jira.JiraHost
+
+					job.Spec = spec
+				} else if job.JobType == config.JobMeegoTransition {
+					spec := &commonmodels.MeegoTransitionJobSpec{}
+					if err := commonmodels.IToiYaml(job.Spec, spec); err != nil {
+						return err
+					}
+
+					spec.MeegoID = meego.ID.Hex()
+					spec.MeegoSystemIdentity = meego.SystemIdentity
+					spec.MeegoURL = meego.MeegoHost
+
+					job.Spec = spec
+				}
+			}
+		}
+
+		for _, hook := range workflow.MeegoHookCtls {
+			if hook.MeegoID == "" {
+				hook.MeegoID = meego.ID.Hex()
+				hook.MeegoSystemIdentity = meego.SystemIdentity
+				hook.MeegoURL = meego.MeegoHost
+			}
+		}
+
+		ms = append(ms,
+			mongo.NewUpdateOneModel().
+				SetFilter(bson.D{{"_id", workflow.ID}}).
+				SetUpdate(bson.D{{"$set",
+					bson.D{
+						{"stages", workflow.Stages},
+					}},
+				}),
+		)
+
+		if len(ms) >= 50 {
+			log.Infof("update %d workflowV4", len(ms))
+			if _, err := mongodb.NewWorkflowV4Coll().BulkWrite(context.TODO(), ms); err != nil {
+				return fmt.Errorf("udpate workflowV4s for project management system identity, error: %s", err)
+			}
+			ms = []mongo.WriteModel{}
+		}
+	}
+	if len(ms) > 0 {
+		log.Infof("update %d workflowV4s", len(ms))
+		if _, err := mongodb.NewWorkflowV4Coll().BulkWrite(context.TODO(), ms); err != nil {
+			return fmt.Errorf("udpate workflowV4s for project management system identity, error: %s", err)
+		}
+	}
+
 	return nil
 }

--- a/pkg/microservice/aslan/core/common/repository/models/configuration_management.go
+++ b/pkg/microservice/aslan/core/common/repository/models/configuration_management.go
@@ -19,11 +19,12 @@ package models
 import "go.mongodb.org/mongo-driver/bson/primitive"
 
 type ConfigurationManagement struct {
-	ID            primitive.ObjectID `json:"id" bson:"_id,omitempty"`
-	Type          string             `json:"type" bson:"type" binding:"required"`
-	AuthConfig    interface{}        `json:"auth_config" bson:"auth_config"`
-	ServerAddress string             `json:"server_address" bson:"server_address" binding:"required"`
-	UpdateTime    int64              `json:"update_time" bson:"update_time"`
+	ID             primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	SystemIdentity string             `json:"system_identity" bson:"system_identity" binding:"required"`
+	Type           string             `json:"type" bson:"type" binding:"required"`
+	AuthConfig     interface{}        `json:"auth_config" bson:"auth_config"`
+	ServerAddress  string             `json:"server_address" bson:"server_address" binding:"required"`
+	UpdateTime     int64              `json:"update_time" bson:"update_time"`
 }
 
 func (ConfigurationManagement) TableName() string {

--- a/pkg/microservice/aslan/core/common/repository/models/project_management.go
+++ b/pkg/microservice/aslan/core/common/repository/models/project_management.go
@@ -23,11 +23,12 @@ import (
 )
 
 type ProjectManagement struct {
-	ID           primitive.ObjectID  `bson:"_id,omitempty"       json:"id" `
-	Type         string              `bson:"type"                json:"type"`
-	JiraAuthType config.JiraAuthType `bson:"jira_auth_type" json:"jira_auth_type"`
-	JiraHost     string              `bson:"jira_host"           json:"jira_host"`
-	JiraUser     string              `bson:"jira_user"           json:"jira_user"`
+	ID             primitive.ObjectID  `bson:"_id,omitempty"       json:"id" `
+	SystemIdentity string              `bson:"system_identity"     json:"system_identity"`
+	Type           string              `bson:"type"                json:"type"`
+	JiraAuthType   config.JiraAuthType `bson:"jira_auth_type" json:"jira_auth_type"`
+	JiraHost       string              `bson:"jira_host"           json:"jira_host"`
+	JiraUser       string              `bson:"jira_user"           json:"jira_user"`
 	// JiraToken is used in place of password for basic auth with username
 	JiraToken string `bson:"jira_token"          json:"jira_token"`
 	// JiraPersonalAccessToken is used for bearer token

--- a/pkg/microservice/aslan/core/common/repository/models/sonar.go
+++ b/pkg/microservice/aslan/core/common/repository/models/sonar.go
@@ -19,9 +19,10 @@ package models
 import "go.mongodb.org/mongo-driver/bson/primitive"
 
 type SonarIntegration struct {
-	ID            primitive.ObjectID `bson:"_id,omitempty"`
-	ServerAddress string             `bson:"server_address"`
-	Token         string             `bson:"token"`
+	ID             primitive.ObjectID `bson:"_id,omitempty"`
+	SystemIdentity string             `bson:"system_identity"`
+	ServerAddress  string             `bson:"server_address"`
+	Token          string             `bson:"token"`
 }
 
 func (SonarIntegration) TableName() string {

--- a/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
@@ -377,6 +377,7 @@ type MeegoTransitionSpec struct {
 	Source          string                     `bson:"source"             json:"source"             yaml:"source"`
 	ProjectKey      string                     `bson:"project_key"        json:"project_key"        yaml:"project_key"`
 	ProjectName     string                     `bson:"project_name"       json:"project_name"       yaml:"project_name"`
+	MeegoID         string                     `bson:"meego_id"           json:"meego_id"           yaml:"meego_id"`
 	WorkItemType    string                     `bson:"work_item_type"     json:"work_item_type"     yaml:"work_item_type"`
 	WorkItemTypeKey string                     `bson:"work_item_type_key" json:"work_item_type_key" yaml:"work_item_type_key"`
 	WorkItems       []*MeegoWorkItemTransition `bson:"work_items"         json:"work_items"         yaml:"work_items"`
@@ -412,6 +413,7 @@ type IssueID struct {
 
 type JobTaskJiraSpec struct {
 	ProjectID    string     `bson:"project_id"  json:"project_id"  yaml:"project_id"`
+	JiraID       string     `bson:"jira_id"  json:"jira_id"  yaml:"jira_id"`
 	IssueType    string     `bson:"issue_type"  json:"issue_type"  yaml:"issue_type"`
 	Issues       []*IssueID `bson:"issues" json:"issues" yaml:"issues"`
 	TargetStatus string     `bson:"target_status" json:"target_status" yaml:"target_status"`

--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -90,6 +90,7 @@ func (w *WorkflowV4) CalculateHash() [md5.Size]byte {
 	return md5.Sum(jsonBytes)
 }
 
+// @todo job spec
 type WorkflowStage struct {
 	Name     string    `bson:"name"          yaml:"name"         json:"name"`
 	Parallel bool      `bson:"parallel"      yaml:"parallel"     json:"parallel"`
@@ -538,7 +539,10 @@ type GrayRollbackTarget struct {
 }
 
 type JiraJobSpec struct {
-	ProjectID string `bson:"project_id"  json:"project_id"  yaml:"project_id"`
+	ProjectID          string `bson:"project_id"  json:"project_id"  yaml:"project_id"`
+	JiraID             string `bson:"jira_id" json:"jira_id" yaml:"jira_id"`
+	JiraSystemIdentity string `bson:"jira_system_identity" json:"jira_system_identity" yaml:"jira_system_identity"`
+	JiraURL            string `bson:"jira_url" json:"jira_url" yaml:"jira_url"`
 	// QueryType: "" means common, "advanced" means use custom jql
 	QueryType string `bson:"query_type" json:"query_type" yaml:"query_type"`
 	// JQL: when query type is advanced, use this
@@ -584,13 +588,16 @@ type ApolloNamespace struct {
 }
 
 type MeegoTransitionJobSpec struct {
-	Source          string                     `bson:"source"             json:"source"`
-	ProjectKey      string                     `bson:"project_key"        json:"project_key"        yaml:"project_key"`
-	ProjectName     string                     `bson:"project_name"       json:"project_name"       yaml:"project_name"`
-	WorkItemType    string                     `bson:"work_item_type"     json:"work_item_type"     yaml:"work_item_type"`
-	WorkItemTypeKey string                     `bson:"work_item_type_key" json:"work_item_type_key" yaml:"work_item_type_key"`
-	Link            string                     `bson:"link"               json:"link"               yaml:"link"`
-	WorkItems       []*MeegoWorkItemTransition `bson:"work_items"         json:"work_items"         yaml:"work_items"`
+	Source              string                     `bson:"source"                json:"source"`
+	ProjectKey          string                     `bson:"project_key"           json:"project_key"           yaml:"project_key"`
+	ProjectName         string                     `bson:"project_name"          json:"project_name"          yaml:"project_name"`
+	MeegoID             string                     `bson:"meego_id"              json:"meego_id"              yaml:"meego_id"`
+	MeegoSystemIdentity string                     `bson:"meego_system_identity" json:"meego_system_identity" yaml:"meego_system_identity"`
+	MeegoURL            string                     `bson:"meego_url"             json:"meego_url"             yaml:"meego_url"`
+	WorkItemType        string                     `bson:"work_item_type"        json:"work_item_type"        yaml:"work_item_type"`
+	WorkItemTypeKey     string                     `bson:"work_item_type_key"    json:"work_item_type_key"    yaml:"work_item_type_key"`
+	Link                string                     `bson:"link"                  json:"link"                  yaml:"link"`
+	WorkItems           []*MeegoWorkItemTransition `bson:"work_items"            json:"work_items"            yaml:"work_items"`
 }
 
 type MeegoWorkItemTransition struct {
@@ -767,10 +774,13 @@ type JiraHook struct {
 }
 
 type MeegoHook struct {
-	Name        string      `bson:"name" json:"name"`
-	Enabled     bool        `bson:"enabled" json:"enabled"`
-	Description string      `bson:"description" json:"description"`
-	WorkflowArg *WorkflowV4 `bson:"workflow_arg" json:"workflow_arg"`
+	Name                string      `bson:"name" json:"name"`
+	MeegoID             string      `bson:"meego_id" json:"meego_id"`
+	MeegoSystemIdentity string      `bson:"meego_system_identity" json:"meego_system_identity"`
+	MeegoURL            string      `bson:"meego_url"             json:"meego_url"`
+	Enabled             bool        `bson:"enabled" json:"enabled"`
+	Description         string      `bson:"description" json:"description"`
+	WorkflowArg         *WorkflowV4 `bson:"workflow_arg" json:"workflow_arg"`
 }
 
 type GeneralHook struct {

--- a/pkg/microservice/aslan/core/common/repository/mongodb/configuration_management.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/configuration_management.go
@@ -99,6 +99,15 @@ func (c *ConfigurationManagementColl) GetByID(ctx context.Context, idString stri
 	return resp, c.FindOne(ctx, query).Decode(resp)
 }
 
+func (c *ConfigurationManagementColl) GetBySystemIdentity(systemIdentity string) (*models.ConfigurationManagement, error) {
+	configManagement := &models.ConfigurationManagement{}
+	query := bson.M{"system_identity": systemIdentity}
+	if err := c.Collection.FindOne(context.TODO(), query).Decode(configManagement); err != nil {
+		return nil, err
+	}
+	return configManagement, nil
+}
+
 func (c *ConfigurationManagementColl) GetApolloByID(ctx context.Context, idString string) (*models.ApolloConfig, error) {
 	info, err := c.GetByID(ctx, idString)
 	if err != nil {

--- a/pkg/microservice/aslan/core/common/repository/mongodb/project_management.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/project_management.go
@@ -62,6 +62,18 @@ func (c *ProjectManagementColl) Create(pm *models.ProjectManagement) error {
 	return nil
 }
 
+func (c *ProjectManagementColl) GetByID(idHex string) (*models.ProjectManagement, error) {
+	pm := &models.ProjectManagement{}
+	id, err := primitive.ObjectIDFromHex(idHex)
+	if err != nil {
+		return nil, err
+	}
+	query := bson.M{"_id": id}
+
+	err = c.FindOne(context.Background(), query).Decode(pm)
+	return pm, err
+}
+
 func (c *ProjectManagementColl) UpdateByID(idHex string, pm *models.ProjectManagement) error {
 	id, err := primitive.ObjectIDFromHex(idHex)
 	if err != nil {
@@ -103,6 +115,7 @@ func (c *ProjectManagementColl) List() ([]*models.ProjectManagement, error) {
 	return resp, cursor.All(context.Background(), &resp)
 }
 
+// Deprecated since 1.19.0
 func (c *ProjectManagementColl) GetJira() (*models.ProjectManagement, error) {
 	jira := &models.ProjectManagement{}
 	query := bson.M{"type": setting.PMJira}
@@ -114,6 +127,22 @@ func (c *ProjectManagementColl) GetJira() (*models.ProjectManagement, error) {
 	return jira, nil
 }
 
+func (c *ProjectManagementColl) GetJiraByID(idHex string) (*models.ProjectManagement, error) {
+	id, err := primitive.ObjectIDFromHex(idHex)
+	if err != nil {
+		return nil, err
+	}
+	jira := &models.ProjectManagement{}
+	query := bson.M{"_id": id, "type": setting.PMJira}
+
+	err = c.Collection.FindOne(context.TODO(), query).Decode(jira)
+	if err != nil {
+		return nil, err
+	}
+	return jira, nil
+}
+
+// Deprecated since 1.19.0
 func (c *ProjectManagementColl) GetMeego() (*models.ProjectManagement, error) {
 	meego := &models.ProjectManagement{}
 	query := bson.M{"type": setting.PMMeego}
@@ -123,4 +152,28 @@ func (c *ProjectManagementColl) GetMeego() (*models.ProjectManagement, error) {
 		return nil, err
 	}
 	return meego, nil
+}
+
+func (c *ProjectManagementColl) GetMeegoByID(idHex string) (*models.ProjectManagement, error) {
+	id, err := primitive.ObjectIDFromHex(idHex)
+	if err != nil {
+		return nil, err
+	}
+	meego := &models.ProjectManagement{}
+	query := bson.M{"_id": id, "type": setting.PMJira}
+
+	err = c.Collection.FindOne(context.TODO(), query).Decode(meego)
+	if err != nil {
+		return nil, err
+	}
+	return meego, nil
+}
+
+func (c *ProjectManagementColl) GetBySystemIdentity(systemIdentity string) (*models.ProjectManagement, error) {
+	projectManagement := &models.ProjectManagement{}
+	query := bson.M{"system_identity": systemIdentity}
+	if err := c.Collection.FindOne(context.TODO(), query).Decode(projectManagement); err != nil {
+		return nil, err
+	}
+	return projectManagement, nil
 }

--- a/pkg/microservice/aslan/core/common/repository/mongodb/project_management.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/project_management.go
@@ -160,7 +160,7 @@ func (c *ProjectManagementColl) GetMeegoByID(idHex string) (*models.ProjectManag
 		return nil, err
 	}
 	meego := &models.ProjectManagement{}
-	query := bson.M{"_id": id, "type": setting.PMJira}
+	query := bson.M{"_id": id, "type": setting.PMMeego}
 
 	err = c.Collection.FindOne(context.TODO(), query).Decode(meego)
 	if err != nil {

--- a/pkg/microservice/aslan/core/common/repository/mongodb/sonar.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/sonar.go
@@ -130,3 +130,12 @@ func (c *SonarIntegrationColl) DeleteByID(ctx context.Context, idstring string) 
 	_, err = c.DeleteOne(ctx, query)
 	return err
 }
+
+func (c *SonarIntegrationColl) GetBySystemIdentity(systemIdentity string) (*models.SonarIntegration, error) {
+	obj := &models.SonarIntegration{}
+	query := bson.M{"system_identity": systemIdentity}
+	if err := c.Collection.FindOne(context.TODO(), query).Decode(obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}

--- a/pkg/microservice/aslan/core/common/repository/mongodb/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/workflow_v4.go
@@ -328,6 +328,9 @@ func (c *WorkflowV4Coll) ListByCursor(opt *ListWorkflowV4Option) (*mongo.Cursor,
 	if len(opt.Names) > 0 {
 		query["name"] = bson.M{"$in": opt.Names}
 	}
+	if len(opt.JobTypes) > 0 {
+		query["stages.jobs.type"] = bson.M{"$in": opt.JobTypes}
+	}
 	return c.Collection.Find(context.TODO(), query)
 }
 

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_jira.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_jira.go
@@ -57,7 +57,7 @@ func (c *JiraJobCtl) Run(ctx context.Context) {
 	c.job.Status = config.StatusRunning
 	c.ack()
 
-	info, err := mongodb.NewProjectManagementColl().GetJira()
+	info, err := mongodb.NewProjectManagementColl().GetJiraByID(c.jobTaskSpec.JiraID)
 	if err != nil {
 		logError(c.job, err.Error(), c.logger)
 		return

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_meego_transition.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_meego_transition.go
@@ -55,7 +55,7 @@ func (c *MeegoTransitionJobCtl) Clean(ctx context.Context) {
 
 func (c *MeegoTransitionJobCtl) Run(ctx context.Context) {
 	// since this runs in aslan, we will connect directly to the database to retrieve meego integration info
-	meegoInfo, err := commonrepo.NewProjectManagementColl().GetMeego()
+	meegoInfo, err := commonrepo.NewProjectManagementColl().GetMeegoByID(c.jobTaskSpec.MeegoID)
 	if err != nil {
 		logError(c.job, err.Error(), c.logger)
 		c.job.Status = config.StatusFailed

--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -1940,6 +1940,16 @@ func GetProductionEstimatedRenderCharts(c *gin.Context) {
 	}
 }
 
+// @Summary Delete Product
+// @Description Delete Product
+// @Tags 	environment
+// @Accept 	json
+// @Produce json
+// @Param 	projectName		query		string							true	"project name"
+// @Param 	name			path		string							true	"env name"
+// @Param 	is_delete		query		string							true	"is delete"
+// @Success 200
+// @Router /api/aslan/environment/environments/{name} [delete]
 func DeleteProduct(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()

--- a/pkg/microservice/aslan/core/system/handler/meego.go
+++ b/pkg/microservice/aslan/core/system/handler/meego.go
@@ -26,21 +26,6 @@ import (
 	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
 )
 
-// @Summary List Meegos
-// @Description List Meegos
-// @Tags 	system
-// @Accept 	json
-// @Produce json
-// @Success 200 		{array} 	models.ProjectManagement
-// @Router /api/aslan/system/meego/ [get]
-// @todo remove it
-func ListMeego(c *gin.Context) {
-	ctx := internalhandler.NewContext(c)
-	defer func() { internalhandler.JSONResponse(c, ctx) }()
-
-	ctx.Resp, ctx.Err = service.ListMeego()
-}
-
 // @Summary List Meego Projects
 // @Description List Meego Projects
 // @Tags 	system

--- a/pkg/microservice/aslan/core/system/handler/meego.go
+++ b/pkg/microservice/aslan/core/system/handler/meego.go
@@ -33,6 +33,7 @@ import (
 // @Produce json
 // @Success 200 		{array} 	models.ProjectManagement
 // @Router /api/aslan/system/meego/ [get]
+// @todo remove it
 func ListMeego(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
@@ -56,6 +57,15 @@ func GetMeegoProjects(c *gin.Context) {
 	ctx.Resp, ctx.Err = service.GetMeegoProjects(id)
 }
 
+// @Summary Get Meego Work Item Type List
+// @Description Get Meego Work Item Type List
+// @Tags 	system
+// @Accept 	json
+// @Produce json
+// @Param 	id 		        path		string										true	"meego id"
+// @Param 	projectID 		path		string										true	"project id"
+// @Success 200 			{object} 	service.MeegoWorkItemTypeResp
+// @Router /api/aslan/system/meego/{id}/projects/{projectID}/work_item/types [get]
 func GetWorkItemTypeList(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
@@ -66,6 +76,19 @@ func GetWorkItemTypeList(c *gin.Context) {
 	ctx.Resp, ctx.Err = service.GetWorkItemTypeList(id, projectID)
 }
 
+// @Summary List Meego Work Items
+// @Description List Meego Work Items
+// @Tags 	system
+// @Accept 	json
+// @Produce json
+// @Param 	id 		        path		string										true	"meego id"
+// @Param 	projectID 		path		string										true	"project id"
+// @Param 	type_key 		query		string										true	"type key"
+// @Param 	page_num 		query		string										true	"page num"
+// @Param 	page_size 		query		string										true	"page size"
+// @Param 	item_name 		query		string										true	"item name"
+// @Success 200 			{object} 	service.MeegoWorkItemResp
+// @Router /api/aslan/system/meego/{id}/projects/{projectID}/work_item [get]
 func ListMeegoWorkItems(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()

--- a/pkg/microservice/aslan/core/system/handler/meego.go
+++ b/pkg/microservice/aslan/core/system/handler/meego.go
@@ -32,7 +32,7 @@ import (
 // @Accept 	json
 // @Produce json
 // @Success 200 		{array} 	models.ProjectManagement
-// @Router /api/aslan/environment/environments/{name}/configs [get]
+// @Router /api/aslan/system/meego/ [get]
 func ListMeego(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
@@ -40,6 +40,14 @@ func ListMeego(c *gin.Context) {
 	ctx.Resp, ctx.Err = service.ListMeego()
 }
 
+// @Summary List Meego Projects
+// @Description List Meego Projects
+// @Tags 	system
+// @Accept 	json
+// @Produce json
+// @Param 	id 		path		string										true	"meego id"
+// @Success 200 	{object} 	service.MeegoProjectResp
+// @Router /api/aslan/system/meego/{id}/projects [get]
 func GetMeegoProjects(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()

--- a/pkg/microservice/aslan/core/system/handler/meego.go
+++ b/pkg/microservice/aslan/core/system/handler/meego.go
@@ -26,20 +26,36 @@ import (
 	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
 )
 
+// @Summary List Meegos
+// @Description List Meegos
+// @Tags 	system
+// @Accept 	json
+// @Produce json
+// @Success 200 		{array} 	models.ProjectManagement
+// @Router /api/aslan/environment/environments/{name}/configs [get]
+func ListMeego(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	ctx.Resp, ctx.Err = service.ListMeego()
+}
+
 func GetMeegoProjects(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
-	ctx.Resp, ctx.Err = service.GetMeegoProjects()
+	id := c.Param("id")
+	ctx.Resp, ctx.Err = service.GetMeegoProjects(id)
 }
 
 func GetWorkItemTypeList(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
+	id := c.Param("id")
 	projectID := c.Param("projectID")
 
-	ctx.Resp, ctx.Err = service.GetWorkItemTypeList(projectID)
+	ctx.Resp, ctx.Err = service.GetWorkItemTypeList(id, projectID)
 }
 
 func ListMeegoWorkItems(c *gin.Context) {
@@ -73,9 +89,10 @@ func ListMeegoWorkItems(c *gin.Context) {
 		return
 	}
 
+	id := c.Param("id")
 	nameQuery := c.Query("item_name")
 
-	ctx.Resp, ctx.Err = service.ListMeegoWorkItems(projectID, typeKey, nameQuery, pageNum, pageSize)
+	ctx.Resp, ctx.Err = service.ListMeegoWorkItems(id, projectID, typeKey, nameQuery, pageNum, pageSize)
 }
 
 func ListAvailableWorkItemTransitions(c *gin.Context) {
@@ -91,5 +108,6 @@ func ListAvailableWorkItemTransitions(c *gin.Context) {
 	}
 	workItemTypeKey := c.Query("type_key")
 
-	ctx.Resp, ctx.Err = service.ListAvailableWorkItemTransitions(projectID, workItemTypeKey, workItemID)
+	id := c.Param("id")
+	ctx.Resp, ctx.Err = service.ListAvailableWorkItemTransitions(id, projectID, workItemTypeKey, workItemID)
 }

--- a/pkg/microservice/aslan/core/system/handler/project_management.go
+++ b/pkg/microservice/aslan/core/system/handler/project_management.go
@@ -51,6 +51,37 @@ func ListProjectManagement(c *gin.Context) {
 	ctx.Resp, ctx.Err = service.ListProjectManagement(ctx.Logger)
 }
 
+// @Summary List Project Management For Project
+// @Description List Project Management For Project
+// @Tags 	system
+// @Accept 	json
+// @Produce json
+// @Success 200 	{array} 	models.ProjectManagement
+// @Router /api/aslan/system/project_management/project [get]
+func ListProjectManagementForProject(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	pms, err := service.ListProjectManagement(ctx.Logger)
+	for _, pm := range pms {
+		pm.JiraToken = ""
+		pm.JiraUser = ""
+		pm.JiraAuthType = ""
+		pm.MeegoPluginID = ""
+		pm.MeegoPluginSecret = ""
+		pm.MeegoUserKey = ""
+	}
+	ctx.Err = err
+	ctx.Resp = pms
+}
+
 func CreateProjectManagement(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()

--- a/pkg/microservice/aslan/core/system/handler/project_management.go
+++ b/pkg/microservice/aslan/core/system/handler/project_management.go
@@ -153,6 +153,14 @@ func Validate(c *gin.Context) {
 	}
 }
 
+// @Summary List Jira Projects
+// @Description List Jira Projects
+// @Tags 	system
+// @Accept 	json
+// @Produce json
+// @Param 	id 		path		string										true	"jira id"
+// @Success 200 	{array} 	service.JiraProjectsResp
+// @Router /api/aslan/system/project_management/{id}/jira/project [get]
 func ListJiraProjects(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()

--- a/pkg/microservice/aslan/core/system/handler/project_management.go
+++ b/pkg/microservice/aslan/core/system/handler/project_management.go
@@ -137,7 +137,7 @@ func Validate(c *gin.Context) {
 		ctx.UnAuthorized = true
 		return
 	}
-	
+
 	req := new(models.ProjectManagement)
 	if err := c.ShouldBindJSON(req); err != nil {
 		ctx.Err = err
@@ -156,13 +156,13 @@ func Validate(c *gin.Context) {
 func ListJiraProjects(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
-	ctx.Resp, ctx.Err = service.ListJiraProjects()
+	ctx.Resp, ctx.Err = service.ListJiraProjects(c.Param("id"))
 }
 
 func SearchJiraIssues(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
-	ctx.Resp, ctx.Err = service.SearchJiraIssues(c.Query("project"), c.Query("type"), c.Query("status"), c.Query("summary"), c.Query("ne") == "true")
+	ctx.Resp, ctx.Err = service.SearchJiraIssues(c.Param("id"), c.Query("project"), c.Query("type"), c.Query("status"), c.Query("summary"), c.Query("ne") == "true")
 }
 
 func SearchJiraProjectIssuesWithJQL(c *gin.Context) {
@@ -171,19 +171,19 @@ func SearchJiraProjectIssuesWithJQL(c *gin.Context) {
 
 	// 5.22 JQL only support {{.system.username}} variable
 	// refactor if more variables are needed
-	ctx.Resp, ctx.Err = service.SearchJiraProjectIssuesWithJQL(c.Query("project"), strings.ReplaceAll(c.Query("jql"), "{{.system.username}}", ctx.UserName), c.Query("summary"))
+	ctx.Resp, ctx.Err = service.SearchJiraProjectIssuesWithJQL(c.Param("id"), c.Query("project"), strings.ReplaceAll(c.Query("jql"), "{{.system.username}}", ctx.UserName), c.Query("summary"))
 }
 
 func GetJiraTypes(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
-	ctx.Resp, ctx.Err = service.GetJiraTypes(c.Query("project"))
+	ctx.Resp, ctx.Err = service.GetJiraTypes(c.Param("id"), c.Query("project"))
 }
 
 func GetJiraAllStatus(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
-	ctx.Resp, ctx.Err = service.GetJiraAllStatus(c.Query("project"))
+	ctx.Resp, ctx.Err = service.GetJiraAllStatus(c.Param("id"), c.Query("project"))
 }
 
 func HandleJiraEvent(c *gin.Context) {

--- a/pkg/microservice/aslan/core/system/handler/router.go
+++ b/pkg/microservice/aslan/core/system/handler/router.go
@@ -298,6 +298,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 	pm := router.Group("project_management")
 	{
 		pm.GET("", ListProjectManagement)
+		pm.GET("/project", ListProjectManagementForProject)
 		pm.POST("", CreateProjectManagement)
 		pm.POST("/validate", Validate)
 		pm.PATCH("/:id", UpdateProjectManagement)
@@ -340,7 +341,6 @@ func (*Router) Inject(router *gin.RouterGroup) {
 	// feishu project management module
 	meego := router.Group("meego")
 	{
-		meego.GET("/", ListMeego)
 		meego.GET("/:id/projects", GetMeegoProjects)
 		meego.GET("/:id/projects/:projectID/work_item/types", GetWorkItemTypeList)
 		meego.GET("/:id/projects/:projectID/work_item", ListMeegoWorkItems)

--- a/pkg/microservice/aslan/core/system/handler/router.go
+++ b/pkg/microservice/aslan/core/system/handler/router.go
@@ -302,11 +302,11 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		pm.POST("/validate", Validate)
 		pm.PATCH("/:id", UpdateProjectManagement)
 		pm.DELETE("/:id", DeleteProjectManagement)
-		pm.GET("/jira/project", ListJiraProjects)
-		pm.GET("/jira/issue", SearchJiraIssues)
-		pm.GET("/jira/issue/jql", SearchJiraProjectIssuesWithJQL)
-		pm.GET("/jira/type", GetJiraTypes)
-		pm.GET("/jira/status", GetJiraAllStatus)
+		pm.GET("/:id/jira/project", ListJiraProjects)
+		pm.GET("/:id/jira/issue", SearchJiraIssues)
+		pm.GET("/:id/jira/issue/jql", SearchJiraProjectIssuesWithJQL)
+		pm.GET("/:id/jira/type", GetJiraTypes)
+		pm.GET("/:id/jira/status", GetJiraAllStatus)
 		pm.POST("/jira/webhook/:workflowName/:hookName", HandleJiraEvent)
 		pm.POST("/meego/webhook/:workflowName/:hookName", HandleMeegoEvent)
 	}
@@ -340,10 +340,11 @@ func (*Router) Inject(router *gin.RouterGroup) {
 	// feishu project management module
 	meego := router.Group("meego")
 	{
-		meego.GET("/projects", GetMeegoProjects)
-		meego.GET("/projects/:projectID/work_item/types", GetWorkItemTypeList)
-		meego.GET("/projects/:projectID/work_item", ListMeegoWorkItems)
-		meego.GET("/projects/:projectID/work_item/:workItemID/transitions", ListAvailableWorkItemTransitions)
+		meego.GET("/", ListMeego)
+		meego.GET("/:id/projects", GetMeegoProjects)
+		meego.GET("/:id/projects/:projectID/work_item/types", GetWorkItemTypeList)
+		meego.GET("/:id/projects/:projectID/work_item", ListMeegoWorkItems)
+		meego.GET("/:id/projects/:projectID/work_item/:workItemID/transitions", ListAvailableWorkItemTransitions)
 	}
 
 	// guanceyun api

--- a/pkg/microservice/aslan/core/system/service/configuration_management.go
+++ b/pkg/microservice/aslan/core/system/service/configuration_management.go
@@ -39,7 +39,7 @@ func CreateConfigurationManagement(args *commonmodels.ConfigurationManagement, l
 		return e.ErrCreateConfigurationManagement.AddErr(err)
 	}
 
-	if _, err := mongodb.NewConfigurationManagementColl().GetBySystemIdentity(args.SystemIdentity); err != nil {
+	if _, err := mongodb.NewConfigurationManagementColl().GetBySystemIdentity(args.SystemIdentity); err == nil {
 		return e.ErrCreateConfigurationManagement.AddErr(fmt.Errorf("can't set the same system identity"))
 	}
 	err := mongodb.NewConfigurationManagementColl().Create(context.Background(), args)
@@ -75,7 +75,7 @@ func UpdateConfigurationManagement(id string, args *commonmodels.ConfigurationMa
 		oldSystemIdentity = oldCm.SystemIdentity
 	}
 	if oldCm.SystemIdentity != "" && args.SystemIdentity != oldSystemIdentity {
-		if _, err := mongodb.NewConfigurationManagementColl().GetBySystemIdentity(args.SystemIdentity); err != nil {
+		if _, err := mongodb.NewConfigurationManagementColl().GetBySystemIdentity(args.SystemIdentity); err == nil {
 			return e.ErrUpdateConfigurationManagement.AddErr(fmt.Errorf("can't set the same system identity"))
 		}
 	}

--- a/pkg/microservice/aslan/core/system/service/configuration_management.go
+++ b/pkg/microservice/aslan/core/system/service/configuration_management.go
@@ -39,6 +39,9 @@ func CreateConfigurationManagement(args *commonmodels.ConfigurationManagement, l
 		return e.ErrCreateConfigurationManagement.AddErr(err)
 	}
 
+	if _, err := mongodb.NewConfigurationManagementColl().GetBySystemIdentity(args.SystemIdentity); err != nil {
+		return e.ErrCreateConfigurationManagement.AddErr(fmt.Errorf("can't set the same system identity"))
+	}
 	err := mongodb.NewConfigurationManagementColl().Create(context.Background(), args)
 	if err != nil {
 		log.Errorf("create configuration management error: %v", err)
@@ -66,7 +69,17 @@ func UpdateConfigurationManagement(id string, args *commonmodels.ConfigurationMa
 		return e.ErrUpdateConfigurationManagement.AddErr(err)
 	}
 
-	err := mongodb.NewConfigurationManagementColl().Update(context.Background(), id, args)
+	var oldSystemIdentity string
+	oldCm, err := mongodb.NewConfigurationManagementColl().GetByID(context.Background(), id)
+	if err == nil {
+		oldSystemIdentity = oldCm.SystemIdentity
+	}
+	if oldCm.SystemIdentity != "" && args.SystemIdentity != oldSystemIdentity {
+		if _, err := mongodb.NewConfigurationManagementColl().GetBySystemIdentity(args.SystemIdentity); err != nil {
+			return e.ErrUpdateConfigurationManagement.AddErr(fmt.Errorf("can't set the same system identity"))
+		}
+	}
+	err = mongodb.NewConfigurationManagementColl().Update(context.Background(), id, args)
 	if err != nil {
 		log.Errorf("update configuration management error: %v", err)
 		return e.ErrUpdateConfigurationManagement.AddErr(err)

--- a/pkg/microservice/aslan/core/system/service/meego.go
+++ b/pkg/microservice/aslan/core/system/service/meego.go
@@ -17,30 +17,10 @@
 package service
 
 import (
-	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/koderover/zadig/pkg/tool/meego"
 )
-
-// type ListMeegoRespone struct {
-// 	ID                string `json:"id" `
-// 	SystemIdentity    string `json:"system_identity"`
-// 	MeegoHost         string `json:"meego_host"`
-// 	MeegoPluginID     string `json:"meego_plugin_id"`
-// 	MeegoPluginSecret string `json:"meego_plugin_secret"`
-// 	MeegoUserKey      string `json:"meego_user_key"`
-// 	UpdatedAt         int64  `json:"updated_at"`
-// }
-
-func ListMeego() ([]*models.ProjectManagement, error) {
-	meegoInfos, err := commonrepo.NewProjectManagementColl().List()
-	if err != nil {
-		log.Errorf("failed to get meego info, err: %s", err)
-		return nil, err
-	}
-	return meegoInfos, nil
-}
 
 func GetMeegoProjects(id string) (*MeegoProjectResp, error) {
 	meegoInfo, err := commonrepo.NewProjectManagementColl().GetMeegoByID(id)

--- a/pkg/microservice/aslan/core/system/service/meego.go
+++ b/pkg/microservice/aslan/core/system/service/meego.go
@@ -17,13 +17,33 @@
 package service
 
 import (
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/koderover/zadig/pkg/tool/meego"
 )
 
-func GetMeegoProjects() (*MeegoProjectResp, error) {
-	meegoInfo, err := commonrepo.NewProjectManagementColl().GetMeego()
+// type ListMeegoRespone struct {
+// 	ID                string `json:"id" `
+// 	SystemIdentity    string `json:"system_identity"`
+// 	MeegoHost         string `json:"meego_host"`
+// 	MeegoPluginID     string `json:"meego_plugin_id"`
+// 	MeegoPluginSecret string `json:"meego_plugin_secret"`
+// 	MeegoUserKey      string `json:"meego_user_key"`
+// 	UpdatedAt         int64  `json:"updated_at"`
+// }
+
+func ListMeego() ([]*models.ProjectManagement, error) {
+	meegoInfos, err := commonrepo.NewProjectManagementColl().List()
+	if err != nil {
+		log.Errorf("failed to get meego info, err: %s", err)
+		return nil, err
+	}
+	return meegoInfos, nil
+}
+
+func GetMeegoProjects(id string) (*MeegoProjectResp, error) {
+	meegoInfo, err := commonrepo.NewProjectManagementColl().GetMeegoByID(id)
 	if err != nil {
 		log.Errorf("failed to get meego info, err: %s", err)
 		return nil, err
@@ -48,8 +68,8 @@ func GetMeegoProjects() (*MeegoProjectResp, error) {
 	return &MeegoProjectResp{Projects: meegoProjectList}, nil
 }
 
-func GetWorkItemTypeList(projectID string) (*MeegoWorkItemTypeResp, error) {
-	meegoInfo, err := commonrepo.NewProjectManagementColl().GetMeego()
+func GetWorkItemTypeList(id, projectID string) (*MeegoWorkItemTypeResp, error) {
+	meegoInfo, err := commonrepo.NewProjectManagementColl().GetMeegoByID(id)
 	if err != nil {
 		log.Errorf("failed to get meego info, err: %s", err)
 		return nil, err
@@ -74,8 +94,8 @@ func GetWorkItemTypeList(projectID string) (*MeegoWorkItemTypeResp, error) {
 	return &MeegoWorkItemTypeResp{WorkItemTypes: meegoWorkItemTypeList}, nil
 }
 
-func ListMeegoWorkItems(projectID, typeKey, nameQuery string, pageNum, pageSize int) (*MeegoWorkItemResp, error) {
-	meegoInfo, err := commonrepo.NewProjectManagementColl().GetMeego()
+func ListMeegoWorkItems(id, projectID, typeKey, nameQuery string, pageNum, pageSize int) (*MeegoWorkItemResp, error) {
+	meegoInfo, err := commonrepo.NewProjectManagementColl().GetMeegoByID(id)
 	if err != nil {
 		log.Errorf("failed to get meego info, err: %s", err)
 		return nil, err
@@ -102,8 +122,8 @@ func ListMeegoWorkItems(projectID, typeKey, nameQuery string, pageNum, pageSize 
 	return &MeegoWorkItemResp{WorkItems: meegoWorkItemList}, nil
 }
 
-func ListAvailableWorkItemTransitions(projectID, typeKey string, workItemID int) (*MeegoTransitionResp, error) {
-	meegoInfo, err := commonrepo.NewProjectManagementColl().GetMeego()
+func ListAvailableWorkItemTransitions(id, projectID, typeKey string, workItemID int) (*MeegoTransitionResp, error) {
+	meegoInfo, err := commonrepo.NewProjectManagementColl().GetMeegoByID(id)
 	if err != nil {
 		log.Errorf("failed to get meego info, err: %s", err)
 		return nil, err

--- a/pkg/microservice/aslan/core/system/service/project_management.go
+++ b/pkg/microservice/aslan/core/system/service/project_management.go
@@ -50,7 +50,6 @@ func ListProjectManagement(log *zap.SugaredLogger) ([]*models.ProjectManagement,
 	return list, nil
 }
 
-// @note ref
 func CreateProjectManagement(pm *models.ProjectManagement, log *zap.SugaredLogger) error {
 	if err := checkType(pm.Type); err != nil {
 		return err

--- a/pkg/microservice/aslan/core/system/service/project_management.go
+++ b/pkg/microservice/aslan/core/system/service/project_management.go
@@ -50,6 +50,7 @@ func ListProjectManagement(log *zap.SugaredLogger) ([]*models.ProjectManagement,
 	return list, nil
 }
 
+// @note ref
 func CreateProjectManagement(pm *models.ProjectManagement, log *zap.SugaredLogger) error {
 	if err := checkType(pm.Type); err != nil {
 		return err

--- a/pkg/microservice/aslan/core/system/service/project_management.go
+++ b/pkg/microservice/aslan/core/system/service/project_management.go
@@ -55,7 +55,7 @@ func CreateProjectManagement(pm *models.ProjectManagement, log *zap.SugaredLogge
 	if err := checkType(pm.Type); err != nil {
 		return err
 	}
-	if _, err := mongodb.NewProjectManagementColl().GetBySystemIdentity(pm.SystemIdentity); err != nil {
+	if _, err := mongodb.NewProjectManagementColl().GetBySystemIdentity(pm.SystemIdentity); err == nil {
 		return fmt.Errorf("can't set the same system identity")
 	}
 	if err := mongodb.NewProjectManagementColl().Create(pm); err != nil {
@@ -76,7 +76,7 @@ func UpdateProjectManagement(idHex string, pm *models.ProjectManagement, log *za
 		oldSystemIdentity = oldPm.SystemIdentity
 	}
 	if oldPm.SystemIdentity != "" && pm.SystemIdentity != oldSystemIdentity {
-		if _, err := mongodb.NewProjectManagementColl().GetBySystemIdentity(pm.SystemIdentity); err != nil {
+		if _, err := mongodb.NewProjectManagementColl().GetBySystemIdentity(pm.SystemIdentity); err == nil {
 			return fmt.Errorf("can't set the same system identity")
 		}
 	}

--- a/pkg/microservice/aslan/core/system/service/sonar.go
+++ b/pkg/microservice/aslan/core/system/service/sonar.go
@@ -86,9 +86,10 @@ func ListSonarIntegration(log *zap.SugaredLogger) ([]*SonarIntegration, int64, e
 	resp := make([]*SonarIntegration, 0)
 	for _, sonar := range sonarList {
 		resp = append(resp, &SonarIntegration{
-			ID:            sonar.ID.Hex(),
-			ServerAddress: sonar.ServerAddress,
-			Token:         sonar.Token,
+			ID:             sonar.ID.Hex(),
+			SystemIdentity: sonar.SystemIdentity,
+			ServerAddress:  sonar.ServerAddress,
+			Token:          sonar.Token,
 		})
 	}
 	return resp, length, nil

--- a/pkg/microservice/aslan/core/system/service/types.go
+++ b/pkg/microservice/aslan/core/system/service/types.go
@@ -49,9 +49,10 @@ type WorkflowConcurrencySettings struct {
 }
 
 type SonarIntegration struct {
-	ID            string `json:"id"`
-	ServerAddress string `json:"server_address"`
-	Token         string `json:"token"`
+	ID             string `json:"id"`
+	SystemIdentity string `json:"system_identity"`
+	ServerAddress  string `json:"server_address"`
+	Token          string `json:"token"`
 }
 
 type OpenAPICreateRegistryReq struct {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_jira.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_jira.go
@@ -70,7 +70,7 @@ func (j *JiraJob) ToJobs(taskID int64) ([]*commonmodels.JobTask, error) {
 		return nil, errors.New("需要指定至少一个 Jira Issue")
 	}
 	j.job.Spec = j.spec
-	info, err := mongodb.NewProjectManagementColl().GetJira()
+	info, err := mongodb.NewProjectManagementColl().GetJiraByID(j.spec.JiraID)
 	if err != nil {
 		return nil, errors.Errorf("get jira info error: %v", err)
 	}
@@ -86,6 +86,7 @@ func (j *JiraJob) ToJobs(taskID int64) ([]*commonmodels.JobTask, error) {
 		JobType: string(config.JobJira),
 		Spec: &commonmodels.JobTaskJiraSpec{
 			ProjectID:    j.spec.ProjectID,
+			JiraID:       j.spec.JiraID,
 			IssueType:    j.spec.IssueType,
 			Issues:       j.spec.Issues,
 			TargetStatus: j.spec.TargetStatus,

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_meego_transition.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_meego_transition.go
@@ -60,14 +60,14 @@ func (j *MeegoTransitionJob) MergeArgs(args *commonmodels.Job) error {
 }
 
 func (j *MeegoTransitionJob) ToJobs(taskID int64) ([]*commonmodels.JobTask, error) {
-	meegoInfo, err := commonrepo.NewProjectManagementColl().GetMeego()
-	if err != nil {
-		return nil, errors.New("failed to find meego integration info")
-	}
 	resp := []*commonmodels.JobTask{}
 	j.spec = &commonmodels.MeegoTransitionJobSpec{}
 	if err := commonmodels.IToi(j.job.Spec, j.spec); err != nil {
 		return resp, err
+	}
+	meegoInfo, err := commonrepo.NewProjectManagementColl().GetMeegoByID(j.spec.MeegoID)
+	if err != nil {
+		return nil, errors.New("failed to find meego integration info")
 	}
 	jobTask := &commonmodels.JobTask{
 		Name: j.job.Name,
@@ -77,6 +77,7 @@ func (j *MeegoTransitionJob) ToJobs(taskID int64) ([]*commonmodels.JobTask, erro
 		},
 		JobType: string(config.JobMeegoTransition),
 		Spec: &commonmodels.MeegoTransitionSpec{
+			MeegoID:         meegoInfo.ID.Hex(),
 			Link:            meegoInfo.MeegoHost,
 			Source:          j.spec.Source,
 			ProjectKey:      j.spec.ProjectKey,

--- a/pkg/microservice/aslan/server/rest/doc/docs.go
+++ b/pkg/microservice/aslan/server/rest/doc/docs.go
@@ -199,6 +199,49 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/aslan/environment/environments/{name}": {
+            "delete": {
+                "description": "Delete Product",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Delete Product",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "is delete",
+                        "name": "is_delete",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/api/aslan/environment/environments/{name}/analysis": {
             "post": {
                 "description": "Run Enviroment Analysis",
@@ -2616,32 +2659,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/aslan/system/meego/": {
-            "get": {
-                "description": "List Meegos",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "system"
-                ],
-                "summary": "List Meegos",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/models.ProjectManagement"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/aslan/system/meego/{id}/projects": {
             "get": {
                 "description": "List Meego Projects",
@@ -2775,6 +2792,32 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/service.MeegoWorkItemTypeResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/aslan/system/project_management/project": {
+            "get": {
+                "description": "List Project Management For Project",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "List Project Management For Project",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.ProjectManagement"
+                            }
                         }
                     }
                 }

--- a/pkg/microservice/aslan/server/rest/doc/docs.go
+++ b/pkg/microservice/aslan/server/rest/doc/docs.go
@@ -2616,6 +2616,205 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/aslan/system/meego/": {
+            "get": {
+                "description": "List Meegos",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "List Meegos",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.ProjectManagement"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/aslan/system/meego/{id}/projects": {
+            "get": {
+                "description": "List Meego Projects",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "List Meego Projects",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "meego id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.MeegoProjectResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/aslan/system/meego/{id}/projects/{projectID}/work_item": {
+            "get": {
+                "description": "List Meego Work Items",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "List Meego Work Items",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "meego id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "project id",
+                        "name": "projectID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "type key",
+                        "name": "type_key",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "page num",
+                        "name": "page_num",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "page size",
+                        "name": "page_size",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "item name",
+                        "name": "item_name",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.MeegoWorkItemResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/aslan/system/meego/{id}/projects/{projectID}/work_item/types": {
+            "get": {
+                "description": "Get Meego Work Item Type List",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "Get Meego Work Item Type List",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "meego id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "project id",
+                        "name": "projectID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.MeegoWorkItemTypeResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/aslan/system/project_management/{id}/jira/project": {
+            "get": {
+                "description": "List Jira Projects",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "List Jira Projects",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "jira id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/service.JiraProjectsResp"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/aslan/system/webhook/config": {
             "get": {
                 "description": "Get webhook config",
@@ -2959,6 +3158,17 @@ const docTemplate = `{
             "x-enum-varnames": [
                 "SourceRuntime",
                 "SourceFromJob"
+            ]
+        },
+        "config.JiraAuthType": {
+            "type": "string",
+            "enum": [
+                "password_or_token",
+                "personal_access_token"
+            ],
+            "x-enum-varnames": [
+                "JiraBasicAuth",
+                "JiraPersonalAccessToken"
             ]
         },
         "github_com_koderover_zadig_pkg_microservice_aslan_core_common_service.EnvService": {
@@ -3775,6 +3985,52 @@ const docTemplate = `{
                 },
                 "is_base": {
                     "type": "boolean"
+                }
+            }
+        },
+        "models.ProjectManagement": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "jira_auth_type": {
+                    "$ref": "#/definitions/config.JiraAuthType"
+                },
+                "jira_host": {
+                    "type": "string"
+                },
+                "jira_personal_access_token": {
+                    "description": "JiraPersonalAccessToken is used for bearer token",
+                    "type": "string"
+                },
+                "jira_token": {
+                    "description": "JiraToken is used in place of password for basic auth with username",
+                    "type": "string"
+                },
+                "jira_user": {
+                    "type": "string"
+                },
+                "meego_host": {
+                    "type": "string"
+                },
+                "meego_plugin_id": {
+                    "type": "string"
+                },
+                "meego_plugin_secret": {
+                    "type": "string"
+                },
+                "meego_user_key": {
+                    "type": "string"
+                },
+                "system_identity": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "integer"
                 }
             }
         },
@@ -4841,6 +5097,17 @@ const docTemplate = `{
                 }
             }
         },
+        "service.JiraProjectsResp": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
         "service.K8sDeployStatusCheckRequest": {
             "type": "object",
             "properties": {
@@ -4949,6 +5216,75 @@ const docTemplate = `{
                 },
                 "variable_yaml": {
                     "type": "string"
+                }
+            }
+        },
+        "service.MeegoProject": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "service.MeegoProjectResp": {
+            "type": "object",
+            "properties": {
+                "projects": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/service.MeegoProject"
+                    }
+                }
+            }
+        },
+        "service.MeegoWorkItem": {
+            "type": "object",
+            "properties": {
+                "current_state": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "service.MeegoWorkItemResp": {
+            "type": "object",
+            "properties": {
+                "work_items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/service.MeegoWorkItem"
+                    }
+                }
+            }
+        },
+        "service.MeegoWorkItemType": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "type_key": {
+                    "type": "string"
+                }
+            }
+        },
+        "service.MeegoWorkItemTypeResp": {
+            "type": "object",
+            "properties": {
+                "work_item_types": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/service.MeegoWorkItemType"
+                    }
                 }
             }
         },

--- a/pkg/microservice/aslan/server/rest/doc/swagger.json
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.json
@@ -2607,6 +2607,205 @@
                 }
             }
         },
+        "/api/aslan/system/meego/": {
+            "get": {
+                "description": "List Meegos",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "List Meegos",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.ProjectManagement"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/aslan/system/meego/{id}/projects": {
+            "get": {
+                "description": "List Meego Projects",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "List Meego Projects",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "meego id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.MeegoProjectResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/aslan/system/meego/{id}/projects/{projectID}/work_item": {
+            "get": {
+                "description": "List Meego Work Items",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "List Meego Work Items",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "meego id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "project id",
+                        "name": "projectID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "type key",
+                        "name": "type_key",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "page num",
+                        "name": "page_num",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "page size",
+                        "name": "page_size",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "item name",
+                        "name": "item_name",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.MeegoWorkItemResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/aslan/system/meego/{id}/projects/{projectID}/work_item/types": {
+            "get": {
+                "description": "Get Meego Work Item Type List",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "Get Meego Work Item Type List",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "meego id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "project id",
+                        "name": "projectID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.MeegoWorkItemTypeResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/aslan/system/project_management/{id}/jira/project": {
+            "get": {
+                "description": "List Jira Projects",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "List Jira Projects",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "jira id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/service.JiraProjectsResp"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/aslan/system/webhook/config": {
             "get": {
                 "description": "Get webhook config",
@@ -2950,6 +3149,17 @@
             "x-enum-varnames": [
                 "SourceRuntime",
                 "SourceFromJob"
+            ]
+        },
+        "config.JiraAuthType": {
+            "type": "string",
+            "enum": [
+                "password_or_token",
+                "personal_access_token"
+            ],
+            "x-enum-varnames": [
+                "JiraBasicAuth",
+                "JiraPersonalAccessToken"
             ]
         },
         "github_com_koderover_zadig_pkg_microservice_aslan_core_common_service.EnvService": {
@@ -3766,6 +3976,52 @@
                 },
                 "is_base": {
                     "type": "boolean"
+                }
+            }
+        },
+        "models.ProjectManagement": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "jira_auth_type": {
+                    "$ref": "#/definitions/config.JiraAuthType"
+                },
+                "jira_host": {
+                    "type": "string"
+                },
+                "jira_personal_access_token": {
+                    "description": "JiraPersonalAccessToken is used for bearer token",
+                    "type": "string"
+                },
+                "jira_token": {
+                    "description": "JiraToken is used in place of password for basic auth with username",
+                    "type": "string"
+                },
+                "jira_user": {
+                    "type": "string"
+                },
+                "meego_host": {
+                    "type": "string"
+                },
+                "meego_plugin_id": {
+                    "type": "string"
+                },
+                "meego_plugin_secret": {
+                    "type": "string"
+                },
+                "meego_user_key": {
+                    "type": "string"
+                },
+                "system_identity": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "integer"
                 }
             }
         },
@@ -4832,6 +5088,17 @@
                 }
             }
         },
+        "service.JiraProjectsResp": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
         "service.K8sDeployStatusCheckRequest": {
             "type": "object",
             "properties": {
@@ -4940,6 +5207,75 @@
                 },
                 "variable_yaml": {
                     "type": "string"
+                }
+            }
+        },
+        "service.MeegoProject": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "service.MeegoProjectResp": {
+            "type": "object",
+            "properties": {
+                "projects": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/service.MeegoProject"
+                    }
+                }
+            }
+        },
+        "service.MeegoWorkItem": {
+            "type": "object",
+            "properties": {
+                "current_state": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "service.MeegoWorkItemResp": {
+            "type": "object",
+            "properties": {
+                "work_items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/service.MeegoWorkItem"
+                    }
+                }
+            }
+        },
+        "service.MeegoWorkItemType": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "type_key": {
+                    "type": "string"
+                }
+            }
+        },
+        "service.MeegoWorkItemTypeResp": {
+            "type": "object",
+            "properties": {
+                "work_item_types": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/service.MeegoWorkItemType"
+                    }
                 }
             }
         },

--- a/pkg/microservice/aslan/server/rest/doc/swagger.json
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.json
@@ -190,6 +190,49 @@
                 }
             }
         },
+        "/api/aslan/environment/environments/{name}": {
+            "delete": {
+                "description": "Delete Product",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Delete Product",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "is delete",
+                        "name": "is_delete",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/api/aslan/environment/environments/{name}/analysis": {
             "post": {
                 "description": "Run Enviroment Analysis",
@@ -2607,32 +2650,6 @@
                 }
             }
         },
-        "/api/aslan/system/meego/": {
-            "get": {
-                "description": "List Meegos",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "system"
-                ],
-                "summary": "List Meegos",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/models.ProjectManagement"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/aslan/system/meego/{id}/projects": {
             "get": {
                 "description": "List Meego Projects",
@@ -2766,6 +2783,32 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/service.MeegoWorkItemTypeResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/aslan/system/project_management/project": {
+            "get": {
+                "description": "List Project Management For Project",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "List Project Management For Project",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.ProjectManagement"
+                            }
                         }
                     }
                 }

--- a/pkg/microservice/aslan/server/rest/doc/swagger.yaml
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.yaml
@@ -37,6 +37,14 @@ definitions:
     x-enum-varnames:
     - SourceRuntime
     - SourceFromJob
+  config.JiraAuthType:
+    enum:
+    - password_or_token
+    - personal_access_token
+    type: string
+    x-enum-varnames:
+    - JiraBasicAuth
+    - JiraPersonalAccessToken
   github_com_koderover_zadig_pkg_microservice_aslan_core_common_service.EnvService:
     properties:
       deployed:
@@ -577,6 +585,37 @@ definitions:
         type: boolean
       is_base:
         type: boolean
+    type: object
+  models.ProjectManagement:
+    properties:
+      id:
+        type: string
+      jira_auth_type:
+        $ref: '#/definitions/config.JiraAuthType'
+      jira_host:
+        type: string
+      jira_personal_access_token:
+        description: JiraPersonalAccessToken is used for bearer token
+        type: string
+      jira_token:
+        description: JiraToken is used in place of password for basic auth with username
+        type: string
+      jira_user:
+        type: string
+      meego_host:
+        type: string
+      meego_plugin_id:
+        type: string
+      meego_plugin_secret:
+        type: string
+      meego_user_key:
+        type: string
+      system_identity:
+        type: string
+      type:
+        type: string
+      updated_at:
+        type: integer
     type: object
   models.RenderInfo:
     properties:
@@ -1308,6 +1347,13 @@ definitions:
           $ref: '#/definitions/resource.HostInfo'
         type: array
     type: object
+  service.JiraProjectsResp:
+    properties:
+      key:
+        type: string
+      name:
+        type: string
+    type: object
   service.K8sDeployStatusCheckRequest:
     properties:
       cluster_id:
@@ -1380,6 +1426,50 @@ definitions:
         type: string
       variable_yaml:
         type: string
+    type: object
+  service.MeegoProject:
+    properties:
+      key:
+        type: string
+      name:
+        type: string
+    type: object
+  service.MeegoProjectResp:
+    properties:
+      projects:
+        items:
+          $ref: '#/definitions/service.MeegoProject'
+        type: array
+    type: object
+  service.MeegoWorkItem:
+    properties:
+      current_state:
+        type: string
+      id:
+        type: integer
+      name:
+        type: string
+    type: object
+  service.MeegoWorkItemResp:
+    properties:
+      work_items:
+        items:
+          $ref: '#/definitions/service.MeegoWorkItem'
+        type: array
+    type: object
+  service.MeegoWorkItemType:
+    properties:
+      name:
+        type: string
+      type_key:
+        type: string
+    type: object
+  service.MeegoWorkItemTypeResp:
+    properties:
+      work_item_types:
+        items:
+          $ref: '#/definitions/service.MeegoWorkItemType'
+        type: array
     type: object
   service.OpenAPIInitializeProjectReq:
     properties:
@@ -3741,6 +3831,139 @@ paths:
           schema:
             $ref: '#/definitions/handler.checkLLMIntegrationResponse'
       summary: Check llm integrations
+      tags:
+      - system
+  /api/aslan/system/meego/:
+    get:
+      consumes:
+      - application/json
+      description: List Meegos
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.ProjectManagement'
+            type: array
+      summary: List Meegos
+      tags:
+      - system
+  /api/aslan/system/meego/{id}/projects:
+    get:
+      consumes:
+      - application/json
+      description: List Meego Projects
+      parameters:
+      - description: meego id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/service.MeegoProjectResp'
+      summary: List Meego Projects
+      tags:
+      - system
+  /api/aslan/system/meego/{id}/projects/{projectID}/work_item:
+    get:
+      consumes:
+      - application/json
+      description: List Meego Work Items
+      parameters:
+      - description: meego id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: project id
+        in: path
+        name: projectID
+        required: true
+        type: string
+      - description: type key
+        in: query
+        name: type_key
+        required: true
+        type: string
+      - description: page num
+        in: query
+        name: page_num
+        required: true
+        type: string
+      - description: page size
+        in: query
+        name: page_size
+        required: true
+        type: string
+      - description: item name
+        in: query
+        name: item_name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/service.MeegoWorkItemResp'
+      summary: List Meego Work Items
+      tags:
+      - system
+  /api/aslan/system/meego/{id}/projects/{projectID}/work_item/types:
+    get:
+      consumes:
+      - application/json
+      description: Get Meego Work Item Type List
+      parameters:
+      - description: meego id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: project id
+        in: path
+        name: projectID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/service.MeegoWorkItemTypeResp'
+      summary: Get Meego Work Item Type List
+      tags:
+      - system
+  /api/aslan/system/project_management/{id}/jira/project:
+    get:
+      consumes:
+      - application/json
+      description: List Jira Projects
+      parameters:
+      - description: jira id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/service.JiraProjectsResp'
+            type: array
+      summary: List Jira Projects
       tags:
       - system
   /api/aslan/system/webhook/config:

--- a/pkg/microservice/aslan/server/rest/doc/swagger.yaml
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.yaml
@@ -2220,6 +2220,35 @@ paths:
       summary: Update Multi products
       tags:
       - environment
+  /api/aslan/environment/environments/{name}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete Product
+      parameters:
+      - description: project name
+        in: query
+        name: projectName
+        required: true
+        type: string
+      - description: env name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: is delete
+        in: query
+        name: is_delete
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Delete Product
+      tags:
+      - environment
   /api/aslan/environment/environments/{name}/analysis:
     post:
       consumes:
@@ -3833,23 +3862,6 @@ paths:
       summary: Check llm integrations
       tags:
       - system
-  /api/aslan/system/meego/:
-    get:
-      consumes:
-      - application/json
-      description: List Meegos
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/models.ProjectManagement'
-            type: array
-      summary: List Meegos
-      tags:
-      - system
   /api/aslan/system/meego/{id}/projects:
     get:
       consumes:
@@ -3964,6 +3976,23 @@ paths:
               $ref: '#/definitions/service.JiraProjectsResp'
             type: array
       summary: List Jira Projects
+      tags:
+      - system
+  /api/aslan/system/project_management/project:
+    get:
+      consumes:
+      - application/json
+      description: List Project Management For Project
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.ProjectManagement'
+            type: array
+      summary: List Project Management For Project
       tags:
       - system
   /api/aslan/system/webhook/config:


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e156b1a</samp>

This pull request adds a new feature to support multiple external systems of the same type in the workflow engine. It introduces a new field `SystemIdentity` to the models and collections of configuration management, project management, and sonar integration systems, and uses this field to identify and query the systems by ID. It also updates the router paths, handler functions, service functions, and job controller functions to use the system ID as a parameter for interacting with the external systems. It also migrates the existing system identity fields for various collections to support the new feature.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e156b1a</samp>

*  Add a new field `SystemIdentity` to the `ConfigurationManagement`, `ProjectManagement`, and `SonarIntegration` structs to store a unique identifier for each system ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-7fe684569e5dfdba58161f2cc92c0ce67b33adc0811ab284f580c60609b8d221L22-R27), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-e51e7b6ea55af2c2defd6eb371571d2b5e4adff011505cdabd0e596c13375a47L26-R31), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-edb87ef4d7b196fad1e968a74029bf211b1ef156fceb0bed830a6553f8ef2b5eL22-R25), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-d710876fb6c2d08ef6a5170dc9b5f6aee848a54e52e8e7e268b07c46f2816b3fL52-R55))
*  Add a new field `MeegoID` to the `MeegoTransitionSpec` struct to store the ID of the meego system that the job is associated with ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-69e2835c88c5841280acae74f5c8d6536bd68d1de912139d98cd6dd4e525d77eR380))
*  Add a new field `JiraID` to the `JobTaskJiraSpec` struct to store the ID of the jira system that the job is associated with ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-69e2835c88c5841280acae74f5c8d6536bd68d1de912139d98cd6dd4e525d77eR416))
*  Add three new fields `JiraSystemIdentity`, `JiraID`, and `JiraURL` to the `JiraJobSpec` struct to store the system identity, ID, and URL of the jira system that the job is associated with ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-95d655186557675089c4ca26d31aa74884ccdfc8855d24c9092f4e4082389a4cL535-R539))
*  Add four new fields `MeegoSystemIdentity`, `MeegoID`, `MeegoURL`, and `MeegoUserKey` to the `MeegoTransitionJobSpec` struct to store the system identity, ID, URL, and user key of the meego system that the job is associated with ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-95d655186557675089c4ca26d31aa74884ccdfc8855d24c9092f4e4082389a4cL581-R594))
*  Add three new fields `MeegoSystemIdentity`, `MeegoID`, and `MeegoURL` to the `MeegoHook` struct to store the system identity, ID, and URL of the meego system that the hook is associated with ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-95d655186557675089c4ca26d31aa74884ccdfc8855d24c9092f4e4082389a4cL764-R777))
*  Add a new function `GetBySystemIdentity` to the `ConfigurationManagementColl`, `ProjectManagementColl`, and `SonarIntegrationColl` structs to query the collections by the system identity field ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-1210241e09f116a6e9189e41868a0ca8dd2551a2863e41d32960685359b08c7bR102-R110), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-eb96c73b9879912a1dc947145c99b2a8eb130cecdb3085422e512b08f402038eR156-R179), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-c8313d7889344e787888f4df4a463a4228215fa814f1709a5ac2975dc843d0e8R133-R141))
*  Add a new function `GetByID` to the `ProjectManagementColl` struct to query the collection by the ID field ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-eb96c73b9879912a1dc947145c99b2a8eb130cecdb3085422e512b08f402038eR65-R76))
*  Add a new function `GetJiraByID` to the `ProjectManagementColl` struct to query the collection by the ID field and the type field for jira systems ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-eb96c73b9879912a1dc947145c99b2a8eb130cecdb3085422e512b08f402038eR130-R145))
*  Add a new function `GetMeegoByID` to the `ProjectManagementColl` struct to query the collection by the ID field and the type field for meego systems ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-eb96c73b9879912a1dc947145c99b2a8eb130cecdb3085422e512b08f402038eR156-R179))
*  Add a new condition to the `ListByCursor` function to filter the workflow collection by the job types field in the option struct ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-128a7e118adf742a01dca18bcba2fa32022fc780af2d89cd0de1a229a3410ae1R331-R333))
*  Change the `GetJira` function call to `GetJiraByID` function call with the `JiraID` field from the job task spec as the argument, to get the jira system info by the ID instead of the type ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-44b9ce0b3aeba4d43b37644f032037abe6f6df88563f302045863224a69d0c55L60-R60))
*  Change the `GetMeego` function call to `GetMeegoByID` function call with the `MeegoID` field from the job task spec as the argument, to get the meego system info by the ID instead of the type ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-47ba7510df15a6a657924d8635d5dbb37c6b1101fc6867a4a2c3eae30cd97c49L58-R58))
*  Add a new function `ListMeego` to the `handler` package to handle the request to list all the meego systems in the project management collection ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-9a5aad5c4b198baeb3561b0dbac260fb97124fc8e7ede9c51b20345b7b5bfcf8L29-R48))
*  Add a new parameter `id` to the `GetMeegoProjects`, `GetWorkItemTypeList`, `ListMeegoWorkItems`, and `ListAvailableWorkItemTransitions` functions to handle the request to get the meego info by the meego system ID ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-9a5aad5c4b198baeb3561b0dbac260fb97124fc8e7ede9c51b20345b7b5bfcf8L40-R58), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-9a5aad5c4b198baeb3561b0dbac260fb97124fc8e7ede9c51b20345b7b5bfcf8L76-R95), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-9a5aad5c4b198baeb3561b0dbac260fb97124fc8e7ede9c51b20345b7b5bfcf8L94-R112))
*  Add a new parameter `id` to the `ListJiraProjects`, `SearchJiraIssues`, `SearchJiraProjectIssuesWithJQL`, `GetJiraTypes`, and `GetJiraAllStatus` functions to handle the request to get the jira info by the jira system ID ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-62f3e43235e6e49dd81ebf025750ce0966db6d6b08d18608366f890861542fd4L159-R159), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-62f3e43235e6e49dd81ebf025750ce0966db6d6b08d18608366f890861542fd4L165-R165), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-62f3e43235e6e49dd81ebf025750ce0966db6d6b08d18608366f890861542fd4L174-R174), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-62f3e43235e6e49dd81ebf025750ce0966db6d6b08d18608366f890861542fd4L180-R180), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-62f3e43235e6e49dd81ebf025750ce0966db6d6b08d18608366f890861542fd4L186-R186))
*  Add a new parameter `id` to the router paths for jira and meego info to match the handler functions with the system ID ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-a788b6154d88f1681af6dd9bb4b9504e74a014ea5e30ba254f38beb73d7bf5d7L305-R309), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-a788b6154d88f1681af6dd9bb4b9504e74a014ea5e30ba254f38beb73d7bf5d7L343-R347))
*  Add a new condition to check if the system identity field is already used by another system before creating or updating a configuration management, project management, or sonar integration system ( [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-6a5138cab08e710f681da75d7449bade5ac40763bf8fdbd656cd4fccead5422eL69-R82), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-87178c36f9a286348b09e20530ca6f80120c9cc254b1f50d8520aa856526e2d5L53-R59), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-87178c36f9a286348b09e20530ca6f80120c9cc254b1f50d8520aa856526e2d5R72-R82), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-6215ab79f3ee789eae057222aeeac553e537d17275be5efbf8dba867fb6caaafL35-R43), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-6215ab79f3ee789eae057222aeeac553e537d17275be5efbf8dba867fb6caaafL47-R70))
*  Add a new logic to get the old system identity field from the existing system by the ID, and compare it with the new system identity field to check if they are different before updating the system ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-6a5138cab08e710f681da75d7449bade5ac40763bf8fdbd656cd4fccead5422eL69-R82), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-87178c36f9a286348b09e20530ca6f80120c9cc254b1f50d8520aa856526e2d5R72-R82), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-6215ab79f3ee789eae057222aeeac553e537d17275be5efbf8dba867fb6caaafL47-R70))
*  Change the `ListMeego`, `GetMeegoProjects`, `GetWorkItemTypeList`, `ListMeegoWorkItems`, and `ListAvailableWorkItemTransitions` functions to use the `GetMeegoByID` function to get the meego system info by the ID instead of the type ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-60a1360efd89e614245fcc2bf1c0bd883ccf30f26c2fb7d656008585c32b7508L25-R50), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-60a1360efd89e614245fcc2bf1c0bd883ccf30f26c2fb7d656008585c32b7508L51-R72), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-60a1360efd89e614245fcc2bf1c0bd883ccf30f26c2fb7d656008585c32b7508L77-R98), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-60a1360efd89e614245fcc2bf1c0bd883ccf30f26c2fb7d656008585c32b7508L105-R126))
*  Change the `ListJiraProjects`, `GetJiraTypes`, `GetJiraAllStatus`, `SearchJiraIssues`, `SearchJiraProjectIssuesWithJQL`, and `HandleMeegoHookEvent` functions to use the `GetJiraByID` or `GetMeegoByID` function to get the system info by the ID instead of the type ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-87178c36f9a286348b09e20530ca6f80120c9cc254b1f50d8520aa856526e2d5L127-R133), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-87178c36f9a286348b09e20530ca6f80120c9cc254b1f50d8520aa856526e2d5L151-R157), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-87178c36f9a286348b09e20530ca6f80120c9cc254b1f50d8520aa856526e2d5L162-R168), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-87178c36f9a286348b09e20530ca6f80120c9cc254b1f50d8520aa856526e2d5L173-R179), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-87178c36f9a286348b09e20530ca6f80120c9cc254b1f50d8520aa856526e2d5L202-R208), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-87178c36f9a286348b09e20530ca6f80120c9cc254b1f50d8520aa856526e2d5L334-R339))
*  Add a comment to indicate that the `GetJira` function is deprecated since version 1.19.0 ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-eb96c73b9879912a1dc947145c99b2a8eb130cecdb3085422e512b08f402038eR118))
*  Add a comment to indicate that the job spec struct needs to be updated ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-95d655186557675089c4ca26d31aa74884ccdfc8855d24c9092f4e4082389a4cR93))
*  Add a new import for the `config` package to use the `JobType` type in the `ListWorkflowV4Option` struct ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-801df8491afb56024402917f8633f318f503e7d7970e88cf71ffe476a0245c5cL28-R30))
*  Add a new import for the `models` package to use the `ProjectManagement` type in the `ListMeego` function ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-60a1360efd89e614245fcc2bf1c0bd883ccf30f26c2fb7d656008585c32b7508R20))
*  Add a new import for the `mongodb` package to use the `GetByID` and `GetBySystemIdentity` functions in the `UpdateSonarIntegration` function ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-6215ab79f3ee789eae057222aeeac553e537d17275be5efbf8dba867fb6caaafR30))
*  Remove an extra blank line in the `Validate` function ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-62f3e43235e6e49dd81ebf025750ce0966db6d6b08d18608366f890861542fd4L140-R140))
*  Add three new functions to migrate the system identity fields for project management, configuration management, and sonar integration collections in the `V1180ToV1190` function ([link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-801df8491afb56024402917f8633f318f503e7d7970e88cf71ffe476a0245c5cR55-R72), [link](https://github.com/koderover/zadig/pull/2990/files?diff=unified&w=0#diff-801df8491afb56024402917f8633f318f503e7d7970e88cf71ffe476a0245c5cR188-R347))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
