### PR TITLE
feat: workflow new var IMAGES

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
@@ -574,6 +574,7 @@ type WorkflowTaskCtx struct {
 	WorkflowTaskCreatorEmail    string
 	WorkflowTaskCreatorMobile   string
 	WorkflowKeyVals             []*KeyVal
+	GlobalContextGetAll         func() map[string]string
 	GlobalContextGet            func(key string) (string, bool)
 	GlobalContextSet            func(key, value string)
 	GlobalContextEach           func(f func(k, v string) bool)

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -103,7 +103,8 @@ func (c *DeployJobCtl) Run(ctx context.Context) {
 
 func (c *DeployJobCtl) preRun() {
 	for _, svc := range c.jobTaskSpec.ServiceAndImages {
-		c.workflowCtx.GlobalContextSet(job.GetJobOutputKey(c.job.Key, IMAGEKEY), svc.Image)
+		// deploy job key is jobName.serviceName
+		c.workflowCtx.GlobalContextSet(job.GetJobOutputKey(c.job.Key+"."+svc.ServiceModule, IMAGEKEY), svc.Image)
 	}
 }
 

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -53,6 +53,7 @@ import (
 	"github.com/koderover/zadig/pkg/tool/kube/getter"
 	"github.com/koderover/zadig/pkg/tool/kube/informer"
 	"github.com/koderover/zadig/pkg/tool/kube/updater"
+	"github.com/koderover/zadig/pkg/types/job"
 )
 
 type DeployJobCtl struct {
@@ -89,6 +90,7 @@ func (c *DeployJobCtl) Clean(ctx context.Context) {}
 func (c *DeployJobCtl) Run(ctx context.Context) {
 	c.job.Status = config.StatusRunning
 	c.ack()
+	c.preRun()
 	if err := c.run(ctx); err != nil {
 		return
 	}
@@ -97,6 +99,12 @@ func (c *DeployJobCtl) Run(ctx context.Context) {
 		return
 	}
 	c.wait(ctx)
+}
+
+func (c *DeployJobCtl) preRun() {
+	for _, svc := range c.jobTaskSpec.ServiceAndImages {
+		c.workflowCtx.GlobalContextSet(job.GetJobOutputKey(c.job.Key, IMAGEKEY), svc.Image)
+	}
 }
 
 func (c *DeployJobCtl) run(ctx context.Context) error {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -102,6 +102,7 @@ func (c *DeployJobCtl) Run(ctx context.Context) {
 }
 
 func (c *DeployJobCtl) preRun() {
+	// set IMAGE job output
 	for _, svc := range c.jobTaskSpec.ServiceAndImages {
 		// deploy job key is jobName.serviceName
 		c.workflowCtx.GlobalContextSet(job.GetJobOutputKey(c.job.Key+"."+svc.ServiceModule, IMAGEKEY), svc.Image)

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
@@ -36,6 +36,7 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/repository"
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/tool/log"
+	"github.com/koderover/zadig/pkg/types/job"
 )
 
 type HelmDeployJobCtl struct {
@@ -69,6 +70,10 @@ func (c *HelmDeployJobCtl) Clean(ctx context.Context) {}
 func (c *HelmDeployJobCtl) Run(ctx context.Context) {
 	c.job.Status = config.StatusRunning
 	c.ack()
+
+	for _, svc := range c.jobTaskSpec.ImageAndModules {
+		c.workflowCtx.GlobalContextSet(job.GetJobOutputKey(c.job.Key, IMAGEKEY), svc.Image)
+	}
 
 	productInfo, err := commonrepo.NewProductColl().Find(&commonrepo.ProductFindOptions{
 		Name:    c.workflowCtx.ProjectName,

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
@@ -71,7 +71,9 @@ func (c *HelmDeployJobCtl) Run(ctx context.Context) {
 	c.job.Status = config.StatusRunning
 	c.ack()
 
+	// set IMAGE job output
 	for _, svc := range c.jobTaskSpec.ImageAndModules {
+		// helm deploy job key is jobName.serviceName
 		c.workflowCtx.GlobalContextSet(job.GetJobOutputKey(c.job.Key+"."+svc.ServiceModule, IMAGEKEY), svc.Image)
 	}
 

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
@@ -72,7 +72,7 @@ func (c *HelmDeployJobCtl) Run(ctx context.Context) {
 	c.ack()
 
 	for _, svc := range c.jobTaskSpec.ImageAndModules {
-		c.workflowCtx.GlobalContextSet(job.GetJobOutputKey(c.job.Key, IMAGEKEY), svc.Image)
+		c.workflowCtx.GlobalContextSet(job.GetJobOutputKey(c.job.Key+"."+svc.ServiceModule, IMAGEKEY), svc.Image)
 	}
 
 	productInfo, err := commonrepo.NewProductColl().Find(&commonrepo.ProductFindOptions{

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/stage.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/stage.go
@@ -63,6 +63,7 @@ func runStage(ctx context.Context, stage *commonmodels.StageTask, workflowCtx *c
 	stageCtl := NewCustomStageCtl(stage, workflowCtx, logger, ack)
 
 	stageCtl.Run(ctx, concurrency)
+	stageCtl.AfterRun()
 }
 
 func RunStages(ctx context.Context, stages []*commonmodels.StageTask, workflowCtx *commonmodels.WorkflowTaskCtx, concurrency int, logger *zap.SugaredLogger, ack func()) {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/stage_custom.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/stage_custom.go
@@ -30,7 +30,7 @@ import (
 	"github.com/koderover/zadig/pkg/tool/log"
 )
 
-var reg = regexp.MustCompile(`{{\.job\.([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)\.IMAGES}}`)
+var reg = regexp.MustCompile(`{{\.job\.([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)\.output\.IMAGE}}`)
 
 type CustomStageCtl struct {
 	stage       *commonmodels.StageTask

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/stage_custom.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/stage_custom.go
@@ -18,12 +18,15 @@ package workflowcontroller
 
 import (
 	"context"
+	"regexp"
 
 	"go.uber.org/zap"
 
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller"
 )
+
+var reg = regexp.MustCompile()
 
 type CustomStageCtl struct {
 	stage       *commonmodels.StageTask
@@ -52,4 +55,11 @@ func (c *CustomStageCtl) Run(ctx context.Context, concurrency int) {
 
 	}
 	jobcontroller.RunJobs(ctx, c.stage.Jobs, c.workflowCtx, workerConcurrency, c.logger, c.ack)
+}
+
+func (c *CustomStageCtl) AfterRun() {
+	// set IMAGES workflow variable
+	// set after a stage has been done for build and some other type job maybe split to many job tasks in one stage
+
+	c.workflowCtx.GlobalContextGetAll
 }

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/stage_custom.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/stage_custom.go
@@ -18,7 +18,6 @@ package workflowcontroller
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -27,7 +26,6 @@ import (
 
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller"
-	"github.com/koderover/zadig/pkg/tool/log"
 )
 
 var reg = regexp.MustCompile(`{{\.job\.([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)\.output\.IMAGE}}`)
@@ -65,10 +63,7 @@ func (c *CustomStageCtl) AfterRun() {
 	// set IMAGES workflow variable
 	// set after a stage has been done for build and some other type job maybe split to many job tasks in one stage
 	// after stage run, concurrent competition of workflowCtx.GlobalContext is not exist
-
-	//TODO DEBUG
-	b, _ := json.MarshalIndent(c.workflowCtx.GlobalContextGetAll(), "", "  ")
-	log.Debugf("workflow context: %s", string(b))
+	
 	jobImages := map[string][]string{}
 	for k, v := range c.workflowCtx.GlobalContextGetAll() {
 		list := reg.FindStringSubmatch(k)

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
@@ -154,6 +154,7 @@ func (c *workflowCtl) Run(ctx context.Context, concurrency int) {
 		DockerMountDir:              fmt.Sprintf("/tmp/%s/docker/%d", uuid.NewString(), time.Now().Unix()),
 		ConfigMapMountDir:           fmt.Sprintf("/tmp/%s/cm/%d", uuid.NewString(), time.Now().Unix()),
 		WorkflowKeyVals:             c.workflowTask.KeyVals,
+		GlobalContextGetAll:         c.getGlobalContextAll,
 		GlobalContextGet:            c.getGlobalContext,
 		GlobalContextSet:            c.setGlobalContext,
 		GlobalContextEach:           c.globalContextEach,
@@ -314,6 +315,17 @@ func (c *workflowCtl) addCluterID(clusterID string) {
 const (
 	split = "@?"
 )
+
+func (c *workflowCtl) getGlobalContextAll() map[string]string {
+	c.globalContextMutex.RLock()
+	defer c.globalContextMutex.RUnlock()
+	res := make(map[string]string, len(c.workflowTask.GlobalContext))
+	for k, v := range c.workflowTask.GlobalContext {
+		k = strings.Join(strings.Split(k, split), ".")
+		res[k] = v
+	}
+	return res
+}
 
 func (c *workflowCtl) getGlobalContext(key string) (string, bool) {
 	c.globalContextMutex.RLock()

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -1894,6 +1894,9 @@ func getDefaultVars(workflow *commonmodels.WorkflowV4, currentJobName string) []
 				}
 			case config.JobZadigDeploy:
 				vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, strings.Join([]string{"job", j.Name, "envName"}, ".")))
+				vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, strings.Join([]string{"job", j.Name, "IMAGES"}, ".")))
+			case config.JobZadigDistributeImage:
+				vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, strings.Join([]string{"job", j.Name, "IMAGES"}, ".")))
 			}
 		}
 	}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -1887,6 +1887,7 @@ func getDefaultVars(workflow *commonmodels.WorkflowV4, currentJobName string) []
 				}
 				vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, strings.Join([]string{"job", j.Name, "SERVICES"}, ".")))
 				vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, strings.Join([]string{"job", j.Name, "BRANCHES"}, ".")))
+				vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, strings.Join([]string{"job", j.Name, "IMAGES"}, ".")))
 				for _, s := range spec.ServiceAndBuilds {
 					vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, strings.Join([]string{"job", j.Name, s.ServiceName, s.ServiceModule, "COMMITID"}, ".")))
 					vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, strings.Join([]string{"job", j.Name, s.ServiceName, s.ServiceModule, "BRANCH"}, ".")))


