### PR TITLE
recover deleted api

### DIFF
--- a/pkg/microservice/aslan/core/workflow/handler/pipeline_task.go
+++ b/pkg/microservice/aslan/core/workflow/handler/pipeline_task.go
@@ -16,179 +16,193 @@ limitations under the License.
 
 package handler
 
-//func GetProductNameByPipelineTask(c *gin.Context) {
-//	ctx := internalhandler.NewContext(c)
-//	args := new(commonmodels.TaskArgs)
-//	data, err := c.GetRawData()
-//	if err != nil {
-//		log.Errorf("c.GetRawData() err : %v", err)
-//		return
-//	}
-//	if err = json.Unmarshal(data, args); err != nil {
-//		log.Errorf("json.Unmarshal err : %v", err)
-//		return
-//	}
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/workflow/service/workflow"
+	"github.com/koderover/zadig/pkg/setting"
+	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
+	e "github.com/koderover/zadig/pkg/tool/errors"
+)
+
+//	func GetProductNameByPipelineTask(c *gin.Context) {
+//		ctx := internalhandler.NewContext(c)
+//		args := new(commonmodels.TaskArgs)
+//		data, err := c.GetRawData()
+//		if err != nil {
+//			log.Errorf("c.GetRawData() err : %v", err)
+//			return
+//		}
+//		if err = json.Unmarshal(data, args); err != nil {
+//			log.Errorf("json.Unmarshal err : %v", err)
+//			return
+//		}
 //
-//	pipeline, err := workflow.GetPipeline(ctx.UserID, args.PipelineName, ctx.Logger)
-//	if err != nil {
-//		log.Errorf("GetProductNameByPipelineTask err : %v", err)
-//		return
-//	}
-//	c.Set("productName", pipeline.ProductName)
-//	c.Request.Body = io.NopCloser(bytes.NewBuffer(data))
-//	c.Next()
-//}
-//
-//// CreatePipelineTask ...
-//func CreatePipelineTask(c *gin.Context) {
-//	ctx := internalhandler.NewContext(c)
-//	defer func() { internalhandler.JSONResponse(c, ctx) }()
-//
-//	args := new(commonmodels.TaskArgs)
-//	data, err := c.GetRawData()
-//	if err != nil {
-//		log.Errorf("CreatePipelineTask c.GetRawData() err : %v", err)
-//	}
-//	if err = json.Unmarshal(data, args); err != nil {
-//		log.Errorf("CreatePipelineTask json.Unmarshal err : %v", err)
-//	}
-//	internalhandler.InsertOperationLog(c, ctx.UserName, c.GetString("productName"), "新增", "单服务-工作流task", args.PipelineName, string(data), ctx.Logger)
-//	c.Request.Body = io.NopCloser(bytes.NewBuffer(data))
-//
-//	if err := c.BindJSON(args); err != nil {
-//		ctx.Err = e.ErrInvalidParam.AddDesc("invalid PipelineTaskArgs")
-//		return
-//	}
-//	if args.TaskCreator == "" {
-//		args.TaskCreator = ctx.UserName
+//		pipeline, err := workflow.GetPipeline(ctx.UserID, args.PipelineName, ctx.Logger)
+//		if err != nil {
+//			log.Errorf("GetProductNameByPipelineTask err : %v", err)
+//			return
+//		}
+//		c.Set("productName", pipeline.ProductName)
+//		c.Request.Body = io.NopCloser(bytes.NewBuffer(data))
+//		c.Next()
 //	}
 //
-//	args.ReqID = ctx.RequestID
-//	ctx.Resp, ctx.Err = workflow.CreatePipelineTask(args, ctx.Logger)
+// // CreatePipelineTask ...
 //
