### PR TITLE
cherrypick #3048

### DIFF
--- a/pkg/tool/metrics/prometheus.go
+++ b/pkg/tool/metrics/prometheus.go
@@ -13,7 +13,6 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/shared/kube/client"
-	"github.com/koderover/zadig/pkg/tool/log"
 )
 
 var (
@@ -118,14 +117,14 @@ func UpdatePodMetrics() error {
 
 	metricsClient, err := client.GetKubeMetricsClient(config.HubServerAddress(), setting.LocalClusterID)
 	if err != nil {
-		log.Errorf("failed to get metrics client, err: %v", err)
+		fmt.Printf("failed to get metrics client, err: %v\n", err)
 		return err
 	}
 
 	podMetrices, err := metricsClient.PodMetricses(config.Namespace()).List(context.TODO(), v1.ListOptions{})
 
 	if err != nil {
-		log.Errorf("failed to get pod metrics, err: %v", err)
+		fmt.Printf("failed to get pod metrics, err: %v\n", err)
 		return err
 	}
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1aa27b5</samp>

Enable job stage to access git repos of service and build, and remove unused import in metrics package. The changes involve passing and rendering the `gitURLs` parameter in `job.go` and `workflow_v4.go`, and using `fmt` instead of `log` in `prometheus.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1aa27b5</samp>

*  Add `gitURLs` variable and parameter to store and pass the git URLs of the service and build repos in the workflow stage ([link](https://github.com/koderover/zadig/pull/3049/files?diff=unified&w=0#diff-cd667032e3bf01aed408f869322d63aed342d028916369c057cf2a090257e6a4L515-R529), [link](https://github.com/koderover/zadig/pull/3049/files?diff=unified&w=0#diff-cd667032e3bf01aed408f869322d63aed342d028916369c057cf2a090257e6a4R539), [link](https://github.com/koderover/zadig/pull/3049/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R1891))
* Remove unused import of `log` package and replace `log.Errorf` with `fmt.Printf` in `metrics/prometheus.go` ([link](https://github.com/koderover/zadig/pull/3049/files?diff=unified&w=0#diff-23b97d21974c576137ecd6a378b1d935c1b77fe882063ac14362e356d379b44bL16), [link](https://github.com/koderover/zadig/pull/3049/files?diff=unified&w=0#diff-23b97d21974c576137ecd6a378b1d935c1b77fe882063ac14362e356d379b44bL121-R120), [link](https://github.com/koderover/zadig/pull/3049/files?diff=unified&w=0#diff-23b97d21974c576137ecd6a378b1d935c1b77fe882063ac14362e356d379b44bL128-R127))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
