### PR TITLE
feat: add gitURLs workflow variable

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
@@ -512,15 +512,21 @@ func getWorkflowStageParams(workflow *commonmodels.WorkflowV4, taskID int64, cre
 				if err := commonmodels.IToi(job.Spec, build); err != nil {
 					return nil, errors.Wrap(err, "Itoi")
 				}
-				var serviceAndModuleName, branchList []string
+				var serviceAndModuleName, branchList, gitURLs []string
 				for _, serviceAndBuild := range build.ServiceAndBuilds {
 					serviceAndModuleName = append(serviceAndModuleName, serviceAndBuild.ServiceModule+"/"+serviceAndBuild.ServiceName)
-					branch, commitID := "", ""
+					branch, commitID, gitURL := "", "", ""
 					if len(serviceAndBuild.Repos) > 0 {
 						branch = serviceAndBuild.Repos[0].Branch
 						commitID = serviceAndBuild.Repos[0].CommitID
+						if serviceAndBuild.Repos[0].AuthType == types.SSHAuthType {
+							gitURL = fmt.Sprintf("%s:%s/%s", serviceAndBuild.Repos[0].Address, serviceAndBuild.Repos[0].RepoOwner, serviceAndBuild.Repos[0].RepoName)
+						} else {
+							gitURL = fmt.Sprintf("%s/%s/%s", serviceAndBuild.Repos[0].Address, serviceAndBuild.Repos[0].RepoOwner, serviceAndBuild.Repos[0].RepoName)
+						}
 					}
 					branchList = append(branchList, branch)
+					gitURLs = append(gitURLs, gitURL)
 					resp = append(resp, &commonmodels.Param{Name: fmt.Sprintf("job.%s.%s.%s.BRANCH",
 						job.Name, serviceAndBuild.ServiceName, serviceAndBuild.ServiceModule),
 						Value: branch, ParamsType: "string", IsCredential: false})
@@ -530,6 +536,7 @@ func getWorkflowStageParams(workflow *commonmodels.WorkflowV4, taskID int64, cre
 				}
 				resp = append(resp, &commonmodels.Param{Name: fmt.Sprintf("job.%s.SERVICES", job.Name), Value: strings.Join(serviceAndModuleName, ","), ParamsType: "string", IsCredential: false})
 				resp = append(resp, &commonmodels.Param{Name: fmt.Sprintf("job.%s.BRANCHES", job.Name), Value: strings.Join(branchList, ","), ParamsType: "string", IsCredential: false})
+				resp = append(resp, &commonmodels.Param{Name: fmt.Sprintf("job.%s.GITURLS", job.Name), Value: strings.Join(gitURLs, ","), ParamsType: "string", IsCredential: false})
 			case config.JobZadigDeploy:
 				deploy := new(commonmodels.ZadigDeployJobSpec)
 				if err := commonmodels.IToi(job.Spec, deploy); err != nil {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -1888,6 +1888,7 @@ func getDefaultVars(workflow *commonmodels.WorkflowV4, currentJobName string) []
 				vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, strings.Join([]string{"job", j.Name, "SERVICES"}, ".")))
 				vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, strings.Join([]string{"job", j.Name, "BRANCHES"}, ".")))
 				vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, strings.Join([]string{"job", j.Name, "IMAGES"}, ".")))
+				vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, strings.Join([]string{"job", j.Name, "GITURLS"}, ".")))
 				for _, s := range spec.ServiceAndBuilds {
 					vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, strings.Join([]string{"job", j.Name, s.ServiceName, s.ServiceModule, "COMMITID"}, ".")))
 					vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, strings.Join([]string{"job", j.Name, s.ServiceName, s.ServiceModule, "BRANCH"}, ".")))


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 94f70e9</samp>

This pull request enhances the job execution feature by allowing git URLs of service and build repositories to be passed as a parameter. This enables job executors to perform tasks that require access to the git repositories, such as code scanning or code analysis.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 94f70e9</samp>

*  Add and pass git URLs of service and build repositories to job execution ([link](https://github.com/koderover/zadig/pull/3035/files?diff=unified&w=0#diff-cd667032e3bf01aed408f869322d63aed342d028916369c057cf2a090257e6a4L515-R529), [link](https://github.com/koderover/zadig/pull/3035/files?diff=unified&w=0#diff-cd667032e3bf01aed408f869322d63aed342d028916369c057cf2a090257e6a4R539))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