-//	// 发送通知
-//	if ctx.Err != nil {
-//		notify.SendFailedTaskMessage(ctx.UserName, args.ProductName, args.PipelineName, ctx.RequestID, config.SingleType, ctx.Err, ctx.Logger)
+//	func CreatePipelineTask(c *gin.Context) {
+//		ctx := internalhandler.NewContext(c)
+//		defer func() { internalhandler.JSONResponse(c, ctx) }()
+//
+//		args := new(commonmodels.TaskArgs)
+//		data, err := c.GetRawData()
+//		if err != nil {
+//			log.Errorf("CreatePipelineTask c.GetRawData() err : %v", err)
+//		}
+//		if err = json.Unmarshal(data, args); err != nil {
+//			log.Errorf("CreatePipelineTask json.Unmarshal err : %v", err)
+//		}
+//		internalhandler.InsertOperationLog(c, ctx.UserName, c.GetString("productName"), "新增", "单服务-工作流task", args.PipelineName, string(data), ctx.Logger)
+//		c.Request.Body = io.NopCloser(bytes.NewBuffer(data))
+//
+//		if err := c.BindJSON(args); err != nil {
+//			ctx.Err = e.ErrInvalidParam.AddDesc("invalid PipelineTaskArgs")
+//			return
+//		}
+//		if args.TaskCreator == "" {
+//			args.TaskCreator = ctx.UserName
+//		}
+//
+//		args.ReqID = ctx.RequestID
+//		ctx.Resp, ctx.Err = workflow.CreatePipelineTask(args, ctx.Logger)
+//
+//		// 发送通知
+//		if ctx.Err != nil {
+//			notify.SendFailedTaskMessage(ctx.UserName, args.ProductName, args.PipelineName, ctx.RequestID, config.SingleType, ctx.Err, ctx.Logger)
+//		}
+//
+// }
+//
+// // ListPipelineTasksResult pipelinetask分页信息
+//
+//	func ListPipelineTasksResult(c *gin.Context) {
+//		ctx := internalhandler.NewContext(c)
+//		defer func() { internalhandler.JSONResponse(c, ctx) }()
+//
+//		maxResult, err := strconv.Atoi(c.Param("max"))
+//		if err != nil {
+//			ctx.Err = e.ErrInvalidParam.AddDesc("invalid max result number")
+//			return
+//		}
+//		startAt, err := strconv.Atoi(c.Param("start"))
+//		if err != nil {
+//			ctx.Err = e.ErrInvalidParam.AddDesc("invalid start at number")
+//			return
+//		}
+//		ctx.Resp, ctx.Err = workflow.ListPipelineTasksV2Result(c.Param("name"), config.SingleType, "", []string{}, maxResult, startAt, ctx.Logger)
 //	}
 //
-//}
+//	func GetPipelineTask(c *gin.Context) {
+//		ctx := internalhandler.NewContext(c)
+//		defer func() { internalhandler.JSONResponse(c, ctx) }()
 //
-//// ListPipelineTasksResult pipelinetask分页信息
-//func ListPipelineTasksResult(c *gin.Context) {
-//	ctx := internalhandler.NewContext(c)
-//	defer func() { internalhandler.JSONResponse(c, ctx) }()
+//		taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+//		if err != nil {
+//			ctx.Err = e.ErrInvalidParam.AddDesc("invalid task id")
+//			return
+//		}
 //
-//	maxResult, err := strconv.Atoi(c.Param("max"))
-//	if err != nil {
-//		ctx.Err = e.ErrInvalidParam.AddDesc("invalid max result number")
-//		return
-//	}
-//	startAt, err := strconv.Atoi(c.Param("start"))
-//	if err != nil {
-//		ctx.Err = e.ErrInvalidParam.AddDesc("invalid start at number")
-//		return
-//	}
-//	ctx.Resp, ctx.Err = workflow.ListPipelineTasksV2Result(c.Param("name"), config.SingleType, "", []string{}, maxResult, startAt, ctx.Logger)
-//}
-//
-//func GetPipelineTask(c *gin.Context) {
-//	ctx := internalhandler.NewContext(c)
-//	defer func() { internalhandler.JSONResponse(c, ctx) }()
-//
-//	taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)
-//	if err != nil {
-//		ctx.Err = e.ErrInvalidParam.AddDesc("invalid task id")
-//		return
+//		ctx.Resp, ctx.Err = workflow.GetPipelineTaskV2(taskID, c.Param("name"), config.SingleType, ctx.Logger)
 //	}
 //
-//	ctx.Resp, ctx.Err = workflow.GetPipelineTaskV2(taskID, c.Param("name"), config.SingleType, ctx.Logger)
-//}
+//	func RestartPipelineTask(c *gin.Context) {
+//		ctx := internalhandler.NewContext(c)
+//		defer func() { internalhandler.JSONResponse(c, ctx) }()
+//		internalhandler.InsertOperationLog(c, ctx.UserName, c.Query("projectName"), "重启", "单服务-工作流task", c.Param("name"), "", ctx.Logger)
 //
-//func RestartPipelineTask(c *gin.Context) {
-//	ctx := internalhandler.NewContext(c)
-//	defer func() { internalhandler.JSONResponse(c, ctx) }()
-//	internalhandler.InsertOperationLog(c, ctx.UserName, c.Query("projectName"), "重启", "单服务-工作流task", c.Param("name"), "", ctx.Logger)
+//		taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+//		if err != nil {
+//			ctx.Err = e.ErrInvalidParam.AddDesc("invalid task id")
+//			return
+//		}
 //
-//	taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)
-//	if err != nil {
-//		ctx.Err = e.ErrInvalidParam.AddDesc("invalid task id")
-//		return
+//		ctx.Err = workflow.RestartPipelineTaskV2(ctx.UserName, taskID, c.Param("name"), config.SingleType, ctx.Logger)
 //	}
 //
