### PR TITLE
add error message to product services

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/apply.go
+++ b/pkg/microservice/aslan/core/common/service/kube/apply.go
@@ -370,6 +370,7 @@ func CreateOrPatchResource(applyParam *ResourceApplyParam, log *zap.SugaredLogge
 				errList = multierror.Append(errList, err)
 				continue
 			}
+			log.Infof("--------- object kind: %s, name: %s", obj.GetObjectKind().GroupVersionKind().Kind, u.GetName())
 
 			switch res := obj.(type) {
 			case *appsv1.Deployment:
@@ -400,6 +401,7 @@ func CreateOrPatchResource(applyParam *ResourceApplyParam, log *zap.SugaredLogge
 				errList = multierror.Append(errList, fmt.Errorf("object is not a appsv1.Deployment or appsv1.StatefulSet"))
 				continue
 			}
+			log.Infof("-------- the errlist is %v", errList.ErrorOrNil())
 
 		case setting.Job:
 			jsonData, err := u.MarshalJSON()
@@ -443,7 +445,6 @@ func CreateOrPatchResource(applyParam *ResourceApplyParam, log *zap.SugaredLogge
 				errList = multierror.Append(errList, errors.Wrapf(err, "failed to create or update %s/%s", u.GetKind(), u.GetName()))
 				continue
 			}
-			log.Infof("%s api verison is %s", u.GetName(), u.GetAPIVersion())
 			if u.GetAPIVersion() == batchv1.SchemeGroupVersion.String() {
 				obj, err := serializer.NewDecoder().JSONToCronJob(jsonData)
 				if err != nil {
@@ -522,7 +523,7 @@ func CreateOrPatchResource(applyParam *ResourceApplyParam, log *zap.SugaredLogge
 		return nil, errList.ErrorOrNil()
 	}
 
-	return res, errList.ErrorOrNil()
+	return res, nil
 }
 
 func PrepareHelmServiceData(applyParam *ResourceApplyParam) (*commonmodels.RenderSet, *commonmodels.ProductService, *commonmodels.Service, error) {

--- a/pkg/microservice/aslan/core/common/service/kube/apply.go
+++ b/pkg/microservice/aslan/core/common/service/kube/apply.go
@@ -370,7 +370,6 @@ func CreateOrPatchResource(applyParam *ResourceApplyParam, log *zap.SugaredLogge
 				errList = multierror.Append(errList, err)
 				continue
 			}
-			log.Infof("--------- object kind: %s, name: %s", obj.GetObjectKind().GroupVersionKind().Kind, u.GetName())
 
 			switch res := obj.(type) {
 			case *appsv1.Deployment:
@@ -401,7 +400,6 @@ func CreateOrPatchResource(applyParam *ResourceApplyParam, log *zap.SugaredLogge
 				errList = multierror.Append(errList, fmt.Errorf("object is not a appsv1.Deployment or appsv1.StatefulSet"))
 				continue
 			}
-			log.Infof("-------- the errlist is %v", errList.ErrorOrNil())
 
 		case setting.Job:
 			jsonData, err := u.MarshalJSON()

--- a/pkg/microservice/aslan/core/common/service/kube/render.go
+++ b/pkg/microservice/aslan/core/common/service/kube/render.go
@@ -618,6 +618,10 @@ func RenderEnvServiceWithTempl(prod *commonmodels.Product, render *commonmodels.
 		return "", err
 	}
 	parsedYaml = ParseSysKeys(prod.Namespace, prod.EnvName, prod.ProductName, service.ServiceName, parsedYaml)
-	parsedYaml, _, _ = ReplaceWorkloadImages(parsedYaml, service.Containers)
+	parsedYaml, _, err = ReplaceWorkloadImages(parsedYaml, service.Containers)
+	if err != nil {
+		log.Error("failed to replace workload images, err: %s", err)
+		return "", err
+	}
 	return parsedYaml, nil
 }

--- a/pkg/microservice/aslan/core/common/service/kube/render.go
+++ b/pkg/microservice/aslan/core/common/service/kube/render.go
@@ -614,14 +614,10 @@ func RenderEnvServiceWithTempl(prod *commonmodels.Product, render *commonmodels.
 	// Note only the keys in TemplateService.ServiceVar can work
 	parsedYaml, err := RenderServiceYaml(svcTmpl.Yaml, prod.ProductName, svcTmpl.ServiceName, render)
 	if err != nil {
-		log.Error("failed to render service yaml, err: %s", err)
+		log.Errorf("failed to render service yaml, err: %s", err)
 		return "", err
 	}
 	parsedYaml = ParseSysKeys(prod.Namespace, prod.EnvName, prod.ProductName, service.ServiceName, parsedYaml)
 	parsedYaml, _, err = ReplaceWorkloadImages(parsedYaml, service.Containers)
-	if err != nil {
-		log.Error("failed to replace workload images, err: %s", err)
-		return "", err
-	}
-	return parsedYaml, nil
+	return parsedYaml, err
 }

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2536,7 +2536,7 @@ func upsertService(env *commonmodels.Product, service *commonmodels.ProductServi
 		return nil, errList
 	}
 
-	manifests := releaseutil.SplitManifests(parsedYaml)
+	//manifests := releaseutil.SplitManifests(parsedYaml)
 	if prevSvc == nil {
 		fakeTemplateSvc := &commonmodels.Service{ServiceName: service.ServiceName, ProductName: service.ServiceName, KubeYamls: util.SplitYaml(parsedYaml)}
 		commonutil.SetCurrentContainerImages(fakeTemplateSvc)
@@ -2544,17 +2544,17 @@ func upsertService(env *commonmodels.Product, service *commonmodels.ProductServi
 	}
 
 	// validate service yaml
-	resources := make([]*unstructured.Unstructured, 0, len(manifests))
-	for _, item := range manifests {
-		u, err := serializer.NewDecoder().YamlToUnstructured([]byte(item))
-		if err != nil {
-			log.Errorf("Failed to convert yaml to Unstructured, manifest is\n%s\n, error: %v", item, err)
-			errList = multierror.Append(errList, err)
-			continue
-		}
-
-		resources = append(resources, u)
-	}
+	//resources := make([]*unstructured.Unstructured, 0, len(manifests))
+	//for _, item := range manifests {
+	//	_, err := serializer.NewDecoder().YamlToUnstructured([]byte(item))
+	//	if err != nil {
+	//		log.Errorf("Failed to convert yaml to Unstructured, manifest is\n%s\n, error: %v", item, err)
+	//		errList = multierror.Append(errList, err)
+	//		continue
+	//	}
+	//
+	//	//resources = append(resources, u)
+	//}
 
 	preResourceYaml := ""
 	// compatibility: prevSvc.Render could be null when prev update failed
@@ -2578,6 +2578,9 @@ func upsertService(env *commonmodels.Product, service *commonmodels.ProductServi
 		AddZadigLabel:       addLabel,
 		SharedEnvHandler:    EnsureUpdateZadigService,
 	}
+
+	log.Infof("------ new yaml to apply is %v", parsedYaml)
+
 	return kube.CreateOrPatchResource(resourceApplyParam, log)
 }
 

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2536,25 +2536,11 @@ func upsertService(env *commonmodels.Product, service *commonmodels.ProductServi
 		return nil, errList
 	}
 
-	//manifests := releaseutil.SplitManifests(parsedYaml)
 	if prevSvc == nil {
 		fakeTemplateSvc := &commonmodels.Service{ServiceName: service.ServiceName, ProductName: service.ServiceName, KubeYamls: util.SplitYaml(parsedYaml)}
 		commonutil.SetCurrentContainerImages(fakeTemplateSvc)
 		service.Containers = fakeTemplateSvc.Containers
 	}
-
-	// validate service yaml
-	//resources := make([]*unstructured.Unstructured, 0, len(manifests))
-	//for _, item := range manifests {
-	//	_, err := serializer.NewDecoder().YamlToUnstructured([]byte(item))
-	//	if err != nil {
-	//		log.Errorf("Failed to convert yaml to Unstructured, manifest is\n%s\n, error: %v", item, err)
-	//		errList = multierror.Append(errList, err)
-	//		continue
-	//	}
-	//
-	//	//resources = append(resources, u)
-	//}
 
 	preResourceYaml := ""
 	// compatibility: prevSvc.Render could be null when prev update failed
@@ -2578,8 +2564,6 @@ func upsertService(env *commonmodels.Product, service *commonmodels.ProductServi
 		AddZadigLabel:       addLabel,
 		SharedEnvHandler:    EnsureUpdateZadigService,
 	}
-
-	log.Infof("------ new yaml of service: %s to apply is %v", service.ServiceName, parsedYaml)
 
 	return kube.CreateOrPatchResource(resourceApplyParam, log)
 }

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2579,7 +2579,7 @@ func upsertService(env *commonmodels.Product, service *commonmodels.ProductServi
 		SharedEnvHandler:    EnsureUpdateZadigService,
 	}
 
-	log.Infof("------ new yaml to apply is %v", parsedYaml)
+	log.Infof("------ new yaml of service: %s to apply is %v", service.ServiceName, parsedYaml)
 
 	return kube.CreateOrPatchResource(resourceApplyParam, log)
 }

--- a/pkg/microservice/aslan/core/environment/service/kube.go
+++ b/pkg/microservice/aslan/core/environment/service/kube.go
@@ -1105,7 +1105,6 @@ func setResourceDeployStatus(namespace string, resourceMap map[string]map[string
 			continue
 		}
 		for _, item := range u.Items {
-			//log.Infof("item: %s", item.GetName())
 			if deployStatus, ok := resources[item.GetName()]; ok && deployStatus.Status == StatusUnDeployed {
 				deployStatus.Status = StatusDeployed
 			}

--- a/pkg/microservice/aslan/core/environment/service/kube.go
+++ b/pkg/microservice/aslan/core/environment/service/kube.go
@@ -1105,7 +1105,7 @@ func setResourceDeployStatus(namespace string, resourceMap map[string]map[string
 			continue
 		}
 		for _, item := range u.Items {
-			log.Infof("item: %s", item.GetName())
+			//log.Infof("item: %s", item.GetName())
 			if deployStatus, ok := resources[item.GetName()]; ok && deployStatus.Status == StatusUnDeployed {
 				deployStatus.Status = StatusDeployed
 			}


### PR DESCRIPTION
### What this PR does / Why we need it:
add error message to product services

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6d04db7</samp>

*  Add log statements to print the resource kind, name, and error list in `CreateOrPatchResource` function ([link](https://github.com/koderover/zadig/pull/3000/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050R373), [link](https://github.com/koderover/zadig/pull/3000/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050R404))
* Remove log statement that prints the resource API version in `CreateOrPatchResource` function ([link](https://github.com/koderover/zadig/pull/3000/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L446))
* Modify `CreateOrPatchResource` function to always return nil as the error ([link](https://github.com/koderover/zadig/pull/3000/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L525-R526))
* Comment out the code that splits and validates the service YAML in `upsertService` function ([link](https://github.com/koderover/zadig/pull/3000/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L2539-R2539), [link](https://github.com/koderover/zadig/pull/3000/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L2547-R2558))
* Add log statement to print the new YAML that is being applied in `upsertService` function ([link](https://github.com/koderover/zadig/pull/3000/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24R2581-R2583))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
