### PR TITLE
Fix product workflow aws s3

### DIFF
--- a/pkg/microservice/aslan/core/common/service/delivery.go
+++ b/pkg/microservice/aslan/core/common/service/delivery.go
@@ -162,7 +162,7 @@ func GetSubTaskContent(deliveryVersion *commonmodels.DeliveryVersion, pipelineTa
 					deliveryPackage := new(commonmodels.DeliveryPackage)
 					deliveryPackage.PackageFileLocation = buildInfo.JobCtx.FileArchiveCtx.FileLocation
 					deliveryPackage.PackageFileName = buildInfo.JobCtx.FileArchiveCtx.FileName
-					storageInfo, _ := s3service.NewS3StorageFromEncryptedURI(pipelineTask.StorageURI)
+					storageInfo, _ := s3service.UnmarshalNewS3StorageFromEncrypted(pipelineTask.StorageURI)
 					deliveryPackage.PackageStorageURI = storageInfo.Endpoint
 					deliveryBuild.PackageInfo = deliveryPackage
 				}
@@ -341,9 +341,9 @@ func GetSubTaskContent(deliveryVersion *commonmodels.DeliveryVersion, pipelineTa
 				}
 				deliveryDistributeFile.PackageFile = releaseFileInfo.PackageFile
 				deliveryDistributeFile.RemoteFileKey = releaseFileInfo.RemoteFileKey
-				storageInfo, _ := s3service.NewS3StorageFromEncryptedURI(releaseFileInfo.DestStorageURL)
+				storageInfo, _ := s3service.UnmarshalNewS3StorageFromEncrypted(releaseFileInfo.DestStorageURL)
 				deliveryDistributeFile.DestStorageURL = storageInfo.Endpoint
-				storageInfo, _ = s3service.NewS3StorageFromEncryptedURI(pipelineTask.StorageURI)
+				storageInfo, _ = s3service.UnmarshalNewS3StorageFromEncrypted(pipelineTask.StorageURI)
 				deliveryDistributeFile.SrcStorageURL = storageInfo.Endpoint
 				deliveryDistributeFile.StartTime = releaseFileInfo.StartTime
 				deliveryDistributeFile.EndTime = releaseFileInfo.EndTime

--- a/pkg/microservice/aslan/core/common/service/s3/s3.go
+++ b/pkg/microservice/aslan/core/common/service/s3/s3.go
@@ -42,8 +42,7 @@ func (s *S3) GetSchema() string {
 	return "https"
 }
 
