### PR TITLE
scanning template

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/scanning.go
+++ b/pkg/microservice/aslan/core/common/repository/models/scanning.go
@@ -27,6 +27,7 @@ import (
 type Scanning struct {
 	ID          primitive.ObjectID `bson:"_id,omitempty" json:"id,omitempty"`
 	Name        string             `bson:"name"          json:"name"`
+	TemplateID  string             `bson:"template_id"   json:"template_id"`
 	ProjectName string             `bson:"project_name"  json:"project_name"`
 	Description string             `bson:"description"   json:"description"`
 	ScannerType string             `bson:"scanner_type"  json:"scanner_type"`

--- a/pkg/microservice/aslan/core/common/repository/models/scanning_template.go
+++ b/pkg/microservice/aslan/core/common/repository/models/scanning_template.go
@@ -35,7 +35,7 @@ type ScanningTemplate struct {
 	Envs []*KeyVal `bson:"envs" json:"envs"`
 	// Script is for other type only
 	Script           string                   `bson:"script"                json:"script"`
-	AdvancedSetting  *ScanningAdvancedSetting `bson:"advanced_setting"      json:"advanced_setting"`
+	AdvancedSetting  *ScanningAdvancedSetting `bson:"advanced_settings"      json:"advanced_settings"`
 	CheckQualityGate bool                     `bson:"check_quality_gate"    json:"check_quality_gate"`
 
 	CreatedAt int64  `bson:"created_at" json:"created_at"`

--- a/pkg/microservice/aslan/core/common/repository/models/scanning_template.go
+++ b/pkg/microservice/aslan/core/common/repository/models/scanning_template.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2023 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type ScanningTemplate struct {
+	ID          primitive.ObjectID `bson:"_id,omitempty" json:"id,omitempty"`
+	Name        string             `bson:"name"          json:"name"`
+	ScannerType string             `bson:"scanner_type"  json:"scanner_type"`
+	// EnableScanner indicates whether user uses sonar scanner instead of the script
+	EnableScanner bool    `bson:"enable_scanner" json:"enable_scanner"`
+	ImageID       string  `bson:"image_id"      json:"image_id"`
+	SonarID       string  `bson:"sonar_id"      json:"sonar_id"`
+	Installs      []*Item `bson:"installs"      json:"installs"`
+	// Parameter is for sonarQube type only
+	Parameter string `bson:"parameter" json:"parameter"`
+	// Envs is the user defined key/values
+	Envs []*KeyVal `bson:"envs" json:"envs"`
+	// Script is for other type only
+	Script           string                   `bson:"script"                json:"script"`
+	AdvancedSetting  *ScanningAdvancedSetting `bson:"advanced_setting"      json:"advanced_setting"`
+	CheckQualityGate bool                     `bson:"check_quality_gate"    json:"check_quality_gate"`
+
+	CreatedAt int64  `bson:"created_at" json:"created_at"`
+	UpdatedAt int64  `bson:"updated_at" json:"updated_at"`
+	UpdatedBy string `bson:"updated_by" json:"updated_by"`
+}
+
+func (ScanningTemplate) TableName() string {
+	return "scanning_template"
+}

--- a/pkg/microservice/aslan/core/common/repository/mongodb/scanning.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/scanning.go
@@ -35,6 +35,7 @@ import (
 type ScanningListOption struct {
 	ProjectName   string
 	ScanningNames []string
+	TemplateID    string
 }
 
 type ScanningColl struct {
@@ -114,9 +115,16 @@ func (c *ScanningColl) List(listOption *ScanningListOption, pageNum, pageSize in
 	}
 
 	if listOption != nil {
-		query["project_name"] = listOption.ProjectName
+		if len(listOption.ProjectName) > 0 {
+			query["project_name"] = listOption.ProjectName
+		}
+
 		if len(listOption.ScanningNames) > 0 {
 			query["name"] = bson.M{"$in": listOption.ScanningNames}
+		}
+
+		if len(listOption.TemplateID) > 0 {
+			query["template_id"] = listOption.TemplateID
 		}
 	}
 
@@ -168,4 +176,22 @@ func (c *ScanningColl) DeleteByID(idstring string) error {
 
 	_, err = c.DeleteOne(context.TODO(), query)
 	return err
+}
+
+func (c *ScanningColl) GetScanningTemplateReference(templateID string) ([]*models.Scanning, error) {
+	query := bson.M{
+		"template_id": templateID,
+	}
+
+	cursor, err := c.Collection.Find(context.TODO(), query)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]*models.Scanning, 0)
+	err = cursor.All(context.TODO(), &ret)
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
 }

--- a/pkg/microservice/aslan/core/common/repository/mongodb/scanning_template.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/scanning_template.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2023 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mongodb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
+)
+
+type ScanningTemplateQueryOption struct {
+	ID   string
+	Name string
+}
+
+type ScanningTemplateColl struct {
+	*mongo.Collection
+	coll string
+}
+
+func NewScanningTemplateColl() *ScanningTemplateColl {
+	name := models.ScanningTemplate{}.TableName()
+	return &ScanningTemplateColl{
+		Collection: mongotool.Database(config.MongoDatabase()).Collection(name),
+		coll:       name,
+	}
+}
+
+func (c *ScanningTemplateColl) GetCollectionName() string {
+	return c.coll
+}
+
+func (c *ScanningTemplateColl) EnsureIndex(ctx context.Context) error {
+	mod := mongo.IndexModel{
+		Keys: bson.D{
+			bson.E{Key: "name", Value: 1},
+		},
+		Options: options.Index().SetUnique(true),
+	}
+	_, err := c.Indexes().CreateOne(ctx, mod)
+	return err
+}
+
+func (c *ScanningTemplateColl) Create(obj *models.ScanningTemplate) error {
+	if obj == nil {
+		return fmt.Errorf("nil object")
+	}
+
+	obj.UpdatedAt = time.Now().Unix()
+
+	_, err := c.InsertOne(context.TODO(), obj)
+	return err
+}
+
+func (c *ScanningTemplateColl) Find(opt *ScanningTemplateQueryOption) (*models.ScanningTemplate, error) {
+	if opt == nil {
+		return nil, errors.New("nil FindOption")
+	}
+	query := bson.M{}
+	if len(opt.ID) > 0 {
+		id, err := primitive.ObjectIDFromHex(opt.ID)
+		if err != nil {
+			return nil, err
+		}
+		query["_id"] = id
+	}
+	if len(opt.Name) > 0 {
+		query["name"] = opt.Name
+	}
+	resp := new(models.ScanningTemplate)
+	err := c.Collection.FindOne(context.TODO(), query).Decode(resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *ScanningTemplateColl) List(pageNum, pageSize int) ([]*models.ScanningTemplate, int, error) {
+	resp := make([]*models.ScanningTemplate, 0)
+	query := bson.M{}
+	count, err := c.EstimatedDocumentCount(context.TODO())
+	if err != nil {
+		return nil, 0, err
+	}
+
+	opt := options.Find()
+	if pageNum != 0 && pageSize != 0 {
+		opt.SetSkip(int64((pageNum - 1) * pageSize)).SetLimit(int64(pageSize))
+	}
+
+	cursor, err := c.Collection.Find(context.TODO(), query, opt)
+	if err != nil {
+		return nil, 0, err
+	}
+	err = cursor.All(context.TODO(), &resp)
+	if err != nil {
+		return nil, 0, err
+	}
+	return resp, int(count), nil
+}
+
+func (c *ScanningTemplateColl) Update(idStr string, obj *models.ScanningTemplate) error {
+	id, err := primitive.ObjectIDFromHex(idStr)
+	if err != nil {
+		return err
+	}
+	query := bson.M{"_id": id}
+	change := bson.M{"$set": obj}
+	_, err = c.UpdateOne(context.TODO(), query, change)
+	return err
+}
+
+func (c *ScanningTemplateColl) DeleteByID(idStr string) error {
+	id, err := primitive.ObjectIDFromHex(idStr)
+	if err != nil {
+		return err
+	}
+	query := bson.M{"_id": id}
+	_, err = c.DeleteOne(context.TODO(), query)
+	return err
+}

--- a/pkg/microservice/aslan/core/common/repository/mongodb/scanning_template.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/scanning_template.go
@@ -27,9 +27,9 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
-	"github.com/koderover/zadig/pkg/microservice/aslan/config"
-	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
-	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+	mongotool "github.com/koderover/zadig/v2/pkg/tool/mongo"
 )
 
 type ScanningTemplateQueryOption struct {

--- a/pkg/microservice/aslan/core/common/service/template/types.go
+++ b/pkg/microservice/aslan/core/common/service/template/types.go
@@ -88,3 +88,8 @@ type BuildTemplateReference struct {
 	ProjectName   string   `json:"project_name"`
 	ServiceModule []string `json:"service_module"`
 }
+
+type ScanningTemplateReference struct {
+	ScanningName string `json:"scanning_name"`
+	ProjectName  string `json:"project_name"`
+}

--- a/pkg/microservice/aslan/core/common/service/template/types.go
+++ b/pkg/microservice/aslan/core/common/service/template/types.go
@@ -91,5 +91,6 @@ type BuildTemplateReference struct {
 
 type ScanningTemplateReference struct {
 	ScanningName string `json:"scanning_name"`
+	ScanningID   string `json:"id"`
 	ProjectName  string `json:"project_name"`
 }

--- a/pkg/microservice/aslan/core/common/service/template/types.go
+++ b/pkg/microservice/aslan/core/common/service/template/types.go
@@ -92,5 +92,6 @@ type BuildTemplateReference struct {
 type ScanningTemplateReference struct {
 	ScanningName string `json:"scanning_name"`
 	ScanningID   string `json:"id"`
+	DisplayName  string `json:"display_name"`
 	ProjectName  string `json:"project_name"`
 }

--- a/pkg/microservice/aslan/core/templatestore/handler/router.go
+++ b/pkg/microservice/aslan/core/templatestore/handler/router.go
@@ -84,4 +84,14 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		workflow.GET("/:id", GetWorkflowTemplateByID)
 		workflow.DELETE("/:id", DeleteWorkflowTemplateByID)
 	}
+
+	scanning := router.Group("scanning")
+	{
+		scanning.POST("", CreateScanningTemplate)
+		scanning.PUT("/:id", UpdateScanningTemplate)
+		scanning.GET("", ListScanningTemplates)
+		scanning.GET("/:id", GetScanningTemplate)
+		scanning.DELETE("/:id", DeleteScanningTemplate)
+		scanning.GET("/:id/reference", GetScanningTemplateReference)
+	}
 }

--- a/pkg/microservice/aslan/core/templatestore/handler/scanning.go
+++ b/pkg/microservice/aslan/core/templatestore/handler/scanning.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2023 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+
+	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	templateservice "github.com/koderover/zadig/pkg/microservice/aslan/core/templatestore/service"
+	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
+	e "github.com/koderover/zadig/pkg/tool/errors"
+)
+
+func GetScanningTemplate(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	// authorization check
+	if !ctx.Resources.IsSystemAdmin {
+		if !ctx.Resources.SystemActions.Template.View {
+			ctx.UnAuthorized = true
+			return
+		}
+	}
+
+	ctx.Resp, ctx.Err = templateservice.GetScanningTemplateByID(c.Param("id"))
+}
+
+func ListScanningTemplates(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	// TODO: Authorization leak
+	// authorization check
+	//if !ctx.Resources.IsSystemAdmin {
+	//	if !ctx.Resources.SystemActions.Template.View {
+	//		ctx.UnAuthorized = true
+	//		return
+	//	}
+	//}
+
+	args := &listYamlQuery{}
+	if err := c.ShouldBindQuery(args); err != nil {
+		ctx.Err = err
+		return
+	}
+
+	ctx.Resp, ctx.Err = templateservice.ListScanningTemplates(args.PageNum, args.PageSize)
+}
+
+func CreateScanningTemplate(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	args := new(commonmodels.ScanningTemplate)
+	err = c.BindJSON(args)
+	if err != nil {
+		ctx.Err = e.ErrInvalidParam.AddDesc("invalid Build args")
+		return
+	}
+
+	bs, _ := json.Marshal(args)
+	internalhandler.InsertOperationLog(c, ctx.UserName, "", "新增", "模板-代码扫描", args.Name, string(bs), ctx.Logger)
+
+	// authorization check
+	if !ctx.Resources.IsSystemAdmin {
+		if !ctx.Resources.SystemActions.Template.Create {
+			ctx.UnAuthorized = true
+			return
+		}
+	}
+
+	ctx.Err = templateservice.CreateScanningTemplate(ctx.UserName, args, ctx.Logger)
+}
+
+func UpdateScanningTemplate(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	args := new(commonmodels.ScanningTemplate)
+	err = c.BindJSON(args)
+	if err != nil {
+		ctx.Err = e.ErrInvalidParam.AddDesc("invalid scanning args")
+		return
+	}
+
+	bs, _ := json.Marshal(args)
+	internalhandler.InsertOperationLog(c, ctx.UserName, "", "更新", "模板-代码扫描", args.Name, string(bs), ctx.Logger)
+
+	// authorization check
+	if !ctx.Resources.IsSystemAdmin {
+		if !ctx.Resources.SystemActions.Template.Edit {
+			ctx.UnAuthorized = true
+			return
+		}
+	}
+
+	ctx.Err = templateservice.UpdateScanningTemplate(c.Param("id"), args, ctx.Logger)
+}
+
+func DeleteScanningTemplate(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	internalhandler.InsertOperationLog(c, ctx.UserName, "", "删除", "模板-构建", c.Param("id"), "", ctx.Logger)
+
+	// authorization check
+	if !ctx.Resources.IsSystemAdmin {
+		if !ctx.Resources.SystemActions.Template.Delete {
+			ctx.UnAuthorized = true
+			return
+		}
+	}
+
+	ctx.Err = templateservice.DeleteScanningTemplate(c.Param("id"), ctx.Logger)
+}
+
+func GetScanningTemplateReference(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	ctx.Resp, ctx.Err = templateservice.GetScanningTemplateReference(c.Param("id"), ctx.Logger)
+}

--- a/pkg/microservice/aslan/core/templatestore/handler/scanning.go
+++ b/pkg/microservice/aslan/core/templatestore/handler/scanning.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
-	templateservice "github.com/koderover/zadig/pkg/microservice/aslan/core/templatestore/service"
-	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
-	e "github.com/koderover/zadig/pkg/tool/errors"
+	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+	templateservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/templatestore/service"
+	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
+	e "github.com/koderover/zadig/v2/pkg/tool/errors"
 )
 
 func GetScanningTemplate(c *gin.Context) {

--- a/pkg/microservice/aslan/core/templatestore/service/build.go
+++ b/pkg/microservice/aslan/core/templatestore/service/build.go
@@ -22,7 +22,6 @@ import (
 	"go.uber.org/zap"
 
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
-	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/template"
 	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
@@ -56,15 +55,15 @@ func AddBuildTemplate(userName string, build *commonmodels.BuildTemplate, logger
 }
 
 func GetBuildTemplateByName(name string) (*commonmodels.BuildTemplate, error) {
-	return mongodb.NewBuildTemplateColl().Find(&commonrepo.BuildTemplateQueryOption{Name: name})
+	return commonrepo.NewBuildTemplateColl().Find(&commonrepo.BuildTemplateQueryOption{Name: name})
 }
 
 func GetBuildTemplateByID(idStr string) (*commonmodels.BuildTemplate, error) {
-	return mongodb.NewBuildTemplateColl().Find(&commonrepo.BuildTemplateQueryOption{ID: idStr})
+	return commonrepo.NewBuildTemplateColl().Find(&commonrepo.BuildTemplateQueryOption{ID: idStr})
 }
 
 func ListBuildTemplates(pageNum, pageSize int) (*BuildTemplateListResp, error) {
-	buildTemplates, count, err := mongodb.NewBuildTemplateColl().List(pageNum, pageSize)
+	buildTemplates, count, err := commonrepo.NewBuildTemplateColl().List(pageNum, pageSize)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +86,7 @@ func RemoveBuildTemplate(id string, logger *zap.SugaredLogger) error {
 	}
 
 	// when template build is used by particular builds, this template can't be deleted
-	usedModules, err := mongodb.NewBuildColl().List(&commonrepo.BuildListOption{
+	usedModules, err := commonrepo.NewBuildColl().List(&commonrepo.BuildListOption{
 		TemplateID: id,
 	})
 	if err != nil {
@@ -97,7 +96,7 @@ func RemoveBuildTemplate(id string, logger *zap.SugaredLogger) error {
 		return fmt.Errorf("template build has beed used, can't be deleted")
 	}
 
-	err = mongodb.NewBuildTemplateColl().DeleteByID(id)
+	err = commonrepo.NewBuildTemplateColl().DeleteByID(id)
 	if err != nil {
 		logger.Errorf("Failed to delete build template %s, err: %s", id, err)
 		return err
@@ -109,11 +108,11 @@ func UpdateBuildTemplate(id string, buildTemplate *commonmodels.BuildTemplate, l
 	_, err := commonrepo.NewBuildTemplateColl().Find(&commonrepo.BuildTemplateQueryOption{
 		ID: id,
 	})
-	if err := commonutil.CheckDefineResourceParam(buildTemplate.PreBuild.ResReq, buildTemplate.PreBuild.ResReqSpec); err != nil {
-		return e.ErrCreateBuildModule.AddDesc(err.Error())
-	}
 	if err != nil {
 		return err
+	}
+	if err := commonutil.CheckDefineResourceParam(buildTemplate.PreBuild.ResReq, buildTemplate.PreBuild.ResReqSpec); err != nil {
+		return e.ErrCreateBuildModule.AddDesc(err.Error())
 	}
 	return commonrepo.NewBuildTemplateColl().Update(id, buildTemplate)
 }

--- a/pkg/microservice/aslan/core/templatestore/service/scanning.go
+++ b/pkg/microservice/aslan/core/templatestore/service/scanning.go
@@ -19,13 +19,13 @@ package service
 import (
 	"fmt"
 
-	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/template"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/template"
 	"go.uber.org/zap"
 
-	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
-	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
-	commonutil "github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
-	e "github.com/koderover/zadig/pkg/tool/errors"
+	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
+	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
+	e "github.com/koderover/zadig/v2/pkg/tool/errors"
 )
 
 type ScanningTemplateBrief struct {

--- a/pkg/microservice/aslan/core/templatestore/service/scanning.go
+++ b/pkg/microservice/aslan/core/templatestore/service/scanning.go
@@ -138,6 +138,7 @@ func GetScanningTemplateReference(id string, logger *zap.SugaredLogger) ([]*temp
 	for _, reference := range referenceList {
 		ret = append(ret, &template.ScanningTemplateReference{
 			ScanningName: reference.Name,
+			ScanningID:   reference.ID.Hex(),
 			ProjectName:  reference.ProjectName,
 		})
 	}

--- a/pkg/microservice/aslan/core/templatestore/service/scanning.go
+++ b/pkg/microservice/aslan/core/templatestore/service/scanning.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2023 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"fmt"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/template"
+	"go.uber.org/zap"
+
+	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
+	commonutil "github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
+	e "github.com/koderover/zadig/pkg/tool/errors"
+)
+
+type ScanningTemplateBrief struct {
+	Id   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type ScanningTemplateListResp struct {
+	ScanningTemplates []*ScanningTemplateBrief `json:"scanning_templates"`
+	Total             int                      `json:"total,omitempty"`
+}
+
+func CreateScanningTemplate(userName string, template *commonmodels.ScanningTemplate, logger *zap.SugaredLogger) error {
+	if len(template.Name) == 0 {
+		return e.ErrCreateScanningModule.AddDesc("empty name")
+	}
+
+	// prevent panic
+	if template.AdvancedSetting != nil {
+		if err := commonutil.CheckDefineResourceParam(template.AdvancedSetting.ResReq, template.AdvancedSetting.ResReqSpec); err != nil {
+			return e.ErrCreateScanningModule.AddDesc(err.Error())
+		}
+	}
+
+	template.UpdatedBy = userName
+	if err := commonrepo.NewScanningTemplateColl().Create(template); err != nil {
+		logger.Errorf("create scanning template %s error: %s", template.Name, err)
+		return e.ErrCreateScanningModule.AddErr(err)
+	}
+	return nil
+}
+
+func UpdateScanningTemplate(id string, template *commonmodels.ScanningTemplate, logger *zap.SugaredLogger) error {
+	_, err := commonrepo.NewScanningTemplateColl().Find(&commonrepo.ScanningTemplateQueryOption{
+		ID: id,
+	})
+
+	if err != nil {
+		logger.Errorf("failed to find the scanning template to be updated, id: %s, error: %s", id, err)
+		return e.ErrCreateScanningModule.AddDesc(fmt.Sprintf("failed to find the given scanning template of id: %s, error: %s", template.ID, err))
+	}
+
+	if template.AdvancedSetting != nil {
+		if err := commonutil.CheckDefineResourceParam(template.AdvancedSetting.ResReq, template.AdvancedSetting.ResReqSpec); err != nil {
+			return e.ErrCreateScanningModule.AddDesc(err.Error())
+		}
+	}
+
+	return commonrepo.NewScanningTemplateColl().Update(id, template)
+}
+
+func GetScanningTemplateByID(idStr string) (*commonmodels.ScanningTemplate, error) {
+	return commonrepo.NewScanningTemplateColl().Find(&commonrepo.ScanningTemplateQueryOption{ID: idStr})
+}
+
+func ListScanningTemplates(pageNum, pageSize int) (*ScanningTemplateListResp, error) {
+	buildTemplates, count, err := commonrepo.NewScanningTemplateColl().List(pageNum, pageSize)
+	if err != nil {
+		return nil, err
+	}
+	ret := &ScanningTemplateListResp{
+		Total: count,
+	}
+
+	for _, bt := range buildTemplates {
+		ret.ScanningTemplates = append(ret.ScanningTemplates, &ScanningTemplateBrief{
+			Id:   bt.ID.Hex(),
+			Name: bt.Name,
+		})
+	}
+
+	return ret, nil
+}
+
+func DeleteScanningTemplate(id string, logger *zap.SugaredLogger) error {
+	_, err := GetScanningTemplateByID(id)
+	if err != nil {
+		logger.Errorf("failed to find scanning template with id: %s, err: %s", id, err)
+		return fmt.Errorf("failed to find scanning template with id: %s, err: %s", id, err)
+	}
+
+	// when template build is used by particular builds, this template can't be deleted
+	_, count, err := commonrepo.NewScanningColl().List(&commonrepo.ScanningListOption{
+		TemplateID: id,
+	}, 0, 0)
+	if err != nil {
+		return fmt.Errorf("failed to find builds with template id: %s, err: %s", id, err)
+	}
+	if count > 0 {
+		logger.Errorf("scanning template of id: %s is in use, it cannot be deleted", id)
+		return fmt.Errorf("template build has beed used, can't be deleted")
+	}
+
+	err = commonrepo.NewScanningTemplateColl().DeleteByID(id)
+	if err != nil {
+		logger.Errorf("Failed to delete build template %s, err: %s", id, err)
+		return err
+	}
+	return nil
+}
+
+func GetScanningTemplateReference(id string, logger *zap.SugaredLogger) ([]*template.ScanningTemplateReference, error) {
+	ret := make([]*template.ScanningTemplateReference, 0)
+	referenceList, err := commonrepo.NewScanningColl().GetScanningTemplateReference(id)
+	if err != nil {
+		logger.Errorf("Failed to get build template reference for template id: %s, the error is: %s", id, err)
+		return ret, err
+	}
+
+	for _, reference := range referenceList {
+		ret = append(ret, &template.ScanningTemplateReference{
+			ScanningName: reference.Name,
+			ProjectName:  reference.ProjectName,
+		})
+	}
+	return ret, nil
+}

--- a/pkg/microservice/aslan/core/templatestore/service/scanning.go
+++ b/pkg/microservice/aslan/core/templatestore/service/scanning.go
@@ -19,6 +19,7 @@ package service
 import (
 	"fmt"
 
+	templaterepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb/template"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/template"
 	"go.uber.org/zap"
 
@@ -136,10 +137,16 @@ func GetScanningTemplateReference(id string, logger *zap.SugaredLogger) ([]*temp
 	}
 
 	for _, reference := range referenceList {
+		projectInfo, err := templaterepo.NewProductColl().Find(reference.ProjectName)
+		if err != nil {
+			logger.Errorf("failed to get project info for template: %s, error: %s", id, err)
+			return nil, err
+		}
 		ret = append(ret, &template.ScanningTemplateReference{
 			ScanningName: reference.Name,
 			ScanningID:   reference.ID.Hex(),
 			ProjectName:  reference.ProjectName,
+			DisplayName:  projectInfo.ProjectName,
 		})
 	}
 	return ret, nil

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_scanning.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_scanning.go
@@ -138,6 +138,29 @@ func (j *ScanningJob) ToJobs(taskID int64) ([]*commonmodels.JobTask, error) {
 		if err != nil {
 			return resp, fmt.Errorf("find scanning: %s error: %v", scanning.Name, err)
 		}
+
+		// if a scanning uses template, we use the information in the template
+		if len(scanningInfo.TemplateID) != 0 {
+			templateInfo, err := commonrepo.NewScanningTemplateColl().Find(&commonrepo.ScanningTemplateQueryOption{
+				ID: scanningInfo.TemplateID,
+			})
+			if err != nil {
+				log.Errorf("failed to get scanning template from mongodb, the error is: %s", err)
+				return nil, err
+			}
+
+			scanningInfo.ScannerType = templateInfo.ScannerType
+			scanningInfo.EnableScanner = templateInfo.EnableScanner
+			scanningInfo.ImageID = templateInfo.ImageID
+			scanningInfo.SonarID = templateInfo.SonarID
+			scanningInfo.Installs = templateInfo.Installs
+			scanningInfo.Parameter = templateInfo.Parameter
+			scanningInfo.Envs = templateInfo.Envs
+			scanningInfo.Script = templateInfo.Script
+			scanningInfo.AdvancedSetting = templateInfo.AdvancedSetting
+			scanningInfo.CheckQualityGate = templateInfo.CheckQualityGate
+		}
+
 		basicImage, err := commonrepo.NewBasicImageColl().Find(scanningInfo.ImageID)
 		if err != nil {
 			return resp, fmt.Errorf("find basic image: %s error: %v", scanningInfo.ImageID, err)

--- a/pkg/microservice/aslan/core/workflow/testing/handler/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/handler/scanning.go
@@ -243,7 +243,6 @@ func GetScanningModule(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	if err != nil {
-
 		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
 		ctx.UnAuthorized = true
 		return

--- a/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
@@ -217,6 +217,28 @@ func CreateScanningTask(id string, req []*ScanningRepoInfo, notificationID, user
 		return 0, err
 	}
 
+	// if a scanning uses template, we use the information in the template
+	if len(scanningInfo.TemplateID) != 0 {
+		templateInfo, err := commonrepo.NewScanningTemplateColl().Find(&commonrepo.ScanningTemplateQueryOption{
+			ID: scanningInfo.TemplateID,
+		})
+		if err != nil {
+			log.Errorf("failed to get scanning template from mongodb, the error is: %s", err)
+			return 0, err
+		}
+
+		scanningInfo.ScannerType = templateInfo.ScannerType
+		scanningInfo.EnableScanner = templateInfo.EnableScanner
+		scanningInfo.ImageID = templateInfo.ImageID
+		scanningInfo.SonarID = templateInfo.SonarID
+		scanningInfo.Installs = templateInfo.Installs
+		scanningInfo.Parameter = templateInfo.Parameter
+		scanningInfo.Envs = templateInfo.Envs
+		scanningInfo.Script = templateInfo.Script
+		scanningInfo.AdvancedSetting = templateInfo.AdvancedSetting
+		scanningInfo.CheckQualityGate = templateInfo.CheckQualityGate
+	}
+
 	scanningName := fmt.Sprintf("%s-%s-%s", scanningInfo.Name, id, "scanning-job")
 
 	nextTaskID, err := commonrepo.NewCounterColl().GetNextSeq(fmt.Sprintf(setting.ScanningTaskFmt, scanningName))

--- a/pkg/microservice/aslan/core/workflow/testing/service/types.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/types.go
@@ -183,6 +183,7 @@ func ConvertToDBScanningModule(args *Scanning) *commonmodels.Scanning {
 		CheckQualityGate: args.CheckQualityGate,
 		Outputs:          args.Outputs,
 		Envs:             args.Envs,
+		TemplateID:       args.TemplateID,
 	}
 }
 

--- a/pkg/microservice/aslan/core/workflow/testing/service/types.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/types.go
@@ -45,6 +45,8 @@ type Scanning struct {
 	CheckQualityGate bool                                  `json:"check_quality_gate"`
 	Outputs          []*commonmodels.Output                `json:"outputs"`
 	NotifyCtls       []*commonmodels.NotifyCtl             `json:"notify_ctls"`
+	// template IDs
+	TemplateID string `json:"template_id"`
 }
 
 // TODO: change the logic of create scanning
@@ -205,6 +207,7 @@ func ConvertDBScanningModule(scanning *commonmodels.Scanning) *Scanning {
 		CheckQualityGate: scanning.CheckQualityGate,
 		Outputs:          scanning.Outputs,
 		Envs:             scanning.Envs,
+		TemplateID:       scanning.TemplateID,
 	}
 }
 

--- a/pkg/microservice/jobexecutor/core/service/step/step_tool_install.go
+++ b/pkg/microservice/jobexecutor/core/service/step/step_tool_install.go
@@ -130,7 +130,7 @@ func (s *ToolInstallStep) runIntallationScripts(tool *step.Tool) error {
 		scripts = append(scripts, disProxyScript)
 	}
 	uid, _ := uuid.NewUUID()
-	file := filepath.Join(os.TempDir(), fmt.Sprintf("install_script_%d.sh", uid))
+	file := filepath.Join(os.TempDir(), fmt.Sprintf("install_script_%d.sh", uid.ID()))
 	if err := ioutil.WriteFile(file, []byte(strings.Join(scripts, "\n")), 0700); err != nil {
 		return fmt.Errorf("write script file error: %v", err)
 	}


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a6ff830</samp>

This pull request adds a new feature of scanning template management, which allows users to create, update, delete and list scanning templates for code quality analysis. It also adds a feature to show the scanning tasks that use a given scanning template. It modifies the data models, the database access layer, the service layer, the handler layer and the router layer to support the new feature. It also refactors some existing code to resolve an import cycle issue. It affects the files `scanning.go`, `build.go`, `scanning_template.go`, `types.go` and `router.go` in various packages.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a6ff830</samp>

*  Add data model and database access layer for scanning template feature ([link](https://github.com/koderover/zadig/pull/3072/files?diff=unified&w=0#diff-0084f5a03cb93189233aa703eb69cecdfeee21b1b0e19f655fe20d9aa836fb2dR1-R48), [link](https://github.com/koderover/zadig/pull/3072/files?diff=unified&w=0#diff-88b6881a05951d1a6f9680293e1770bbc493039e690dd2d4043d07b8aaf82f2dR1-R145))
*  Add field to store scanning template ID in scanning task struct and option ([link](https://github.com/koderover/zadig/pull/3072/files?diff=unified&w=0#diff-b019d8a97c6eb1a2ac2d7919efdc1dbf7493556ecea151a0f661595bcef5d0d4R30), [link](https://github.com/koderover/zadig/pull/3072/files?diff=unified&w=0#diff-9141d40125be04020b1c93545d4c6541b106c14901cb965ead4ac67fe51a8b1aR38))
*  Add MongoDB query and index logic for filtering scanning tasks by template ID ([link](https://github.com/koderover/zadig/pull/3072/files?diff=unified&w=0#diff-9141d40125be04020b1c93545d4c6541b106c14901cb965ead4ac67fe51a8b1aL117-R128), [link](https://github.com/koderover/zadig/pull/3072/files?diff=unified&w=0#diff-9141d40125be04020b1c93545d4c6541b106c14901cb965ead4ac67fe51a8b1aR180-R197))
*  Add data type for scanning template reference ([link](https://github.com/koderover/zadig/pull/3072/files?diff=unified&w=0#diff-fb4cb59ab4d039dbd915e5da4a80a42f56be176cbb0d3dbbe700efeee2eba7cfR91-R95))
*  Add RESTful API for scanning template endpoints ([link](https://github.com/koderover/zadig/pull/3072/files?diff=unified&w=0#diff-ad60c7b9659276d9c90b76bd34055e7375ce00f5effceafdf86e11ae0bcbc154R87-R96), [link](https://github.com/koderover/zadig/pull/3072/files?diff=unified&w=0#diff-6f4df50cddb68c39b8e5fcb508d322d451ed7ded58a638b57174471381612e7cR1-R171))
*  Add core service layer for scanning template feature ([link](https://github.com/koderover/zadig/pull/3072/files?diff=unified&w=0#diff-488e6111aab14a6d5ce7eeecffe4f973633b633c29ef164ec75d477513ac8445R1-R145))
*  Avoid import cycle between `mongodb` and `service` packages by using `commonrepo` package ([link](https://github.com/koderover/zadig/pull/3072/files?diff=unified&w=0#diff-f2d1bada8826365c0d50ca3408bbd27b5121a0c743021dfb0691418ef4f9aa8dL25), [link](https://github.com/koderover/zadig/pull/3072/files?diff=unified&w=0#diff-f2d1bada8826365c0d50ca3408bbd27b5121a0c743021dfb0691418ef4f9aa8dL59-R66), [link](https://github.com/koderover/zadig/pull/3072/files?diff=unified&w=0#diff-f2d1bada8826365c0d50ca3408bbd27b5121a0c743021dfb0691418ef4f9aa8dL90-R89), [link](https://github.com/koderover/zadig/pull/3072/files?diff=unified&w=0#diff-f2d1bada8826365c0d50ca3408bbd27b5121a0c743021dfb0691418ef4f9aa8dL100-R99))
*  Move resource parameter check after finding build template in `UpdateBuildTemplate` function ([link](https://github.com/koderover/zadig/pull/3072/files?diff=unified&w=0#diff-f2d1bada8826365c0d50ca3408bbd27b5121a0c743021dfb0691418ef4f9aa8dL112-R116))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
