### PR TITLE
bugfix for ua unable to update migration table

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/1190.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/1190.go
@@ -526,7 +526,7 @@ func migrateSonarScanningModules() error {
 				return fmt.Errorf("failed to update scannings, error: %s", err)
 			}
 		}
-
+		
 		err = internaldb.NewMigrationColl().UpdateMigrationStatus(migrationInfo.ID,
 			map[string]interface{}{
 				"sonar_migration": true,

--- a/pkg/cli/upgradeassistant/cmd/migrate/utils.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/utils.go
@@ -18,7 +18,15 @@ func getMigrationInfo() (*internalmodels.Migration, error) {
 		if err != mongo.ErrNoDocuments {
 			return nil, fmt.Errorf("failed to get migration info from db, err: %s", err)
 		} else {
-			return internaldb.NewMigrationColl().InitializeMigrationInfo()
+			err := internaldb.NewMigrationColl().InitializeMigrationInfo()
+			if err != nil {
+				return nil, fmt.Errorf("failed to create migration info in db, err: %s", err)
+			}
+			createdInfo, err := internaldb.NewMigrationColl().GetMigrationInfo()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get migration info from db, err: %s", err)
+			}
+			return createdInfo, nil
 		}
 	}
 	return migrationInfo, nil

--- a/pkg/cli/upgradeassistant/internal/repository/mongodb/migration.go
+++ b/pkg/cli/upgradeassistant/internal/repository/mongodb/migration.go
@@ -2,7 +2,6 @@ package mongodb
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
@@ -51,18 +50,11 @@ func (c *MigrationColl) UpdateMigrationStatus(id primitive.ObjectID, kvs map[str
 	return err
 }
 
-func (c *MigrationColl) InitializeMigrationInfo() (*models.Migration, error) {
+func (c *MigrationColl) InitializeMigrationInfo() error {
 	resp := &models.Migration{
 		SonarMigration: false,
 	}
-	res, err := c.InsertOne(context.TODO(), resp, options.InsertOne())
-	if err != nil {
-		return nil, err
-	}
-	if id, ok := res.InsertedID.(primitive.ObjectID); !ok {
-		return nil, fmt.Errorf("invalid inserted id: %+v", res.InsertedID)
-	} else {
-		res.InsertedID = id
-	}
-	return resp, nil
+	_, err := c.InsertOne(context.TODO(), resp, options.InsertOne())
+
+	return err
 }


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6dad890</samp>

This pull request enhances the `upgradeassistant` CLI tool by refactoring the `mongodb` package and improving the error handling and readability of the migration code.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6dad890</samp>

*  Simplify the `InitializeMigrationInfo` function by removing unused import and return value ([link](https://github.com/koderover/zadig/pull/3061/files?diff=unified&w=0#diff-5950e4433376bd3e6c16133ce747da0b29afa545c4a41184534f2f91c3a256fbL5), [link](https://github.com/koderover/zadig/pull/3061/files?diff=unified&w=0#diff-5950e4433376bd3e6c16133ce747da0b29afa545c4a41184534f2f91c3a256fbL54-R59))
*  Modify the `getMigrationInfo` function in `utils.go` to handle error cases and return the created info ([link](https://github.com/koderover/zadig/pull/3061/files?diff=unified&w=0#diff-c879b923c0baa3efa5771035ccae2cd47c2cfd4416aac30f658a30ad884c4022L21-R29))
*  Add a blank line to improve the readability of the code in `1190.go` ([link](https://github.com/koderover/zadig/pull/3061/files?diff=unified&w=0#diff-801df8491afb56024402917f8633f318f503e7d7970e88cf71ffe476a0245c5cL529-R529))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
