### PR TITLE
fix reponame_org vars

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
@@ -418,6 +418,8 @@ func getReposVariables(repos []*types.Repository) []*commonmodels.KeyVal {
 			ret = append(ret, &commonmodels.KeyVal{Key: fmt.Sprintf("%s_PR", repoName), Value: strconv.Itoa(repo.PR), IsCredential: false})
 		}
 
+		ret = append(ret, &commonmodels.KeyVal{Key: fmt.Sprintf("%s_ORG", repoName), Value: repo.RepoOwner, IsCredential: false})
+
 		if len(repo.PRs) > 0 {
 			prStrs := []string{}
 			for _, pr := range repo.PRs {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_build.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_build.go
@@ -489,9 +489,6 @@ func getBuildJobVariables(build *commonmodels.ServiceAndBuild, taskID int64, pro
 	buildURL := fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d", configbase.SystemAddress(), project, workflowName, taskID)
 	ret = append(ret, &commonmodels.KeyVal{Key: "BUILD_URL", Value: buildURL, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "PKG_FILE", Value: build.Package, IsCredential: false})
-	for _, repo := range build.Repos {
-		ret = append(ret, &commonmodels.KeyVal{Key: strings.ReplaceAll(repo.RepoName, "-", "_") + "_ORG", Value: strings.ReplaceAll(repo.RepoOwner, "-", "_"), IsCredential: false})
-	}
 	return ret
 }
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_freestyle.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_freestyle.go
@@ -311,9 +311,6 @@ func getfreestyleJobVariables(steps []*commonmodels.StepTask, taskID int64, proj
 		repos = append(repos, stepSpec.Repos...)
 	}
 	ret = append(ret, getReposVariables(repos)...)
-	for _, repo := range repos {
-		ret = append(ret, &commonmodels.KeyVal{Key: repo.RepoName + "_ORG", Value: repo.RepoOwner, IsCredential: false})
-	}
 	ret = append(ret, &commonmodels.KeyVal{Key: "PROJECT", Value: project, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "TASK_ID", Value: fmt.Sprintf("%d", taskID), IsCredential: false})
 	buildURL := fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d", configbase.SystemAddress(), project, workflowName, taskID)


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cb5d6a8</samp>

Remove redundant loops that create repository-related variables for build and freestyle jobs. Add a new variable for the repository owner to the `getReposVariables` function.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cb5d6a8</samp>

*  Add new environment variables for repository owners ([repo_name]_ORG) to the `getReposVariables` function ([link](https://github.com/koderover/zadig/pull/3013/files?diff=unified&w=0#diff-cd667032e3bf01aed408f869322d63aed342d028916369c057cf2a090257e6a4R421-R422)) in `job.go`

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
