### PR TITLE
refactor: release plan workflow execute

### DIFF
--- a/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
@@ -43,10 +43,10 @@ func ListReleasePlans(c *gin.Context) {
 		return
 	}
 
-	//if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.View {
-	//	ctx.UnAuthorized = true
-	//	return
-	//}
+	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.View {
+		ctx.UnAuthorized = true
+		return
+	}
 
 	opt := new(ListReleasePlanOption)
 	if err := c.ShouldBindQuery(&opt); err != nil {
@@ -68,10 +68,10 @@ func GetReleasePlan(c *gin.Context) {
 		return
 	}
 
-	//if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.View {
-	//	ctx.UnAuthorized = true
-	//	return
-	//}
+	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.View {
+		ctx.UnAuthorized = true
+		return
+	}
 
 	ctx.Resp, ctx.Err = service.GetReleasePlan(c.Param("id"))
 }
@@ -87,10 +87,10 @@ func GetReleasePlanLogs(c *gin.Context) {
 		return
 	}
 
-	//if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.View {
-	//	ctx.UnAuthorized = true
-	//	return
-	//}
+	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.View {
+		ctx.UnAuthorized = true
+		return
+	}
 
 	ctx.Resp, ctx.Err = service.GetReleasePlanLogs(c.Param("id"))
 }
@@ -106,10 +106,10 @@ func CreateReleasePlan(c *gin.Context) {
 		return
 	}
 
