### PR TITLE
fix dup key for configuration management

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/configuration_management.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/configuration_management.go
@@ -26,7 +26,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
@@ -53,15 +52,8 @@ func (c *ConfigurationManagementColl) GetCollectionName() string {
 }
 
 func (c *ConfigurationManagementColl) EnsureIndex(ctx context.Context) error {
-	mod := mongo.IndexModel{
-		Keys: bson.D{
-			bson.E{Key: "server_address", Value: 1},
-		},
-		Options: options.Index().SetUnique(true),
-	}
-
-	_, err := c.Indexes().CreateOne(ctx, mod)
-	return err
+	_, _ = c.Indexes().DropOne(ctx, "server_address_1")
+	return nil
 }
 
 func (c *ConfigurationManagementColl) Create(ctx context.Context, args *models.ConfigurationManagement) error {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bcf2f2b</samp>

Improved configuration management by removing unused dependency and fixing index logic. This avoids service duplication when switching servers.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bcf2f2b</samp>

*  Drop existing index on `server_address` field to avoid duplicates in configuration management collection ([link](https://github.com/koderover/zadig/pull/3018/files?diff=unified&w=0#diff-1210241e09f116a6e9189e41868a0ca8dd2551a2863e41d32960685359b08c7bL56-R55))
* Remove unused `options` package from mongo driver import ([link](https://github.com/koderover/zadig/pull/3018/files?diff=unified&w=0#diff-1210241e09f116a6e9189e41868a0ca8dd2551a2863e41d32960685359b08c7bL29))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
