### PR TITLE
optimize logic of get gitlab 

### DIFF
--- a/pkg/tool/git/gitlab/namespace.go
+++ b/pkg/tool/git/gitlab/namespace.go
@@ -17,7 +17,6 @@ limitations under the License.
 package gitlab
 
 import (
-	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -49,7 +48,6 @@ func (c *Client) listUsers(keyword string, opts *ListOptions) ([]*gitlab.Namespa
 	}
 	for _, n := range ns {
 		namespace := n.(*gitlab.Namespace)
-		log.Infof("--------- namespace kind is %v", namespace.Kind)
 		if namespace.Kind == "user" {
 			res = append(res, namespace)
 		}

--- a/pkg/tool/git/gitlab/namespace.go
+++ b/pkg/tool/git/gitlab/namespace.go
@@ -51,7 +51,7 @@ func (c *Client) listUsers(keyword string, opts *ListOptions) ([]*gitlab.Namespa
 		namespace := n.(*gitlab.Namespace)
 		log.Infof("--------- namespace kind is %v", namespace.Kind)
 		if namespace.Kind == "user" {
-			res = append(res)
+			res = append(res, namespace)
 		}
 	}
 

--- a/pkg/tool/git/gitlab/namespace.go
+++ b/pkg/tool/git/gitlab/namespace.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gitlab
 
 import (
+	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -48,6 +49,7 @@ func (c *Client) listUsers(keyword string, opts *ListOptions) ([]*gitlab.Namespa
 	}
 	for _, n := range ns {
 		namespace := n.(*gitlab.Namespace)
+		log.Infof("--------- namespace kind is %v", namespace.Kind)
 		if namespace.Kind == "user" {
 			res = append(res)
 		}
@@ -86,9 +88,10 @@ func (c *Client) listGroups(keyword string, opts *ListOptions) ([]*gitlab.Namesp
 	for _, n := range ns {
 		groupInfo := n.(*gitlab.Group)
 		res = append(res, &gitlab.Namespace{
-			Name: groupInfo.Name,
-			Path: groupInfo.Path,
-			Kind: "group",
+			Name:     groupInfo.Name,
+			Path:     groupInfo.Path,
+			FullPath: groupInfo.FullPath,
+			Kind:     "group",
 		})
 	}
 	return res, err


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 42e8ce3</samp>

Improved the `git/gitlab` package to support both user and group namespaces. Renamed `ListNamespaces` to reflect its new functionality and deprecated the old version. Extracted a new `listGroups` function to handle group API calls.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 42e8ce3</samp>

*  Rename `ListNamespaces` to `listUsers` and make it private ([link](https://github.com/koderover/zadig/pull/3037/files?diff=unified&w=0#diff-2e19d28f877c076404d9ea4594cbe91c7541dd5870da91edbf4cb158d9d3ddffL23-R23))
*  Add `listGroups` function to list group namespaces using the API ([link](https://github.com/koderover/zadig/pull/3037/files?diff=unified&w=0#diff-2e19d28f877c076404d9ea4594cbe91c7541dd5870da91edbf4cb158d9d3ddffR50-R125))
*  Mark `listNamespaces` as deprecated and rename it from `ListNamespaces` ([link](https://github.com/koderover/zadig/pull/3037/files?diff=unified&w=0#diff-2e19d28f877c076404d9ea4594cbe91c7541dd5870da91edbf4cb158d9d3ddffR50-R125), [link](https://github.com/koderover/zadig/pull/3037/files?diff=unified&w=0#diff-2e19d28f877c076404d9ea4594cbe91c7541dd5870da91edbf4cb158d9d3ddffR131-R146))
*  Add new `ListNamespaces` function to the public interface that calls `listUsers` and `listGroups` and merges their results ([link](https://github.com/koderover/zadig/pull/3037/files?diff=unified&w=0#diff-2e19d28f877c076404d9ea4594cbe91c7541dd5870da91edbf4cb158d9d3ddffR131-R146))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