### PR DESCRIPTION
Signed-off-by: M-Cosmosss <yuzhou@koderover.com>### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6d953b9</samp>

This pull request adds support for setting and getting image variables in the global context of a workflow task. It defines a new field and a new method for the `WorkflowTaskCtx` type, implements the `AfterRun` method for the `CustomStageCtl` type, and updates the workflow controller and service logic to handle the image variables.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6d953b9</samp>

*  Add a new field `GlobalContextGetAll` to the `WorkflowTaskCtx` type, which is a function that returns a map of all the global context variables in a workflow task ([link](https://github.com/koderover/zadig/pull/3012/files?diff=unified&w=0#diff-69e2835c88c5841280acae74f5c8d6536bd68d1de912139d98cd6dd4e525d77eR577))
* Implement the `AfterRun` method for the `CustomStageCtl` type, which sets the image variables in the global context based on the output of the build jobs in the stage ([link](https://github.com/koderover/zadig/pull/3012/files?diff=unified&w=0#diff-305171c94b24f244b625d531f7314a71e2bf82d69764542ad98b36a7fa61d6b9R63-R82))
* Call the `AfterRun` method of the `stageCtl` interface after running a stage in a workflow ([link](https://github.com/koderover/zadig/pull/3012/files?diff=unified&w=0#diff-ed3de18af5a3a6cbfe7411a1e7548590101bb3e75d11f07b49d066e5ed6070b0R66))
* Assign the `getGlobalContextAll` function to the `GlobalContextGetAll` field of the `workflowCtx` variable, which is an instance of the `WorkflowTaskCtx` type ([link](https://github.com/koderover/zadig/pull/3012/files?diff=unified&w=0#diff-a4a438c2d42ac182c17f19f65f29b3b7651be53dc88554da295d0d735c5840e8R157))
* Define the `getGlobalContextAll` function for the `workflowCtl` type, which returns a copy of the global context map in the workflow task ([link](https://github.com/koderover/zadig/pull/3012/files?diff=unified&w=0#diff-a4a438c2d42ac182c17f19f65f29b3b7651be53dc88554da295d0d735c5840e8R319-R329))
* Append the image variable template to the `vars` slice, which is a list of default variables that are available in a workflow task ([link](https://github.com/koderover/zadig/pull/3012/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R1890))
* Import some packages that are used by the `CustomStageCtl` type, such as `encoding/json`, `fmt`, `regexp`, and `strings` ([link](https://github.com/koderover/zadig/pull/3012/files?diff=unified&w=0#diff-305171c94b24f244b625d531f7314a71e2bf82d69764542ad98b36a7fa61d6b9R21-R24))
* Declare a global variable `reg` that is a regular expression to match the image variables in the global context, such as `{{.job.build.IMAGES}}` ([link](https://github.com/koderover/zadig/pull/3012/files?diff=unified&w=0#diff-305171c94b24f244b625d531f7314a71e2bf82d69764542ad98b36a7fa61d6b9L26-R34))
* Replace the `split` constant with a dot in the keys of the global context map, since the `split` constant is a slash that is used to escape the dot in the database ([link](https://github.com/koderover/zadig/pull/3012/files?diff=unified&w=0#diff-a4a438c2d42ac182c17f19f65f29b3b7651be53dc88554da295d0d735c5840e8R319-R329))
* Add a log package import and a log statement for debugging purposes in `pkg/microservice/aslan/core/common/service/workflowcontroller/stage_custom.go` ([link](https://github.com/koderover/zadig/pull/3012/files?diff=unified&w=0#diff-305171c94b24f244b625d531f7314a71e2bf82d69764542ad98b36a7fa61d6b9L26-R34))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
