### PR TITLE
improve and fix release plan

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/models/release_plan.go
@@ -41,7 +41,6 @@ type ReleasePlan struct {
 
 	Jobs []*ReleaseJob `bson:"jobs"       yaml:"jobs"                   json:"jobs"`
 
-	//Logs   []*ReleasePlanLog        `bson:"logs"       yaml:"logs"                   json:"logs"`
 	Status config.ReleasePlanStatus `bson:"status"       yaml:"status"                   json:"status"`
 
 	PlanningTime  int64 `bson:"planning_time"       yaml:"planning_time"                   json:"planning_time"`

--- a/pkg/microservice/aslan/core/common/repository/models/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/models/release_plan.go
@@ -41,7 +41,7 @@ type ReleasePlan struct {
 
 	Jobs []*ReleaseJob `bson:"jobs"       yaml:"jobs"                   json:"jobs"`
 
-	Logs   []*ReleasePlanLog        `bson:"logs"       yaml:"logs"                   json:"logs"`
+	//Logs   []*ReleasePlanLog        `bson:"logs"       yaml:"logs"                   json:"logs"`
 	Status config.ReleasePlanStatus `bson:"status"       yaml:"status"                   json:"status"`
 
 	PlanningTime  int64 `bson:"planning_time"       yaml:"planning_time"                   json:"planning_time"`
@@ -86,13 +86,19 @@ type WorkflowReleaseJobSpec struct {
 }
 
 type ReleasePlanLog struct {
-	Username   string      `bson:"username"                    json:"username"`
-	Account    string      `bson:"account"                     json:"account"`
-	Verb       string      `bson:"verb"                        json:"verb"`
-	TargetName string      `bson:"target_name"                 json:"target_name"`
-	TargetType string      `bson:"target_type"                 json:"target_type"`
-	Before     interface{} `bson:"before"                      json:"before"`
-	After      interface{} `bson:"after"                       json:"after"`
-	Detail     string      `bson:"detail"                      json:"detail"`
-	CreatedAt  int64       `bson:"created_at"                  json:"created_at"`
+	ID         primitive.ObjectID `bson:"_id,omitempty"                  json:"id"`
+	PlanID     string             `bson:"plan_id"                    json:"plan_id"`
+	Username   string             `bson:"username"                    json:"username"`
+	Account    string             `bson:"account"                     json:"account"`
+	Verb       string             `bson:"verb"                        json:"verb"`
+	TargetName string             `bson:"target_name"                 json:"target_name"`
+	TargetType string             `bson:"target_type"                 json:"target_type"`
+	Before     interface{}        `bson:"before"                      json:"before"`
+	After      interface{}        `bson:"after"                       json:"after"`
+	Detail     string             `bson:"detail"                      json:"detail"`
+	CreatedAt  int64              `bson:"created_at"                  json:"created_at"`
+}
+
+func (ReleasePlanLog) TableName() string {
+	return "release_plan_log"
 }

--- a/pkg/microservice/aslan/core/common/repository/mongodb/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/release_plan.go
@@ -53,13 +53,13 @@ func (c *ReleasePlanColl) EnsureIndex(ctx context.Context) error {
 	return nil
 }
 
-func (c *ReleasePlanColl) Create(args *models.ReleasePlan) error {
+func (c *ReleasePlanColl) Create(args *models.ReleasePlan) (string, error) {
 	if args == nil {
-		return errors.New("nil ReleasePlan")
+		return "", errors.New("nil ReleasePlan")
 	}
 
-	_, err := c.InsertOne(context.Background(), args)
-	return err
+	res, err := c.InsertOne(context.Background(), args)
+	return res.InsertedID.(primitive.ObjectID).Hex(), err
 }
 
 func (c *ReleasePlanColl) GetByID(ctx context.Context, idString string) (*models.ReleasePlan, error) {

--- a/pkg/microservice/aslan/core/common/repository/mongodb/release_plan_log.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/release_plan_log.go
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 The KodeRover Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongodb
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
+)
+
+type ReleasePlanLogColl struct {
+	*mongo.Collection
+
+	coll string
+}
+
+func NewReleasePlanLogColl() *ReleasePlanLogColl {
+	name := models.ReleasePlanLog{}.TableName()
+	return &ReleasePlanLogColl{
+		Collection: mongotool.Database(config.MongoDatabase()).Collection(name),
+		coll:       name,
+	}
+}
+
+func (c *ReleasePlanLogColl) GetCollectionName() string {
+	return c.coll
+}
+
+func (c *ReleasePlanLogColl) EnsureIndex(ctx context.Context) error {
+	return nil
+}
+
+func (c *ReleasePlanLogColl) Create(args *models.ReleasePlanLog) error {
+	if args == nil {
+		return errors.New("nil ReleasePlanLog")
+	}
+
+	_, err := c.InsertOne(context.Background(), args)
+	return err
+}
+
+type ListReleasePlanLogOption struct {
+	PlanID string
+	IsSort bool
+}
+
+func (c *ReleasePlanLogColl) ListByOptions(opt *ListReleasePlanLogOption) ([]*models.ReleasePlanLog, error) {
+	if opt == nil {
+		return nil, errors.New("nil ListOption")
+	}
+
+	query := bson.M{}
+
+	var resp []*models.ReleasePlanLog
+	ctx := context.Background()
+	opts := options.Find()
+	if opt.IsSort {
+		opts.SetSort(bson.D{{"create_time", -1}})
+	}
+	if opt.PlanID != "" {
+		query["plan_id"] = opt.PlanID
+	}
+
+	cursor, err := c.Collection.Find(ctx, query, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	err = cursor.All(ctx, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
@@ -76,6 +76,25 @@ func GetReleasePlan(c *gin.Context) {
 	ctx.Resp, ctx.Err = service.GetReleasePlan(c.Param("id"))
 }
 
+func GetReleasePlanLogs(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	//if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.View {
+	//	ctx.UnAuthorized = true
+	//	return
+	//}
+
+	ctx.Resp, ctx.Err = service.GetReleasePlanLogs(c.Param("id"))
+}
+
 func CreateReleasePlan(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()

--- a/pkg/microservice/aslan/core/release_plan/handler/router.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/router.go
@@ -26,6 +26,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		v1.GET("", ListReleasePlans)
 		v1.POST("", CreateReleasePlan)
 		v1.GET("/:id", GetReleasePlan)
+		v1.GET("/:id/logs", GetReleasePlanLogs)
 		v1.PUT("/:id", UpdateReleasePlan)
 		v1.DELETE("/:id", DeleteReleasePlan)
 

--- a/pkg/microservice/aslan/core/release_plan/service/approval.go
+++ b/pkg/microservice/aslan/core/release_plan/service/approval.go
@@ -449,7 +449,7 @@ func updateLarkApproval(ctx context.Context, approval *models.Approval) error {
 		}
 		if finalInstance.ApproveOrReject == config.Reject && !isApprove {
 			approval.Status = config.StatusReject
-			return errors.New("Approval has been rejected")
+			return nil
 		}
 		return errors.New("check final larkApproval status failed")
 	}

--- a/pkg/microservice/aslan/core/release_plan/service/approval.go
+++ b/pkg/microservice/aslan/core/release_plan/service/approval.go
@@ -216,7 +216,7 @@ func createNativeApproval(plan *models.ReleasePlan, url string) error {
 	}
 	approval := plan.Approval.NativeApproval
 
-	func() {
+	go func() {
 		email, err := systemconfig.New().GetEmailHost()
 		if err != nil {
 			log.Errorf("CreateNativeApproval GetEmailHost error, error msg:%s", err)

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -412,10 +412,12 @@ func ApproveReleasePlan(c *handler.Context, planID string, req *ApproveRequest) 
 	switch plan.Approval.Status {
 	case config.StatusPassed:
 		planLog = &models.ReleasePlanLog{
+			Username:   "系统",
 			Verb:       VerbUpdate,
-			TargetType: TargetTypeReleasePlanStatus,
 			TargetName: TargetTypeReleasePlanStatus,
+			TargetType: TargetTypeReleasePlanStatus,
 			Detail:     "审批通过",
+			After:      config.StatusExecuting,
 			CreatedAt:  time.Now().Unix(),
 		}
 		plan.Status = config.StatusExecuting
@@ -423,11 +425,8 @@ func ApproveReleasePlan(c *handler.Context, planID string, req *ApproveRequest) 
 		setReleaseJobsForExecuting(plan)
 	case config.StatusReject:
 		planLog = &models.ReleasePlanLog{
-			Verb:       VerbUpdate,
-			TargetType: TargetTypeReleasePlanStatus,
-			TargetName: TargetTypeReleasePlanStatus,
-			Detail:     "审批拒绝",
-			CreatedAt:  time.Now().Unix(),
+			Detail:    "审批被拒绝",
+			CreatedAt: time.Now().Unix(),
 		}
 	}
 	if err = mongodb.NewReleasePlanColl().UpdateByID(ctx, planID, plan); err != nil {

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -351,6 +351,7 @@ func UpdateReleasePlanStatus(c *handler.Context, planID, status string) error {
 			Username:   c.UserName,
 			Account:    c.Account,
 			Verb:       VerbUpdate,
+			TargetName: TargetTypeReleasePlanStatus,
 			TargetType: TargetTypeReleasePlanStatus,
 			Detail:     detail,
 			Before:     plan.Status,
@@ -413,6 +414,7 @@ func ApproveReleasePlan(c *handler.Context, planID string, req *ApproveRequest) 
 		planLog = &models.ReleasePlanLog{
 			Verb:       VerbUpdate,
 			TargetType: TargetTypeReleasePlanStatus,
+			TargetName: TargetTypeReleasePlanStatus,
 			Detail:     "审批通过",
 			CreatedAt:  time.Now().Unix(),
 		}
@@ -423,6 +425,7 @@ func ApproveReleasePlan(c *handler.Context, planID string, req *ApproveRequest) 
 		planLog = &models.ReleasePlanLog{
 			Verb:       VerbUpdate,
 			TargetType: TargetTypeReleasePlanStatus,
+			TargetName: TargetTypeReleasePlanStatus,
 			Detail:     "审批拒绝",
 			CreatedAt:  time.Now().Unix(),
 		}

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -412,6 +412,7 @@ func ApproveReleasePlan(c *handler.Context, planID string, req *ApproveRequest) 
 	switch plan.Approval.Status {
 	case config.StatusPassed:
 		planLog = &models.ReleasePlanLog{
+			PlanID:     planID,
 			Username:   "系统",
 			Verb:       VerbUpdate,
 			TargetName: TargetTypeReleasePlanStatus,
@@ -425,6 +426,7 @@ func ApproveReleasePlan(c *handler.Context, planID string, req *ApproveRequest) 
 		setReleaseJobsForExecuting(plan)
 	case config.StatusReject:
 		planLog = &models.ReleasePlanLog{
+			PlanID:    planID,
 			Detail:    "审批被拒绝",
 			CreatedAt: time.Now().Unix(),
 		}
@@ -437,7 +439,6 @@ func ApproveReleasePlan(c *handler.Context, planID string, req *ApproveRequest) 
 		if planLog == nil {
 			return
 		}
-		planLog.PlanID = planID
 		if err := mongodb.NewReleasePlanLogColl().Create(planLog); err != nil {
 			log.Errorf("create release plan log error: %v", err)
 		}

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -86,16 +86,27 @@ func CreateReleasePlan(c *handler.Context, args *models.ReleasePlan) error {
 	args.CreateTime = time.Now().Unix()
 	args.UpdateTime = time.Now().Unix()
 	args.Status = config.StatusPlanning
-	args.Logs = append(args.Logs, &models.ReleasePlanLog{
-		Username:   c.UserName,
-		Account:    c.Account,
-		Verb:       VerbCreate,
-		TargetName: args.Name,
-		TargetType: TargetTypeReleasePlan,
-		CreatedAt:  time.Now().Unix(),
-	})
 
-	return mongodb.NewReleasePlanColl().Create(args)
+	planID, err := mongodb.NewReleasePlanColl().Create(args)
+	if err != nil {
+		return errors.Wrap(err, "create release plan error")
+	}
+
+	go func() {
+		if err := mongodb.NewReleasePlanLogColl().Create(&models.ReleasePlanLog{
+			PlanID:     planID,
+			Username:   c.UserName,
+			Account:    c.Account,
+			Verb:       VerbCreate,
+			TargetName: args.Name,
+			TargetType: TargetTypeReleasePlan,
+			CreatedAt:  time.Now().Unix(),
+		}); err != nil {
+			log.Errorf("create release plan log error: %v", err)
+		}
+	}()
+
+	return nil
 }
 
 type ListReleasePlanResp struct {
@@ -121,6 +132,13 @@ func ListReleasePlans(pageNum, pageSize int64) (*ListReleasePlanResp, error) {
 
 func GetReleasePlan(id string) (*models.ReleasePlan, error) {
 	return mongodb.NewReleasePlanColl().GetByID(context.Background(), id)
+}
+
+func GetReleasePlanLogs(id string) ([]*models.ReleasePlanLog, error) {
+	return mongodb.NewReleasePlanLogColl().ListByOptions(&mongodb.ListReleasePlanLogOption{
+		PlanID: id,
+		IsSort: true,
+	})
 }
 
 func DeleteReleasePlan(c *gin.Context, username, id string) error {
@@ -166,20 +184,27 @@ func UpdateReleasePlan(c *handler.Context, planID string, args *UpdateReleasePla
 
 	plan.UpdatedBy = c.UserName
 	plan.UpdateTime = time.Now().Unix()
-	plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
-		Username:   c.UserName,
-		Account:    c.Account,
-		Verb:       updater.Verb(),
-		Before:     before,
-		After:      after,
-		TargetName: updater.TargetName(),
-		TargetType: updater.TargetType(),
-		CreatedAt:  time.Now().Unix(),
-	})
 
 	if err = mongodb.NewReleasePlanColl().UpdateByID(ctx, planID, plan); err != nil {
 		return errors.Wrap(err, "update plan")
 	}
+
+	go func() {
+		if err := mongodb.NewReleasePlanLogColl().Create(&models.ReleasePlanLog{
+			PlanID:     planID,
+			Username:   c.UserName,
+			Account:    c.Account,
+			Verb:       updater.Verb(),
+			Before:     before,
+			After:      after,
+			TargetName: updater.TargetName(),
+			TargetType: updater.TargetType(),
+			CreatedAt:  time.Now().Unix(),
+		}); err != nil {
+			log.Errorf("create release plan log error: %v", err)
+		}
+	}()
+
 	return nil
 }
 
@@ -190,13 +215,13 @@ type ExecuteReleaseJobArgs struct {
 	Spec interface{} `json:"spec"`
 }
 
-func ExecuteReleaseJob(c *handler.Context, id string, args *ExecuteReleaseJobArgs) error {
-	getLock(id).Lock()
-	defer getLock(id).Unlock()
+func ExecuteReleaseJob(c *handler.Context, planID string, args *ExecuteReleaseJobArgs) error {
+	getLock(planID).Lock()
+	defer getLock(planID).Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
-	plan, err := mongodb.NewReleasePlanColl().GetByID(ctx, id)
+	plan, err := mongodb.NewReleasePlanColl().GetByID(ctx, planID)
 	if err != nil {
 		return errors.Wrap(err, "get plan")
 	}
@@ -226,14 +251,6 @@ func ExecuteReleaseJob(c *handler.Context, id string, args *ExecuteReleaseJobArg
 
 	plan.UpdatedBy = c.UserName
 	plan.UpdateTime = time.Now().Unix()
-	plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
-		Username:   c.UserName,
-		Account:    c.Account,
-		Verb:       VerbExecute,
-		TargetName: args.Name,
-		TargetType: TargetTypeReleaseJob,
-		CreatedAt:  time.Now().Unix(),
-	})
 
 	if checkReleasePlanJobsAllDone(plan) {
 		plan.ExecutingTime = time.Now().Unix()
@@ -241,19 +258,34 @@ func ExecuteReleaseJob(c *handler.Context, id string, args *ExecuteReleaseJobArg
 		plan.Status = config.StatusSuccess
 	}
 
-	if err = mongodb.NewReleasePlanColl().UpdateByID(ctx, id, plan); err != nil {
+	if err = mongodb.NewReleasePlanColl().UpdateByID(ctx, planID, plan); err != nil {
 		return errors.Wrap(err, "update plan")
 	}
+
+	go func() {
+		if err := mongodb.NewReleasePlanLogColl().Create(&models.ReleasePlanLog{
+			PlanID:     planID,
+			Username:   c.UserName,
+			Account:    c.Account,
+			Verb:       VerbExecute,
+			TargetName: args.Name,
+			TargetType: TargetTypeReleaseJob,
+			CreatedAt:  time.Now().Unix(),
+		}); err != nil {
+			log.Errorf("create release plan log error: %v", err)
+		}
+	}()
+
 	return nil
 }
 
-func UpdateReleasePlanStatus(c *handler.Context, id, status string) error {
-	getLock(id).Lock()
-	defer getLock(id).Unlock()
+func UpdateReleasePlanStatus(c *handler.Context, planID, status string) error {
+	getLock(planID).Lock()
+	defer getLock(planID).Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
-	plan, err := mongodb.NewReleasePlanColl().GetByID(ctx, id)
+	plan, err := mongodb.NewReleasePlanColl().GetByID(ctx, planID)
 	if err != nil {
 		return errors.Wrap(err, "get plan")
 	}
@@ -305,22 +337,28 @@ func UpdateReleasePlanStatus(c *handler.Context, id, status string) error {
 		}
 		plan.PlanningTime = time.Now().Unix()
 	}
-	plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
-		Username: c.UserName,
-		Account:  c.Account,
-		Verb:     VerbUpdate,
-		//TargetName: targetName,
-		TargetType: TargetTypeReleasePlanStatus,
-		Detail:     detail,
-		Before:     plan.Status,
-		After:      status,
-		CreatedAt:  time.Now().Unix(),
-	})
 	plan.Status = config.ReleasePlanStatus(status)
 
-	if err = mongodb.NewReleasePlanColl().UpdateByID(ctx, id, plan); err != nil {
+	if err = mongodb.NewReleasePlanColl().UpdateByID(ctx, planID, plan); err != nil {
 		return errors.Wrap(err, "update plan")
 	}
+
+	go func() {
+		if err := mongodb.NewReleasePlanLogColl().Create(&models.ReleasePlanLog{
+			PlanID:     planID,
+			Username:   c.UserName,
+			Account:    c.Account,
+			Verb:       VerbUpdate,
+			TargetType: TargetTypeReleasePlanStatus,
+			Detail:     detail,
+			Before:     plan.Status,
+			After:      status,
+			CreatedAt:  time.Now().Unix(),
+		}); err != nil {
+			log.Errorf("create release plan log error: %v", err)
+		}
+	}()
+
 	return nil
 }
 
@@ -329,13 +367,13 @@ type ApproveRequest struct {
 	Comment string `json:"comment"`
 }
 
-func ApproveReleasePlan(c *handler.Context, id string, req *ApproveRequest) error {
-	getLock(id).Lock()
-	defer getLock(id).Unlock()
+func ApproveReleasePlan(c *handler.Context, planID string, req *ApproveRequest) error {
+	getLock(planID).Lock()
+	defer getLock(planID).Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
-	plan, err := mongodb.NewReleasePlanColl().GetByID(ctx, id)
+	plan, err := mongodb.NewReleasePlanColl().GetByID(ctx, planID)
 	if err != nil {
 		return errors.Wrap(err, "get plan")
 	}
@@ -367,28 +405,40 @@ func ApproveReleasePlan(c *handler.Context, id string, req *ApproveRequest) erro
 	if approved {
 		plan.Approval.Status = config.StatusPassed
 	}
+	var planLog *models.ReleasePlanLog
 	switch plan.Approval.Status {
 	case config.StatusPassed:
-		plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
+		planLog = &models.ReleasePlanLog{
 			Verb:       VerbUpdate,
 			TargetType: TargetTypeReleasePlanStatus,
 			Detail:     "审批通过",
 			CreatedAt:  time.Now().Unix(),
-		})
+		}
 		plan.Status = config.StatusExecuting
 		plan.ApprovalTime = time.Now().Unix()
 		setReleaseJobsForExecuting(plan)
 	case config.StatusReject:
-		plan.Logs = append(plan.Logs, &models.ReleasePlanLog{
+		planLog = &models.ReleasePlanLog{
 			Verb:       VerbUpdate,
 			TargetType: TargetTypeReleasePlanStatus,
 			Detail:     "审批拒绝",
 			CreatedAt:  time.Now().Unix(),
-		})
+		}
 	}
-	if err = mongodb.NewReleasePlanColl().UpdateByID(ctx, id, plan); err != nil {
+	if err = mongodb.NewReleasePlanColl().UpdateByID(ctx, planID, plan); err != nil {
 		return errors.Wrap(err, "update plan")
 	}
+
+	go func() {
+		if planLog == nil {
+			return
+		}
+		planLog.PlanID = planID
+		if err := mongodb.NewReleasePlanLogColl().Create(planLog); err != nil {
+			log.Errorf("create release plan log error: %v", err)
+		}
+	}()
+
 	return nil
 }
 

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -303,7 +303,6 @@ func UpdateReleasePlanStatus(c *handler.Context, planID, status string) error {
 		return errors.Wrap(err, "get user")
 	}
 
-	//targetName := plan.Name + "状态"
 	detail := ""
 
 	// target status check and update
@@ -326,6 +325,9 @@ func UpdateReleasePlanStatus(c *handler.Context, planID, status string) error {
 		if err := createApprovalInstance(plan, userInfo.Phone); err != nil {
 			return errors.Wrap(err, "create approval instance")
 		}
+	case config.StatusCancel:
+		// set executing status final time
+		plan.ExecutingTime = time.Now().Unix()
 	}
 
 	// original status check and update

--- a/pkg/microservice/aslan/core/release_plan/service/update.go
+++ b/pkg/microservice/aslan/core/release_plan/service/update.go
@@ -49,7 +49,7 @@ const (
 	TargetTypeReleasePlan       = "发布计划"
 	TargetTypeReleasePlanStatus = "发布计划状态"
 	TargetTypeMetadata          = "元数据"
-	TargetTypeReleaseJob        = "发布任务"
+	TargetTypeReleaseJob        = "发布内容"
 	TargetTypeApproval          = "审批"
 	TargetTypeDescription       = "需求关联"
 

--- a/pkg/microservice/aslan/core/release_plan/service/watcher.go
+++ b/pkg/microservice/aslan/core/release_plan/service/watcher.go
@@ -159,6 +159,7 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 	switch plan.Approval.Status {
 	case config.StatusPassed:
 		planLog = &models.ReleasePlanLog{
+			PlanID:     plan.ID.Hex(),
 			Username:   "系统",
 			Verb:       VerbUpdate,
 			TargetName: TargetTypeReleasePlanStatus,
@@ -172,6 +173,7 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 		setReleaseJobsForExecuting(plan)
 	case config.StatusReject:
 		planLog = &models.ReleasePlanLog{
+			PlanID:    plan.ID.Hex(),
 			Detail:    "审批被拒绝",
 			CreatedAt: time.Now().Unix(),
 		}
@@ -185,7 +187,6 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 		if planLog == nil {
 			return
 		}
-		planLog.PlanID = plan.ID.Hex()
 		if err := mongodb.NewReleasePlanLogColl().Create(planLog); err != nil {
 			log.Errorf("create release plan log error: %v", err)
 		}

--- a/pkg/microservice/aslan/core/release_plan/service/watcher.go
+++ b/pkg/microservice/aslan/core/release_plan/service/watcher.go
@@ -153,10 +153,12 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 	switch plan.Approval.Status {
 	case config.StatusPassed:
 		planLog = &models.ReleasePlanLog{
+			Username:   "系统",
 			Verb:       VerbUpdate,
 			TargetName: TargetTypeReleasePlanStatus,
 			TargetType: TargetTypeReleasePlanStatus,
 			Detail:     "审批通过",
+			After:      config.StatusExecuting,
 			CreatedAt:  time.Now().Unix(),
 		}
 		plan.Status = config.StatusExecuting
@@ -164,11 +166,8 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 		setReleaseJobsForExecuting(plan)
 	case config.StatusReject:
 		planLog = &models.ReleasePlanLog{
-			Verb:       VerbUpdate,
-			TargetName: TargetTypeReleasePlanStatus,
-			TargetType: TargetTypeReleasePlanStatus,
-			Detail:     "审批拒绝",
-			CreatedAt:  time.Now().Unix(),
+			Detail:    "审批被拒绝",
+			CreatedAt: time.Now().Unix(),
 		}
 	}
 

--- a/pkg/microservice/aslan/core/release_plan/service/watcher.go
+++ b/pkg/microservice/aslan/core/release_plan/service/watcher.go
@@ -136,13 +136,19 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 		return nil
 	}
 
+	// skip if plan has been rejected
+	if plan.Approval.Status == config.StatusReject {
+		return nil
+	}
+
 	switch plan.Approval.Type {
 	case config.LarkApproval:
 		err = updateLarkApproval(ctx, plan.Approval)
 	case config.DingTalkApproval:
 		err = updateDingTalkApproval(ctx, plan.Approval)
-		// NativeApproval is update when approve
+	// NativeApproval is update when approve
 	case config.NativeApproval:
+		return nil
 	default:
 		err = errors.Errorf("unknown approval type %s", plan.Approval.Type)
 	}

--- a/pkg/microservice/aslan/core/release_plan/service/watcher.go
+++ b/pkg/microservice/aslan/core/release_plan/service/watcher.go
@@ -154,6 +154,7 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 	case config.StatusPassed:
 		planLog = &models.ReleasePlanLog{
 			Verb:       VerbUpdate,
+			TargetName: TargetTypeReleasePlanStatus,
 			TargetType: TargetTypeReleasePlanStatus,
 			Detail:     "审批通过",
 			CreatedAt:  time.Now().Unix(),
@@ -164,6 +165,7 @@ func updatePlanApproval(plan *models.ReleasePlan) error {
 	case config.StatusReject:
 		planLog = &models.ReleasePlanLog{
 			Verb:       VerbUpdate,
+			TargetName: TargetTypeReleasePlanStatus,
 			TargetType: TargetTypeReleasePlanStatus,
 			Detail:     "审批拒绝",
 			CreatedAt:  time.Now().Unix(),

--- a/pkg/microservice/aslan/core/service.go
+++ b/pkg/microservice/aslan/core/service.go
@@ -453,6 +453,7 @@ func initDatabase() {
 		commonrepo.NewImageTagsCollColl(),
 		commonrepo.NewLLMIntegrationColl(),
 		commonrepo.NewReleasePlanColl(),
+		commonrepo.NewReleasePlanLogColl(),
 
 		// msg queue
 		commonrepo.NewMsgQueueCommonColl(),

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_nacos.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_nacos.go
@@ -41,7 +41,7 @@ type NacosJob struct {
 
 func (j *NacosJob) Instantiate() error {
 	j.spec = &commonmodels.NacosJobSpec{}
-	if err := commonmodels.IToiYaml(j.job.Spec, j.spec); err != nil {
+	if err := commonmodels.IToi(j.job.Spec, j.spec); err != nil {
 		return err
 	}
 	j.job.Spec = j.spec
@@ -171,7 +171,7 @@ func (j *NacosJob) ToJobs(taskID int64) ([]*commonmodels.JobTask, error) {
 
 func (j *NacosJob) LintJob() error {
 	j.spec = &commonmodels.NacosJobSpec{}
-	if err := commonmodels.IToiYaml(j.job.Spec, j.spec); err != nil {
+	if err := commonmodels.IToi(j.job.Spec, j.spec); err != nil {
 		return err
 	}
 

--- a/pkg/types/nacos.go
+++ b/pkg/types/nacos.go
@@ -27,4 +27,8 @@ type NacosConfig struct {
 	Desc    string `bson:"description,omitempty"   json:"description,omitempty"   yaml:"description,omitempty"`
 	Format  string `bson:"format,omitempty"        json:"format,omitempty"        yaml:"format,omitempty"`
 	Content string `bson:"content,omitempty"       json:"content,omitempty"       yaml:"content,omitempty"`
+
+	// for frontend
+	Diff        interface{} `bson:"diff,omitempty" json:"diff,omitempty" yaml:"diff,omitempty"`
+	Persistence interface{} `bson:"persistence,omitempty" json:"persistence,omitempty" yaml:"persistence,omitempty"`
 }


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ce0b73a</samp>

Refactored the release plan service to store the release plan logs in a separate MongoDB collection, instead of appending them to the release plan document. This improves the performance and scalability of the service, and allows the client to fetch the logs by plan ID. Added a new handler, router, and service function to handle the HTTP GET request for the logs. Modified some existing functions to use goroutines for asynchronous operations, such as sending email notifications and creating logs. Added a new file `release_plan_log.go` to the `mongodb` package, which defines the type and methods for the new collection. Updated the `initDatabase` function to create and index the new collection.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ce0b73a</samp>

*  Refactor the release plan logs to use a separate collection instead of storing them in the same collection as the release plans ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-d8635583436a02bda02f03d481624721e703adea0d4cf781c09567771344e92aL44-R44), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-d8635583436a02bda02f03d481624721e703adea0d4cf781c09567771344e92aL89-R104), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-1a311a15ce8e53b0e42903ec48ea2dda5ddcd8d390fdeef511d74729c5bdbe2fL56-R62), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-53a7bfa38cf651e6bde2f8bfb29bf82c845852543d7e4114a982b913bed88bddR1-R96), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-f343155bdfde6d5048a343a8a3a25d2ef9dd90fbb0ea5fb6d3612b08b757328bL145-R165), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL89-R109), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL169-R207), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL193-R224), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL229-L236), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL244-R288), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL308-R361), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL332-R376), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL370-R441), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-f1e929d38a5e72be79b316b01b0c29b86449ed13cafbdce11dee89bf31df0559L152-R170), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-f1e929d38a5e72be79b316b01b0c29b86449ed13cafbdce11dee89bf31df0559R176-R186), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-a74fa9c9aa31979c0e1634097c1a6b3e84ea13e0686ad037178b5d1208e9f9deR456))
  * Add an `ID` field and a `PlanID` field to the `ReleasePlanLog` type in `release_plan.go` to store the MongoDB document ID and the reference to the release plan ID ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-d8635583436a02bda02f03d481624721e703adea0d4cf781c09567771344e92aL89-R104))
  * Add a `TableName` method to the `ReleasePlanLog` type to return the collection name `release_plan_log` ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-d8635583436a02bda02f03d481624721e703adea0d4cf781c09567771344e92aL89-R104))
  * Add a new file `release_plan_log.go` to the `mongodb` package, which defines the `ReleasePlanLogColl` type and its methods to create and list the logs by options ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-53a7bfa38cf651e6bde2f8bfb29bf82c845852543d7e4114a982b913bed88bddR1-R96))
  * Modify the `Create` method of the `ReleasePlanColl` type in `release_plan.go` to return the inserted document ID as a string ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-1a311a15ce8e53b0e42903ec48ea2dda5ddcd8d390fdeef511d74729c5bdbe2fL56-R62))
  * Modify the `OpenAPICreateReleasePlan` and `CreateReleasePlan` functions in `openapi.go` and `release_plan.go` to use the new `Create` method of the `ReleasePlanColl` type and a goroutine to create a release plan log with the verb `VerbCreate` ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-f343155bdfde6d5048a343a8a3a25d2ef9dd90fbb0ea5fb6d3612b08b757328bL145-R165), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL89-R109))
  * Modify the `UpdateReleasePlan` function in `release_plan.go` to use the new `Create` method of the `ReleasePlanLogColl` type and a goroutine to create a release plan log with the updated information ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL169-R207))
  * Modify the `ExecuteReleaseJob` function in `release_plan.go` to use the new `Create` method of the `ReleasePlanLogColl` type and a goroutine to create a release plan log with the verb `VerbExecute` and the executed job name ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL193-R224))
  * Modify the `UpdateReleasePlanStatus` function in `release_plan.go` to use the new `Create` method of the `ReleasePlanLogColl` type and a goroutine to create a release plan log with the updated status and detail ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL244-R288))
  * Modify the `ApproveReleasePlan` function in `release_plan.go` to use the new `Create` method of the `ReleasePlanLogColl` type and a goroutine to create a release plan log with the approval status and detail ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL332-R376))
  * Modify the `updatePlanApproval` function in `watcher.go` to use the new `Create` method of the `ReleasePlanLogColl` type and a goroutine to create a release plan log with the approval status and detail ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-f1e929d38a5e72be79b316b01b0c29b86449ed13cafbdce11dee89bf31df0559L152-R170), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-f1e929d38a5e72be79b316b01b0c29b86449ed13cafbdce11dee89bf31df0559R176-R186))
  * Modify the `initDatabase` function in `service.go` to add the `ReleasePlanLogColl` type to the list of collections that need to be initialized and ensured index ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-a74fa9c9aa31979c0e1634097c1a6b3e84ea13e0686ad037178b5d1208e9f9deR456))
  * Remove the code that appended the log to the `Logs` field of the plan in the `ExecuteReleaseJob`, `UpdateReleasePlanStatus`, and `ApproveReleasePlan` functions in `release_plan.go`, and the `updatePlanApproval` function in `watcher.go`, as it is no longer needed ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL229-L236), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL308-R361), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL370-R441), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-f1e929d38a5e72be79b316b01b0c29b86449ed13cafbdce11dee89bf31df0559L152-R170))
  * Comment out the `Logs` field of the `ReleasePlan` type in `release_plan.go`, as it is no longer used ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-d8635583436a02bda02f03d481624721e703adea0d4cf781c09567771344e92aL44-R44))
