### PR TITLE
scanning upgrade

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/utils.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/utils.go
@@ -1,0 +1,25 @@
+package migrate
+
+import (
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/mongo"
+
+	internalmodels "github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/repository/models"
+	internaldb "github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/repository/mongodb"
+)
+
+// getMigrationInfo get the current migration status from the mongodb, if none exists, initialize one and return the
+// initialized data.
+// NOTE THAT THE INITIALIZATION FUNCTION NEEDS TO BE UPDATED TO AVOID DATA CORRUPTION
+func getMigrationInfo() (*internalmodels.Migration, error) {
+	migrationInfo, err := internaldb.NewMigrationColl().GetMigrationInfo()
+	if err != nil {
+		if err != mongo.ErrNoDocuments {
+			return nil, fmt.Errorf("failed to get migration info from db, err: %s", err)
+		} else {
+			return internaldb.NewMigrationColl().InitializeMigrationInfo()
+		}
+	}
+	return migrationInfo, nil
+}

--- a/pkg/cli/upgradeassistant/internal/repository/models/migration.go
+++ b/pkg/cli/upgradeassistant/internal/repository/models/migration.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2023 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type Migration struct {
+	ID             primitive.ObjectID `bson:"_id,omitempty"`
+	SonarMigration bool               `bson:"sonar_migration"`
+}
+
+func (Migration) TableName() string {
+	return "migration"
+}

