### PR TITLE
debug logs and bugfix

### DIFF
--- a/pkg/microservice/user/core/service/permission/authz.go
+++ b/pkg/microservice/user/core/service/permission/authz.go
@@ -97,7 +97,6 @@ func GetUserAuthInfo(uid string, logger *zap.SugaredLogger) (*AuthorizedResource
 
 		// project admin does not have any bindings, it is special
 		if role.Name == ProjectAdminRole {
-			logger.Infof("adding project admin role for project key: %s", role.Namespace)
 			projectActionMap[role.Namespace].IsProjectAdmin = true
 			continue
 		}

--- a/pkg/shared/handler/base.go
+++ b/pkg/shared/handler/base.go
@@ -108,9 +108,6 @@ func NewContextWithAuthorization(c *gin.Context) (*Context, error) {
 		logger.Errorf("failed to generate user authorization info, error: %s", err)
 		return resp, err
 	}
-	for projectKey, authInfo := range resourceAuthInfo.ProjectAuthInfo {
-		fmt.Printf(">>>>>>>>>>>>>>>>>>>>> project key: [%s], is project admin: [%+v] <<<<<<<<<<<<<<<<<<<<<<<\n", projectKey, authInfo.IsProjectAdmin)
-	}
 	resp.Resources = resourceAuthInfo
 	return resp, nil
 }


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0c0429d</samp>

This pull request adds logging and tracing statements to the `permission` and `handler` packages to improve the visibility of the user's authorization information. It also fixes a bug in the `permission` service that omitted the `all-user` group from the user's permissions.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0c0429d</samp>

*  Add logging statements to print the user's authorization information for projects ([link](https://github.com/koderover/zadig/pull/3032/files?diff=unified&w=0#diff-8e32d843dd52fe5dde42205189fd63aa1109feaf06a035ef6f1aae9c9da86376R100), [link](https://github.com/koderover/zadig/pull/3032/files?diff=unified&w=0#diff-fb515ec11a52b9b6ce8d6ff668438063ed51e699393bd5e01350e358d5b274a7R111-R113))
* Include the `all-user` group ID in the user's permission query for projects ([link](https://github.com/koderover/zadig/pull/3032/files?diff=unified&w=0#diff-137dd3f09b86b1c75917d907ed4cacd8749162d4aa3c3d6e724236efc5497e94R67-R68))
* Remove an empty line from the `handler` package ([link](https://github.com/koderover/zadig/pull/3032/files?diff=unified&w=0#diff-0f8a8ee855a0910d9a79938a5d3fe54e784aa806d54f11d14dcc7ec3968f32b2L204))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