-func (s *S3) GetEncryptedURL() (encrypted string, err error) {
-	//return crypto.AesEncrypt(s.GetURL())
+func (s *S3) GetEncrypted() (encrypted string, err error) {
 	b, err := json.Marshal(s)
 	if err != nil {
 		return "", err

--- a/pkg/microservice/aslan/core/common/service/s3/s3.go
+++ b/pkg/microservice/aslan/core/common/service/s3/s3.go
@@ -17,13 +17,12 @@ limitations under the License.
 package s3
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"path/filepath"
 	"strings"
 
-	config2 "github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
@@ -43,8 +42,21 @@ func (s *S3) GetSchema() string {
 	return "https"
 }
 
+func (s *S3) GetEncrypted() (encrypted string, err error) {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return "", err
+	}
+	return crypto.AesEncrypt(string(b))
+}
+
 func (s *S3) GetEncryptedURL() (encrypted string, err error) {
-	return crypto.AesEncrypt(s.GetURL())
+	//return crypto.AesEncrypt(s.GetURL())
+	b, err := json.Marshal(s)
+	if err != nil {
+		return "", err
+	}
+	return crypto.AesEncrypt(string(b))
 }
 
 func (s *S3) GetURL() string {
@@ -57,35 +69,40 @@ func (s *S3) GetURL() string {
 }
 
 func NewS3StorageFromURL(uri string) (*S3, error) {
-	store, err := url.Parse(uri)
-	if err != nil {
+	s3 := new(S3)
+	if err := json.Unmarshal([]byte(uri), s3); err != nil {
 		return nil, err
 	}
-
-	sk, _ := store.User.Password()
-	paths := strings.Split(strings.TrimLeft(store.Path, "/"), "/")
-	bucket := paths[0]
-
-	var subfolder string
-	if len(paths) > 1 {
-		subfolder = strings.Join(paths[1:], "/")
-	}
-
-	ret := &S3{
-		&models.S3Storage{
-			Ak:        store.User.Username(),
-			Sk:        sk,
-			Endpoint:  store.Host,
-			Bucket:    bucket,
-			Subfolder: subfolder,
-			Insecure:  store.Scheme == "http",
-		},
-	}
-	if strings.Contains(store.Host, config2.MinioServiceName()) {
-		ret.Provider = setting.ProviderSourceSystemDefault
-	}
-
-	return ret, nil
+	return s3, nil
+	//store, err := url.Parse(uri)
+	//if err != nil {
+	//	return nil, err
+	//}
+	//
+	//sk, _ := store.User.Password()
+	//paths := strings.Split(strings.TrimLeft(store.Path, "/"), "/")
+	//bucket := paths[0]
+	//
+	//var subfolder string
+	//if len(paths) > 1 {
+	//	subfolder = strings.Join(paths[1:], "/")
+	//}
+	//
+	//ret := &S3{
+	//	&models.S3Storage{
+	//		Ak:        store.User.Username(),
+	//		Sk:        sk,
+	//		Endpoint:  store.Host,
+	//		Bucket:    bucket,
+	//		Subfolder: subfolder,
+	//		Insecure:  store.Scheme == "http",
+	//	},
+	//}
+	//if strings.Contains(store.Host, config2.MinioServiceName()) {
+	//	ret.Provider = setting.ProviderSourceSystemDefault
+	//}
+	//
+	//return ret, nil
 }
 
 func NewS3StorageFromEncryptedURI(encryptedURI string) (*S3, error) {

--- a/pkg/microservice/aslan/core/common/service/s3/s3.go
+++ b/pkg/microservice/aslan/core/common/service/s3/s3.go
@@ -42,14 +42,6 @@ func (s *S3) GetSchema() string {
 	return "https"
 }
 
-func (s *S3) GetEncrypted() (encrypted string, err error) {
-	b, err := json.Marshal(s)
-	if err != nil {
-		return "", err
-	}
-	return crypto.AesEncrypt(string(b))
-}
-
 func (s *S3) GetEncryptedURL() (encrypted string, err error) {
 	//return crypto.AesEncrypt(s.GetURL())
 	b, err := json.Marshal(s)
@@ -68,50 +60,21 @@ func (s *S3) GetURL() string {
 	)
 }
 
-func NewS3StorageFromURL(uri string) (*S3, error) {
+func UnmarshalNewS3Storage(str string) (*S3, error) {
 	s3 := new(S3)
-	if err := json.Unmarshal([]byte(uri), s3); err != nil {
+	if err := json.Unmarshal([]byte(str), s3); err != nil {
 		return nil, err
 	}
 	return s3, nil
-	//store, err := url.Parse(uri)
-	//if err != nil {
-	//	return nil, err
-	//}
-	//
-	//sk, _ := store.User.Password()
-	//paths := strings.Split(strings.TrimLeft(store.Path, "/"), "/")
-	//bucket := paths[0]
-	//
-	//var subfolder string
-	//if len(paths) > 1 {
-	//	subfolder = strings.Join(paths[1:], "/")
-	//}
-	//
-	//ret := &S3{
-	//	&models.S3Storage{
-	//		Ak:        store.User.Username(),
-	//		Sk:        sk,
-	//		Endpoint:  store.Host,
-	//		Bucket:    bucket,
-	//		Subfolder: subfolder,
-	//		Insecure:  store.Scheme == "http",
-	//	},
-	//}
-	//if strings.Contains(store.Host, config2.MinioServiceName()) {
-	//	ret.Provider = setting.ProviderSourceSystemDefault
-	//}
-	//
-	//return ret, nil
 }
 
-func NewS3StorageFromEncryptedURI(encryptedURI string) (*S3, error) {
-	uri, err := crypto.AesDecrypt(encryptedURI)
+func UnmarshalNewS3StorageFromEncrypted(encrypted string) (*S3, error) {
+	uri, err := crypto.AesDecrypt(encrypted)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewS3StorageFromURL(uri)
+	return UnmarshalNewS3Storage(uri)
 }
 
 func (s *S3) GetURI() string {

--- a/pkg/microservice/aslan/core/common/service/scmnotify/scmnotify.go
+++ b/pkg/microservice/aslan/core/common/service/scmnotify/scmnotify.go
@@ -245,7 +245,7 @@ func downloadReport(taskInfo *task.Task, fileName, testName string, logger *zap.
 	var store *s3.S3
 	var err error
 
-	if store, err = s3.NewS3StorageFromEncryptedURI(taskInfo.StorageURI); err != nil {
+	if store, err = s3.UnmarshalNewS3StorageFromEncrypted(taskInfo.StorageURI); err != nil {
 		logger.Errorf("failed to create s3 storage %s", taskInfo.StorageURI)
 		return nil, err
 	}

--- a/pkg/microservice/aslan/core/system/service/s3.go
+++ b/pkg/microservice/aslan/core/system/service/s3.go
@@ -134,9 +134,9 @@ func ListTars(id, kind string, serviceNames []string, logger *zap.SugaredLogger)
 	defaultS3 = s3.S3{
 		S3Storage: store,
 	}
-	defaultURL, err = defaultS3.GetEncryptedURL()
+	defaultURL, err = defaultS3.GetEncrypted()
 	if err != nil {
-		logger.Errorf("defaultS3 GetEncryptedURL err:%s", err)
+		logger.Errorf("defaultS3 GetEncrypted err:%s", err)
 		return nil, err
 	}
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/artifact_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/artifact_task.go
@@ -61,7 +61,7 @@ func CreateArtifactPackageTask(args *commonmodels.ArtifactPackageTaskArgs, taskC
 		return 0, err
 	}
 
-	defaultURL, err := defaultS3.GetEncryptedURL()
+	defaultURL, err := defaultS3.GetEncrypted()
 	if err != nil {
 		err = e.ErrS3Storage.AddErr(err)
 		return 0, err

--- a/pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/nsq_handlers.go
@@ -287,7 +287,7 @@ func (h *TaskAckHandler) uploadTaskData(pt *task.Task) error {
 							deliveryArtifact.ImageTag = buildInfo.JobCtx.FileArchiveCtx.FileName
 							deliveryArtifact.Type = string(config.File)
 							deliveryArtifact.PackageFileLocation = buildInfo.JobCtx.FileArchiveCtx.FileLocation
-							if storageInfo, err := s3.NewS3StorageFromEncryptedURI(pt.StorageURI); err == nil {
+							if storageInfo, err := s3.UnmarshalNewS3StorageFromEncrypted(pt.StorageURI); err == nil {
 								deliveryArtifact.PackageStorageURI = storageInfo.Endpoint + "/" + storageInfo.Bucket
 							}
 
@@ -588,9 +588,9 @@ func (h *TaskAckHandler) uploadTaskData(pt *task.Task) error {
 							deliveryActivity.CreatedBy = pt.TaskCreator
 							deliveryActivity.URL = fmt.Sprintf("/v1/projects/detail/%s/pipelines/multi/%s/%d", pt.ProductName, pt.PipelineName, pt.TaskID)
 							deliveryActivity.RemoteFileKey = releaseFileInfo.RemoteFileKey
-							storageInfo, _ := s3.NewS3StorageFromEncryptedURI(releaseFileInfo.DestStorageURL)
+							storageInfo, _ := s3.UnmarshalNewS3StorageFromEncrypted(releaseFileInfo.DestStorageURL)
 							deliveryActivity.DistStorageURL = storageInfo.Endpoint
-							storageInfo, _ = s3.NewS3StorageFromEncryptedURI(pt.StorageURI)
+							storageInfo, _ = s3.UnmarshalNewS3StorageFromEncrypted(pt.StorageURI)
 							deliveryActivity.SrcStorageURL = storageInfo.Endpoint
 							deliveryActivity.CreatedTime = time.Now().Unix() + 6
 							deliveryActivity.StartTime = releaseFileInfo.StartTime

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
@@ -1135,7 +1135,7 @@ func GePackageFileContent(pipelineName string, taskID int64, log *zap.SugaredLog
 			storageURL = resp.StorageURI
 		}
 	}
-	storage, err := s3.NewS3StorageFromEncryptedURI(storageURL)
+	storage, err := s3.UnmarshalNewS3StorageFromEncrypted(storageURL)
 	if err != nil {
 		log.Errorf("failed to get s3 storage %s", storageURL)
 		return nil, packageFile, fmt.Errorf("failed to get s3 storage %s", storageURL)

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
@@ -846,6 +846,7 @@ func TestArgsToTestSubtask(args *commonmodels.TestTaskArgs, pt *task.Task, log *
 					Bucket:   storageInfo.Bucket,
 					Insecure: storageInfo.Insecure,
 					Provider: storageInfo.Provider,
+					Region:   storageInfo.Region,
 				}
 				testTask.JobCtx.UploadInfo = testModule.PostTest.ObjectStorageUpload.UploadDetail
 			}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
@@ -178,7 +178,7 @@ func CreatePipelineTask(args *commonmodels.TaskArgs, log *zap.SugaredLogger) (*C
 
 	var defaultStorageURI string
 	if defaultS3, err := s3.FindDefaultS3(); err == nil {
-		defaultStorageURI, err = defaultS3.GetEncryptedURL()
+		defaultStorageURI, err = defaultS3.GetEncrypted()
 		if err != nil {
 			return nil, e.ErrS3Storage.AddErr(err)
 		}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/service_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/service_task.go
@@ -204,7 +204,7 @@ func CreateServiceTask(args *commonmodels.ServiceTaskArgs, log *zap.SugaredLogge
 		return nil, err
 	}
 
-	defaultURL, err := defaultS3.GetEncryptedURL()
+	defaultURL, err := defaultS3.GetEncrypted()
 	if err != nil {
 		err = e.ErrS3Storage.AddErr(err)
 		return nil, err

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -1304,7 +1304,7 @@ func getDefaultAndDestS3StoreURL(workflow *commonmodels.Workflow, log *zap.Sugar
 			S3Storage: distributeS3Store,
 		}
 
-		destURL, err = defaultS3.GetEncryptedURL()
+		destURL, err = defaultS3.GetEncrypted()
 		if err != nil {
 			return
 		}
@@ -1316,7 +1316,7 @@ func getDefaultAndDestS3StoreURL(workflow *commonmodels.Workflow, log *zap.Sugar
 		return
 	}
 
-	defaultURL, err = defaultS3.GetEncryptedURL()
+	defaultURL, err = defaultS3.GetEncrypted()
 	if err != nil {
 		err = e.ErrS3Storage.AddErr(err)
 		return
@@ -2811,7 +2811,7 @@ func ensurePipelineTask(taskOpt *taskmodels.TaskOpt, log *zap.SugaredLogger) err
 						S3Storage: storage,
 					}
 
-					task.DestStorageURL, err = defaultS3.GetEncryptedURL()
+					task.DestStorageURL, err = defaultS3.GetEncrypted()
 					if err != nil {
 						return err
 					}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -1719,6 +1719,7 @@ func testArgsToSubtask(args *commonmodels.WorkflowTaskArgs, pt *taskmodels.Task,
 						Bucket:   storageInfo.Bucket,
 						Insecure: storageInfo.Insecure,
 						Provider: storageInfo.Provider,
+						Region:   storageInfo.Region,
 					}
 					testTask.JobCtx.UploadInfo = testModule.PostTest.ObjectStorageUpload.UploadDetail
 				}
@@ -2319,6 +2320,7 @@ func BuildModuleToSubTasks(args *commonmodels.BuildModuleArgs, log *zap.SugaredL
 				Bucket:   storageInfo.Bucket,
 				Insecure: storageInfo.Insecure,
 				Provider: storageInfo.Provider,
+				Region:   storageInfo.Region,
 			}
 			build.JobCtx.UploadInfo = module.PostBuild.ObjectStorageUpload.UploadDetail
 		}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v3.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v3.go
@@ -97,7 +97,7 @@ func CreateWorkflowTaskV3(args *commonmodels.WorkflowV3Args, username, reqID str
 
 	var defaultStorageURI string
 	if defaultS3, err := s3.FindDefaultS3(); err == nil {
-		defaultStorageURI, err = defaultS3.GetEncryptedURL()
+		defaultStorageURI, err = defaultS3.GetEncrypted()
 		if err != nil {
 			return nil, e.ErrS3Storage.AddErr(err)
 		}

--- a/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
@@ -370,7 +370,7 @@ func CreateScanningTask(id string, req []*ScanningRepoInfo, notificationID, user
 		return 0, e.ErrFindDefaultS3Storage.AddDesc("default storage is required by distribute task")
 	}
 
-	defaultURL, err := defaultS3.GetEncryptedURL()
+	defaultURL, err := defaultS3.GetEncrypted()
 	if err != nil {
 		log.Errorf("cannot convert the s3 config to an encrypted URI, error: %s", err)
 		return 0, e.ErrS3Storage.AddErr(err)

--- a/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
@@ -65,7 +65,7 @@ func CreateTestTask(args *commonmodels.TestTaskArgs, log *zap.SugaredLogger) (*C
 		return nil, err
 	}
 
-	defaultURL, err := defaultS3Store.GetEncryptedURL()
+	defaultURL, err := defaultS3Store.GetEncrypted()
 	if err != nil {
 		err = e.ErrS3Storage.AddErr(err)
 		return nil, err

--- a/pkg/microservice/aslan/core/workflow/testing/service/testing.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/testing.go
@@ -341,7 +341,7 @@ func GetHTMLTestReport(pipelineName, pipelineType, taskIDStr, testName string, l
 		return "", e.ErrGetTestReport.AddErr(err)
 	}
 
-	store, err := s3.NewS3StorageFromEncryptedURI(task.StorageURI)
+	store, err := s3.UnmarshalNewS3StorageFromEncrypted(task.StorageURI)
 	if err != nil {
 		log.Errorf("parse storageURI failed, err: %s", err)
 		return "", e.ErrGetTestReport.AddErr(err)

--- a/pkg/microservice/reaper/core/service/archive/file_archive.go
+++ b/pkg/microservice/reaper/core/service/archive/file_archive.go
@@ -226,7 +226,7 @@ func (c *WorkspaceAchiever) Achieve(target string) ([]string, error) {
 	//	return err
 	//}
 
-	if store, err := s3.NewS3StorageFromEncryptedURI(c.StorageURI, c.aesKey); err == nil {
+	if store, err := s3.UnmarshalNewS3StorageFromEncrypted(c.StorageURI, c.aesKey); err == nil {
 		forcedPathStyle := true
 		if store.Provider == setting.ProviderSourceAli {
 			forcedPathStyle = false

--- a/pkg/microservice/reaper/core/service/reaper/archive.go
+++ b/pkg/microservice/reaper/core/service/reaper/archive.go
@@ -34,7 +34,7 @@ func (r *Reaper) archiveS3Files() (err error) {
 	if r.Ctx.FileArchiveCtx != nil && r.Ctx.StorageURI != "" {
 		var store *s3.S3
 
-		if store, err = s3.NewS3StorageFromEncryptedURI(r.Ctx.StorageURI, r.Ctx.AesKey); err != nil {
+		if store, err = s3.UnmarshalNewS3StorageFromEncrypted(r.Ctx.StorageURI, r.Ctx.AesKey); err != nil {
 			log.Errorf("failed to create s3 storage %s", r.Ctx.StorageURI)
 			return
 		}
@@ -79,7 +79,7 @@ func (r *Reaper) archiveTestFiles() error {
 		return nil
 	}
 
-	store, err := s3.NewS3StorageFromEncryptedURI(r.Ctx.StorageURI, r.Ctx.AesKey)
+	store, err := s3.UnmarshalNewS3StorageFromEncrypted(r.Ctx.StorageURI, r.Ctx.AesKey)
 	if err != nil {
 		log.Errorf("failed to create s3 storage %s, err: %s", r.Ctx.StorageURI, err)
 		return err
@@ -132,7 +132,7 @@ func (r *Reaper) archiveHTMLTestReportFile() error {
 		return nil
 	}
 
-	store, err := s3.NewS3StorageFromEncryptedURI(r.Ctx.StorageURI, r.Ctx.AesKey)
+	store, err := s3.UnmarshalNewS3StorageFromEncrypted(r.Ctx.StorageURI, r.Ctx.AesKey)
 	if err != nil {
 		log.Errorf("failed to create s3 storage %s, err: %s", r.Ctx.StorageURI, err)
 		return err

--- a/pkg/microservice/reaper/core/service/reaper/artifact.go
+++ b/pkg/microservice/reaper/core/service/reaper/artifact.go
@@ -38,7 +38,7 @@ func artifactsUpload(ctx *meta.Context, activeWorkspace string, artifactPaths []
 	)
 
 	if ctx.StorageURI != "" {
-		if store, err = s3.NewS3StorageFromEncryptedURI(ctx.StorageURI, ctx.AesKey); err != nil {
+		if store, err = s3.UnmarshalNewS3StorageFromEncrypted(ctx.StorageURI, ctx.AesKey); err != nil {
 			log.Errorf("artifactsUpload failed to create s3 storage err:%v", err)
 			return err
 		}

--- a/pkg/microservice/reaper/core/service/reaper/cachemanager.go
+++ b/pkg/microservice/reaper/core/service/reaper/cachemanager.go
@@ -182,7 +182,7 @@ func (gcm *TarCacheManager) Unarchive(source, dest string) error {
 func (gcm *TarCacheManager) getS3Storage() (*s3.S3, error) {
 	var err error
 	var store *s3.S3
-	if store, err = s3.NewS3StorageFromEncryptedURI(gcm.StorageURI, gcm.aesKey); err != nil {
+	if store, err = s3.UnmarshalNewS3StorageFromEncrypted(gcm.StorageURI, gcm.aesKey); err != nil {
 		log.Errorf("Archive failed to create s3 storage %s", gcm.StorageURI)
 		return nil, err
 	}

--- a/pkg/microservice/reaper/core/service/reaper/script.go
+++ b/pkg/microservice/reaper/core/service/reaper/script.go
@@ -447,7 +447,7 @@ func (r *Reaper) RunPMDeployScripts() error {
 func (r *Reaper) downloadArtifactFile() error {
 	var err error
 	var store *s3.S3
-	if store, err = s3.NewS3StorageFromEncryptedURI(r.Ctx.ArtifactInfo.URL, r.Ctx.AesKey); err != nil {
+	if store, err = s3.UnmarshalNewS3StorageFromEncrypted(r.Ctx.ArtifactInfo.URL, r.Ctx.AesKey); err != nil {
 		log.Errorf("Archive failed to create s3 storage %s", r.Ctx.ArtifactInfo.URL)
 		return err
 	}

--- a/pkg/microservice/reaper/internal/s3/s3.go
+++ b/pkg/microservice/reaper/internal/s3/s3.go
@@ -45,48 +45,21 @@ func (s *S3) GetSchema() string {
 	return "https"
 }
 
-func NewS3StorageFromURL(uri string) (*S3, error) {
+func UnmarshalNewS3Storage(str string) (*S3, error) {
 	s3 := new(S3)
-	if err := json.Unmarshal([]byte(uri), s3); err != nil {
+	if err := json.Unmarshal([]byte(str), s3); err != nil {
 		return nil, err
 	}
 	return s3, nil
-	//store, err := url.Parse(uri)
-	//if err != nil {
-	//	return nil, err
-	//}
-	//
-	//sk, _ := store.User.Password()
-	//paths := strings.Split(strings.TrimLeft(store.Path, "/"), "/")
-	//bucket := paths[0]
-	//
-	//var subfolder string
-	//if len(paths) > 1 {
-	//	subfolder = strings.Join(paths[1:], "/")
-	//}
-	//
-	//ret := &S3{
-	//	Ak:        store.User.Username(),
-	//	Sk:        sk,
-	//	Endpoint:  store.Host,
-	//	Bucket:    bucket,
-	//	Subfolder: subfolder,
-	//	Insecure:  store.Scheme == "http",
-	//}
-	//if strings.Contains(store.Host, setting.AliyunHost) {
-	//	ret.Provider = setting.ProviderSourceAli
-	//}
-	//
-	//return ret, nil
 }
 
-func NewS3StorageFromEncryptedURI(encryptedURI, aesKey string) (*S3, error) {
-	uri, err := crypto.AesDecrypt(encryptedURI, aesKey)
+func UnmarshalNewS3StorageFromEncrypted(encrypted, aesKey string) (*S3, error) {
+	uri, err := crypto.AesDecrypt(encrypted, aesKey)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewS3StorageFromURL(uri)
+	return UnmarshalNewS3Storage(uri)
 }
 
 func (s *S3) GetURI() string {

--- a/pkg/microservice/reaper/internal/s3/s3.go
+++ b/pkg/microservice/reaper/internal/s3/s3.go
@@ -17,13 +17,12 @@ limitations under the License.
 package s3
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"path/filepath"
 	"strings"
 
-	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/tool/crypto"
 )
 
@@ -47,33 +46,38 @@ func (s *S3) GetSchema() string {
 }
 
 func NewS3StorageFromURL(uri string) (*S3, error) {
-	store, err := url.Parse(uri)
-	if err != nil {
+	s3 := new(S3)
+	if err := json.Unmarshal([]byte(uri), s3); err != nil {
 		return nil, err
 	}
-
-	sk, _ := store.User.Password()
-	paths := strings.Split(strings.TrimLeft(store.Path, "/"), "/")
-	bucket := paths[0]
-
-	var subfolder string
-	if len(paths) > 1 {
-		subfolder = strings.Join(paths[1:], "/")
-	}
-
-	ret := &S3{
-		Ak:        store.User.Username(),
-		Sk:        sk,
-		Endpoint:  store.Host,
-		Bucket:    bucket,
-		Subfolder: subfolder,
-		Insecure:  store.Scheme == "http",
-	}
-	if strings.Contains(store.Host, setting.AliyunHost) {
-		ret.Provider = setting.ProviderSourceAli
-	}
-
-	return ret, nil
+	return s3, nil
+	//store, err := url.Parse(uri)
+	//if err != nil {
+	//	return nil, err
+	//}
+	//
+	//sk, _ := store.User.Password()
+	//paths := strings.Split(strings.TrimLeft(store.Path, "/"), "/")
+	//bucket := paths[0]
+	//
+	//var subfolder string
+	//if len(paths) > 1 {
+	//	subfolder = strings.Join(paths[1:], "/")
+	//}
+	//
+	//ret := &S3{
+	//	Ak:        store.User.Username(),
+	//	Sk:        sk,
+	//	Endpoint:  store.Host,
+	//	Bucket:    bucket,
+	//	Subfolder: subfolder,
+	//	Insecure:  store.Scheme == "http",
+	//}
+	//if strings.Contains(store.Host, setting.AliyunHost) {
+	//	ret.Provider = setting.ProviderSourceAli
+	//}
+	//
+	//return ret, nil
 }
 
 func NewS3StorageFromEncryptedURI(encryptedURI, aesKey string) (*S3, error) {

--- a/pkg/microservice/warpdrive/core/service/taskcontroller/task_helper.go
+++ b/pkg/microservice/warpdrive/core/service/taskcontroller/task_helper.go
@@ -508,7 +508,7 @@ func downloadReport(taskInfo *task.Task, fileName, testName string, logger *zap.
 	var store *s3.S3
 	var err error
 
-	if store, err = s3.NewS3StorageFromEncryptedURI(taskInfo.StorageURI); err != nil {
+	if store, err = s3.UnmarshalNewS3StorageFromEncrypted(taskInfo.StorageURI); err != nil {
 		logger.Errorf("failed to create s3 storage %s", taskInfo.StorageURI)
 		return nil, err
 	}

--- a/pkg/microservice/warpdrive/core/service/taskplugin/deploy_helm.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/deploy_helm.go
@@ -381,7 +381,7 @@ func (p *HelmDeployTaskPlugin) downloadService(productName, serviceName, storage
 		return tarFilePath, nil
 	}
 
-	s3Storage, err := s3.NewS3StorageFromEncryptedURI(storageURI)
+	s3Storage, err := s3.UnmarshalNewS3StorageFromEncrypted(storageURI)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/microservice/warpdrive/core/service/taskplugin/distribute_kodo.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/distribute_kodo.go
@@ -136,7 +136,7 @@ func (p *Distribute2S3TaskPlugin) Run(ctx context.Context, pipelineTask *task.Ta
 		}
 
 		var srcStorage *s3.S3
-		srcStorage, err = s3.NewS3StorageFromEncryptedURI(pipelineTask.StorageURI)
+		srcStorage, err = s3.UnmarshalNewS3StorageFromEncrypted(pipelineTask.StorageURI)
 		if err != nil {
 			p.Log.Errorf("failed to init source s3 client")
 			return
@@ -181,7 +181,7 @@ func (p *Distribute2S3TaskPlugin) Run(ctx context.Context, pipelineTask *task.Ta
 	}
 
 	var destStorage *s3.S3
-	destStorage, err = s3.NewS3StorageFromEncryptedURI(p.Task.DestStorageURL)
+	destStorage, err = s3.UnmarshalNewS3StorageFromEncrypted(p.Task.DestStorageURL)
 	if err != nil {
 		p.Log.Errorf("failed to init destination s3 client %v", err)
 		return

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -244,6 +244,7 @@ func (b *JobCtxBuilder) BuildReaperContext(pipelineTask *task.Task, serviceName 
 			Bucket:   b.JobCtx.UploadStorageInfo.Bucket,
 			Insecure: b.JobCtx.UploadStorageInfo.Insecure,
 			Provider: b.JobCtx.UploadStorageInfo.Provider,
+			Region:   b.JobCtx.UploadStorageInfo.Region,
 		}
 	}
 

--- a/pkg/microservice/warpdrive/core/service/taskplugin/job.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/job.go
@@ -127,7 +127,7 @@ func saveContainerLog(pipelineTask *task.Task, namespace, clusterID, fileName st
 		}()
 		if err = saveFile(buf, tempFileName); err == nil {
 			var store *s3.S3
-			if store, err = s3.NewS3StorageFromEncryptedURI(pipelineTask.StorageURI); err != nil {
+			if store, err = s3.UnmarshalNewS3StorageFromEncrypted(pipelineTask.StorageURI); err != nil {
 				log.Errorf("failed to Create S3 endpoint from Encrypted URI: %s, the error is: %s ", pipelineTask.StorageURI, err)
 				return err
 			}

--- a/pkg/microservice/warpdrive/core/service/taskplugin/release_image.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/release_image.go
@@ -974,7 +974,7 @@ func (p *ReleaseImagePlugin) downloadService(productName, serviceName, storageUR
 		return tarFilePath, nil
 	}
 
-	s3Storage, err := s3.NewS3StorageFromEncryptedURI(storageURI)
+	s3Storage, err := s3.UnmarshalNewS3StorageFromEncrypted(storageURI)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/microservice/warpdrive/core/service/taskplugin/s3/s3.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/s3/s3.go
@@ -17,13 +17,11 @@ limitations under the License.
 package s3
 
 import (
-	"errors"
+	"encoding/json"
 	"fmt"
-	"net/url"
 	"path/filepath"
 	"strings"
 
-	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/tool/crypto"
 )
 
@@ -68,44 +66,49 @@ func (s *S3) GetURL() string {
 }
 
 func NewS3StorageFromURL(uri string) (*S3, error) {
-	store, err := url.Parse(uri)
-	if err != nil {
+	s3 := new(S3)
+	if err := json.Unmarshal([]byte(uri), s3); err != nil {
 		return nil, err
 	}
-
-	sk, _ := store.User.Password()
-	paths := strings.Split(strings.TrimLeft(store.Path, "/"), "/")
-	bucket := paths[0]
-
-	var subfolder string
-	if len(paths) > 1 {
-		subfolder = strings.Join(paths[1:], "/")
-	}
-
-	ret := &S3{
-		&Storage{
-			Ak:        store.User.Username(),
-			Sk:        sk,
-			Endpoint:  store.Host,
-			Bucket:    bucket,
-			Subfolder: subfolder,
-			Insecure:  store.Scheme == "http",
-		},
-	}
-	if strings.Contains(store.Host, setting.AliyunHost) {
-		ret.Provider = setting.ProviderSourceAli
-	}
-	if strings.Contains(store.Host, setting.AWSHost) {
-		// aws endpoint looks like <bucket>.s3.<region>.amazonaws.com
-		segmentation := strings.Split(store.Host, ".")
-		if len(segmentation) < 3 {
-			return nil, errors.New("cannot find region for aws s3")
-		}
-		// we get the third part of the endpoint
-		ret.Region = segmentation[2]
-	}
-
-	return ret, nil
+	return s3, nil
+	//store, err := url.Parse(uri)
+	//if err != nil {
+	//	return nil, err
+	//}
+	//
+	//sk, _ := store.User.Password()
+	//paths := strings.Split(strings.TrimLeft(store.Path, "/"), "/")
+	//bucket := paths[0]
+	//
+	//var subfolder string
+	//if len(paths) > 1 {
+	//	subfolder = strings.Join(paths[1:], "/")
+	//}
+	//
+	//ret := &S3{
+	//	&Storage{
+	//		Ak:        store.User.Username(),
+	//		Sk:        sk,
+	//		Endpoint:  store.Host,
+	//		Bucket:    bucket,
+	//		Subfolder: subfolder,
+	//		Insecure:  store.Scheme == "http",
+	//	},
+	//}
+	//if strings.Contains(store.Host, setting.AliyunHost) {
+	//	ret.Provider = setting.ProviderSourceAli
+	//}
+	//if strings.Contains(store.Host, setting.AWSHost) {
+	//	// aws endpoint looks like <bucket>.s3.<region>.amazonaws.com
+	//	segmentation := strings.Split(store.Host, ".")
+	//	if len(segmentation) < 3 {
+	//		return nil, errors.New("cannot find region for aws s3")
+	//	}
+	//	// we get the third part of the endpoint
+	//	ret.Region = segmentation[2]
+	//}
+	//
+	//return ret, nil
 }
 
 func NewS3StorageFromEncryptedURI(encryptedURI string) (*S3, error) {

--- a/pkg/microservice/warpdrive/core/service/taskplugin/s3/s3.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/s3/s3.go
@@ -65,59 +65,21 @@ func (s *S3) GetURL() string {
 	)
 }
 
-func NewS3StorageFromURL(uri string) (*S3, error) {
+func UnmarshalNewS3Storage(str string) (*S3, error) {
 	s3 := new(S3)
-	if err := json.Unmarshal([]byte(uri), s3); err != nil {
+	if err := json.Unmarshal([]byte(str), s3); err != nil {
 		return nil, err
 	}
 	return s3, nil
-	//store, err := url.Parse(uri)
-	//if err != nil {
-	//	return nil, err
-	//}
-	//
-	//sk, _ := store.User.Password()
-	//paths := strings.Split(strings.TrimLeft(store.Path, "/"), "/")
-	//bucket := paths[0]
-	//
-	//var subfolder string
-	//if len(paths) > 1 {
-	//	subfolder = strings.Join(paths[1:], "/")
-	//}
-	//
-	//ret := &S3{
-	//	&Storage{
-	//		Ak:        store.User.Username(),
-	//		Sk:        sk,
-	//		Endpoint:  store.Host,
-	//		Bucket:    bucket,
-	//		Subfolder: subfolder,
-	//		Insecure:  store.Scheme == "http",
-	//	},
-	//}
-	//if strings.Contains(store.Host, setting.AliyunHost) {
-	//	ret.Provider = setting.ProviderSourceAli
-	//}
-	//if strings.Contains(store.Host, setting.AWSHost) {
-	//	// aws endpoint looks like <bucket>.s3.<region>.amazonaws.com
-	//	segmentation := strings.Split(store.Host, ".")
-	//	if len(segmentation) < 3 {
-	//		return nil, errors.New("cannot find region for aws s3")
-	//	}
-	//	// we get the third part of the endpoint
-	//	ret.Region = segmentation[2]
-	//}
-	//
-	//return ret, nil
 }
 
-func NewS3StorageFromEncryptedURI(encryptedURI string) (*S3, error) {
-	uri, err := crypto.AesDecrypt(encryptedURI)
+func UnmarshalNewS3StorageFromEncrypted(encrypted string) (*S3, error) {
+	uri, err := crypto.AesDecrypt(encrypted)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewS3StorageFromURL(uri)
+	return UnmarshalNewS3Storage(uri)
 }
 
 func (s *S3) GetURI() string {

--- a/pkg/microservice/warpdrive/core/service/taskplugin/testing.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/testing.go
@@ -360,7 +360,7 @@ func (p *TestPlugin) Complete(ctx context.Context, pipelineTask *task.Task, serv
 		p.Task.JobCtx.TestType = setting.FunctionTest
 	}
 
-	store, err := s3.NewS3StorageFromEncryptedURI(pipelineTask.StorageURI)
+	store, err := s3.UnmarshalNewS3StorageFromEncrypted(pipelineTask.StorageURI)
 	if err != nil {
 		return
 	}

--- a/pkg/microservice/warpdrive/core/service/taskplugin/trigger.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/trigger.go
@@ -163,7 +163,7 @@ func (p *TriggerTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, pi
 func (p *TriggerTaskPlugin) getS3Storage(pipelineTask *task.Task) (string, error) {
 	var err error
 	var store *s3.S3
-	if store, err = s3.NewS3StorageFromEncryptedURI(pipelineTask.StorageURI); err != nil {
+	if store, err = s3.UnmarshalNewS3StorageFromEncrypted(pipelineTask.StorageURI); err != nil {
 		log.Errorf("Archive failed to create s3 storage %s", pipelineTask.StorageURI)
 		return "", err
 	}


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d8c90a</samp>

This pull request improves the `S3` service by encrypting its data with JSON and AES, and refactoring its code. It also cleans up some unused imports in `s3.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1d8c90a</samp>

*  Add `GetEncrypted` method to `S3` struct to return a JSON-encoded and AES-encrypted string of the struct fields ([link](https://github.com/koderover/zadig/pull/3076/files?diff=unified&w=0#diff-6071d38ca8e33f618d9137488bee24300e82234778920e014426e11779ce2d26L46-R59))
*  Modify `GetEncryptedURL` method to call `GetEncrypted` instead of encrypting only the URL ([link](https://github.com/koderover/zadig/pull/3076/files?diff=unified&w=0#diff-6071d38ca8e33f618d9137488bee24300e82234778920e014426e11779ce2d26L46-R59))
*  Rewrite `NewS3StorageFromURL` function to accept a JSON-encoded and AES-encrypted string of the `S3` struct fields instead of a URL ([link](https://github.com/koderover/zadig/pull/3076/files?diff=unified&w=0#diff-6071d38ca8e33f618d9137488bee24300e82234778920e014426e11779ce2d26L60-R105))
*  Remove unused imports of `net/url` and `config2` from `s3.go` ([link](https://github.com/koderover/zadig/pull/3076/files?diff=unified&w=0#diff-6071d38ca8e33f618d9137488bee24300e82234778920e014426e11779ce2d26L20-R25))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
