### PR TITLE
remove environmnet creating wait stage

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/k8s.go
+++ b/pkg/microservice/aslan/core/environment/service/k8s.go
@@ -566,15 +566,15 @@ func (k *K8sService) createGroup(username string, product *commonmodels.Product,
 		return err
 	}
 
-	if err := waitResourceRunning(kubeClient, prod.Namespace, resources, config.ServiceStartTimeout(), k.log); err != nil {
-		k.log.Errorf(
-			"service group %s/%+v doesn't start in %d seconds: %v",
-			prod.Namespace,
-			updatableServiceNameList, config.ServiceStartTimeout(), err)
-
-		err = e.ErrUpdateEnv.AddErr(
-			fmt.Errorf(e.StartPodTimeout+"\n %s", "["+strings.Join(updatableServiceNameList, "], [")+"]"))
-		return err
-	}
+	//if err := waitResourceRunning(kubeClient, prod.Namespace, resources, config.ServiceStartTimeout(), k.log); err != nil {
+	//	k.log.Errorf(
+	//		"service group %s/%+v doesn't start in %d seconds: %v",
+	//		prod.Namespace,
+	//		updatableServiceNameList, config.ServiceStartTimeout(), err)
+	//
+	//	err = e.ErrUpdateEnv.AddErr(
+	//		fmt.Errorf(e.StartPodTimeout+"\n %s", "["+strings.Join(updatableServiceNameList, "], [")+"]"))
+	//	return err
+	//}
 	return nil
 }

--- a/pkg/microservice/aslan/core/environment/service/k8s.go
+++ b/pkg/microservice/aslan/core/environment/service/k8s.go
@@ -561,20 +561,5 @@ func (k *K8sService) createGroup(username string, product *commonmodels.Product,
 	}
 	wg.Wait()
 
-	// 如果创建依赖服务组有返回错误, 停止等待
-	if err := errList.ErrorOrNil(); err != nil {
-		return err
-	}
-
-	//if err := waitResourceRunning(kubeClient, prod.Namespace, resources, config.ServiceStartTimeout(), k.log); err != nil {
-	//	k.log.Errorf(
-	//		"service group %s/%+v doesn't start in %d seconds: %v",
-	//		prod.Namespace,
-	//		updatableServiceNameList, config.ServiceStartTimeout(), err)
-	//
-	//	err = e.ErrUpdateEnv.AddErr(
-	//		fmt.Errorf(e.StartPodTimeout+"\n %s", "["+strings.Join(updatableServiceNameList, "], [")+"]"))
-	//	return err
-	//}
-	return nil
+	return errList.ErrorOrNil()
 }


### PR DESCRIPTION
### What this PR does / Why we need it:
remove resource wait stage when creating env

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d9ab95e</samp>

*  Comment out code that waits for resources to be running after creating a service group ([link](https://github.com/koderover/zadig/pull/3016/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136L569-R578)). This is to avoid timeout errors in the update environment operation, which is triggered by the user or by the CI/CD pipeline. The user can check the status of the resources manually. The code is in `k8s.go`, which handles the logic of interacting with Kubernetes clusters for environment management.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
