### PR TITLE
[WIP] update service index data

### DIFF
--- a/pkg/microservice/aslan/core/collaboration/repository/mongodb/collaboration_instance.go
+++ b/pkg/microservice/aslan/core/collaboration/repository/mongodb/collaboration_instance.go
@@ -55,6 +55,9 @@ func (c *CollaborationInstanceColl) GetCollectionName() string {
 }
 
 func (c *CollaborationInstanceColl) EnsureIndex(ctx context.Context) error {
+
+	c.Indexes().DropOne(ctx, "project_name_1_collaboration_name_1_user_uid_1")
+
 	mod := []mongo.IndexModel{
 		{
 			Keys: bson.D{
@@ -62,7 +65,7 @@ func (c *CollaborationInstanceColl) EnsureIndex(ctx context.Context) error {
 				bson.E{Key: "collaboration_name", Value: 1},
 				bson.E{Key: "user_uid", Value: 1},
 			},
-			Options: options.Index().SetUnique(true),
+			Options: options.Index().SetUnique(true).SetName("user_unique"),
 		},
 	}
 

--- a/pkg/microservice/aslan/core/common/repository/mongodb/delivery_build.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/delivery_build.go
@@ -56,6 +56,9 @@ func (c *DeliveryBuildColl) GetCollectionName() string {
 }
 
 func (c *DeliveryBuildColl) EnsureIndex(ctx context.Context) error {
+
+	c.Indexes().DropOne(ctx, "release_id_1_service_name_1_deleted_at_1")
+
 	mod := []mongo.IndexModel{
 		{
 			Keys: bson.D{
@@ -63,7 +66,7 @@ func (c *DeliveryBuildColl) EnsureIndex(ctx context.Context) error {
 				bson.E{Key: "service_name", Value: 1},
 				bson.E{Key: "deleted_at", Value: 1},
 			},
-			Options: options.Index().SetUnique(true),
+			Options: options.Index().SetUnique(true).SetName("service_unique"),
 		},
 		{
 			Keys: bson.D{

--- a/pkg/microservice/aslan/core/common/repository/mongodb/delivery_deploy.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/delivery_deploy.go
@@ -56,6 +56,7 @@ func (c *DeliveryDeployColl) GetCollectionName() string {
 }
 
 func (c *DeliveryDeployColl) EnsureIndex(ctx context.Context) error {
+	c.Indexes().DropOne(ctx, "release_id_1_service_name_1_container_name_1_deleted_at_1")
 	mod := []mongo.IndexModel{
 		{
 			Keys: bson.D{
@@ -64,7 +65,7 @@ func (c *DeliveryDeployColl) EnsureIndex(ctx context.Context) error {
 				bson.E{Key: "container_name", Value: 1},
 				bson.E{Key: "deleted_at", Value: 1},
 			},
-			Options: options.Index().SetUnique(true),
+			Options: options.Index().SetUnique(true).SetName("container_unique"),
 		},
 		{
 			Keys: bson.D{
@@ -77,7 +78,7 @@ func (c *DeliveryDeployColl) EnsureIndex(ctx context.Context) error {
 
 	_, _ = c.Indexes().DropOne(ctx, "release_id_1_service_name_1_deleted_at_1")
 	_, err := c.Indexes().CreateMany(ctx, mod)
-	
+
 	return err
 }
 

--- a/pkg/microservice/aslan/core/common/repository/mongodb/delivery_distribute.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/delivery_distribute.go
@@ -58,6 +58,9 @@ func (c *DeliveryDistributeColl) GetCollectionName() string {
 }
 
 func (c *DeliveryDistributeColl) EnsureIndex(ctx context.Context) error {
+
+	c.Indexes().DropOne(ctx, "release_id_1_service_name_1_chart_name_1_deleted_at_1")
+
 	mod := []mongo.IndexModel{
 		{
 			Keys: bson.D{
@@ -66,7 +69,7 @@ func (c *DeliveryDistributeColl) EnsureIndex(ctx context.Context) error {
 				bson.E{Key: "chart_name", Value: 1},
 				bson.E{Key: "deleted_at", Value: 1},
 			},
-			Options: options.Index().SetUnique(false),
+			Options: options.Index().SetUnique(false).SetName("service_unique"),
 		},
 		{
 			Keys: bson.D{

--- a/pkg/microservice/aslan/core/common/repository/mongodb/delivery_version.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/delivery_version.go
@@ -60,6 +60,7 @@ func (c *DeliveryVersionColl) GetCollectionName() string {
 }
 
 func (c *DeliveryVersionColl) EnsureIndex(ctx context.Context) error {
+	c.Indexes().DropOne(ctx, "org_id_1_product_name_1_workflow_name_1_version_1_deleted_at_1")
 	mod := []mongo.IndexModel{
 		{
 			Keys: bson.D{
@@ -69,7 +70,7 @@ func (c *DeliveryVersionColl) EnsureIndex(ctx context.Context) error {
 				bson.E{Key: "version", Value: 1},
 				bson.E{Key: "deleted_at", Value: 1},
 			},
-			Options: options.Index().SetUnique(true),
+			Options: options.Index().SetUnique(true).SetName("version_unique"),
 		},
 		{
 			Keys: bson.D{

--- a/pkg/microservice/aslan/core/common/repository/mongodb/diff_note.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/diff_note.go
@@ -56,13 +56,14 @@ func (c *DiffNoteColl) GetCollectionName() string {
 }
 
 func (c *DiffNoteColl) EnsureIndex(ctx context.Context) error {
+	c.Indexes().DropOne(ctx, "repo.codehost_id_1_repo.project_id_1_merge_request_id_1")
 	mod := mongo.IndexModel{
 		Keys: bson.D{
 			bson.E{Key: "repo.codehost_id", Value: 1},
 			bson.E{Key: "repo.project_id", Value: 1},
 			bson.E{Key: "merge_request_id", Value: 1},
 		},
-		Options: options.Index().SetUnique(false),
+		Options: options.Index().SetUnique(false).SetName("mr_unique"),
 	}
 
 	_, err := c.Indexes().CreateOne(ctx, mod)

--- a/pkg/microservice/aslan/core/common/repository/mongodb/env_resource.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/env_resource.go
@@ -47,6 +47,7 @@ func (c *EnvResourceColl) GetCollectionName() string {
 }
 
 func (c *EnvResourceColl) EnsureIndex(ctx context.Context) error {
+	c.Indexes().DropOne(ctx, "name_1_create_time_1_env_name_1_type_1_product_name_1")
 	mod := mongo.IndexModel{
 		Keys: bson.D{
 			bson.E{Key: "name", Value: 1},
@@ -55,7 +56,7 @@ func (c *EnvResourceColl) EnsureIndex(ctx context.Context) error {
 			bson.E{Key: "type", Value: 1},
 			bson.E{Key: "product_name", Value: 1},
 		},
-		Options: options.Index().SetUnique(true),
+		Options: options.Index().SetUnique(true).SetName("resource_unique"),
 	}
 
 	_, err := c.Indexes().CreateOne(ctx, mod)

--- a/pkg/microservice/aslan/core/common/repository/mongodb/env_svc_depend.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/env_svc_depend.go
@@ -46,6 +46,7 @@ func (c *EnvSvcDependColl) GetCollectionName() string {
 }
 
 func (c *EnvSvcDependColl) EnsureIndex(ctx context.Context) error {
+	c.Indexes().DropOne(ctx, "name_1_service_name_1_env_name_1_product_name_1_service_module_1")
 	mod := mongo.IndexModel{
 		Keys: bson.D{
 			bson.E{Key: "name", Value: 1},
@@ -54,7 +55,7 @@ func (c *EnvSvcDependColl) EnsureIndex(ctx context.Context) error {
 			bson.E{Key: "product_name", Value: 1},
 			bson.E{Key: "service_module", Value: 1},
 		},
-		Options: options.Index().SetUnique(true),
+		Options: options.Index().SetUnique(true).SetName("service_module_unique"),
 	}
 
 	_, err := c.Indexes().CreateOne(ctx, mod)

--- a/pkg/microservice/aslan/core/common/repository/mongodb/image_tags.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/image_tags.go
@@ -28,6 +28,7 @@ func NewImageTagsCollColl() *ImageTagsColl {
 }
 
 func (c *ImageTagsColl) EnsureIndex(ctx context.Context) error {
+	c.Indexes().DropOne(ctx, "registry_id_1_reg_provider_1_image_name_1_namespace_1")
 	mod := mongo.IndexModel{
 		Keys: bson.D{
 			bson.E{Key: "registry_id", Value: 1},
@@ -35,7 +36,7 @@ func (c *ImageTagsColl) EnsureIndex(ctx context.Context) error {
 			bson.E{Key: "image_name", Value: 1},
 			bson.E{Key: "namespace", Value: 1},
 		},
-		Options: options.Index().SetUnique(true),
+		Options: options.Index().SetUnique(true).SetName("image_unique"),
 	}
 
 	_, err := c.Indexes().CreateOne(ctx, mod)

--- a/pkg/microservice/aslan/core/common/repository/mongodb/it_report.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/it_report.go
@@ -47,13 +47,14 @@ func (c *ItReportColl) GetCollectionName() string {
 }
 
 func (c *ItReportColl) EnsureIndex(ctx context.Context) error {
+	c.Indexes().DropOne(ctx, "pipeline_name_1_pipeline_task_id_1_test_name_1")
 	mod := mongo.IndexModel{
 		Keys: bson.D{
 			bson.E{Key: "pipeline_name", Value: 1},
 			bson.E{Key: "pipeline_task_id", Value: 1},
 			bson.E{Key: "test_name", Value: 1},
 		},
-		Options: options.Index().SetUnique(true),
+		Options: options.Index().SetUnique(true).SetName("test_name_unique"),
 	}
 
 	_, err := c.Indexes().CreateOne(ctx, mod)

--- a/pkg/microservice/aslan/core/common/repository/mongodb/production_service.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/production_service.go
@@ -47,13 +47,15 @@ func NewProductionServiceColl() *ProductionServiceColl {
 }
 
 func (c *ProductionServiceColl) EnsureIndex(ctx context.Context) error {
+	c.Indexes().DropOne(ctx, "product_name_1_service_name_1_revision_1")
+
 	mod := mongo.IndexModel{
 		Keys: bson.D{
 			bson.E{Key: "product_name", Value: 1},
 			bson.E{Key: "service_name", Value: 1},
 			bson.E{Key: "revision", Value: 1},
 		},
-		Options: options.Index().SetUnique(true),
+		Options: options.Index().SetUnique(true).SetName("service_unique"),
 	}
 	_, err := c.Indexes().CreateOne(ctx, mod)
 	return err

--- a/pkg/microservice/aslan/core/common/repository/mongodb/service.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/service.go
@@ -93,6 +93,8 @@ func (c *ServiceColl) GetCollectionName() string {
 }
 
 func (c *ServiceColl) EnsureIndex(ctx context.Context) error {
+	c.Indexes().DropOne(ctx, "service_name_1_product_name_1_revision_1")
+	c.Indexes().DropOne(ctx, "product_name_1_service_name_1_type_1_revision_1_status_1")
 	mod := []mongo.IndexModel{
 		{
 			Keys: bson.D{
@@ -100,7 +102,7 @@ func (c *ServiceColl) EnsureIndex(ctx context.Context) error {
 				bson.E{Key: "product_name", Value: 1},
 				bson.E{Key: "revision", Value: 1},
 			},
-			Options: options.Index().SetUnique(true),
+			Options: options.Index().SetUnique(true).SetName("service_unique"),
 		},
 		{
 			Keys: bson.D{
@@ -129,7 +131,7 @@ func (c *ServiceColl) EnsureIndex(ctx context.Context) error {
 				bson.E{Key: "revision", Value: 1},
 				bson.E{Key: "status", Value: 1},
 			},
-			Options: options.Index().SetUnique(false),
+			Options: options.Index().SetUnique(false).SetName("service_name_idx"),
 		},
 	}
 

--- a/pkg/microservice/aslan/core/common/repository/mongodb/services_in_external_env.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/services_in_external_env.go
@@ -48,6 +48,7 @@ func (c *ServicesInExternalEnvColl) GetCollectionName() string {
 }
 
 func (c *ServicesInExternalEnvColl) EnsureIndex(ctx context.Context) error {
+	c.Indexes().DropOne(ctx, "product_name_1_env_name_1_service_name_1")
 	mods := []mongo.IndexModel{
 		{
 			Keys: bson.D{
@@ -55,7 +56,7 @@ func (c *ServicesInExternalEnvColl) EnsureIndex(ctx context.Context) error {
 				bson.E{Key: "env_name", Value: 1},
 				bson.E{Key: "service_name", Value: 1},
 			},
-			Options: options.Index().SetUnique(true),
+			Options: options.Index().SetUnique(true).SetName("service_name_unique"),
 		},
 		{
 			Keys: bson.D{

--- a/pkg/microservice/aslan/core/common/repository/mongodb/stats.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/stats.go
@@ -51,6 +51,7 @@ func (c *StatsColl) GetCollectionName() string {
 }
 
 func (c *StatsColl) EnsureIndex(ctx context.Context) error {
+	c.Indexes().DropOne(ctx, "req_id_1_user_1_event_1_start_time_1_end_time_1")
 	mod := mongo.IndexModel{
 		Keys: bson.D{
 			bson.E{Key: "req_id", Value: 1},
@@ -59,7 +60,7 @@ func (c *StatsColl) EnsureIndex(ctx context.Context) error {
 			bson.E{Key: "start_time", Value: 1},
 			bson.E{Key: "end_time", Value: 1},
 		},
-		Options: options.Index().SetUnique(true),
+		Options: options.Index().SetUnique(true).SetName("event_unique"),
 	}
 
 	_, err := c.Indexes().CreateOne(ctx, mod)

--- a/pkg/microservice/aslan/core/label/repository/mongodb/labelbinding.go
+++ b/pkg/microservice/aslan/core/label/repository/mongodb/labelbinding.go
@@ -46,6 +46,7 @@ func (c *LabelBindingColl) GetCollectionName() string {
 }
 
 func (c *LabelBindingColl) EnsureIndex(ctx context.Context) error {
+	c.Indexes().DropOne(ctx, "resource_name_1_project_name_1_label_id_1_resource_type_1")
 	mod := mongo.IndexModel{
 		Keys: bson.D{
 			bson.E{Key: "resource_name", Value: 1},
@@ -53,7 +54,7 @@ func (c *LabelBindingColl) EnsureIndex(ctx context.Context) error {
 			bson.E{Key: "label_id", Value: 1},
 			bson.E{Key: "resource_type", Value: 1},
 		},
-		Options: options.Index().SetUnique(true),
+		Options: options.Index().SetUnique(true).SetName("label_resource_unique"),
 	}
 
 	_, err := c.Indexes().CreateOne(ctx, mod)


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 830ef3c</samp>

This pull request improves the data integrity of the `production_service` collection by enforcing a unique constraint on service name and revision per product. It also cleans up the old index and names the new one for better readability and maintenance.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 830ef3c</samp>

* Drop existing index on `product_name`, `service_name` and `revision` fields in `production_service` collection to avoid conflicts with new index ([link](https://github.com/koderover/zadig/pull/2991/files?diff=unified&w=0#diff-1ad3c4da0aa92f32013570e108079300e5a06f5d09f98bd82a07d860ac08d8dcR50-R51))
* Create new index with name `service_unique` on `product_name`, `service_name` and `revision` fields in `production_service` collection to enforce uniqueness of service revisions ([link](https://github.com/koderover/zadig/pull/2991/files?diff=unified&w=0#diff-1ad3c4da0aa92f32013570e108079300e5a06f5d09f98bd82a07d860ac08d8dcL56-R58))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
