### PR TITLE
add service name env variable

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_build.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_build.go
@@ -479,6 +479,7 @@ func getBuildJobVariables(build *commonmodels.ServiceAndBuild, taskID int64, pro
 
 	ret = append(ret, &commonmodels.KeyVal{Key: "TASK_ID", Value: fmt.Sprintf("%d", taskID), IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "SERVICE", Value: build.ServiceName, IsCredential: false})
+	ret = append(ret, &commonmodels.KeyVal{Key: "SERVICE_NAME", Value: build.ServiceName, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "SERVICE_MODULE", Value: build.ServiceModule, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "PROJECT", Value: project, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "WORKFLOW", Value: workflowName, IsCredential: false})

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_testing.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_testing.go
@@ -548,6 +548,7 @@ func getTestingJobVariables(repos []*types.Repository, taskID int64, project, wo
 	ret = append(ret, &commonmodels.KeyVal{Key: "TESTING_NAME", Value: testingName, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "TESTING_TYPE", Value: testType, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "SERVICE", Value: serviceName, IsCredential: false})
+	ret = append(ret, &commonmodels.KeyVal{Key: "SERVICE_NAME", Value: serviceName, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "SERVICE_MODULE", Value: serviceModule, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "WORKFLOW", Value: workflowName, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "CI", Value: "true", IsCredential: false})

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -1242,7 +1242,7 @@ func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, 
 				continue
 			}
 			for _, arg := range taskJobSpec.Properties.Envs {
-				if arg.Key == "SERVICE" {
+				if arg.Key == "SERVICE_NAME" {
 					spec.ServiceName = arg.Value
 					continue
 				}
@@ -1312,7 +1312,7 @@ func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, 
 					spec.TestType = arg.Value
 					continue
 				}
-				if arg.Key == "SERVICE" {
+				if arg.Key == "SERVICE_NAME" {
 					spec.ServiceName = arg.Value
 					continue
 				}

--- a/pkg/microservice/warpdrive/core/service/taskplugin/build.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/build.go
@@ -244,6 +244,7 @@ func (p *BuildTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipe
 	for _, env := range p.Task.JobCtx.EnvVars {
 		if env.Key == "SERVICE" {
 			p.Task.JobCtx.EnvVars = append(p.Task.JobCtx.EnvVars, &task.KeyVal{Key: "SERVICE_MODULE", Value: env.Value})
+			p.Task.JobCtx.EnvVars = append(p.Task.JobCtx.EnvVars, &task.KeyVal{Key: "SERVICE_NAME", Value: strings.TrimPrefix(p.Task.ServiceName, env.Value+"_")})
 			break
 		}
 	}


### PR DESCRIPTION
### What this PR does / Why we need it:
add service name env variable 

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6c0dade</samp>

*  Add `SERVICE_NAME` environment variable to build and testing jobs ([link](https://github.com/koderover/zadig/pull/2994/files?diff=unified&w=0#diff-4869da926fe09ee6d3c747d5e63300b59a2a830a285f3929dae0233f7f62695cR482), [link](https://github.com/koderover/zadig/pull/2994/files?diff=unified&w=0#diff-8cde9ebf507918a052f674f56e227cbb8ac8e72f618f4469f128751987dd5fc5R551), [link](https://github.com/koderover/zadig/pull/2994/files?diff=unified&w=0#diff-f5d40817e0b50e462d685039df2072b1273509b9b00061eda543c40da81e9131R247))
*  Use `SERVICE_NAME` instead of `SERVICE` to extract service name from task job spec properties in `workflow_task_v4.go` ([link](https://github.com/koderover/zadig/pull/2994/files?diff=unified&w=0#diff-5a9b5157a24d6d74d66a54b3d6b2a961d0b468af078c53b04301e590ab97e165L1245-R1245), [link](https://github.com/koderover/zadig/pull/2994/files?diff=unified&w=0#diff-5a9b5157a24d6d74d66a54b3d6b2a961d0b468af078c53b04301e590ab97e165L1315-R1315))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
