### PR TITLE
fix panic when wd get product info

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -1853,13 +1853,15 @@ func GetProductInfo(username, envName, productName string, log *zap.SugaredLogge
 		return nil, e.ErrGetEnv
 	}
 
-	renderSetOpt := &commonrepo.RenderSetFindOption{Name: prod.Render.Name, Revision: prod.Render.Revision, ProductTmpl: productName}
-	renderSet, err := commonrepo.NewRenderSetColl().Find(renderSetOpt)
-	if err != nil {
-		log.Errorf("find helm renderset[%s] error: %v", prod.Render.Name, err)
-		return prod, nil
+	if prod.Render != nil {
+		renderSetOpt := &commonrepo.RenderSetFindOption{Name: prod.Render.Name, Revision: prod.Render.Revision, ProductTmpl: productName}
+		renderSet, err := commonrepo.NewRenderSetColl().Find(renderSetOpt)
+		if err != nil {
+			log.Errorf("find helm renderset[%s] error: %v", prod.Render.Name, err)
+			return prod, nil
+		}
+		prod.ServiceRenders = renderSet.ChartInfos
 	}
-	prod.ServiceRenders = renderSet.ChartInfos
 
 	return prod, nil
 }

--- a/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/deploy.go
@@ -441,16 +441,6 @@ func (p *DeployTaskPlugin) getService(ctx context.Context, name, serviceType, pr
 	return s, nil
 }
 
-func getProductInfo(ctx context.Context, httpClient *httpclient.Client, envName, productName string) (*types.Product, error) {
-	url := fmt.Sprintf("/api/environment/environments/%s/productInfo", envName)
-	prod := &types.Product{}
-	_, err := httpClient.Get(url, httpclient.SetResult(prod), httpclient.SetQueryParam("projectName", productName), httpclient.SetQueryParam("ifPassFilter", "true"))
-	if err != nil {
-		return nil, err
-	}
-	return prod, nil
-}
-
 func getRenderedManifests(ctx context.Context, httpClient *httpclient.Client, envName, productName string, serviceName string) ([]string, error) {
 	url := "/api/environment/export/service"
 	prod := make([]string, 0)


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e8c891</samp>

This pull request fixes a potential bug in the environment service and refactors the task plugin interface. It adds a nil check for `prod.Render` in `environment.go` and removes the `getProductInfo` function from `deploy.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1e8c891</samp>

*  Add nil check for product render set to avoid potential error ([link](https://github.com/koderover/zadig/pull/2997/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L1856-R1864))
*  Remove unused getProductInfo function from task plugin package ([link](https://github.com/koderover/zadig/pull/2997/files?diff=unified&w=0#diff-9b8d72a57eca69a24c890acc2d09faa9e330ee0157337dd88e4d63a189805227L444-L453))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
