### PR TITLE
fix local cluster dost not have default schedule strategy

### DIFF
--- a/pkg/microservice/aslan/core/multicluster/service/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/service/clusters.go
@@ -341,11 +341,11 @@ func CreateCluster(args *K8SCluster, logger *zap.SugaredLogger) (*commonmodels.K
 		}
 		// init local cluster
 	} else {
-		args.AdvancedConfig = &AdvancedConfig{
+		advancedConfig = &commonmodels.AdvancedConfig{
 			ClusterAccessYaml: kube.ClusterAccessYamlTemplate,
 			ScheduleWorkflow:  true,
 			Strategy:          setting.NormalSchedule,
-			ScheduleStrategy: []*ScheduleStrategy{
+			ScheduleStrategy: []*commonmodels.ScheduleStrategy{
 				{
 					StrategyID:   primitive.NewObjectID().Hex(),
 					StrategyName: setting.NormalScheduleName,


### PR DESCRIPTION
### What this PR does / Why we need it:
fix local cluster dost not have default schedule strategy.

### What is changed and how it works?
fix local cluster dost not have default schedule strategy.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [x] fix of a previous issue
