### PR TITLE
fix user init error

### DIFF
--- a/pkg/microservice/user/core/service/permission/authz.go
+++ b/pkg/microservice/user/core/service/permission/authz.go
@@ -447,8 +447,8 @@ func ListAuthorizedEnvs(uid, projectKey string, logger *zap.SugaredLogger) (read
 	editEnvSet := sets.NewString()
 	collaborationInstance, findErr := mongodb.NewCollaborationInstanceColl().FindInstance(uid, projectKey)
 	if findErr != nil {
-		logger.Errorf("failed to find user collaboration mode, error: %s", err)
-		err = fmt.Errorf("failed to find user collaboration mode, error: %s", err)
+		logger.Errorf("failed to find user collaboration mode, error: %s", findErr)
+		err = fmt.Errorf("failed to find user collaboration mode, error: %s", findErr)
 		return
 	}
 


### PR DESCRIPTION
### What this PR does / Why we need it:
fix user init error

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 36fa479</samp>

*  Add rollback statements to `syncUserRoleBinding` function to ensure data consistency and avoid partial updates in case of errors or panics ([link](https://github.com/koderover/zadig/pull/3028/files?diff=unified&w=0#diff-4677fe67ba966b984c329b4373dabd6094a92e5ed33568cd17502eb7f3c4be04R195), [link](https://github.com/koderover/zadig/pull/3028/files?diff=unified&w=0#diff-4677fe67ba966b984c329b4373dabd6094a92e5ed33568cd17502eb7f3c4be04L238-R241), [link](https://github.com/koderover/zadig/pull/3028/files?diff=unified&w=0#diff-4677fe67ba966b984c329b4373dabd6094a92e5ed33568cd17502eb7f3c4be04R416))
*  Add commit statements to `syncUserRoleBinding` function to ensure transaction closure and data persistence in case of success or no documents found ([link](https://github.com/koderover/zadig/pull/3028/files?diff=unified&w=0#diff-4677fe67ba966b984c329b4373dabd6094a92e5ed33568cd17502eb7f3c4be04L211), [link](https://github.com/koderover/zadig/pull/3028/files?diff=unified&w=0#diff-4677fe67ba966b984c329b4373dabd6094a92e5ed33568cd17502eb7f3c4be04R374))
*  Fix bug in `ListAuthorizedEnvs` function to use correct error variable when finding user collaboration mode ([link](https://github.com/koderover/zadig/pull/3028/files?diff=unified&w=0#diff-8e32d843dd52fe5dde42205189fd63aa1109feaf06a035ef6f1aae9c9da86376L450-R451))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
