### PR TITLE
fix: docker build step add default context dir

### DIFF
--- a/pkg/microservice/jobexecutor/core/service/step/step_docker_build.go
+++ b/pkg/microservice/jobexecutor/core/service/step/step_docker_build.go
@@ -129,6 +129,9 @@ func (s *DockerBuildStep) runDockerBuild() error {
 
 func (s *DockerBuildStep) dockerCommands() []*exec.Cmd {
 	cmds := make([]*exec.Cmd, 0)
+	if s.spec.WorkDir == "" {
+		s.spec.WorkDir = "."
+	}
 	cmds = append(
 		cmds,
 		dockerBuildCmd(

--- a/pkg/microservice/reaper/core/service/reaper/reaper.go
+++ b/pkg/microservice/reaper/core/service/reaper/reaper.go
@@ -300,6 +300,9 @@ func (r *Reaper) setProxy(ctx *meta.DockerBuildCtx, cfg *meta.Proxy) {
 
 func (r *Reaper) dockerCommands() []*exec.Cmd {
 	cmds := make([]*exec.Cmd, 0)
+	if r.Ctx.DockerBuildCtx.WorkDir == "" {
+		r.Ctx.DockerBuildCtx.WorkDir = "."
+	}
 	cmds = append(
 		cmds,
 		dockerBuildCmd(


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 85e97ff</samp>

Set default work directory to `.` for docker build and reaper steps. This improves the usability and reliability of these steps when the work directory is not specified by the user.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 85e97ff</samp>

*  Set the default work directory for docker builds and reaper service to `"."` if not specified in the step spec or the context ([link](https://github.com/koderover/zadig/pull/3057/files?diff=unified&w=0#diff-5c10d1b1824b9ebfafcd11dc21f801a5f4018ec47326a32682e28cb93e624a00R132-R134), [link](https://github.com/koderover/zadig/pull/3057/files?diff=unified&w=0#diff-81665bd0249cbf747d030b652b84195780e796e1bbaaaf95494615816933a776R303-R305))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
