### PR TITLE
feat: add release plan openapi and fix bugs

### DIFF
--- a/pkg/microservice/aslan/core/common/util/template.go
+++ b/pkg/microservice/aslan/core/common/util/template.go
@@ -23,9 +23,10 @@ import (
 	"strings"
 	gotemplate "text/template"
 
+	"gopkg.in/yaml.v2"
+
 	commomtemplate "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/template"
 	"github.com/koderover/zadig/pkg/setting"
-	"gopkg.in/yaml.v2"
 )
 
 var (

--- a/pkg/microservice/aslan/core/release_plan/handler/openapi.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/openapi.go
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023 The KodeRover Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package handler
+
+import (
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/release_plan/service"
+	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
+	e "github.com/koderover/zadig/pkg/tool/errors"
+)
+
+type OpenAPIListReleasePlanOption struct {
+	PageNum  int64 `form:"pageNum" binding:"required"`
+	PageSize int64 `form:"pageSize" binding:"required"`
+}
+
+func OpenAPIListReleasePlans(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	//if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.View {
+	//	ctx.UnAuthorized = true
+	//	return
+	//}
+
+	opt := new(OpenAPIListReleasePlanOption)
+	if err := c.ShouldBindQuery(&opt); err != nil {
+		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+
+	ctx.Resp, ctx.Err = service.OpenAPIListReleasePlans(opt.PageNum, opt.PageSize)
+}
+
+func OpenAPIGetReleasePlan(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	//if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.View {
+	//	ctx.UnAuthorized = true
+	//	return
+	//}
+
+	ctx.Resp, ctx.Err = service.OpenAPIGetReleasePlan(c.Param("id"))
+}
+
+func OpenAPICreateReleasePlan(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	//if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.Create {
+	//	ctx.UnAuthorized = true
+	//	return
+	//}
+
+	opt := new(service.OpenAPICreateReleasePlanArgs)
+	if err := c.ShouldBindJSON(&opt); err != nil {
+		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+
+	ctx.Err = service.OpenAPICreateReleasePlan(ctx, opt)
+}

--- a/pkg/microservice/aslan/core/release_plan/handler/router.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/router.go
@@ -34,3 +34,14 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		v1.POST("/:id/approve", ApproveReleasePlan)
 	}
 }
+
+type OpenAPIRouter struct{}
+
+func (*OpenAPIRouter) Inject(router *gin.RouterGroup) {
+	v1 := router.Group("v1")
+	{
+		v1.GET("", OpenAPIListReleasePlans)
+		v1.POST("", OpenAPICreateReleasePlan)
+		v1.GET("/:id", OpenAPIGetReleasePlan)
+	}
+}

--- a/pkg/microservice/aslan/core/release_plan/service/openapi.go
+++ b/pkg/microservice/aslan/core/release_plan/service/openapi.go
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2023 The KodeRover Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
+	"github.com/koderover/zadig/pkg/setting"
+	"github.com/koderover/zadig/pkg/shared/client/user"
+	"github.com/koderover/zadig/pkg/shared/handler"
+	e "github.com/koderover/zadig/pkg/tool/errors"
+	"github.com/koderover/zadig/pkg/tool/log"
+)
+
+type OpenAPIListReleasePlanResp struct {
+	List  []*OpenAPIListReleasePlanInfo `json:"list"`
+	Total int64                         `json:"total"`
+}
+
+type OpenAPIListReleasePlanInfo struct {
+	ID          primitive.ObjectID `bson:"_id,omitempty"       yaml:"-"                   json:"id"`
+	Index       int64              `bson:"index"       yaml:"index"                   json:"index"`
+	Name        string             `bson:"name"       yaml:"name"                   json:"name"`
+	Manager     string             `bson:"manager"       yaml:"manager"                   json:"manager"`
+	Description string             `bson:"description"       yaml:"description"                   json:"description"`
+	CreatedBy   string             `bson:"created_by"       yaml:"created_by"                   json:"created_by"`
+	CreateTime  int64              `bson:"create_time"       yaml:"create_time"                   json:"create_time"`
+}
+
+func OpenAPIListReleasePlans(pageNum, pageSize int64) (*OpenAPIListReleasePlanResp, error) {
+	list, total, err := mongodb.NewReleasePlanColl().ListByOptions(&mongodb.ListReleasePlanOption{
+		PageNum:        pageNum,
+		PageSize:       pageSize,
+		IsSort:         true,
+		ExcludedFields: []string{"jobs", "logs"},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "ListReleasePlans")
+	}
+	resp := make([]*OpenAPIListReleasePlanInfo, 0)
+	for _, plan := range list {
+		resp = append(resp, &OpenAPIListReleasePlanInfo{
+			ID:          plan.ID,
+			Index:       plan.Index,
+			Name:        plan.Name,
+			Manager:     plan.Manager,
+			Description: plan.Description,
+			CreatedBy:   plan.CreatedBy,
+			CreateTime:  plan.CreateTime,
+		})
+	}
+	return &OpenAPIListReleasePlanResp{
+		List:  resp,
+		Total: total,
+	}, nil
+}
+
+func OpenAPIGetReleasePlan(id string) (*models.ReleasePlan, error) {
+	return mongodb.NewReleasePlanColl().GetByID(context.Background(), id)
+}
+
+type OpenAPICreateReleasePlanArgs struct {
+	Name string `bson:"name"       yaml:"name"                   json:"name"`
+	// ManagerID is the user id of the manager
+	ManagerID   string           `bson:"manager_id"       yaml:"manager_id"                   json:"manager_id"`
+	StartTime   int64            `bson:"start_time"       yaml:"start_time"                   json:"start_time"`
+	EndTime     int64            `bson:"end_time"       yaml:"end_time"                   json:"end_time"`
+	Description string           `bson:"description"       yaml:"description"                   json:"description"`
+	Approval    *models.Approval `bson:"approval"       yaml:"approval"                   json:"approval,omitempty"`
+}
+
+func OpenAPICreateReleasePlan(c *handler.Context, rawArgs *OpenAPICreateReleasePlanArgs) error {
+	args := &models.ReleasePlan{
+		Name:        rawArgs.Name,
+		ManagerID:   rawArgs.ManagerID,
+		StartTime:   rawArgs.StartTime,
+		EndTime:     rawArgs.EndTime,
+		Description: rawArgs.Description,
+		Approval:    rawArgs.Approval,
+	}
+	if args.Name == "" || args.ManagerID == "" {
+		return errors.New("Required parameters are missing")
+	}
+	if args.StartTime > args.EndTime || args.EndTime < time.Now().Unix() {
+		return errors.New("Invalid release time range")
+	}
+	userInfo, err := user.New().GetUserByID(args.ManagerID)
+	if err != nil {
+		return errors.Errorf("Failed to get user by id %s, error: %v", args.ManagerID, err)
+	}
+	args.Manager = userInfo.Name
+
+	if args.Approval != nil {
+		if err := lintApproval(args.Approval); err != nil {
+			return errors.Errorf("lintApproval error: %v", err)
+		}
+		if args.Approval.Type == config.LarkApproval {
+			if err := createLarkApprovalDefinition(args.Approval.LarkApproval); err != nil {
+				return errors.Errorf("createLarkApprovalDefinition error: %v", err)
+			}
+		}
+	}
+
+	nextID, err := mongodb.NewCounterColl().GetNextSeq(setting.ReleasePlanFmt)
+	if err != nil {
+		log.Errorf("OpenAPICreateReleasePlan.GetNextSeq error: %v", err)
+		return e.ErrGetCounter.AddDesc(err.Error())
+	}
+	args.Index = nextID
+	args.CreatedBy = c.UserName
+	args.UpdatedBy = c.UserName
+	args.CreateTime = time.Now().Unix()
+	args.UpdateTime = time.Now().Unix()
+	args.Status = config.StatusPlanning
+	args.Logs = append(args.Logs, &models.ReleasePlanLog{
+		Username:   c.UserName,
+		Account:    c.Account,
+		Verb:       VerbCreate,
+		TargetName: args.Name,
+		TargetType: TargetTypeReleasePlan,
+		CreatedAt:  time.Now().Unix(),
+	})
+
+	return mongodb.NewReleasePlanColl().Create(args)
+}

