### PR TITLE
improve: apollo job support set updater username

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/configuration_management.go
+++ b/pkg/microservice/aslan/core/common/repository/models/configuration_management.go
@@ -33,12 +33,12 @@ func (ConfigurationManagement) TableName() string {
 
 type ApolloConfig struct {
 	ServerAddress string `json:"server_address"`
-	// User is the username of apollo for update config
-	User string `json:"user"`
 	*ApolloAuthConfig
 }
 
 type ApolloAuthConfig struct {
+	// User is the username of apollo for update config
+	User  string `json:"user"`
 	Token string `json:"token" bson:"token"`
 }
 

--- a/pkg/microservice/aslan/core/common/repository/models/configuration_management.go
+++ b/pkg/microservice/aslan/core/common/repository/models/configuration_management.go
@@ -33,8 +33,11 @@ func (ConfigurationManagement) TableName() string {
 
 type ApolloConfig struct {
 	ServerAddress string `json:"server_address"`
+	// User is the username of apollo for update config
+	User string `json:"user"`
 	*ApolloAuthConfig
 }
+
 type ApolloAuthConfig struct {
 	Token string `json:"token" bson:"token"`
 }

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_apollo.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_apollo.go
@@ -87,7 +87,7 @@ func (c *ApolloJobCtl) Run(ctx context.Context) {
 			&apollo.ReleaseArgs{
 				ReleaseTitle:   time.Now().Format("20060102150405") + "-zadig",
 				ReleaseComment: fmt.Sprintf("工作流 %s\n详情: %s", c.workflowCtx.WorkflowDisplayName, link),
-				ReleasedBy:     "zadig",
+				ReleasedBy:     info.ApolloAuthConfig.User,
 			})
 		if err != nil {
 			fail = true

--- a/pkg/microservice/aslan/core/system/service/configuration_management.go
+++ b/pkg/microservice/aslan/core/system/service/configuration_management.go
@@ -179,6 +179,7 @@ func marshalConfigurationManagementAuthConfig(management *commonmodels.Configura
 	case setting.SourceFromApollo:
 		management.AuthConfig = &commonmodels.ApolloAuthConfig{
 			Token: gjson.Get(rawJson, "token").String(),
+			User:  gjson.Get(rawJson, "user").String(),
 		}
 	case setting.SourceFromNacos:
 		management.AuthConfig = &commonmodels.NacosAuthConfig{


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a9ee049</samp>

Added `User` field to `ApolloConfig` type to support apollo configuration management. This feature enables zadig users to update apollo configs with their own credentials.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a9ee049</samp>

*  Added a `User` field to the `ApolloConfig` type to store the apollo username for updating config ([link](https://github.com/koderover/zadig/pull/3059/files?diff=unified&w=0#diff-7fe684569e5dfdba58161f2cc92c0ce67b33adc0811ab284f580c60609b8d221L36-R40))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
