### PR TITLE
fix user init error

### DIFF
--- a/pkg/microservice/user/core/service.go
+++ b/pkg/microservice/user/core/service.go
@@ -233,14 +233,9 @@ func syncUserRoleBinding() {
 	// 2. read-only
 	// 3. read-project-only
 	projectList, err := mongodb.NewProjectColl().List()
-	if err != nil {
-		if err != mongo.ErrNoDocuments {
-			tx.Rollback()
-			log.Panicf("Failed to get project list to create project default role, error: %s", err)
-		} else {
-			tx.Commit()
-			return
-		}
+	if err != nil && err != mongo.ErrNoDocuments {
+		tx.Rollback()
+		log.Panicf("Failed to get project list to create project default role, error: %s", err)
 	}
 
 	for _, project := range projectList {
@@ -366,14 +361,9 @@ RoleLoop:
 
 	// after syncing all the roles into the database, sync the user-role binding into the mysql table and we are done
 	rbList, err := mongodb.NewRoleBindingColl().List()
-	if err != nil {
-		if err != mongo.ErrNoDocuments {
-			tx.Rollback()
-			log.Panicf("failed to find role bindings to sync, error: %s", err)
-		} else {
-			tx.Commit()
-			return
-		}
+	if err != nil && err != mongo.ErrNoDocuments {
+		tx.Rollback()
+		log.Panicf("failed to find role bindings to sync, error: %s", err)
 	}
 
 	userRBmap := make(map[string][]uint)

--- a/pkg/microservice/user/core/service.go
+++ b/pkg/microservice/user/core/service.go
@@ -191,7 +191,7 @@ func syncUserRoleBinding() {
 
 	// if there are no role presented in the roles table, it means that the move all the roles and corresponding role binding into mysql
 	allRoles, err := mongodb.NewRoleColl().List()
-	log.Infof("find all roles count: %v, err: %v", len(allRoles), err)
+	log.Infof("find all roles count: %v, err: %+v", len(allRoles), err)
 	if err != nil && err != mongo.ErrNoDocuments {
 		tx.Rollback()
 		log.Panicf("failed to list all roles from previous system, error: %s", err)
@@ -240,7 +240,7 @@ func syncUserRoleBinding() {
 		log.Panicf("Failed to get project list to create project default role, error: %s", err)
 	}
 
-	log.Infof("projectList count: %v, err: %s", len(projectList), err)
+	log.Infof("projectList count: %v, err: %+v", len(projectList), err)
 
 	for _, project := range projectList {
 		projectAdminRole := &models.NewRole{

--- a/pkg/microservice/user/core/service.go
+++ b/pkg/microservice/user/core/service.go
@@ -174,6 +174,7 @@ func initializeSystemActions() {
 // this action will only be performed once regardless of the version, the execution condition is there are no roles in mysql table
 // since this could be a lengthy procedure, the helm installation process need to be modified.
 func syncUserRoleBinding() {
+	log.Infof("start sync user role binding")
 	// check if the mysql Role exists
 	var roleCount int64
 	err := repository.DB.Table("role").Count(&roleCount).Error
@@ -190,6 +191,7 @@ func syncUserRoleBinding() {
 
 	// if there are no role presented in the roles table, it means that the move all the roles and corresponding role binding into mysql
 	allRoles, err := mongodb.NewRoleColl().List()
+	log.Infof("find all roles count: %v, err: %v", len(allRoles), err)
 	if err != nil {
 		if err != mongo.ErrNoDocuments {
 			tx.Rollback()
@@ -237,6 +239,8 @@ func syncUserRoleBinding() {
 		tx.Rollback()
 		log.Panicf("Failed to get project list to create project default role, error: %s", err)
 	}
+
+	log.Infof("projectList count: %v, err: %s", len(projectList), err)
 
 	for _, project := range projectList {
 		projectAdminRole := &models.NewRole{
@@ -359,6 +363,7 @@ RoleLoop:
 		}
 	}
 
+	log.Infof("start handling rolebindings")
 	// after syncing all the roles into the database, sync the user-role binding into the mysql table and we are done
 	rbList, err := mongodb.NewRoleBindingColl().List()
 	if err != nil && err != mongo.ErrNoDocuments {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba09186</samp>

Refactor error handling in `syncUserRoleBinding` and `core` functions in `service.go`. Simplify code and handle `mongo.ErrNoDocuments` error consistently.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ba09186</samp>

*  Simplify error handling logic in `syncUserRoleBinding` function by combining two conditions for `mongo.ErrNoDocuments` into one and only rolling back and panicking on other errors ([link](https://github.com/koderover/zadig/pull/3029/files?diff=unified&w=0#diff-4677fe67ba966b984c329b4373dabd6094a92e5ed33568cd17502eb7f3c4be04L236-R238))
* Apply the same simplification to `rbList` variable in `core` package and avoid unnecessary checks for `mongo.ErrNoDocuments` ([link](https://github.com/koderover/zadig/pull/3029/files?diff=unified&w=0#diff-4677fe67ba966b984c329b4373dabd6094a92e5ed33568cd17502eb7f3c4be04L369-R366))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
