### PR TITLE
fix init user error when already init it

### DIFF
--- a/pkg/microservice/aslan/core/system/service/initialization.go
+++ b/pkg/microservice/aslan/core/system/service/initialization.go
@@ -82,7 +82,7 @@ func InitializeUser(username, password, company, email string, phone int64, reas
 	}
 
 	if userCountInfo.TotalUser > 0 {
-		return fmt.Errorf("there are users in the system, cannot reinitialize")
+		return nil
 	}
 
 	userInfo, err := user.New().CreateUser(&user.CreateUserArgs{


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9730a0f</samp>

Fix a bug that prevents system initialization when upgrading from an older version with existing users. Modify `InitializeUser` in `initialization.go` to return nil instead of an error if users are found.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9730a0f</samp>

*  Return nil instead of error if there are users in the system to avoid blocking initialization process when upgrading from older version ([link](https://github.com/koderover/zadig/pull/3003/files?diff=unified&w=0#diff-7a9d786e7c5173e3a9d1eade27df592d3ed815e5261c863eeb147bea287e34beL85-R85))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