-//	ctx.Err = workflow.RestartPipelineTaskV2(ctx.UserName, taskID, c.Param("name"), config.SingleType, ctx.Logger)
-//}
+//	func CancelTaskV2(c *gin.Context) {
+//		ctx := internalhandler.NewContext(c)
+//		defer func() { internalhandler.JSONResponse(c, ctx) }()
+//		internalhandler.InsertOperationLog(c, ctx.UserName, c.Query("projectName"), "取消", "单服务-工作流task", c.Param("name"), "", ctx.Logger)
 //
-//func CancelTaskV2(c *gin.Context) {
-//	ctx := internalhandler.NewContext(c)
-//	defer func() { internalhandler.JSONResponse(c, ctx) }()
-//	internalhandler.InsertOperationLog(c, ctx.UserName, c.Query("projectName"), "取消", "单服务-工作流task", c.Param("name"), "", ctx.Logger)
-//
-//	taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)
-//	if err != nil {
-//		ctx.Err = e.ErrInvalidParam.AddDesc("invalid task id")
-//		return
-//	}
-//	ctx.Err = commonservice.CancelTaskV2(ctx.UserName, c.Param("name"), taskID, config.SingleType, ctx.RequestID, ctx.Logger)
-//}
-//
-//// ListPipelineUpdatableProductNames 启动任务时检查部署环境
-//func ListPipelineUpdatableProductNames(c *gin.Context) {
-//	ctx := internalhandler.NewContext(c)
-//	defer func() { internalhandler.JSONResponse(c, ctx) }()
-//
-//	ctx.Resp, ctx.Err = workflow.ListPipelineUpdatableProductNames(ctx.UserName, c.Param("name"), ctx.Logger)
-//}
-//
-//func GetPackageFile(c *gin.Context) {
-//	ctx := internalhandler.NewContext(c)
-//	defer func() { internalhandler.JSONResponse(c, ctx) }()
-//
-//	pipelineName := c.Query("pipelineName")
-//	if pipelineName == "" {
-//		ctx.Err = e.ErrInvalidParam.AddDesc("invalid pipelineName")
-//		return
+//		taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+//		if err != nil {
+//			ctx.Err = e.ErrInvalidParam.AddDesc("invalid task id")
+//			return
+//		}
+//		ctx.Err = commonservice.CancelTaskV2(ctx.UserName, c.Param("name"), taskID, config.SingleType, ctx.RequestID, ctx.Logger)
 //	}
 //
-//	taskID, err := strconv.ParseInt(c.Query("taskId"), 10, 64)
-//	if err != nil {
-//		ctx.Err = e.ErrInvalidParam.AddDesc("invalid taskId")
-//		return
+// // ListPipelineUpdatableProductNames 启动任务时检查部署环境
+//
+//	func ListPipelineUpdatableProductNames(c *gin.Context) {
+//		ctx := internalhandler.NewContext(c)
+//		defer func() { internalhandler.JSONResponse(c, ctx) }()
+//
+//		ctx.Resp, ctx.Err = workflow.ListPipelineUpdatableProductNames(ctx.UserName, c.Param("name"), ctx.Logger)
 //	}
 //
-//	resp, pkgFile, err := workflow.GePackageFileContent(pipelineName, taskID, ctx.Logger)
-//	if err != nil {
-//		ctx.Err = err
-//		return
-//	}
-//	c.Writer.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, pkgFile))
-//	c.Data(200, "application/octet-stream", resp)
-//}
+//	func GetPackageFile(c *gin.Context) {
+//		ctx := internalhandler.NewContext(c)
+//		defer func() { internalhandler.JSONResponse(c, ctx) }()
 //
-//func GetArtifactFile(c *gin.Context) {
-//	ctx := internalhandler.NewContext(c)
-//	defer func() { internalhandler.JSONResponse(c, ctx) }()
+//		pipelineName := c.Query("pipelineName")
+//		if pipelineName == "" {
+//			ctx.Err = e.ErrInvalidParam.AddDesc("invalid pipelineName")
+//			return
+//		}
 //
-//	taskID, err := strconv.ParseInt(c.Param("taskId"), 10, 64)
-//	if err != nil {
-//		ctx.Err = e.ErrInvalidParam.AddDesc("invalid task id")
-//		return
-//	}
-//	notHistoryFileFlag, err := strconv.ParseBool(c.DefaultQuery("notHistoryFileFlag", "false"))
-//	if err != nil {
-//		ctx.Err = e.ErrInvalidParam.AddDesc("invalid notHistoryFileFlag")
-//		return
-//	}
+//		taskID, err := strconv.ParseInt(c.Query("taskId"), 10, 64)
+//		if err != nil {
+//			ctx.Err = e.ErrInvalidParam.AddDesc("invalid taskId")
+//			return
+//		}
 //