-	//if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.Create {
-	//	ctx.UnAuthorized = true
-	//	return
-	//}
+	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.Create {
+		ctx.UnAuthorized = true
+		return
+	}
 
 	req := new(models.ReleasePlan)
 	if err := c.ShouldBindJSON(req); err != nil {
@@ -130,10 +130,10 @@ func UpdateReleasePlan(c *gin.Context) {
 		return
 	}
 
-	//if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.Edit {
-	//	ctx.UnAuthorized = true
-	//	return
-	//}
+	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.Edit {
+		ctx.UnAuthorized = true
+		return
+	}
 
 	req := new(service.UpdateReleasePlanArgs)
 	if err := c.ShouldBindJSON(req); err != nil {
@@ -154,10 +154,10 @@ func DeleteReleasePlan(c *gin.Context) {
 		return
 	}
 
-	//if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.Delete {
-	//	ctx.UnAuthorized = true
-	//	return
-	//}
+	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.Delete {
+		ctx.UnAuthorized = true
+		return
+	}
 
 	ctx.Err = service.DeleteReleasePlan(c, ctx.UserName, c.Param("id"))
 }

--- a/pkg/microservice/aslan/core/release_plan/service/errors.go
+++ b/pkg/microservice/aslan/core/release_plan/service/errors.go
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 The KodeRover Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import "github.com/pkg/errors"
+
+var (
+	ErrPermissionDenied = errors.New("permission denied")
+)

--- a/pkg/microservice/aslan/core/release_plan/service/execute.go
+++ b/pkg/microservice/aslan/core/release_plan/service/execute.go
@@ -23,16 +23,20 @@ import (
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/workflow/service/workflow"
+	"github.com/koderover/zadig/pkg/shared/handler"
+	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
+	"github.com/koderover/zadig/pkg/types"
 )
 
 type ReleaseJobExecutor interface {
 	Execute(plan *models.ReleasePlan) error
 }
 
-func NewReleaseJobExecutor(username string, args *ExecuteReleaseJobArgs) (ReleaseJobExecutor, error) {
+func NewReleaseJobExecutor(c *handler.Context, args *ExecuteReleaseJobArgs) (ReleaseJobExecutor, error) {
 	switch config.ReleasePlanJobType(args.Type) {
 	case config.JobText:
-		return NewTextReleaseJobExecutor(username, args)
+		return NewTextReleaseJobExecutor(c.UserName, args)
 	case config.JobWorkflow:
 		return NewWorkflowReleaseJobExecutor(username, args)
 	default:
@@ -50,13 +54,13 @@ type TextReleaseJobSpec struct {
 	Remark string `json:"remark"`
 }
 
-func NewTextReleaseJobExecutor(username string, args *ExecuteReleaseJobArgs) (ReleaseJobExecutor, error) {
+func NewTextReleaseJobExecutor(c *handler.Context, args *ExecuteReleaseJobArgs) (ReleaseJobExecutor, error) {
 	var executor TextReleaseJobExecutor
 	if err := models.IToi(args.Spec, &executor.Spec); err != nil {
 		return nil, errors.Wrap(err, "invalid spec")
 	}
 	executor.ID = args.ID
-	executor.ExecutedBy = username
+	executor.ExecutedBy = c.UserName
 	return &executor, nil
 }
 
@@ -83,22 +87,21 @@ func (e *TextReleaseJobExecutor) Execute(plan *models.ReleasePlan) error {
 }
 
 type WorkflowReleaseJobExecutor struct {
-	ID         string
-	ExecutedBy string
-	Spec       WorkflowReleaseJobSpec
+	ID   string
+	Ctx  *handler.Context
+	Spec WorkflowReleaseJobSpec
 }
 
 type WorkflowReleaseJobSpec struct {
-	TaskID int64 `json:"task_id"`
 }
 
-func NewWorkflowReleaseJobExecutor(username string, args *ExecuteReleaseJobArgs) (ReleaseJobExecutor, error) {
+func NewWorkflowReleaseJobExecutor(c *handler.Context, args *ExecuteReleaseJobArgs) (ReleaseJobExecutor, error) {
 	var executor WorkflowReleaseJobExecutor
 	if err := models.IToi(args.Spec, &executor.Spec); err != nil {
 		return nil, errors.Wrap(err, "invalid spec")
 	}
 	executor.ID = args.ID
-	executor.ExecutedBy = username
+	executor.Ctx = c
 	return &executor, nil
 }
 
@@ -111,15 +114,44 @@ func (e *WorkflowReleaseJobExecutor) Execute(plan *models.ReleasePlan) error {
 		if err := models.IToi(job.Spec, spec); err != nil {
 			return errors.Wrap(err, "invalid spec")
 		}
+		if spec.Workflow == nil {
+			return errors.Errorf("workflow is nil")
+		}
 		// workflow support retry after failed
 		if job.Status != config.ReleasePlanJobStatusTodo && job.Status != config.ReleasePlanJobStatusFailed {
 			return errors.Errorf("job %s status %s can't execute", job.Name, job.Status)
 		}
-		spec.TaskID = e.Spec.TaskID
+		// check workflow execute permission
+		ctx := e.Ctx
+		if !ctx.Resources.IsSystemAdmin {
+			if _, ok := ctx.Resources.ProjectAuthInfo[spec.Workflow.Project]; !ok {
+				return ErrPermissionDenied
+			}
+
+			if !ctx.Resources.ProjectAuthInfo[spec.Workflow.Project].IsProjectAdmin &&
+				!ctx.Resources.ProjectAuthInfo[spec.Workflow.Project].Workflow.Execute {
+				// check if the permission is given by collaboration mode
+				permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, spec.Workflow.Project, types.ResourceTypeWorkflow, spec.Workflow.Name, types.WorkflowActionRun)
+				if err != nil || !permitted {
+					return ErrPermissionDenied
+				}
+			}
+		}
+
+		result, err := workflow.CreateWorkflowTaskV4(&workflow.CreateWorkflowTaskV4Args{
+			Name:    ctx.UserName,
+			Account: ctx.Account,
+			UserID:  ctx.UserID,
+		}, spec.Workflow, ctx.Logger)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create workflow task %s", spec.Workflow.Name)
+		}
+
+		spec.TaskID = result.TaskID
 		spec.Status = config.StatusPrepare
 		job.Spec = spec
 		job.Status = config.ReleasePlanJobStatusRunning
-		job.ExecutedBy = e.ExecutedBy
+		job.ExecutedBy = ctx.UserName
 		job.ExecutedTime = time.Now().Unix()
 		return nil
 	}

--- a/pkg/microservice/aslan/core/release_plan/service/execute.go
+++ b/pkg/microservice/aslan/core/release_plan/service/execute.go
@@ -36,9 +36,9 @@ type ReleaseJobExecutor interface {
 func NewReleaseJobExecutor(c *handler.Context, args *ExecuteReleaseJobArgs) (ReleaseJobExecutor, error) {
 	switch config.ReleasePlanJobType(args.Type) {
 	case config.JobText:
-		return NewTextReleaseJobExecutor(c.UserName, args)
+		return NewTextReleaseJobExecutor(c, args)
 	case config.JobWorkflow:
-		return NewWorkflowReleaseJobExecutor(username, args)
+		return NewWorkflowReleaseJobExecutor(c, args)
 	default:
 		return nil, errors.Errorf("invalid release job type: %s", args.Type)
 	}

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -241,7 +241,12 @@ func ExecuteReleaseJob(c *handler.Context, planID string, args *ExecuteReleaseJo
 		return errors.Errorf("only manager can execute")
 	}
 
-	executor, err := NewReleaseJobExecutor(c, args)
+	executor, err := NewReleaseJobExecutor(&ExecuteReleaseJobContext{
+		AuthResources: c.Resources,
+		UserID:        c.UserID,
+		Account:       c.Account,
+		UserName:      c.UserName,
+	}, args)
 	if err != nil {
 		return errors.Wrap(err, "new release job executor")
 	}

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -241,7 +241,7 @@ func ExecuteReleaseJob(c *handler.Context, planID string, args *ExecuteReleaseJo
 		return errors.Errorf("only manager can execute")
 	}
 
-	executor, err := NewReleaseJobExecutor(c.UserName, args)
+	executor, err := NewReleaseJobExecutor(c, args)
 	if err != nil {
 		return errors.Wrap(err, "new release job executor")
 	}

--- a/pkg/microservice/user/core/service/user/authz.go
+++ b/pkg/microservice/user/core/service/user/authz.go
@@ -490,6 +490,12 @@ func generateDefaultSystemActions() *SystemActions {
 			ViewInsight:       false,
 			EditInsightConfig: false,
 		},
+		ReleasePlan: &ReleasePlanActions{
+			Create: false,
+			View:   false,
+			Edit:   false,
+			Delete: false,
+		},
 	}
 }
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab1aa69</samp>

This pull request refactors the release job executor logic to use a more consistent and informative request context parameter. It also defines a custom error for the release plan service and updates the function call to the release job executor constructor. The affected files are `execute.go`, `errors.go`, and `release_plan.go` in the `service` package.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab1aa69</samp>

*  Add a custom error `ErrPermissionDenied` for the release plan service ([link](https://github.com/koderover/zadig/pull/3005/files?diff=unified&w=0#diff-555b3f1f2956ff6c01ccfdf9c0a9d3883534f0393025ce005fb394de9ec10facR1-R23))
*  Modify the signatures of the release job executor constructors to take a `handler.Context` parameter instead of a `username` string ([link](https://github.com/koderover/zadig/pull/3005/files?diff=unified&w=0#diff-a4fd07f0050e6c59ed00fb0256d4096d1b111e8498d7a2bcb3201f75a24ac43eL32-R39), [link](https://github.com/koderover/zadig/pull/3005/files?diff=unified&w=0#diff-a4fd07f0050e6c59ed00fb0256d4096d1b111e8498d7a2bcb3201f75a24ac43eL53-R57), [link](https://github.com/koderover/zadig/pull/3005/files?diff=unified&w=0#diff-a4fd07f0050e6c59ed00fb0256d4096d1b111e8498d7a2bcb3201f75a24ac43eL59-R63), [link](https://github.com/koderover/zadig/pull/3005/files?diff=unified&w=0#diff-a4fd07f0050e6c59ed00fb0256d4096d1b111e8498d7a2bcb3201f75a24ac43eL101-R104))
*  Modify the definition of the `WorkflowReleaseJobExecutor` struct to have a `Ctx` field of type `handler.Context` and remove the redundant `ExecutedBy` field ([link](https://github.com/koderover/zadig/pull/3005/files?diff=unified&w=0#diff-a4fd07f0050e6c59ed00fb0256d4096d1b111e8498d7a2bcb3201f75a24ac43eL86-R98))
  - Check the permission of the user in the context to execute the workflow release job ([link](https://github.com/koderover/zadig/pull/3005/files?diff=unified&w=0#diff-a4fd07f0050e6c59ed00fb0256d4096d1b111e8498d7a2bcb3201f75a24ac43eL114-R154))
*  Modify the call to the `NewReleaseJobExecutor` function in the `ExecuteReleaseJob` function to pass the `c` parameter of type `handler.Context` ([link](https://github.com/koderover/zadig/pull/3005/files?diff=unified&w=0#diff-39c8c783d7d4f26916cae1e659e1939e06022c9de7ab626771e8af5bf3d4167cL244-R244))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