* Add a new handler function `GetReleasePlanLogs` in `release_plan.go` to handle the HTTP GET request to fetch the release plan logs by ID ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R79-R97))
  * Use the `service.GetReleasePlanLogs` method to get the logs from the database, and return a JSON response with the logs or an error ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R79-R97))
* Add a new route in `router.go` to map the `/:id/logs` path to the `GetReleasePlanLogs` handler function ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-35aa675932bf6312a17e222c3b61023210d89cece6f0e6d895b4c47baf6ad797R29))
  * Allow the client to access the release plan logs API endpoint ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-35aa675932bf6312a17e222c3b61023210d89cece6f0e6d895b4c47baf6ad797R29))
* Add a new function `GetReleasePlanLogs` in `release_plan.go` to get the release plan logs by ID from the database ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cR137-R143))
  * Use the `ListByOptions` method of the `ReleasePlanLogColl` type to query the logs with the ID and a sorting option as the query options ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cR137-R143))
* Modify the `createNativeApproval` function in `approval.go` to use a goroutine to send the email notification asynchronously ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-1e72fc8abccbf7bdcf683fe423313b0c672aa28ccbc609f975d1effc20ff4151L219-R219))
  * Improve the performance and responsiveness of the function ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-1e72fc8abccbf7bdcf683fe423313b0c672aa28ccbc609f975d1effc20ff4151L219-R219))
* Rename the function parameter `id` to `planID` in the `ExecuteReleaseJob`, `UpdateReleasePlanStatus`, and `ApproveReleasePlan` functions in `release_plan.go` for consistency and clarity ([link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL193-R224), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL244-R288), [link](https://github.com/koderover/zadig/pull/3001/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL332-R376))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
