### PR TITLE
remove sync ldap users api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ docker/*.tar.gz
 /main
 
 test/integration/reporters/*.xml
+pkg/cli/upgradeassistant/cmd/migrate/*_test.go

--- a/pkg/microservice/user/core/handler/router.go
+++ b/pkg/microservice/user/core/handler/router.go
@@ -50,8 +50,6 @@ func (*Router) Inject(router *gin.RouterGroup) {
 
 		users.POST("/users/search", user.ListUsers)
 
-		users.POST("/users/ldap/:ldapId", user.SyncLdapUser)
-
 		users.GET("/user/count", user.CountSystemUsers)
 
 		router.GET("login", login.Login)

--- a/pkg/microservice/user/core/handler/user/user.go
+++ b/pkg/microservice/user/core/handler/user/user.go
@@ -28,6 +28,7 @@ import (
 	e "github.com/koderover/zadig/pkg/tool/errors"
 )
 
+// Deprecated
 func SyncLdapUser(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e47ee50</samp>

Removed the route and deprecated the handler for syncing LDAP users in `user` microservice. This is part of a refactoring to use a unified identity service instead of LDAP.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e47ee50</samp>

* Remove the route for syncing LDAP users from the user handlers ([link](https://github.com/koderover/zadig/pull/3002/files?diff=unified&w=0#diff-0b485a7e48d3c2da1434ecf93cdce55b003a19eba7cc0a1e15735c9728cb14c7L53-L54))
* Mark the `SyncLdapUser` function as deprecated and add a comment explaining the reason ([link](https://github.com/koderover/zadig/pull/3002/files?diff=unified&w=0#diff-b1bfca648f9fb3f1f0209f279ec43dd674b84fae5e1420db9bfd74090882271cR31))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
