### PR TITLE
fix: apollo support set user

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_apollo.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_apollo.go
@@ -76,7 +76,7 @@ func (c *ApolloJobCtl) Run(ctx context.Context) {
 	client := apollo.NewClient(info.ServerAddress, info.Token)
 	for _, namespace := range c.jobTaskSpec.NamespaceList {
 		for _, kv := range namespace.KeyValList {
-			err := client.UpdateKeyVal(namespace.AppID, namespace.Env, namespace.ClusterID, namespace.Namespace, kv.Key, kv.Val, "zadig")
+			err := client.UpdateKeyVal(namespace.AppID, namespace.Env, namespace.ClusterID, namespace.Namespace, kv.Key, kv.Val, info.ApolloAuthConfig.User)
 			if err != nil {
 				fail = true
 				namespace.Error = fmt.Sprintf("update error: %v", err)


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a6d0fe</samp>

Use custom user name for Apollo auth config in `JobApollo` task. Fix hard-coded user name in `job_apollo.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1a6d0fe</samp>

*  Update Apollo user name from config instead of hard-coding it ([link](https://github.com/koderover/zadig/pull/3071/files?diff=unified&w=0#diff-a3934f381c68fac0daec66fe1fe12fac1e081628a8d5b32c463aa8fc96a4adefL79-R79))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
