### PR TITLE
fix a bug where repo owner is different from repo namespace

### DIFF
--- a/pkg/microservice/aslan/core/code/handler/codehost.go
+++ b/pkg/microservice/aslan/core/code/handler/codehost.go
@@ -231,7 +231,7 @@ func CodeHostGetCommits(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	codehostID := c.Param("codehostId")
-	repoOwner := c.Query("repoOwner")
+	repoNamespace := c.Query("repoNamespace")
 	repoName := c.Query("repoName") // pro Name, id/name -> gitlab = id
 
 	args := new(CodeHostGetPageNateListArgs)
@@ -244,8 +244,8 @@ func CodeHostGetCommits(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam.AddDesc("empty codehostId")
 		return
 	}
-	if repoOwner == "" {
-		ctx.Err = e.ErrInvalidParam.AddDesc("empty repoOwner")
+	if repoNamespace == "" {
+		ctx.Err = e.ErrInvalidParam.AddDesc("empty repoNamespace")
 		return
 	}
 	if repoName == "" {
@@ -256,7 +256,7 @@ func CodeHostGetCommits(c *gin.Context) {
 	targetBr := c.Query("branchName")
 
 	chID, _ := strconv.Atoi(codehostID)
-	ctx.Resp, ctx.Err = service.CodeHostListCommits(chID, repoName, strings.Replace(repoOwner, "%2F", "/", -1), targetBr, args.Page, args.PerPage, ctx.Logger)
+	ctx.Resp, ctx.Err = service.CodeHostListCommits(chID, repoName, strings.Replace(repoNamespace, "%2F", "/", -1), targetBr, args.Page, args.PerPage, ctx.Logger)
 }
 
 func ListRepoInfos(c *gin.Context) {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e39b96c</samp>

Refactored codehost handler and service to support GitLab group repositories. Fixed a bug with slash encoding in `codehost.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e39b96c</samp>

*  Rename `repoOwner` to `repoNamespace` and update error message in `codehost.go` to support GitLab groups ([link](https://github.com/koderover/zadig/pull/3067/files?diff=unified&w=0#diff-e75417185bd3b617a5bc1945983fc6d3097d497260224ef5dc880a3732d5d142L234-R234), [link](https://github.com/koderover/zadig/pull/3067/files?diff=unified&w=0#diff-e75417185bd3b617a5bc1945983fc6d3097d497260224ef5dc880a3732d5d142L247-R248), [link](https://github.com/koderover/zadig/pull/3067/files?diff=unified&w=0#diff-e75417185bd3b617a5bc1945983fc6d3097d497260224ef5dc880a3732d5d142L259-R259))
*  Replace encoded slash with normal slash in `repoNamespace` argument for `CodeHostListCommits` service function in `codehost.go` to handle nested GitLab repositories ([link](https://github.com/koderover/zadig/pull/3067/files?diff=unified&w=0#diff-e75417185bd3b617a5bc1945983fc6d3097d497260224ef5dc880a3732d5d142L259-R259))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