-//	resp, err := workflow.GetArtifactFileContent(c.Param("pipelineName"), taskID, notHistoryFileFlag, ctx.Logger)
-//	if err != nil {
-//		ctx.Err = err
-//		return
+//		resp, pkgFile, err := workflow.GePackageFileContent(pipelineName, taskID, ctx.Logger)
+//		if err != nil {
+//			ctx.Err = err
+//			return
+//		}
+//		c.Writer.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, pkgFile))
+//		c.Data(200, "application/octet-stream", resp)
 //	}
-//	if notHistoryFileFlag {
-//		c.Writer.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, setting.ArtifactResultOut))
-//	} else {
-//		c.Writer.Header().Set("Content-Disposition", `attachment; filename="artifact.tar.gz"`)
-//	}
-//
-//	c.Data(200, "application/octet-stream", resp)
-//}
+
+func GetArtifactFile(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	taskID, err := strconv.ParseInt(c.Param("taskId"), 10, 64)
+	if err != nil {
+		ctx.Err = e.ErrInvalidParam.AddDesc("invalid task id")
+		return
+	}
+	notHistoryFileFlag, err := strconv.ParseBool(c.DefaultQuery("notHistoryFileFlag", "false"))
+	if err != nil {
+		ctx.Err = e.ErrInvalidParam.AddDesc("invalid notHistoryFileFlag")
+		return
+	}
+
+	resp, err := workflow.GetArtifactFileContent(c.Param("pipelineName"), taskID, notHistoryFileFlag, ctx.Logger)
+	if err != nil {
+		ctx.Err = err
+		return
+	}
+	if notHistoryFileFlag {
+		c.Writer.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, setting.ArtifactResultOut))
+	} else {
+		c.Writer.Header().Set("Content-Disposition", `attachment; filename="artifact.tar.gz"`)
+	}
+
+	c.Data(200, "application/octet-stream", resp)
+}

--- a/pkg/microservice/aslan/core/workflow/handler/router.go
+++ b/pkg/microservice/aslan/core/workflow/handler/router.go
@@ -75,17 +75,17 @@ func (*Router) Inject(router *gin.RouterGroup) {
 	// ---------------------------------------------------------------------------------------
 	// Pipeline 任务管理接口
 	// ---------------------------------------------------------------------------------------
-	//taskV2 := router.Group("v2/tasks")
-	//{
-	//	taskV2.POST("", GetProductNameByPipelineTask, CreatePipelineTask)
-	//	taskV2.GET("/max/:max/start/:start/pipelines/:name", ListPipelineTasksResult)
-	//	taskV2.GET("/id/:id/pipelines/:name", GetPipelineTask)
-	//	taskV2.POST("/id/:id/pipelines/:name/restart", GetProductNameByPipeline, RestartPipelineTask)
-	//	taskV2.DELETE("/id/:id/pipelines/:name", GetProductNameByPipeline, CancelTaskV2)
-	//	taskV2.GET("/pipelines/:name/products", ListPipelineUpdatableProductNames)
-	//	taskV2.GET("/file", GetPackageFile)
-	//	taskV2.GET("/workflow/:pipelineName/taskId/:taskId", GetArtifactFile)
-	//}
+	taskV2 := router.Group("v2/tasks")
+	{
+		//	taskV2.POST("", GetProductNameByPipelineTask, CreatePipelineTask)
+		//	taskV2.GET("/max/:max/start/:start/pipelines/:name", ListPipelineTasksResult)
+		//	taskV2.GET("/id/:id/pipelines/:name", GetPipelineTask)
+		//	taskV2.POST("/id/:id/pipelines/:name/restart", GetProductNameByPipeline, RestartPipelineTask)
+		//	taskV2.DELETE("/id/:id/pipelines/:name", GetProductNameByPipeline, CancelTaskV2)
+		//	taskV2.GET("/pipelines/:name/products", ListPipelineUpdatableProductNames)
+		//	taskV2.GET("/file", GetPackageFile)
+		taskV2.GET("/workflow/:pipelineName/taskId/:taskId", GetArtifactFile)
+	}
 
 	// ---------------------------------------------------------------------------------------
 	// Pipeline Favorite 接口


### PR DESCRIPTION
### What this PR does / Why we need it:
recover deleted api

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 173c538</samp>

*  Enable the endpoint for downloading the artifact file by uncommenting the `taskV2` group in the `Inject` function ([link](https://github.com/koderover/zadig/pull/2995/files?diff=unified&w=0#diff-fd8d832ab541e6bdd527d9eb797a280356448994200abf5bf794925ffcaff834L78-R88))
*  Remove the unused code in the `handler` package that defines the functions for the pipeline task management interface ([link](https://github.com/koderover/zadig/pull/2995/files?diff=unified&w=0#diff-05ffe57d769ebe723bb696c809528b015d257d13d846ae2d24bbc4fcf2d65a5cL19-R208))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