--- a/pkg/microservice/aslan/core/release_plan/service/openapi.go
+++ b/pkg/microservice/aslan/core/release_plan/service/openapi.go
@@ -81,12 +81,13 @@ func OpenAPIGetReleasePlan(id string) (*models.ReleasePlan, error) {
 }
 
 type OpenAPICreateReleasePlanArgs struct {
-	Name        string           `bson:"name"       yaml:"name"                   json:"name"`
-	Manager     string           `bson:"manager"       yaml:"manager"                   json:"manager"`
-	StartTime   int64            `bson:"start_time"       yaml:"start_time"                   json:"start_time"`
-	EndTime     int64            `bson:"end_time"       yaml:"end_time"                   json:"end_time"`
-	Description string           `bson:"description"       yaml:"description"                   json:"description"`
-	Approval    *models.Approval `bson:"approval"       yaml:"approval"                   json:"approval,omitempty"`
+	Name                string           `bson:"name"       yaml:"name"                   json:"name"`
+	Manager             string           `bson:"manager"       yaml:"manager"                   json:"manager"`
+	ManagerIdentityType string           `bson:"manager_identity_type"       yaml:"manager_identity_type"                   json:"manager_identity_type"`
+	StartTime           int64            `bson:"start_time"       yaml:"start_time"                   json:"start_time"`
+	EndTime             int64            `bson:"end_time"       yaml:"end_time"                   json:"end_time"`
+	Description         string           `bson:"description"       yaml:"description"                   json:"description"`
+	Approval            *models.Approval `bson:"approval"       yaml:"approval"                   json:"approval,omitempty"`
 }
 
 func OpenAPICreateReleasePlan(c *handler.Context, rawArgs *OpenAPICreateReleasePlanArgs) error {
@@ -105,7 +106,8 @@ func OpenAPICreateReleasePlan(c *handler.Context, rawArgs *OpenAPICreateReleaseP
 		return errors.Wrap(err, "lint release time range error")
 	}
 	searchUserResp, err := user.New().SearchUser(&user.SearchUserArgs{
-		Account: args.Manager,
+		Account:      args.Manager,
+		IdentityType: rawArgs.ManagerIdentityType,
 	})
 	if err != nil {
 		return errors.Errorf("Failed to get user %s, error: %v", args.Manager, err)

--- a/pkg/microservice/aslan/core/release_plan/service/openapi.go
+++ b/pkg/microservice/aslan/core/release_plan/service/openapi.go
@@ -102,8 +102,8 @@ func OpenAPICreateReleasePlan(c *handler.Context, rawArgs *OpenAPICreateReleaseP
 	if args.Name == "" || args.ManagerID == "" {
 		return errors.New("Required parameters are missing")
 	}
-	if args.StartTime > args.EndTime || args.EndTime < time.Now().Unix() {
-		return errors.New("Invalid release time range")
+	if err := lintReleaseTimeRange(args.StartTime, args.EndTime); err != nil {
+		return errors.Wrap(err, "lint release time range error")
 	}
 	userInfo, err := user.New().GetUserByID(args.ManagerID)
 	if err != nil {

--- a/pkg/microservice/aslan/core/release_plan/service/update.go
+++ b/pkg/microservice/aslan/core/release_plan/service/update.go
@@ -189,16 +189,7 @@ func (u *TimeRangeUpdater) Update(plan *models.ReleasePlan) (before interface{},
 }
 
 func (u *TimeRangeUpdater) Lint() error {
-	if u.StartTime == 0 || u.EndTime == 0 {
-		return fmt.Errorf("start_time and end_time cannot be empty")
-	}
-	if u.StartTime >= u.EndTime {
-		return fmt.Errorf("start_time must be less than end_time")
-	}
-	if u.EndTime < time.Now().Unix() {
-		return fmt.Errorf("end_time must be greater than now")
-	}
-	return nil
+	return lintReleaseTimeRange(u.StartTime, u.EndTime)
 }
 
 func (u *TimeRangeUpdater) TargetName() string {

--- a/pkg/microservice/aslan/server/rest/router.go
+++ b/pkg/microservice/aslan/server/rest/router.go
@@ -105,6 +105,7 @@ func (s *engine) injectRouterGroup(router *gin.RouterGroup) {
 		"/openapi/quality":      new(testinghandler.QualityRouter),
 		"/openapi/build":        new(buildhandler.OpenAPIRouter),
 		"/openapi/service":      new(servicehandler.OpenAPIRouter),
+		"/openapi/release_plan": new(releaseplanhandler.OpenAPIRouter),
 	} {
 		r.Inject(router.Group(name))
 	}


### PR DESCRIPTION
Signed-off-by: M-Cosmosss <yuzhou@koderover.com>### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ef00c95</samp>

Refactored the release plan logic and added openapi endpoints for release plans. The changes include removing unused imports, simplifying the code, reusing the linting function, and defining new handlers, services and routes for the openapi endpoints. The new endpoints allow users to list, get and create release plans using the openapi specification.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ef00c95</samp>

*  Add handlers, services and routes for openapi endpoints related to release plans ([link](https://github.com/koderover/zadig/pull/2998/files?diff=unified&w=0#diff-8758295bf6b8120569023908e1a6a35af9b5deaaa753190dd79eac3fdeccb44dR1-R101), [link](https://github.com/koderover/zadig/pull/2998/files?diff=unified&w=0#diff-35aa675932bf6312a17e222c3b61023210d89cece6f0e6d895b4c47baf6ad797R37-R47), [link](https://github.com/koderover/zadig/pull/2998/files?diff=unified&w=0#diff-f343155bdfde6d5048a343a8a3a25d2ef9dd90fbb0ea5fb6d3612b08b757328bR1-R146), [link](https://github.com/koderover/zadig/pull/2998/files?diff=unified&w=0#diff-30e4f93858e028bb4bcaa7da5e4914049b2fb708bc0f6cfffb34e8f043b54cd4R108))
*  Refactor `CreateReleasePlan` and `TimeRangeUpdater.Lint` functions to use `lintReleaseTimeRange` function for validating release time range ([link](https://github.com/koderover/zadig/pull/2998/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL48-R49), [link](https://github.com/koderover/zadig/pull/2998/files?diff=unified&w=0#diff-7947730bf8903869386d417e33f7417d9e44be012e368c73723a8cd1298c0659L192-R192))
*  Simplify `lintWorkflow` function to only check for nil workflow ([link](https://github.com/koderover/zadig/pull/2998/files?diff=unified&w=0#diff-d7af80d78b65f3338a7fa25bda2985224529429305ef16eb4a0a33bf4b0faa02L50-R62))
*  Modify `ExecuteReleaseJob` function to allow execution without start and end time ([link](https://github.com/koderover/zadig/pull/2998/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL208-R212))
*  Reorder import of `util` package in `template.go` to follow convention ([link](https://github.com/koderover/zadig/pull/2998/files?diff=unified&w=0#diff-ed09e82b61201968cfeaac1613ab8aeafeda64d1944dbdfbfbc8413ca0881707L26-R29))
*  Remove unused import of `jobctl` package in `lint.go` ([link](https://github.com/koderover/zadig/pull/2998/files?diff=unified&w=0#diff-d7af80d78b65f3338a7fa25bda2985224529429305ef16eb4a0a33bf4b0faa02L28))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
