### PR TITLE
fix panic for update pod metrics

### DIFF
--- a/pkg/tool/metrics/prometheus.go
+++ b/pkg/tool/metrics/prometheus.go
@@ -13,7 +13,6 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/shared/kube/client"
-	"github.com/koderover/zadig/pkg/tool/log"
 )
 
 var (
@@ -118,14 +117,14 @@ func UpdatePodMetrics() error {
 
 	metricsClient, err := client.GetKubeMetricsClient(config.HubServerAddress(), setting.LocalClusterID)
 	if err != nil {
-		log.Errorf("failed to get metrics client, err: %v", err)
+		fmt.Printf("failed to get metrics client, err: %v\n", err)
 		return err
 	}
 
 	podMetrices, err := metricsClient.PodMetricses(config.Namespace()).List(context.TODO(), v1.ListOptions{})
 
 	if err != nil {
-		log.Errorf("failed to get pod metrics, err: %v", err)
+		fmt.Printf("failed to get pod metrics, err: %v\n", err)
 		return err
 	}
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 532757c</samp>

Refactored error logging in `UpdatePodMetrics` function to use `fmt` instead of `log` package. This improves code readability and user experience in `pkg/tool/metrics/prometheus.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 532757c</samp>

* Replace log package with fmt for error output in `UpdatePodMetrics` function ([link](https://github.com/koderover/zadig/pull/3048/files?diff=unified&w=0#diff-23b97d21974c576137ecd6a378b1d935c1b77fe882063ac14362e356d379b44bL16), [link](https://github.com/koderover/zadig/pull/3048/files?diff=unified&w=0#diff-23b97d21974c576137ecd6a378b1d935c1b77fe882063ac14362e356d379b44bL121-R120), [link](https://github.com/koderover/zadig/pull/3048/files?diff=unified&w=0#diff-23b97d21974c576137ecd6a378b1d935c1b77fe882063ac14362e356d379b44bL128-R127))
* Remove unused log import in `pkg/tool/metrics/prometheus.go` ([link](https://github.com/koderover/zadig/pull/3048/files?diff=unified&w=0#diff-23b97d21974c576137ecd6a378b1d935c1b77fe882063ac14362e356d379b44bL16))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
