### PR TITLE
add debug log

### DIFF
--- a/pkg/microservice/jobexecutor/core/service/step/step_git.go
+++ b/pkg/microservice/jobexecutor/core/service/step/step_git.go
@@ -255,7 +255,10 @@ func (s *GitStep) buildGitCommands(repo *types.Repository, hostNames sets.String
 	} else if repo.Source == types.ProviderGitee || repo.Source == types.ProviderGiteeEE {
 		cmds = append(cmds, &c.Command{Cmd: c.RemoteAdd(repo.RemoteName, HTTPSCloneURL(repo.Source, repo.OauthToken, repo.RepoOwner, repo.RepoName, repo.Address)), DisableTrace: true})
 	} else if repo.Source == types.ProviderOther {
+		log.Infof("1")
+		log.Infof("auth type is %s", repo.AuthType)
 		if repo.AuthType == types.SSHAuthType {
+			log.Infof("2")
 			host := getHost(repo.Address)
 			if !hostNames.Has(host) {
 				if err := writeSSHFile(repo.SSHKey, host); err != nil {
@@ -268,20 +271,24 @@ func (s *GitStep) buildGitCommands(repo *types.Repository, hostNames sets.String
 			if strings.Contains(repo.Address, ":") {
 				remoteName = fmt.Sprintf("%s/%s/%s.git", repo.Address, repo.RepoOwner, repo.RepoName)
 			}
+			log.Infof("5")
 			cmds = append(cmds, &c.Command{
 				Cmd:          c.RemoteAdd(repo.RemoteName, remoteName),
 				DisableTrace: true,
 			})
 		} else if repo.AuthType == types.PrivateAccessTokenAuthType {
+			log.Infof("3")
 			u, err := url.Parse(repo.Address)
 			if err != nil {
 				log.Errorf("failed to parse url,err:%s", err)
 			} else {
+				log.Infof("4")
 				host := strings.TrimSuffix(strings.Join([]string{u.Host, u.Path}, "/"), "/")
 				cmds = append(cmds, &c.Command{
 					Cmd:          c.RemoteAdd(repo.RemoteName, OAuthCloneURL(repo.Source, repo.PrivateAccessToken, host, repo.RepoOwner, repo.RepoName, u.Scheme)),
 					DisableTrace: true,
 				})
+				log.Infof("1 cmds: %+v", cmds)
 			}
 		}
 	} else {

--- a/pkg/microservice/reaper/core/service/reaper/git.go
+++ b/pkg/microservice/reaper/core/service/reaper/git.go
@@ -253,6 +253,7 @@ func (r *Reaper) buildGitCommands(repo *meta.Repo, hostNames sets.String) []*c.C
 					Cmd:          c.RemoteAdd(repo.RemoteName, r.Ctx.Git.OAuthCloneURL(repo.Source, repo.PrivateAccessToken, host, repo.Owner, repo.Name, u.Scheme)),
 					DisableTrace: true,
 				})
+				log.Infof("2 cmds: %+v", cmds)
 			}
 		}
 	} else {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ede3e2</samp>

Add debug log statements to print the git commands in the `jobexecutor` and `reaper` services. This helps to troubleshoot any issues with the git operations in these services.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4ede3e2</samp>

*  Add debug log statements to print the git commands generated by the `buildGitCommands` function in the job executor and reaper services ([link](https://github.com/koderover/zadig/pull/3015/files?diff=unified&w=0#diff-7856a64839d3a12d7f56dcb54ff0a9c37bb64251829b52bfb5bbf67818e8456bR285), [link](https://github.com/koderover/zadig/pull/3015/files?diff=unified&w=0#diff-e4b038c35a5a2f19eebd8b54d3163d9168058bb720da2b97903c8d7e279df50fR256))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