--- a/pkg/cli/upgradeassistant/internal/repository/models/scanning.go
+++ b/pkg/cli/upgradeassistant/internal/repository/models/scanning.go
@@ -17,12 +17,28 @@ limitations under the License.
 package models
 
 import (
+	"github.com/koderover/zadig/pkg/types"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type Scanning struct {
-	ID      primitive.ObjectID `bson:"_id,omitempty" json:"id,omitempty"`
-	ImageID string             `bson:"image_id"      json:"image_id"`
+	ID              primitive.ObjectID       `bson:"_id,omitempty"  json:"id,omitempty"`
+	ImageID         string                   `bson:"image_id"       json:"image_id"`
+	EnableScanner   bool                     `bson:"enable_scanner" json:"enable_scanner"`
+	ScannerType     string                   `bson:"scanner_type"   json:"scanner_type"`
+	PreScript       string                   `bson:"pre_script"       json:"pre_script"`
+	Script          string                   `bson:"script"           json:"script"`
+	AdvancedSetting *ScanningAdvancedSetting `bson:"advanced_setting" json:"advanced_setting"`
+}
+
+type ScanningAdvancedSetting struct {
+	Cache *ScanningCacheSetting `bson:"cache"        json:"cache"`
+}
+
+type ScanningCacheSetting struct {
+	CacheEnable  bool               `bson:"cache_enable"        json:"cache_enable"`
+	CacheDirType types.CacheDirType `bson:"cache_dir_type"      json:"cache_dir_type"`
+	CacheUserDir string             `bson:"cache_user_dir"      json:"cache_user_dir"`
 }
 
 func (Scanning) TableName() string {

--- a/pkg/cli/upgradeassistant/internal/repository/mongodb/migration.go
+++ b/pkg/cli/upgradeassistant/internal/repository/mongodb/migration.go
@@ -1,0 +1,68 @@
+package mongodb
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/repository/models"
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type MigrationColl struct {
+	*mongo.Collection
+
+	coll string
+}
+
+func NewMigrationColl() *MigrationColl {
+	name := models.Migration{}.TableName()
+	coll := &MigrationColl{Collection: mongotool.Database(config.MongoDatabase()).Collection(name), coll: name}
+
+	return coll
+}
+
+func (c *MigrationColl) GetMigrationInfo() (*models.Migration, error) {
+	query := bson.M{}
+
+	var resp *models.Migration
+	ctx := context.Background()
+	opts := options.FindOne()
+	err := c.Collection.FindOne(ctx, query, opts).Decode(&resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func (c *MigrationColl) UpdateMigrationStatus(id primitive.ObjectID, kvs map[string]interface{}) error {
+	query := bson.M{"_id": id}
+	change := bson.M{}
+	for key, val := range kvs {
+		change[key] = val
+	}
+	changeQuery := bson.M{"$set": change}
+	_, err := c.Collection.UpdateOne(context.TODO(), query, changeQuery)
+	return err
+}
+
+func (c *MigrationColl) InitializeMigrationInfo() (*models.Migration, error) {
+	resp := &models.Migration{
+		SonarMigration: false,
+	}
+	res, err := c.InsertOne(context.TODO(), resp, options.InsertOne())
+	if err != nil {
+		return nil, err
+	}
+	if id, ok := res.InsertedID.(primitive.ObjectID); !ok {
+		return nil, fmt.Errorf("invalid inserted id: %+v", res.InsertedID)
+	} else {
+		res.InsertedID = id
+	}
+	return resp, nil
+}

--- a/pkg/cli/upgradeassistant/internal/repository/mongodb/scanning.go
+++ b/pkg/cli/upgradeassistant/internal/repository/mongodb/scanning.go
@@ -20,15 +20,18 @@ import (
 	"context"
 	"errors"
 
-	"github.com/koderover/zadig/pkg/microservice/aslan/config"
-	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
-	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/repository/models"
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
 )
 
 type ScanningListOption struct {
+	Type string
 }
 
 type ScanningColl struct {
@@ -51,6 +54,10 @@ func (c *ScanningColl) List(opt *ScanningListOption) ([]*models.Scanning, error)
 
 	query := bson.M{}
 
+	if len(opt.Type) != 0 {
+		query["scanner_type"] = opt.Type
+	}
+
 	var resp []*models.Scanning
 	ctx := context.Background()
 	opts := options.Find()
@@ -65,4 +72,12 @@ func (c *ScanningColl) List(opt *ScanningListOption) ([]*models.Scanning, error)
 	}
 
 	return resp, nil
+}
+
+func (c *ScanningColl) Update(id primitive.ObjectID, update *models.Scanning) error {
+	query := bson.M{"_id": id}
+	change := bson.M{"$set": update}
+
+	_, err := c.UpdateOne(context.TODO(), query, change)
+	return err
 }

--- a/pkg/microservice/aslan/core/common/repository/models/scanning.go
+++ b/pkg/microservice/aslan/core/common/repository/models/scanning.go
@@ -25,18 +25,21 @@ import (
 )
 
 type Scanning struct {
-	ID          primitive.ObjectID  `bson:"_id,omitempty" json:"id,omitempty"`
-	Name        string              `bson:"name"          json:"name"`
-	ProjectName string              `bson:"project_name"  json:"project_name"`
-	Description string              `bson:"description"   json:"description"`
-	ScannerType string              `bson:"scanner_type"  json:"scanner_type"`
-	ImageID     string              `bson:"image_id"      json:"image_id"`
-	SonarID     string              `bson:"sonar_id"      json:"sonar_id"`
-	Repos       []*types.Repository `bson:"repos"         json:"repos"`
-	Installs    []*Item             `bson:"installs"      json:"installs"`
-	PreScript   string              `bson:"pre_script"    json:"pre_script"`
+	ID          primitive.ObjectID `bson:"_id,omitempty" json:"id,omitempty"`
+	Name        string             `bson:"name"          json:"name"`
+	ProjectName string             `bson:"project_name"  json:"project_name"`
+	Description string             `bson:"description"   json:"description"`
+	ScannerType string             `bson:"scanner_type"  json:"scanner_type"`
+	// EnableScanner indicates whether user uses sonar scanner instead of the script
+	EnableScanner bool                `bson:"enable_scanner" json:"enable_scanner"`
+	ImageID       string              `bson:"image_id"      json:"image_id"`
+	SonarID       string              `bson:"sonar_id"      json:"sonar_id"`
+	Repos         []*types.Repository `bson:"repos"         json:"repos"`
+	Installs      []*Item             `bson:"installs"      json:"installs"`
 	// Parameter is for sonarQube type only
 	Parameter string `bson:"parameter" json:"parameter"`
+	// Envs is the user defined key/values
+	Envs []*KeyVal `bson:"envs" json:"envs"`
 	// Script is for other type only
 	Script           string                   `bson:"script"                json:"script"`
 	AdvancedSetting  *ScanningAdvancedSetting `bson:"advanced_setting"      json:"advanced_setting"`
@@ -53,13 +56,14 @@ func (Scanning) TableName() string {
 }
 
 type ScanningAdvancedSetting struct {
-	ClusterID  string              `bson:"cluster_id"   json:"cluster_id"`
-	StrategyID string              `bson:"strategy_id"  json:"strategy_id"`
-	Timeout    int64               `bson:"timeout"      json:"timeout"`
-	ResReq     setting.Request     `bson:"res_req"      json:"res_req"`
-	ResReqSpec setting.RequestSpec `bson:"res_req_spec" json:"res_req_spec"`
-	HookCtl    *ScanningHookCtl    `bson:"hook_ctl"     json:"hook_ctl"`
-	NotifyCtls []*NotifyCtl        `bson:"notify_ctls"     json:"notify_ctls"`
+	ClusterID  string                `bson:"cluster_id"   json:"cluster_id"`
+	StrategyID string                `bson:"strategy_id"  json:"strategy_id"`
+	Timeout    int64                 `bson:"timeout"      json:"timeout"`
+	ResReq     setting.Request       `bson:"res_req"      json:"res_req"`
+	ResReqSpec setting.RequestSpec   `bson:"res_req_spec" json:"res_req_spec"`
+	HookCtl    *ScanningHookCtl      `bson:"hook_ctl"     json:"hook_ctl"`
+	NotifyCtls []*NotifyCtl          `bson:"notify_ctls"  json:"notify_ctls"`
+	Cache      *ScanningCacheSetting `bson:"cache"        json:"cache"`
 }
 
 type ScanningHookCtl struct {
@@ -82,4 +86,10 @@ type ScanningHook struct {
 type SonarInfo struct {
 	ServerAddress string `bson:"server_address" json:"server_address"`
 	Token         string `bson:"token"          json:"token"`
+}
+
+type ScanningCacheSetting struct {
+	CacheEnable  bool               `bson:"cache_enable"        json:"cache_enable"`
+	CacheDirType types.CacheDirType `bson:"cache_dir_type"      json:"cache_dir_type"`
+	CacheUserDir string             `bson:"cache_user_dir"      json:"cache_user_dir"`
 }

--- a/pkg/microservice/aslan/core/common/repository/models/task/scanning.go
+++ b/pkg/microservice/aslan/core/common/repository/models/task/scanning.go
@@ -26,29 +26,37 @@ import (
 )
 
 type Scanning struct {
-	TaskType     config.TaskType     `bson:"type"            json:"type"`
-	Status       config.Status       `bson:"status"          json:"status,omitempty"`
-	ScanningID   string              `bson:"scanning_id"     json:"scanning_id"`
-	Name         string              `bson:"name"            json:"name"`
-	Error        string              `bson:"error,omitempty" json:"error,omitempty"`
-	ImageInfo    string              `bson:"image_info"      json:"image_info"`
-	SonarInfo    *models.SonarInfo   `bson:"sonar_info"      json:"sonar_info"`
-	InstallItems []*models.Item      `bson:"install_items"   json:"install_items"`
-	InstallCtx   []*models.Install   `bson:"-"               json:"install_ctx"`
-	Repos        []*types.Repository `bson:"repos"           json:"repos"`
-	Proxy        *models.Proxy       `bson:"proxy"           json:"proxy"`
-	ClusterID    string              `bson:"cluster_id"      json:"cluster_id"`
-	StrategyID   string              `bson:"strategy_id"     json:"strategy_id"`
+	TaskType      config.TaskType     `bson:"type"            json:"type"`
+	Status        config.Status       `bson:"status"          json:"status,omitempty"`
+	ScanningID    string              `bson:"scanning_id"     json:"scanning_id"`
+	Name          string              `bson:"name"            json:"name"`
+	Error         string              `bson:"error,omitempty" json:"error,omitempty"`
+	ImageInfo     string              `bson:"image_info"      json:"image_info"`
+	SonarInfo     *models.SonarInfo   `bson:"sonar_info"      json:"sonar_info"`
+	EnableScanner bool                `bson:"enable_scanner"  json:"enable_scanner"`
+	InstallItems  []*models.Item      `bson:"install_items"   json:"install_items"`
+	InstallCtx    []*models.Install   `bson:"-"               json:"install_ctx"`
+	Repos         []*types.Repository `bson:"repos"           json:"repos"`
+	Proxy         *models.Proxy       `bson:"proxy"           json:"proxy"`
+	ClusterID     string              `bson:"cluster_id"      json:"cluster_id"`
+	StrategyID    string              `bson:"strategy_id"     json:"strategy_id"`
 	// ResReq defines job requested resources
-	ResReq     setting.Request             `bson:"res_req"       json:"res_req"`
-	ResReqSpec setting.RequestSpec         `bson:"res_req_spec"  json:"res_req_spec"`
-	Timeout    int64                       `bson:"timeout"       json:"timeout"`
-	Registries []*models.RegistryNamespace `bson:"-"             json:"registries"`
+	ResReq     setting.Request     `bson:"res_req"       json:"res_req"`
+	ResReqSpec setting.RequestSpec `bson:"res_req_spec"  json:"res_req_spec"`
+	// Cache settings
+	Cache        types.Cache        `bson:"cache"               json:"cache"`
+	CacheEnable  bool               `bson:"cache_enable"        json:"cache_enable"`
+	CacheDirType types.CacheDirType `bson:"cache_dir_type"      json:"cache_dir_type"`
+	CacheUserDir string             `bson:"cache_user_dir"      json:"cache_user_dir"`
+	// Task timeout
+	Timeout    int64                       `bson:"timeout"        json:"timeout"`
+	Registries []*models.RegistryNamespace `bson:"-"              json:"registries"`
 	// Parameter is for sonarQube type only
 	Parameter string `bson:"parameter" json:"parameter"`
+	// Envs is the user defined key/values
+	Envs []*models.KeyVal `bson:"envs" json:"envs"`
 	// Script is for other type only
 	Script           string `bson:"script"                json:"script"`
-	PreScript        string `bson:"pre_script"            json:"pre_script"`
 	CheckQualityGate bool   `bson:"check_quality_gate"    json:"check_quality_gate"`
 }
 

--- a/pkg/microservice/aslan/core/project/service/product.go
+++ b/pkg/microservice/aslan/core/project/service/product.go
@@ -718,6 +718,11 @@ func DeleteProductTemplate(userName, productName, requestID string, isDelete boo
 		return err
 	}
 
+	if err = DeleteScanningModules(productName, log); err != nil {
+		log.Errorf("DeleteProductTemplate Delete productName %s scannings err: %s", productName, err)
+		return err
+	}
+
 	// delete collaboration_mode and collaboration_instance
 	if err := DeleteCollabrationMode(productName, userName, log); err != nil {
 		log.Errorf("DeleteCollabrationMode err:%s", err)

--- a/pkg/microservice/aslan/core/project/service/testing.go
+++ b/pkg/microservice/aslan/core/project/service/testing.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/koderover/zadig/pkg/microservice/aslan/core/workflow/testing/service"
 	"go.uber.org/zap"
 
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	commonservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/workflow/testing/service"
 )
 
 func DeleteTestModules(productName, requestID string, log *zap.SugaredLogger) error {

--- a/pkg/microservice/aslan/core/project/service/testing.go
+++ b/pkg/microservice/aslan/core/project/service/testing.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/workflow/testing/service"
 	"go.uber.org/zap"
 
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
@@ -36,6 +37,29 @@ func DeleteTestModules(productName, requestID string, log *zap.SugaredLogger) er
 	for _, testing := range testings {
 		if err = commonservice.DeleteTestModule(testing.Name, productName, requestID, log); err != nil {
 			errList = multierror.Append(errList, fmt.Errorf("productName %s test delete %s error: %v", productName, testing.Name, err))
+		}
+	}
+	if err := errList.ErrorOrNil(); err != nil {
+		log.Error(err)
+		return err
+	}
+	return nil
+}
+
+func DeleteScanningModules(productName string, log *zap.SugaredLogger) error {
+	scannings, _, err := commonrepo.NewScanningColl().List(&commonrepo.ScanningListOption{
+		ProjectName: "productName",
+	}, 0, 0)
+
+	if err != nil {
+		return err
+	}
+
+	errList := new(multierror.Error)
+
+	for _, scanning := range scannings {
+		if err = service.DeleteScanningModuleByID(scanning.ID.Hex(), log); err != nil {
+			errList = multierror.Append(errList, fmt.Errorf("productName %s scanning delete %s error: %v", productName, scanning.Name, err))
 		}
 	}
 	if err := errList.ErrorOrNil(); err != nil {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/convert.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/convert.go
@@ -76,6 +76,7 @@ func ConvertQueueToTask(queueTask *commonmodels.Queue) *task.Task {
 		Features:                queueTask.Features,
 		IsRestart:               queueTask.IsRestart,
 		StorageEndpoint:         queueTask.StorageEndpoint,
+		ScanningArgs:            queueTask.ScanningArgs,
 	}
 }
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"path"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -391,49 +390,6 @@ func jobNameFormat(jobName string) string {
 	jobName = strings.Trim(jobName, "-")
 	jobName = strings.ToLower(jobName)
 	return jobName
-}
-
-func getReposVariables(repos []*types.Repository) []*commonmodels.KeyVal {
-	ret := make([]*commonmodels.KeyVal, 0)
-	for index, repo := range repos {
-
-		repoNameIndex := fmt.Sprintf("REPONAME_%d", index)
-		ret = append(ret, &commonmodels.KeyVal{Key: fmt.Sprintf(repoNameIndex), Value: repo.RepoName, IsCredential: false})
-
-		repoName := strings.Replace(repo.RepoName, "-", "_", -1)
-		repoName = strings.Replace(repoName, ".", "_", -1)
-
-		repoIndex := fmt.Sprintf("REPO_%d", index)
-		ret = append(ret, &commonmodels.KeyVal{Key: fmt.Sprintf(repoIndex), Value: repoName, IsCredential: false})
-
-		if len(repo.Branch) > 0 {
-			ret = append(ret, &commonmodels.KeyVal{Key: fmt.Sprintf("%s_BRANCH", repoName), Value: repo.Branch, IsCredential: false})
-		}
-
-		if len(repo.Tag) > 0 {
-			ret = append(ret, &commonmodels.KeyVal{Key: fmt.Sprintf("%s_TAG", repoName), Value: repo.Tag, IsCredential: false})
-		}
-
-		if repo.PR > 0 {
-			ret = append(ret, &commonmodels.KeyVal{Key: fmt.Sprintf("%s_PR", repoName), Value: strconv.Itoa(repo.PR), IsCredential: false})
-		}
-
-		ret = append(ret, &commonmodels.KeyVal{Key: fmt.Sprintf("%s_ORG", repoName), Value: repo.RepoOwner, IsCredential: false})
-
-		if len(repo.PRs) > 0 {
-			prStrs := []string{}
-			for _, pr := range repo.PRs {
-				prStrs = append(prStrs, strconv.Itoa(pr))
-			}
-			ret = append(ret, &commonmodels.KeyVal{Key: fmt.Sprintf("%s_PR", repoName), Value: strings.Join(prStrs, ","), IsCredential: false})
-		}
-
-		if len(repo.CommitID) > 0 {
-			ret = append(ret, &commonmodels.KeyVal{Key: fmt.Sprintf("%s_COMMIT_ID", repoName), Value: repo.CommitID, IsCredential: false})
-		}
-		ret = append(ret, getEnvFromCommitMsg(repo.CommitMessage)...)
-	}
-	return ret
 }
 
 // before workflowflow task was created, we need to remove the fixed mark from variables.

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_build.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_build.go
@@ -472,20 +472,19 @@ func replaceWrapLine(script string) string {
 
 func getBuildJobVariables(build *commonmodels.ServiceAndBuild, taskID int64, project, workflowName, image string, registry *commonmodels.RegistryNamespace, log *zap.SugaredLogger) []*commonmodels.KeyVal {
 	ret := make([]*commonmodels.KeyVal, 0)
+	// basic envs
+	ret = append(ret, PrepareDefaultWorkflowTaskEnvs(project, workflowName, taskID)...)
+	// repo envs
 	ret = append(ret, getReposVariables(build.Repos)...)
+	// build specific envs
 	ret = append(ret, &commonmodels.KeyVal{Key: "DOCKER_REGISTRY_HOST", Value: registry.RegAddr, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "DOCKER_REGISTRY_AK", Value: registry.AccessKey, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "DOCKER_REGISTRY_SK", Value: registry.SecretKey, IsCredential: true})
 
-	ret = append(ret, &commonmodels.KeyVal{Key: "TASK_ID", Value: fmt.Sprintf("%d", taskID), IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "SERVICE", Value: build.ServiceName, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "SERVICE_NAME", Value: build.ServiceName, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "SERVICE_MODULE", Value: build.ServiceModule, IsCredential: false})
-	ret = append(ret, &commonmodels.KeyVal{Key: "PROJECT", Value: project, IsCredential: false})
-	ret = append(ret, &commonmodels.KeyVal{Key: "WORKFLOW", Value: workflowName, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "IMAGE", Value: image, IsCredential: false})
-	ret = append(ret, &commonmodels.KeyVal{Key: "CI", Value: "true", IsCredential: false})
-	ret = append(ret, &commonmodels.KeyVal{Key: "ZADIG", Value: "true", IsCredential: false})
 	buildURL := fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d", configbase.SystemAddress(), project, workflowName, taskID)
 	ret = append(ret, &commonmodels.KeyVal{Key: "BUILD_URL", Value: buildURL, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "PKG_FILE", Value: build.Package, IsCredential: false})

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_build.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_build.go
@@ -474,7 +474,7 @@ func replaceWrapLine(script string) string {
 func getBuildJobVariables(build *commonmodels.ServiceAndBuild, taskID int64, project, workflowName, workflowDisplayName, image string, registry *commonmodels.RegistryNamespace, log *zap.SugaredLogger) []*commonmodels.KeyVal {
 	ret := make([]*commonmodels.KeyVal, 0)
 	// basic envs
-	ret = append(ret, PrepareDefaultWorkflowTaskEnvs(project, workflowName, taskID)...)
+	ret = append(ret, PrepareDefaultWorkflowTaskEnvs(project, workflowName, workflowDisplayName, taskID)...)
 	// repo envs
 	ret = append(ret, getReposVariables(build.Repos)...)
 	// build specific envs

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_freestyle.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_freestyle.go
@@ -312,7 +312,7 @@ func getfreestyleJobVariables(steps []*commonmodels.StepTask, taskID int64, proj
 		repos = append(repos, stepSpec.Repos...)
 	}
 	// basic envs
-	ret = append(ret, PrepareDefaultWorkflowTaskEnvs(project, workflowName, taskID)...)
+	ret = append(ret, PrepareDefaultWorkflowTaskEnvs(project, workflowName, workflowDisplayName, taskID)...)
 	// repo envs
 	ret = append(ret, getReposVariables(repos)...)
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_freestyle.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_freestyle.go
@@ -18,6 +18,7 @@ package job
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"go.uber.org/zap"
@@ -211,7 +212,7 @@ func (j *FreeStyleJob) ToJobs(taskID int64) ([]*commonmodels.JobTask, error) {
 	jobTaskSpec.Properties.BuildOS = basicImage.Value
 	// save user defined variables.
 	jobTaskSpec.Properties.CustomEnvs = jobTaskSpec.Properties.Envs
-	jobTaskSpec.Properties.Envs = append(jobTaskSpec.Properties.Envs, getfreestyleJobVariables(jobTaskSpec.Steps, taskID, j.workflow.Project, j.workflow.Name)...)
+	jobTaskSpec.Properties.Envs = append(jobTaskSpec.Properties.Envs, getfreestyleJobVariables(jobTaskSpec.Steps, taskID, j.workflow.Project, j.workflow.Name, j.workflow.DisplayName)...)
 	return []*commonmodels.JobTask{jobTask}, nil
 }
 
@@ -296,7 +297,7 @@ func (j *FreeStyleJob) stepsToStepTasks(step []*commonmodels.Step) []*commonmode
 	return resp
 }
 
-func getfreestyleJobVariables(steps []*commonmodels.StepTask, taskID int64, project, workflowName string) []*commonmodels.KeyVal {
+func getfreestyleJobVariables(steps []*commonmodels.StepTask, taskID int64, project, workflowName, workflowDisplayName string) []*commonmodels.KeyVal {
 	ret := []*commonmodels.KeyVal{}
 	repos := []*types.Repository{}
 	for _, step := range steps {
@@ -315,7 +316,7 @@ func getfreestyleJobVariables(steps []*commonmodels.StepTask, taskID int64, proj
 	// repo envs
 	ret = append(ret, getReposVariables(repos)...)
 
-	buildURL := fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d", configbase.SystemAddress(), project, workflowName, taskID)
+	buildURL := fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d?display_name=%s", configbase.SystemAddress(), project, workflowName, taskID, url.QueryEscape(workflowDisplayName))
 	ret = append(ret, &commonmodels.KeyVal{Key: "BUILD_URL", Value: buildURL, IsCredential: false})
 	return ret
 }

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_freestyle.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_freestyle.go
@@ -310,9 +310,11 @@ func getfreestyleJobVariables(steps []*commonmodels.StepTask, taskID int64, proj
 		}
 		repos = append(repos, stepSpec.Repos...)
 	}
+	// basic envs
+	ret = append(ret, PrepareDefaultWorkflowTaskEnvs(project, workflowName, taskID)...)
+	// repo envs
 	ret = append(ret, getReposVariables(repos)...)
-	ret = append(ret, &commonmodels.KeyVal{Key: "PROJECT", Value: project, IsCredential: false})
-	ret = append(ret, &commonmodels.KeyVal{Key: "TASK_ID", Value: fmt.Sprintf("%d", taskID), IsCredential: false})
+
 	buildURL := fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d", configbase.SystemAddress(), project, workflowName, taskID)
 	ret = append(ret, &commonmodels.KeyVal{Key: "BUILD_URL", Value: buildURL, IsCredential: false})
 	return ret

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_scanning.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_scanning.go
@@ -163,7 +163,7 @@ func (j *ScanningJob) ToJobs(taskID int64) ([]*commonmodels.JobTask, error) {
 			Timeout: timeout,
 			Outputs: scanningInfo.Outputs,
 		}
-		envs := getScanningJobVariables(scanning.Repos, taskID, j.workflow.Project, j.workflow.Name)
+		envs := getScanningJobVariables(scanning.Repos, taskID, j.workflow.Project, j.workflow.Name, j.workflow.DisplayName)
 		envs = append(envs, &commonmodels.KeyVal{
 			Key:   "SCANNING_NAME",
 			Value: scanning.Name,
@@ -345,11 +345,11 @@ func (j *ScanningJob) GetOutPuts(log *zap.SugaredLogger) []string {
 	return resp
 }
 
-func getScanningJobVariables(repos []*types.Repository, taskID int64, project, workflowName string) []*commonmodels.KeyVal {
+func getScanningJobVariables(repos []*types.Repository, taskID int64, project, workflowName, workflowDisplayName string) []*commonmodels.KeyVal {
 	ret := []*commonmodels.KeyVal{}
 
 	// basic envs
-	ret = append(ret, PrepareDefaultWorkflowTaskEnvs(project, workflowName, taskID)...)
+	ret = append(ret, PrepareDefaultWorkflowTaskEnvs(project, workflowName, workflowDisplayName, taskID)...)
 	// repo envs
 	ret = append(ret, getReposVariables(repos)...)
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_scanning.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_scanning.go
@@ -220,7 +220,12 @@ func (j *ScanningJob) ToJobs(taskID int64) ([]*commonmodels.JobTask, error) {
 		repoName := ""
 		branch := ""
 		if len(scanningInfo.Repos) > 0 {
-			repoName = scanningInfo.Repos[0].RepoName
+			if scanningInfo.Repos[0].CheckoutPath != "" {
+				repoName = scanningInfo.Repos[0].CheckoutPath
+			} else {
+				repoName = scanningInfo.Repos[0].RepoName
+			}
+
 			branch = scanningInfo.Repos[0].Branch
 		}
 		// init debug before step
@@ -261,8 +266,14 @@ func (j *ScanningJob) ToJobs(taskID int64) ([]*commonmodels.JobTask, error) {
 			}
 			jobTaskSpec.Properties.Envs = append(jobTaskSpec.Properties.Envs, sonarLinkKeyVal)
 			jobTaskSpec.Properties.Envs = append(jobTaskSpec.Properties.Envs, &commonmodels.KeyVal{
-				Key:   "SONAR_TOKEN",
-				Value: sonarInfo.Token,
+				Key:          "SONAR_TOKEN",
+				Value:        sonarInfo.Token,
+				IsCredential: true,
+			})
+
+			jobTaskSpec.Properties.Envs = append(jobTaskSpec.Properties.Envs, &commonmodels.KeyVal{
+				Key:   "SONAR_URL",
+				Value: sonarInfo.ServerAddress,
 			})
 
 			if scanningInfo.EnableScanner {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_testing.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_testing.go
@@ -18,6 +18,7 @@ package job
 
 import (
 	"fmt"
+	"net/url"
 	"path"
 	"strings"
 
@@ -358,7 +359,7 @@ func (j *TestingJob) toJobtask(testing *commonmodels.TestModule, defaultS3 *comm
 		jobTaskSpec.Properties.CacheDirType = testingInfo.CacheDirType
 		jobTaskSpec.Properties.CacheUserDir = testingInfo.CacheUserDir
 	}
-	jobTaskSpec.Properties.Envs = append(jobTaskSpec.Properties.CustomEnvs, getTestingJobVariables(testing.Repos, taskID, j.workflow.Project, j.workflow.Name, testing.ProjectName, testing.Name, testType, serviceName, serviceModule, logger)...)
+	jobTaskSpec.Properties.Envs = append(jobTaskSpec.Properties.CustomEnvs, getTestingJobVariables(testing.Repos, taskID, j.workflow.Project, j.workflow.Name, j.workflow.DisplayName, testing.ProjectName, testing.Name, testType, serviceName, serviceModule, logger)...)
 
 	if jobTaskSpec.Properties.CacheEnable && jobTaskSpec.Properties.Cache.MediumType == types.NFSMedium {
 		jobTaskSpec.Properties.CacheUserDir = renderEnv(jobTaskSpec.Properties.CacheUserDir, jobTaskSpec.Properties.Envs)
@@ -538,7 +539,7 @@ func (j *TestingJob) GetOutPuts(log *zap.SugaredLogger) []string {
 	return resp
 }
 
-func getTestingJobVariables(repos []*types.Repository, taskID int64, project, workflowName, testingProject, testingName, testType, serviceName, serviceModule string, log *zap.SugaredLogger) []*commonmodels.KeyVal {
+func getTestingJobVariables(repos []*types.Repository, taskID int64, project, workflowName, workflowDisplayName, testingProject, testingName, testType, serviceName, serviceModule string, log *zap.SugaredLogger) []*commonmodels.KeyVal {
 	ret := make([]*commonmodels.KeyVal, 0)
 	// basic envs
 	ret = append(ret, PrepareDefaultWorkflowTaskEnvs(project, workflowName, taskID)...)
@@ -551,7 +552,7 @@ func getTestingJobVariables(repos []*types.Repository, taskID int64, project, wo
 	ret = append(ret, &commonmodels.KeyVal{Key: "SERVICE", Value: serviceName, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "SERVICE_NAME", Value: serviceName, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "SERVICE_MODULE", Value: serviceModule, IsCredential: false})
-	buildURL := fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d", configbase.SystemAddress(), project, workflowName, taskID)
+	buildURL := fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d?display_name=%s", configbase.SystemAddress(), project, workflowName, taskID, url.QueryEscape(workflowDisplayName))
 	ret = append(ret, &commonmodels.KeyVal{Key: "BUILD_URL", Value: buildURL, IsCredential: false})
 	return ret
 }

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_testing.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_testing.go
@@ -540,19 +540,17 @@ func (j *TestingJob) GetOutPuts(log *zap.SugaredLogger) []string {
 
 func getTestingJobVariables(repos []*types.Repository, taskID int64, project, workflowName, testingProject, testingName, testType, serviceName, serviceModule string, log *zap.SugaredLogger) []*commonmodels.KeyVal {
 	ret := make([]*commonmodels.KeyVal, 0)
+	// basic envs
+	ret = append(ret, PrepareDefaultWorkflowTaskEnvs(project, workflowName, taskID)...)
+	// repo envs
 	ret = append(ret, getReposVariables(repos)...)
 
-	ret = append(ret, &commonmodels.KeyVal{Key: "TASK_ID", Value: fmt.Sprintf("%d", taskID), IsCredential: false})
-	ret = append(ret, &commonmodels.KeyVal{Key: "PROJECT", Value: project, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "TESTING_PROJECT", Value: testingProject, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "TESTING_NAME", Value: testingName, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "TESTING_TYPE", Value: testType, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "SERVICE", Value: serviceName, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "SERVICE_NAME", Value: serviceName, IsCredential: false})
 	ret = append(ret, &commonmodels.KeyVal{Key: "SERVICE_MODULE", Value: serviceModule, IsCredential: false})
-	ret = append(ret, &commonmodels.KeyVal{Key: "WORKFLOW", Value: workflowName, IsCredential: false})
-	ret = append(ret, &commonmodels.KeyVal{Key: "CI", Value: "true", IsCredential: false})
-	ret = append(ret, &commonmodels.KeyVal{Key: "ZADIG", Value: "true", IsCredential: false})
 	buildURL := fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d", configbase.SystemAddress(), project, workflowName, taskID)
 	ret = append(ret, &commonmodels.KeyVal{Key: "BUILD_URL", Value: buildURL, IsCredential: false})
 	return ret

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_testing.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_testing.go
@@ -542,7 +542,7 @@ func (j *TestingJob) GetOutPuts(log *zap.SugaredLogger) []string {
 func getTestingJobVariables(repos []*types.Repository, taskID int64, project, workflowName, workflowDisplayName, testingProject, testingName, testType, serviceName, serviceModule string, log *zap.SugaredLogger) []*commonmodels.KeyVal {
 	ret := make([]*commonmodels.KeyVal, 0)
 	// basic envs
-	ret = append(ret, PrepareDefaultWorkflowTaskEnvs(project, workflowName, taskID)...)
+	ret = append(ret, PrepareDefaultWorkflowTaskEnvs(project, workflowName, workflowDisplayName, taskID)...)
 	// repo envs
 	ret = append(ret, getReposVariables(repos)...)
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/utils.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/utils.go
@@ -18,6 +18,7 @@ package job
 
 import (
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -27,7 +28,7 @@ import (
 )
 
 // System level default environment variables (every workflow type will have it)
-func PrepareDefaultWorkflowTaskEnvs(projectKey, workflowName string, taskID int64) []*commonmodels.KeyVal {
+func PrepareDefaultWorkflowTaskEnvs(projectKey, workflowName, workflowDisplayName string, taskID int64) []*commonmodels.KeyVal {
 	envs := make([]*commonmodels.KeyVal, 0)
 
 	envs = append(envs,
@@ -38,7 +39,7 @@ func PrepareDefaultWorkflowTaskEnvs(projectKey, workflowName string, taskID int6
 		&commonmodels.KeyVal{Key: "WORKFLOW", Value: workflowName},
 	)
 
-	url := GetLink(configbase.SystemAddress(), projectKey, workflowName, taskID)
+	url := GetLink(configbase.SystemAddress(), projectKey, workflowName, workflowDisplayName, taskID)
 
 	envs = append(envs, &commonmodels.KeyVal{Key: "TASK_URL", Value: url})
 	envs = append(envs, &commonmodels.KeyVal{Key: "TASK_ID", Value: strconv.FormatInt(taskID, 10)})
@@ -46,8 +47,8 @@ func PrepareDefaultWorkflowTaskEnvs(projectKey, workflowName string, taskID int6
 	return envs
 }
 
-func GetLink(baseURI, projectKey, workflowName string, taskID int64) string {
-	return fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d", baseURI, projectKey, workflowName, taskID)
+func GetLink(baseURI, projectKey, workflowName, workflowDisplayName string, taskID int64) string {
+	return fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d?display_name=%s", baseURI, projectKey, workflowName, taskID, url.QueryEscape(workflowDisplayName))
 }
 
 func getReposVariables(repos []*types.Repository) []*commonmodels.KeyVal {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/utils.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/utils.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2023 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package job
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	configbase "github.com/koderover/zadig/pkg/config"
+	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/pkg/types"
+)
+
+// System level default environment variables (every workflow type will have it)
+func PrepareDefaultWorkflowTaskEnvs(projectKey, workflowName string, taskID int64) []*commonmodels.KeyVal {
+	envs := make([]*commonmodels.KeyVal, 0)
+
+	envs = append(envs,
+		&commonmodels.KeyVal{Key: "WORKSPACE", Value: "/workspace"},
+		&commonmodels.KeyVal{Key: "CI", Value: "true"},
+		&commonmodels.KeyVal{Key: "ZADIG", Value: "true"},
+		&commonmodels.KeyVal{Key: "PROJECT", Value: projectKey},
+		&commonmodels.KeyVal{Key: "WORKFLOW", Value: workflowName},
+	)
+
+	url := GetLink(configbase.SystemAddress(), projectKey, workflowName, taskID)
+
+	envs = append(envs, &commonmodels.KeyVal{Key: "TASK_URL", Value: url})
+	envs = append(envs, &commonmodels.KeyVal{Key: "TASK_ID", Value: strconv.FormatInt(taskID, 10)})
+
+	return envs
+}
+
+func GetLink(baseURI, projectKey, workflowName string, taskID int64) string {
+	return fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d", baseURI, projectKey, workflowName, taskID)
+}
+
+func getReposVariables(repos []*types.Repository) []*commonmodels.KeyVal {
+	ret := make([]*commonmodels.KeyVal, 0)
+	for index, repo := range repos {
+
+		repoNameIndex := fmt.Sprintf("REPONAME_%d", index)
+		ret = append(ret, &commonmodels.KeyVal{Key: fmt.Sprintf(repoNameIndex), Value: repo.RepoName, IsCredential: false})
+
+		repoName := strings.Replace(repo.RepoName, "-", "_", -1)
+		repoName = strings.Replace(repoName, ".", "_", -1)
+
+		repoIndex := fmt.Sprintf("REPO_%d", index)
+		ret = append(ret, &commonmodels.KeyVal{Key: fmt.Sprintf(repoIndex), Value: repoName, IsCredential: false})
+
+		if len(repo.Branch) > 0 {
+			ret = append(ret, &commonmodels.KeyVal{Key: fmt.Sprintf("%s_BRANCH", repoName), Value: repo.Branch, IsCredential: false})
+		}
+
+		if len(repo.Tag) > 0 {
+			ret = append(ret, &commonmodels.KeyVal{Key: fmt.Sprintf("%s_TAG", repoName), Value: repo.Tag, IsCredential: false})
+		}
+
+		if repo.PR > 0 {
+			ret = append(ret, &commonmodels.KeyVal{Key: fmt.Sprintf("%s_PR", repoName), Value: strconv.Itoa(repo.PR), IsCredential: false})
+		}
+
+		ret = append(ret, &commonmodels.KeyVal{Key: fmt.Sprintf("%s_ORG", repoName), Value: repo.RepoOwner, IsCredential: false})
+
+		if len(repo.PRs) > 0 {
+			prStrs := []string{}
+			for _, pr := range repo.PRs {
+				prStrs = append(prStrs, strconv.Itoa(pr))
+			}
+			ret = append(ret, &commonmodels.KeyVal{Key: fmt.Sprintf("%s_PR", repoName), Value: strings.Join(prStrs, ","), IsCredential: false})
+		}
+
+		if len(repo.CommitID) > 0 {
+			ret = append(ret, &commonmodels.KeyVal{Key: fmt.Sprintf("%s_COMMIT_ID", repoName), Value: repo.CommitID, IsCredential: false})
+		}
+		ret = append(ret, getEnvFromCommitMsg(repo.CommitMessage)...)
+	}
+	return ret
+}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
@@ -823,7 +823,6 @@ func TestArgsToTestSubtask(args *commonmodels.TestTaskArgs, pt *task.Task, log *
 			}
 		}
 		envs = append(envs, &commonmodels.KeyVal{Key: "TEST_URL", Value: GetLink(pt, configbase.SystemAddress(), config.TestType)})
-		envs = append(envs, &commonmodels.KeyVal{Key: "WORKSPACE", Value: "/workspace"})
 		testTask.JobCtx.EnvVars = envs
 		testTask.ImageID = testModule.PreTest.ImageID
 		testTask.BuildOS = testModule.PreTest.BuildOS

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_validation.go
@@ -590,7 +590,6 @@ func prepareTaskEnvs(pt *task.Task, log *zap.SugaredLogger) []*commonmodels.KeyV
 		&commonmodels.KeyVal{Key: "IMAGE", Value: pt.TaskArgs.Deploy.Image},
 		&commonmodels.KeyVal{Key: "PKG_FILE", Value: pt.TaskArgs.Deploy.PackageFile},
 		&commonmodels.KeyVal{Key: "LOG_FILE", Value: "/tmp/user_script.log"},
-		&commonmodels.KeyVal{Key: "WORKSPACE", Value: "/workspace"},
 	)
 
 	// 设置编译模块参数化配置信息

--- a/pkg/microservice/aslan/core/workflow/testing/handler/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/handler/scanning.go
@@ -307,7 +307,6 @@ func CreateScanningTask(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	if err != nil {
-
 		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
 		ctx.UnAuthorized = true
 		return

--- a/pkg/microservice/aslan/core/workflow/testing/service/openapi.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/openapi.go
@@ -78,7 +78,6 @@ func generateScanningModuleFromOpenAPIInput(req *OpenAPICreateScanningReq, log *
 		Description:      req.Description,
 		ScannerType:      req.ScannerType,
 		Installs:         req.Addons,
-		PreScript:        req.PrelaunchScript,
 		Parameter:        req.SonarParameter,
 		Script:           req.Script,
 		CheckQualityGate: req.EnableQualityGate,

--- a/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
@@ -209,7 +209,7 @@ func CreateScanningTask(id string, req []*ScanningRepoInfo, notificationID, user
 		return 0, err
 	}
 
-	scanningName := fmt.Sprintf("%s_%s_%s", scanningInfo.Name, id, "scanning-job")
+	scanningName := fmt.Sprintf("%s-%s-%s", scanningInfo.Name, id, "scanning-job")
 
 	nextTaskID, err := commonrepo.NewCounterColl().GetNextSeq(fmt.Sprintf(setting.ScanningTaskFmt, scanningName))
 	if err != nil {

--- a/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
@@ -235,6 +235,11 @@ func CreateScanningTask(id string, req []*ScanningRepoInfo, notificationID, user
 		return 0, err
 	}
 
+	clusterInfo, err := commonrepo.NewK8SClusterColl().Get(scanningInfo.AdvancedSetting.ClusterID)
+	if err != nil {
+		return 0, e.ErrConvertSubTasks.AddErr(fmt.Errorf("failed to get cluster: %s, err: %s", scanningInfo.AdvancedSetting.ClusterID, err))
+	}
+
 	repos := make([]*types.Repository, 0)
 	for _, arg := range req {
 		rep, err := systemconfig.New().GetCodeHost(arg.CodehostID)
@@ -279,24 +284,39 @@ func CreateScanningTask(id string, req []*ScanningRepoInfo, notificationID, user
 		repos = append(repos, repoInfo)
 	}
 
+	// compatibility code
+	cacheEnabled := false
+	cacheDirType := types.WorkspaceCacheDir
+	userCacheDir := ""
+	if scanningInfo.AdvancedSetting.Cache != nil {
+		cacheEnabled = scanningInfo.AdvancedSetting.Cache.CacheEnable
+		cacheDirType = scanningInfo.AdvancedSetting.Cache.CacheDirType
+		userCacheDir = scanningInfo.AdvancedSetting.Cache.CacheUserDir
+	}
+
 	scanningTask := &task.Scanning{
-		TaskType:   config.TaskScanning,
-		Status:     config.StatusCreated,
-		ScanningID: scanningInfo.ID.Hex(),
-		Name:       scanningInfo.Name,
-		ImageInfo:  scanningImage,
-		ResReq:     scanningInfo.AdvancedSetting.ResReq,
-		ResReqSpec: scanningInfo.AdvancedSetting.ResReqSpec,
-		Registries: registries,
-		Parameter:  scanningInfo.Parameter,
-		Script:     scanningInfo.Script,
+		TaskType:      config.TaskScanning,
+		Status:        config.StatusCreated,
+		ScanningID:    scanningInfo.ID.Hex(),
+		Name:          scanningInfo.Name,
+		EnableScanner: scanningInfo.EnableScanner,
+		ImageInfo:     scanningImage,
+		ResReq:        scanningInfo.AdvancedSetting.ResReq,
+		ResReqSpec:    scanningInfo.AdvancedSetting.ResReqSpec,
+		Registries:    registries,
+		Parameter:     scanningInfo.Parameter,
+		Envs:          scanningInfo.Envs,
+		Script:        scanningInfo.Script,
 		// the timeout we save is measured in minute
 		Timeout:          scanningInfo.AdvancedSetting.Timeout * 60,
 		ClusterID:        scanningInfo.AdvancedSetting.ClusterID,
 		StrategyID:       scanningInfo.AdvancedSetting.StrategyID,
+		Cache:            clusterInfo.Cache,
+		CacheEnable:      cacheEnabled,
+		CacheDirType:     cacheDirType,
+		CacheUserDir:     userCacheDir,
 		Repos:            repos,
 		InstallItems:     scanningInfo.Installs,
-		PreScript:        scanningInfo.PreScript,
 		CheckQualityGate: scanningInfo.CheckQualityGate,
 	}
 

--- a/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
@@ -209,7 +209,7 @@ func CreateScanningTask(id string, req []*ScanningRepoInfo, notificationID, user
 		return 0, err
 	}
 
-	scanningName := fmt.Sprintf("%s-%s-%s", scanningInfo.Name, id, "scanning-job")
+	scanningName := fmt.Sprintf("%s_%s_%s", scanningInfo.Name, id, "scanning-job")
 
 	nextTaskID, err := commonrepo.NewCounterColl().GetNextSeq(fmt.Sprintf(setting.ScanningTaskFmt, scanningName))
 	if err != nil {

--- a/pkg/microservice/aslan/core/workflow/testing/service/types.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/types.go
@@ -26,19 +26,20 @@ import (
 const DefaultScanningTimeout = 60 * 60
 
 type Scanning struct {
-	ID          string               `json:"id"`
-	Name        string               `json:"name"`
-	ProjectName string               `json:"project_name"`
-	Description string               `json:"description"`
-	ScannerType string               `json:"scanner_type"`
-	ImageID     string               `json:"image_id"`
-	SonarID     string               `json:"sonar_id"`
-	Installs    []*commonmodels.Item `json:"installs"`
-	Repos       []*types.Repository  `json:"repos"`
-	PreScript   string               `json:"pre_script"`
+	ID            string               `json:"id"`
+	Name          string               `json:"name"`
+	ProjectName   string               `json:"project_name"`
+	Description   string               `json:"description"`
+	ScannerType   string               `json:"scanner_type"`
+	EnableScanner bool                 `json:"enable_scanner"`
+	ImageID       string               `json:"image_id"`
+	SonarID       string               `json:"sonar_id"`
+	Installs      []*commonmodels.Item `json:"installs"`
+	Repos         []*types.Repository  `json:"repos"`
 	// Parameter is for sonarQube type only
 	Parameter string `json:"parameter"`
-	// Script is for other type only
+	// Envs is the user defined key/values
+	Envs             []*commonmodels.KeyVal                `json:"envs"`
 	Script           string                                `json:"script"`
 	AdvancedSetting  *commonmodels.ScanningAdvancedSetting `json:"advanced_settings"`
 	CheckQualityGate bool                                  `json:"check_quality_gate"`
@@ -46,6 +47,7 @@ type Scanning struct {
 	NotifyCtls       []*commonmodels.NotifyCtl             `json:"notify_ctls"`
 }
 
+// TODO: change the logic of create scanning
 type OpenAPICreateScanningReq struct {
 	Name        string                    `json:"name"`
 	ProjectName string                    `json:"project_key"`
@@ -55,7 +57,6 @@ type OpenAPICreateScanningReq struct {
 	RepoInfo    []*types.OpenAPIRepoInput `json:"repo_info"`
 	// FIMXE: currently only one sonar system is required, so we just fill in the default sonar ID.
 	Addons            []*commonmodels.Item          `json:"addons"`
-	PrelaunchScript   string                        `json:"prelaunch_script"`
 	SonarParameter    string                        `json:"sonar_parameter"`
 	Script            string                        `json:"script"`
 	EnableQualityGate bool                          `json:"enable_quality_gate"`
@@ -167,6 +168,7 @@ func ConvertToDBScanningModule(args *Scanning) *commonmodels.Scanning {
 		ProjectName:      args.ProjectName,
 		Description:      args.Description,
 		ScannerType:      args.ScannerType,
+		EnableScanner:    args.EnableScanner,
 		ImageID:          args.ImageID,
 		SonarID:          args.SonarID,
 		Repos:            args.Repos,
@@ -174,7 +176,6 @@ func ConvertToDBScanningModule(args *Scanning) *commonmodels.Scanning {
 		Script:           args.Script,
 		AdvancedSetting:  args.AdvancedSetting,
 		Installs:         args.Installs,
-		PreScript:        args.PreScript,
 		CheckQualityGate: args.CheckQualityGate,
 		Outputs:          args.Outputs,
 	}
@@ -190,6 +191,7 @@ func ConvertDBScanningModule(scanning *commonmodels.Scanning) *Scanning {
 		ProjectName:      scanning.ProjectName,
 		Description:      scanning.Description,
 		ScannerType:      scanning.ScannerType,
+		EnableScanner:    scanning.EnableScanner,
 		ImageID:          scanning.ImageID,
 		SonarID:          scanning.SonarID,
 		Repos:            scanning.Repos,
@@ -197,7 +199,6 @@ func ConvertDBScanningModule(scanning *commonmodels.Scanning) *Scanning {
 		Script:           scanning.Script,
 		AdvancedSetting:  scanning.AdvancedSetting,
 		Installs:         scanning.Installs,
-		PreScript:        scanning.PreScript,
 		CheckQualityGate: scanning.CheckQualityGate,
 		Outputs:          scanning.Outputs,
 	}

--- a/pkg/microservice/aslan/core/workflow/testing/service/types.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/types.go
@@ -178,6 +178,7 @@ func ConvertToDBScanningModule(args *Scanning) *commonmodels.Scanning {
 		Installs:         args.Installs,
 		CheckQualityGate: args.CheckQualityGate,
 		Outputs:          args.Outputs,
+		Envs:             args.Envs,
 	}
 }
 
@@ -201,6 +202,7 @@ func ConvertDBScanningModule(scanning *commonmodels.Scanning) *Scanning {
 		Installs:         scanning.Installs,
 		CheckQualityGate: scanning.CheckQualityGate,
 		Outputs:          scanning.Outputs,
+		Envs:             scanning.Envs,
 	}
 }
 

--- a/pkg/microservice/reaper/core/service/meta/types.go
+++ b/pkg/microservice/reaper/core/service/meta/types.go
@@ -136,6 +136,7 @@ type Context struct {
 	ScannerFlag           bool   `yaml:"scanner_flag"`
 	ScannerType           string `yaml:"scanner_type"`
 	SonarParameter        string `yaml:"sonar_parameter"`
+	SonarEnableScanner    bool   `yaml:"sonar_enable_scanner"`
 	SonarServer           string `yaml:"sonar_server"`
 	SonarLogin            string `yaml:"sonar_login"`
 	SonarCheckQualityGate bool   `yaml:"sonar_check_quality_gate"`

--- a/pkg/microservice/reaper/core/service/reaper/reaper.go
+++ b/pkg/microservice/reaper/core/service/reaper/reaper.go
@@ -400,7 +400,7 @@ func (r *Reaper) Exec() (err error) {
 	}
 	log.Infof("Execution ended. Duration: %.2f seconds.", time.Since(startTimeRunBuildScript).Seconds())
 
-	if r.Ctx.ScannerFlag && r.Ctx.ScannerType == types.ScanningTypeSonar {
+	if r.Ctx.ScannerFlag && r.Ctx.ScannerType == types.ScanningTypeSonar && r.Ctx.SonarEnableScanner {
 		// for sonar type we write the sonar parameter into config file and go with sonar-scanner command
 		log.Info("Executing SonarQube Scanning process.")
 		startTimeRunSonar := time.Now()
@@ -617,8 +617,6 @@ func (r *Reaper) maskSecretEnvs(message string) string {
 func (r *Reaper) getUserEnvs() []string {
 	envs := os.Environ()
 	envs = append(envs,
-		"CI=true",
-		"ZADIG=true",
 		fmt.Sprintf("HOME=%s", config.Home()),
 		fmt.Sprintf("WORKSPACE=%s", r.ActiveWorkspace),
 		// TODO: readme文件可以使用别的方式代替

--- a/pkg/microservice/warpdrive/core/service/taskplugin/artifact_deploy.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/artifact_deploy.go
@@ -195,7 +195,7 @@ func (p *ArtifactDeployTaskPlugin) Run(ctx context.Context, pipelineTask *task.T
 	p.KubeNamespace = pipelineTask.ConfigPayload.Build.KubeNamespace
 
 	//instantiates variables like ${<REPO>_BRANCH} ${${REPO_index}_BRANCH} ..
-	p.Task.JobCtx.EnvVars = append(p.Task.JobCtx.EnvVars, InstantiateBuildSysVariables(&p.Task.JobCtx)...)
+	p.Task.JobCtx.EnvVars = append(p.Task.JobCtx.EnvVars, CreateEnvsFromRepoInfo(p.Task.JobCtx.Builds)...)
 
 	jobCtx := JobCtxBuilder{
 		JobName:     p.JobName,

--- a/pkg/microservice/warpdrive/core/service/taskplugin/build_v3.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/build_v3.go
@@ -117,7 +117,7 @@ func (p *BuildTaskV3Plugin) Run(ctx context.Context, pipelineTask *task.Task, pi
 	p.KubeNamespace = pipelineTask.ConfigPayload.Build.KubeNamespace
 
 	//instantiates variables like ${<REPO>_BRANCH} ${${REPO_index}_BRANCH} ...
-	p.Task.JobCtx.EnvVars = append(p.Task.JobCtx.EnvVars, InstantiateBuildSysVariables(&p.Task.JobCtx)...)
+	p.Task.JobCtx.EnvVars = append(p.Task.JobCtx.EnvVars, CreateEnvsFromRepoInfo(p.Task.JobCtx.Builds)...)
 
 	jobCtx := JobCtxBuilder{
 		JobName:     p.JobName,

--- a/pkg/microservice/warpdrive/core/service/taskplugin/scanning.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/scanning.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
 	"strings"
 	"time"
 
+	"github.com/koderover/zadig/pkg/types"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -147,11 +149,24 @@ func (p *ScanPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipelineC
 		repoList = append(repoList, repo)
 	}
 
+	// ============== environment variables ============================
 	envVars := make([]*task.KeyVal, 0)
+
+	envVars = append(envVars, PrepareDefaultWorkflowTaskEnvs(pipelineTask)...)
+
+	envVars = append(envVars, CreateEnvsFromRepoInfo(repoList)...)
+
 	if len(repoList) > 0 {
 		envVars = append(envVars, &task.KeyVal{
 			Key:   "BRANCH",
 			Value: repoList[0].Branch,
+		})
+	}
+
+	if p.Task.SonarInfo != nil {
+		envVars = append(envVars, &task.KeyVal{
+			Key:   "SONAR_TOKEN",
+			Value: p.Task.SonarInfo.Token,
 		})
 	}
 
@@ -169,16 +184,36 @@ func (p *ScanPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipelineC
 
 	// if the scanning task is of sonar type, then we add the sonar parameter to the context
 	if p.Task.SonarInfo != nil {
-		reaperContext.SonarParameter = p.Task.Parameter
 		reaperContext.SonarServer = p.Task.SonarInfo.ServerAddress
 		reaperContext.SonarLogin = p.Task.SonarInfo.Token
 		reaperContext.ScannerType = ScanningTypeSonar
-		reaperContext.Scripts = append(reaperContext.Scripts, strings.Split(replaceWrapLine(p.Task.PreScript), "\n")...)
 		reaperContext.SonarCheckQualityGate = p.Task.CheckQualityGate
 	} else {
 		reaperContext.ScannerType = ScanningTypeOther
-		reaperContext.Scripts = append(reaperContext.Scripts, strings.Split(replaceWrapLine(p.Task.Script), "\n")...)
 	}
+	reaperContext.Scripts = append(reaperContext.Scripts, strings.Split(replaceWrapLine(p.Task.Script), "\n")...)
+
+	if p.Task.CacheEnable {
+		// job creation usage
+		pipelineCtx.CacheEnable = true
+		pipelineCtx.Cache = p.Task.Cache
+		pipelineCtx.CacheDirType = p.Task.CacheDirType
+		pipelineCtx.CacheUserDir = p.Task.CacheUserDir
+		// job usage
+		reaperContext.CacheEnable = p.Task.CacheEnable
+		reaperContext.CacheDirType = p.Task.CacheDirType
+		reaperContext.CacheUserDir = p.Task.CacheUserDir
+		reaperContext.Cache = p.Task.Cache
+
+		// Since we allow users to use custom environment variables, variable resolution is required.
+		if pipelineCtx.CacheEnable && pipelineCtx.Cache.MediumType == types.NFSMedium {
+			pipelineCtx.CacheUserDir = p.renderEnv(pipelineCtx.CacheUserDir, envVars)
+			pipelineCtx.Cache.NFSProperties.Subpath = p.renderEnv(pipelineCtx.Cache.NFSProperties.Subpath, envVars)
+		}
+	}
+
+	reaperContext.SonarEnableScanner = p.Task.EnableScanner
+	reaperContext.SonarParameter = p.Task.Parameter
 
 	jobCtxBytes, err := yaml.Marshal(reaperContext)
 	if err != nil {
@@ -385,4 +420,22 @@ func (p *ScanPlugin) IsTaskEnabled() bool {
 
 func (p *ScanPlugin) ResetError() {
 	p.Task.Error = ""
+}
+
+// Note: Since there are few environment variables and few variables to be replaced,
+// this method is temporarily used.
+func (p *ScanPlugin) renderEnv(data string, envs []*task.KeyVal) string {
+	mapper := func(data string) string {
+		for _, envar := range envs {
+			if data != envar.Key {
+				continue
+			}
+
+			return envar.Value
+		}
+
+		return fmt.Sprintf("$%s", data)
+	}
+
+	return os.Expand(data, mapper)
 }

--- a/pkg/microservice/warpdrive/core/service/taskplugin/scanning.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/scanning.go
@@ -156,6 +156,14 @@ func (p *ScanPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipelineC
 
 	envVars = append(envVars, CreateEnvsFromRepoInfo(repoList)...)
 
+	for _, env := range p.Task.Envs {
+		envVars = append(envVars, &task.KeyVal{
+			Key:          env.Key,
+			Value:        env.Value,
+			IsCredential: env.IsCredential,
+		})
+	}
+
 	if len(repoList) > 0 {
 		envVars = append(envVars, &task.KeyVal{
 			Key:   "BRANCH",
@@ -165,8 +173,15 @@ func (p *ScanPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipelineC
 
 	if p.Task.SonarInfo != nil {
 		envVars = append(envVars, &task.KeyVal{
-			Key:   "SONAR_TOKEN",
-			Value: p.Task.SonarInfo.Token,
+			Key:          "SONAR_TOKEN",
+			Value:        p.Task.SonarInfo.Token,
+			IsCredential: true,
+		})
+
+		envVars = append(envVars, &task.KeyVal{
+			Key:          "SONAR_URL",
+			Value:        p.Task.SonarInfo.ServerAddress,
+			IsCredential: false,
 		})
 	}
 

--- a/pkg/microservice/warpdrive/core/service/taskplugin/testing.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/testing.go
@@ -171,7 +171,7 @@ func (p *TestPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipelineC
 		workflowName = pipelineTask.WorkflowArgs.WorkflowName
 	}
 	p.Task.JobCtx.EnvVars = append(p.Task.JobCtx.EnvVars, &task.KeyVal{Key: "WORKFLOW", Value: workflowName})
-	p.Task.JobCtx.EnvVars = append(p.Task.JobCtx.EnvVars, InstantiateBuildSysVariables(&p.Task.JobCtx)...)
+	p.Task.JobCtx.EnvVars = append(p.Task.JobCtx.EnvVars, CreateEnvsFromRepoInfo(p.Task.JobCtx.Builds)...)
 	namespaceEnvVar := &task.KeyVal{Key: "DEPLOY_ENV", Value: p.KubeNamespace, IsCredential: false}
 	linkedNamespaceEnvVar := &task.KeyVal{Key: "LINKED_ENV", Value: linkedNamespace, IsCredential: false}
 	envNameEnvVar := &task.KeyVal{Key: "ENV_NAME", Value: envName, IsCredential: false}

--- a/pkg/microservice/warpdrive/core/service/taskplugin/utils.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/utils.go
@@ -355,8 +355,7 @@ func GetLink(p *task.Task, baseURI string, taskType config.PipelineType) string 
 	case config.TestType:
 		url = fmt.Sprintf("%s/v1/projects/detail/%s/test/detail/function/%s/%d", baseURI, p.ProductName, p.PipelineName, p.TaskID)
 	case config.ScanningType:
-		seg := strings.Split(p.PipelineName, "_")
-		url = fmt.Sprintf("%s/v1/projects/detail/%s/scanner/detail/%s/%d", baseURI, p.ProductName, seg[0], p.TaskID)
+		url = fmt.Sprintf("%s/v1/projects/detail/%s/scanner/detail/%s/%d", baseURI, p.ProductName, p.ScanningArgs.ScanningName, p.TaskID)
 	}
 	return url
 }

--- a/pkg/microservice/warpdrive/core/service/taskplugin/utils.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/utils.go
@@ -355,7 +355,7 @@ func GetLink(p *task.Task, baseURI string, taskType config.PipelineType) string 
 	case config.TestType:
 		url = fmt.Sprintf("%s/v1/projects/detail/%s/test/detail/function/%s/%d", baseURI, p.ProductName, p.PipelineName, p.TaskID)
 	case config.ScanningType:
-		url = fmt.Sprintf("%s/v1/projects/detail/%s/scanner/detail/%s/%d", baseURI, p.ProductName, p.ScanningArgs.ScanningName, p.TaskID)
+		url = fmt.Sprintf("%s/v1/projects/detail/%s/scanner/detail/%s/task/%d?id=%s", baseURI, p.ProductName, p.ScanningArgs.ScanningName, p.TaskID, p.ScanningArgs.ScanningID)
 	}
 	return url
 }

--- a/pkg/microservice/warpdrive/core/service/taskplugin/utils.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/utils.go
@@ -355,7 +355,8 @@ func GetLink(p *task.Task, baseURI string, taskType config.PipelineType) string 
 	case config.TestType:
 		url = fmt.Sprintf("%s/v1/projects/detail/%s/test/detail/function/%s/%d", baseURI, p.ProductName, p.PipelineName, p.TaskID)
 	case config.ScanningType:
-		url = fmt.Sprintf("%s/v1/projects/detail/%s/scanner/detail/%s/%d", baseURI, p.ProductName, p.PipelineName, p.TaskID)
+		seg := strings.Split(p.PipelineName, "_")
+		url = fmt.Sprintf("%s/v1/projects/detail/%s/scanner/detail/%s/%d", baseURI, p.ProductName, seg[0], p.TaskID)
 	}
 	return url
 }

--- a/pkg/microservice/warpdrive/core/service/types/reaper.go
+++ b/pkg/microservice/warpdrive/core/service/types/reaper.go
@@ -134,6 +134,7 @@ type Context struct {
 	ScannerFlag           bool   `yaml:"scanner_flag"`
 	ScannerType           string `yaml:"scanner_type"`
 	SonarParameter        string `yaml:"sonar_parameter"`
+	SonarEnableScanner    bool   `yaml:"sonar_enable_scanner"`
 	SonarServer           string `yaml:"sonar_server"`
 	SonarLogin            string `yaml:"sonar_login"`
 	SonarCheckQualityGate bool   `yaml:"sonar_check_quality_gate"`

--- a/pkg/microservice/warpdrive/core/service/types/task/model.go
+++ b/pkg/microservice/warpdrive/core/service/types/task/model.go
@@ -65,6 +65,8 @@ type Task struct {
 	WorkflowArgs *WorkflowTaskArgs `bson:"workflow_args"         json:"workflow_args,omitempty"`
 	// TestArgs test workflow args
 	TestArgs *TestTaskArgs `bson:"test_args,omitempty"         json:"test_args,omitempty"`
+	// ScanningArgs argument for scanning tasks
+	ScanningArgs *ScanningArgs `bson:"scanning_args,omitempty" json:"scanning_args,omitempty"`
 	// ServiceTaskArgs sh deploy args
 	ServiceTaskArgs *ServiceTaskArgs `bson:"service_args,omitempty"         json:"service_args,omitempty"`
 	// ArtifactPackageTaskArgs arguments for artifact-package type tasks
@@ -242,6 +244,14 @@ type TestTaskArgs struct {
 	CodehostID     int    `bson:"codehost_id"      json:"codehost_id"`
 	RepoOwner      string `bson:"repo_owner"       json:"repo_owner"`
 	RepoName       string `bson:"repo_name"        json:"repo_name"`
+}
+
+type ScanningArgs struct {
+	ScanningName string `json:"scanning_name" bson:"scanning_name"`
+	ScanningID   string `json:"scanning_id"   bson:"scanning_id"`
+
+	// NotificationID is the id of scmnotify.Notification
+	NotificationID string `bson:"notification_id" json:"notification_id"`
 }
 
 type BuildArgs struct {

--- a/pkg/microservice/warpdrive/core/service/types/task/scanning.go
+++ b/pkg/microservice/warpdrive/core/service/types/task/scanning.go
@@ -24,27 +24,35 @@ import (
 )
 
 type Scanning struct {
-	TaskType   config.TaskType     `bson:"type"            json:"type"`
-	Status     config.Status       `bson:"status"          json:"status,omitempty"`
-	ScanningID string              `bson:"scanning_id"     json:"scanning_id"`
-	Name       string              `bson:"name"            json:"name"`
-	Error      string              `bson:"error,omitempty" json:"error,omitempty"`
-	ImageInfo  string              `bson:"image_info"      json:"image_info"`
-	SonarInfo  *models.SonarInfo   `bson:"sonar_info"      json:"sonar_info"`
-	Repos      []*types.Repository `bson:"repos"           json:"repos"`
-	Proxy      *models.Proxy       `bson:"proxy"           json:"proxy"`
-	ClusterID  string              `bson:"cluster_id"      json:"cluster_id"`
-	StrategyID string              `bson:"strategy_id"     json:"strategy_id"`
+	TaskType      config.TaskType     `bson:"type"            json:"type"`
+	Status        config.Status       `bson:"status"          json:"status,omitempty"`
+	ScanningID    string              `bson:"scanning_id"     json:"scanning_id"`
+	Name          string              `bson:"name"            json:"name"`
+	Error         string              `bson:"error,omitempty" json:"error,omitempty"`
+	ImageInfo     string              `bson:"image_info"      json:"image_info"`
+	SonarInfo     *models.SonarInfo   `bson:"sonar_info"      json:"sonar_info"`
+	EnableScanner bool                `bson:"enable_scanner"  json:"enable_scanner"`
+	InstallCtx    []*Install          `bson:"-"               json:"install_ctx"`
+	Repos         []*types.Repository `bson:"repos"           json:"repos"`
+	Proxy         *models.Proxy       `bson:"proxy"           json:"proxy"`
+	ClusterID     string              `bson:"cluster_id"      json:"cluster_id"`
+	StrategyID    string              `bson:"strategy_id"     json:"strategy_id"`
 	// ResReq defines job requested resources
-	ResReq     setting.Request      `bson:"res_req"       json:"res_req"`
-	ResReqSpec setting.RequestSpec  `bson:"res_req_spec"  json:"res_req_spec"`
+	ResReq     setting.Request     `bson:"res_req"       json:"res_req"`
+	ResReqSpec setting.RequestSpec `bson:"res_req_spec"  json:"res_req_spec"`
+	// Cache settings
+	Cache        types.Cache        `bson:"cache"               json:"cache"`
+	CacheEnable  bool               `bson:"cache_enable"        json:"cache_enable"`
+	CacheDirType types.CacheDirType `bson:"cache_dir_type"      json:"cache_dir_type"`
+	CacheUserDir string             `bson:"cache_user_dir"      json:"cache_user_dir"`
+	// Task timeout
 	Timeout    int64                `bson:"timeout"       json:"timeout"`
 	Registries []*RegistryNamespace `bson:"-"             json:"registries"`
 	// Parameter is for sonarQube type only
 	Parameter string `bson:"parameter" json:"parameter"`
+	// Envs is the user defined key/values
+	Envs []*models.KeyVal `bson:"envs" json:"envs"`
 	// Script is for other type only
-	Script           string     `bson:"script"                json:"script"`
-	PreScript        string     `bson:"pre_script"            json:"pre_script"`
-	CheckQualityGate bool       `bson:"check_quality_gate"    json:"check_quality_gate"`
-	InstallCtx       []*Install `bson:"-"                     json:"install_ctx"`
+	Script           string `bson:"script"                json:"script"`
+	CheckQualityGate bool   `bson:"check_quality_gate"    json:"check_quality_gate"`
 }


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9f0d09b</samp>

This pull request adds support for sonar scanner and cache settings for scanning tasks in the workflow, testing, and reaper services. It also refactors and simplifies the generation of environment variables for workflow tasks in the warpdrive and aslan services, using common functions and removing unused or redundant code. It updates the models and types to reflect the changes in the scanning task options.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9f0d09b</samp>

*  Add `EnableScanner` field to `Scanning` structs to indicate whether to use sonar scanner for scanning tasks ([link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-b019d8a97c6eb1a2ac2d7919efdc1dbf7493556ecea151a0f661595bcef5d0d4L28-R42), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-3099f51cfa686b0cdab1bb7d317772ba0dd70fc07da9c9a9c8ec84d5d0a7d788L29-R59), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-d9c21c848569759601387917ecaafc204d9bcde710a1997f891f9b9be45148e5R238-R242), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-c76ce97d0bbad006a475686268fd2e1bab3ea25b780e963aaf9fa3e7182b61bcL29-R42), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-c76ce97d0bbad006a475686268fd2e1bab3ea25b780e963aaf9fa3e7182b61bcR171), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-c76ce97d0bbad006a475686268fd2e1bab3ea25b780e963aaf9fa3e7182b61bcR194), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-785b61b9647e5eff9a9defa6bd79cdbfdffdac18b380327ccdb89be6d03a34b5R139))
*  Add cache-related fields to `Scanning` and `ScanningAdvancedSetting` structs to store cache settings for scanning tasks ([link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-b019d8a97c6eb1a2ac2d7919efdc1dbf7493556ecea151a0f661595bcef5d0d4L56-R66), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-b019d8a97c6eb1a2ac2d7919efdc1dbf7493556ecea151a0f661595bcef5d0d4R90-R95), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-d9c21c848569759601387917ecaafc204d9bcde710a1997f891f9b9be45148e5L282-R319))
*  Add `Envs` field to `Scanning` struct to store user-defined key/values for scanning tasks ([link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-c76ce97d0bbad006a475686268fd2e1bab3ea25b780e963aaf9fa3e7182b61bcL29-R42))
*  Replace manual appending of basic environment variables with calls to `PrepareDefaultWorkflowTaskEnvs` in various functions to generate system level default environment variables for workflow tasks ([link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-4869da926fe09ee6d3c747d5e63300b59a2a830a285f3929dae0233f7f62695cL475-R487), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-8a809ea09e11fbe9301d30510d8e13dc2e13deb5c5d7723f2814192a4d91d988L313-R317), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-8cde9ebf507918a052f674f56e227cbb8ac8e72f618f4469f128751987dd5fc5L543-R547), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-98eeafb103c9b66a212554c07c7d005f4361725054ad60ca8cf3dcd408ca5590L198-R198), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-f5d40817e0b50e462d685039df2072b1273509b9b00061eda543c40da81e9131R183-R185), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-dec284d28b96603e4ac7e2fd147581daed22745708b4d5be37ec79352dc5f7e3L120-R120), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-011710bf487b419f6cd001735c3d510d5e6b07037b3b5d80f716fb35f7aaba8fL150-R158))
*  Replace calls to `InstantiateBuildSysVariables` with calls to `CreateEnvsFromRepoInfo` in `Run` functions of `build.go` and `build_v3.go` to generate repo-related environment variables for workflow tasks ([link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-f5d40817e0b50e462d685039df2072b1273509b9b00061eda543c40da81e9131L238-R236), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-dec284d28b96603e4ac7e2fd147581daed22745708b4d5be37ec79352dc5f7e3L120-R120))
*  Add `getScanningJobVariables` function to generate environment variables for scanning tasks based on repositories and workflow information ([link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-8ce6648bcd34814704b4ce0fb5f896cccff5cfc80f48da92a359a5bac85ff2c3R347-R357))
*  Use `getScanningJobVariables` to set the `Envs` field of `jobTaskSpec` in `ToJobs` function ([link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-8ce6648bcd34814704b4ce0fb5f896cccff5cfc80f48da92a359a5bac85ff2c3L166-R171), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-8ce6648bcd34814704b4ce0fb5f896cccff5cfc80f48da92a359a5bac85ff2c3L183-R185))
*  Use `Script` field of `scanningInfo` to set the `PreScript` field of `sonarShellStep` in `ToJobs` function ([link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-8ce6648bcd34814704b4ce0fb5f896cccff5cfc80f48da92a359a5bac85ff2c3L238-R240))
*  Add condition to check `EnableScanner` field of `scanningInfo` and skip `sonarShellStep` if true in `ToJobs` function ([link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-8ce6648bcd34814704b4ce0fb5f896cccff5cfc80f48da92a359a5bac85ff2c3L261-R282))
*  Add condition to check `SonarEnableScanner` field of `reaperContext` and execute sonar scanner command if true in `Exec` function ([link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-81665bd0249cbf747d030b652b84195780e796e1bbaaaf95494615816933a776L403-R403))
*  Remove unused import of `strconv` from `job.go` and `build.go` ([link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-cd667032e3bf01aed408f869322d63aed342d028916369c057cf2a090257e6a4L25), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-f5d40817e0b50e462d685039df2072b1273509b9b00061eda543c40da81e9131L25))
*  Remove unused function `getReposVariables` from `job.go` and move it to `utils.go` ([link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-cd667032e3bf01aed408f869322d63aed342d028916369c057cf2a090257e6a4L396-L438), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-565d88128a807904fe57ade94da16289b6878da6d2b9346910ad2e07884f097cR1-R94))
*  Remove redundant appending of `WORKFLOW`, `CI` and `ZADIG` environment variables from `getTestingJobVariables` and `getUserEnvs` functions ([link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-8cde9ebf507918a052f674f56e227cbb8ac8e72f618f4469f128751987dd5fc5L553-L555), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-81665bd0249cbf747d030b652b84195780e796e1bbaaaf95494615816933a776L620-L621))
*  Remove redundant appending of `WORKSPACE` environment variable from `TestArgsToTestSubtask` and `prepareTaskEnvs` functions ([link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-3a9aed32d3722a7eb3a76d79dfd8c1a994acb4f875829cb8f1f80ebaf367b8abL826), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-0a53e2e2cfb242d5e493660e8d8d6f7bd52cd45fe8450d8ce8bc591670405304L593))
*  Remove `PrelaunchScript` field from `OpenAPICreateScanningReq` struct and related functions as it is no longer used for scanning tasks ([link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-7698b6a5f2d24dfb4321459c1f297845d08015bf4293e7c8a44a6bc8a01fecc1L310), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-56f097cd49c8e9ac38eaa59e10932b66d0ae2ee643a78efb18c4f6e3e4ee3fd7L81), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-c76ce97d0bbad006a475686268fd2e1bab3ea25b780e963aaf9fa3e7182b61bcL58), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-c76ce97d0bbad006a475686268fd2e1bab3ea25b780e963aaf9fa3e7182b61bcL177), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-c76ce97d0bbad006a475686268fd2e1bab3ea25b780e963aaf9fa3e7182b61bcL200))
*  Add TODO comment to `CreateScanning` function to suggest changing the logic of creating scanning tasks ([link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-c76ce97d0bbad006a475686268fd2e1bab3ea25b780e963aaf9fa3e7182b61bcR50))
*  Add `renderEnv` function to resolve user-defined environment variables in cache settings ([link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-011710bf487b419f6cd001735c3d510d5e6b07037b3b5d80f716fb35f7aaba8fL23-R27), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-011710bf487b419f6cd001735c3d510d5e6b07037b3b5d80f716fb35f7aaba8fL172-R217), [link](https://github.com/koderover/zadig/pull/3042/files?diff=unified&w=0#diff-011710bf487b419f6cd001735c3d510d5e6b07037b3b5d80f716fb35f7aaba8fR424-R441))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
