### PR TITLE
Feature/production ns choose (#3039)

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/product.go
@@ -567,3 +567,22 @@ func (c *ProductColl) ListProductionNamespace(clusterID string) ([]string, error
 	}
 	return resp.List(), nil
 }
+
+func (c *ProductColl) ListProductByNamespace(clusterID string, namespace string) ([]*models.Product, error) {
+	ret := make([]*models.Product, 0)
+	query := bson.M{"cluster_id": clusterID, "namespace": namespace}
+	opt := options.Find()
+	ctx := context.Background()
+
+	cursor, err := c.Collection.Find(ctx, query, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	err = cursor.All(ctx, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}

--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -142,12 +142,34 @@ func UpdateMultiProductionProducts(c *gin.Context) {
 	updateMultiEnvWrapper(c, request, true, ctx)
 }
 
+func checkNamespaceUsed(clusterID, namespace string) string {
+	productionEnvs, err := mongodb.NewProductColl().ListProductByNamespace(clusterID, namespace)
+	if err != nil {
+		log.Errorf("failed to find ")
+		return ""
+	}
+
+	geneEnvDes := func(env *commonmodels.Product) string {
+		return fmt.Sprintf("%s/%s", env.ProductName, env.EnvName)
+	}
+
+	retStr := ""
+	if len(productionEnvs) > 0 {
+		nsStrs := make([]string, 0)
+		for _, env := range productionEnvs {
+			nsStrs = append(nsStrs, geneEnvDes(env))
+		}
+		retStr = fmt.Sprintf("命名空间%s已被以下环境使用: [%s]，请确认后再操作", namespace, strings.Join(nsStrs, ","))
+	}
+	return retStr
+}
+
 func ensureProductionNamespace(createArgs []*service.CreateSingleProductArg) error {
 	for _, arg := range createArgs {
-		namespace, err := service.ListNamespaceFromCluster(arg.ClusterID)
-		if err != nil {
-			return err
-		}
+		//namespace, err := service.ListNamespaceFromCluster(arg.ClusterID)
+		//if err != nil {
+		//	return err
+		//}
 
 		// 1. check specified namespace
 		filterK8sNamespaces := sets.NewString("kube-node-lease", "kube-public", "kube-system")
@@ -166,26 +188,27 @@ func ensureProductionNamespace(createArgs []*service.CreateSingleProductArg) err
 		}
 
 		// 3. check production namespace
-		productionEnvs, err := mongodb.NewProductColl().ListProductionNamespace(arg.ClusterID)
-		if err != nil {
-			return err
-		}
-		filterK8sNamespaces.Insert(productionEnvs...)
-		if filterK8sNamespaces.Has(arg.Namespace) {
-			return fmt.Errorf("namespace %s is invalid, it has been used for other production environment", arg.Namespace)
-		}
+		//productionEnvs, err := mongodb.NewProductColl().ListProductByNamespace(arg.ClusterID, arg.Namespace)
+		//if err != nil {
+		//	return err
+		//}
+
+		//filterK8sNamespaces.Insert(productionEnvs...)
+		//if filterK8sNamespaces.Has(arg.Namespace) {
+		//	return fmt.Errorf("namespace %s is invalid, it has been used for other production environment", arg.Namespace)
+		//}
 
 		// 4. check namespace created by koderover
-		for _, ns := range namespace {
-			if ns.Name == arg.Namespace {
-				if value, IsExist := ns.Labels[setting.EnvCreatedBy]; IsExist {
-					if value == setting.EnvCreator {
-						return fmt.Errorf("namespace %s is invalid, namespace created by koderover cannot be used", arg.Namespace)
-					}
-				}
-				return nil
-			}
-		}
+		//for _, ns := range namespace {
+		//	if ns.Name == arg.Namespace {
+		//		if value, IsExist := ns.Labels[setting.EnvCreatedBy]; IsExist {
+		//			if value == setting.EnvCreator {
+		//				return fmt.Errorf("namespace %s is invalid, namespace created by koderover cannot be used", arg.Namespace)
+		//			}
+		//		}
+		//		return nil
+		//	}
+		//}
 
 		//5. arg.namespace is not in valid namespace list
 		//return fmt.Errorf("namespace %s does not belong to legal namespace", arg.Namespace)
@@ -341,6 +364,13 @@ func CreateProduct(c *gin.Context) {
 
 		ctx.Err = service.CreateProduct(ctx.UserName, ctx.RequestID, args, ctx.Logger)
 	}
+}
+
+func ValidateProductionNamespace(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	ctx.Resp = checkNamespaceUsed(c.Query("clusterId"), c.Query("namespace"))
 }
 
 func CreateProductionProduct(c *gin.Context) {

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -137,6 +137,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 	production := router.Group("production")
 	{
 		production.POST("/environments", CreateProductionProduct)
+		production.GET("/environments/namespace/validate", ValidateProductionNamespace)
 
 		production.PUT("/environments", UpdateMultiProductionProducts)
 		production.PUT("/environments/:name/services", DeleteProductionProductServices)

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -1149,8 +1149,11 @@ func SyncHelmProductEnvironment(productName, envName, requestID string, log *zap
 		log.Errorf("UpdateHelmProductRenderset GetProductEnv envName:%s productName: %s error, error msg:%s", envName, productName, err)
 		return err
 	}
+
+	product.EnsureRenderInfo()
 	opt := &commonrepo.RenderSetFindOption{
-		Name:        product.Namespace,
+		Name:        product.Render.Name,
+		Revision:    product.Render.Revision,
 		EnvName:     envName,
 		ProductTmpl: productName,
 	}
@@ -1214,9 +1217,11 @@ func UpdateHelmProductRenderset(productName, envName, userName, requestID string
 		log.Errorf("UpdateHelmProductRenderset GetProductEnv envName:%s productName: %s error, error msg:%s", envName, productName, err)
 		return err
 	}
+	product.EnsureRenderInfo()
 	opt := &commonrepo.RenderSetFindOption{
-		Name:        product.Namespace,
+		Name:        product.Render.Name,
 		EnvName:     envName,
+		Revision:    product.Render.Revision,
 		ProductTmpl: productName,
 	}
 	productRenderset, _, err := commonrepo.NewRenderSetColl().FindRenderSet(opt)

--- a/pkg/microservice/aslan/core/environment/service/k8s.go
+++ b/pkg/microservice/aslan/core/environment/service/k8s.go
@@ -147,9 +147,10 @@ func (k *K8sService) updateService(args *SvcOptArgs) error {
 
 	exitedProd.EnsureRenderInfo()
 	curRenderset, _, err := commonrepo.NewRenderSetColl().FindRenderSet(&commonrepo.RenderSetFindOption{
-		Name:     exitedProd.Render.Name,
-		EnvName:  exitedProd.EnvName,
-		Revision: exitedProd.Render.Revision,
+		Name:        exitedProd.Render.Name,
+		EnvName:     exitedProd.EnvName,
+		Revision:    exitedProd.Render.Revision,
+		ProductTmpl: exitedProd.ProductName,
 	})
 	if err != nil {
 		return e.ErrUpdateEnv.AddErr(fmt.Errorf("failed to find render set, err: %s", err))


### PR DESCRIPTION
* fix service container image update logic



* add ns check



* change function type



---------

### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0db1b1b</samp>

This pull request adds a new API endpoint for validating production namespaces and updates the product model and the render set query option to use the render set name and revision. It also refactors the environment handler and service packages and adds a new function to the MongoDB repository. The changes aim to improve the user experience and the code quality of the environment management feature.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0db1b1b</samp>

*  Add a new API endpoint for validating production namespaces ([link](https://github.com/koderover/zadig/pull/3041/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eR369-R375), [link](https://github.com/koderover/zadig/pull/3041/files?diff=unified&w=0#diff-bc855cdae7fd5951f2dd616071a0a85b20273c7a89fc1725f032de2b17ff7bd7R140))
  - Define a new handler function `ValidateProductionNamespace` that calls `checkNamespaceUsed` to check whether a namespace is available for creating a production environment ([link](https://github.com/koderover/zadig/pull/3041/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eR369-R375))
  - Register the new route `/environments/namespace/validate` in the `router.go` file and map it to the handler function ([link](https://github.com/koderover/zadig/pull/3041/files?diff=unified&w=0#diff-bc855cdae7fd5951f2dd616071a0a85b20273c7a89fc1725f032de2b17ff7bd7R140))
* Simplify the logic of checking production namespaces in the `ensureProductionNamespace` function ([link](https://github.com/koderover/zadig/pull/3041/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL145-R172), [link](https://github.com/koderover/zadig/pull/3041/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL169-R211))
  - Replace the call to `service.ListNamespaceFromCluster` with a call to `checkNamespaceUsed`, which is a new function that queries the MongoDB collection for products that match a given cluster ID and namespace ([link](https://github.com/koderover/zadig/pull/3041/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL145-R172))
  - Comment out the original logic of looping through the products and comparing the namespaces, which is no longer needed ([link](https://github.com/koderover/zadig/pull/3041/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL169-R211))
* Add a new function `ListProductByNamespace` to the `ProductColl` struct in the `mongodb` package ([link](https://github.com/koderover/zadig/pull/3041/files?diff=unified&w=0#diff-150810b9b9a9ae4e2d85ea333a4ca97a7ca4ca8c02b80ff11d17cc853f75ba14R570-R588))
* Align the render set query option with the new product model, which has a `Render` field that contains the render set information ([link](https://github.com/koderover/zadig/pull/3041/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L1152-R1156), [link](https://github.com/koderover/zadig/pull/3041/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L1217-R1224), [link](https://github.com/koderover/zadig/pull/3041/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136L150-R153))
  - Modify the `RenderSetFindOption` struct in the `service` package to add the `ProductTmpl` field and replace the `Namespace` field with the `Render.Name` and `Render.Revision` fields ([link](https://github.com/koderover/zadig/pull/3041/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L1152-R1156))
  - Apply the same change to the `RenderSetFindOption` struct in the `UpdateHelmProductRenderset` and `updateService` functions in the `service` package ([link](https://github.com/koderover/zadig/pull/3041/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L1217-R1224), [link](https://github.com/koderover/zadig/pull/3041/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136L150-R153))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
