### PR TITLE
add svc resource parse logic

### DIFF
--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -59,6 +59,11 @@ import (
 	yamlutil "github.com/koderover/zadig/pkg/util/yaml"
 )
 
+type SvcResources struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}
+
 type ServiceOption struct {
 	ServiceModules     []*ServiceModule                 `json:"service_module"`
 	SystemVariable     []*Variable                      `json:"system_variable"`
@@ -66,6 +71,7 @@ type ServiceOption struct {
 	ServiceVariableKVs []*commontypes.ServiceVariableKV `json:"service_variable_kvs"`
 	Yaml               string                           `json:"yaml"`
 	Service            *commonmodels.Service            `json:"service,omitempty"`
+	Resources          []*SvcResources                  `json:"resources"`
 }
 
 type ServiceModule struct {
@@ -161,7 +167,6 @@ func GetServiceOption(args *commonmodels.Service, log *zap.SugaredLogger) (*Serv
 			Value: ""},
 	}
 
-	//serviceOption.VariableYaml = getTemplateMergedVariables(args)
 	serviceOption.VariableYaml = args.VariableYaml
 	serviceOption.ServiceVariableKVs = args.ServiceVariableKVs
 
@@ -169,6 +174,23 @@ func GetServiceOption(args *commonmodels.Service, log *zap.SugaredLogger) (*Serv
 		args.Source == setting.SourceFromGerrit || args.Source == setting.SourceFromGitee {
 		serviceOption.Yaml = args.Yaml
 	}
+
+	serviceOption.Resources = make([]*SvcResources, 0)
+	renderedYaml, err := commonutil.RenderK8sSvcYamlStrict(args.Yaml, args.ProductName, args.ServiceName, args.VariableYaml)
+	if err != nil {
+		log.Errorf("failed to render k8s svc yaml: %s/%s, err: %s", args.ProductName, args.ServiceName, err)
+	}
+	renderedYaml = util.ReplaceWrapLine(renderedYaml)
+	yamlDataArray := util.SplitYaml(renderedYaml)
+	for _, yamlData := range yamlDataArray {
+		resKind := new(types.KubeResourceKind)
+		if err := yaml.Unmarshal([]byte(yamlData), &resKind); err != nil {
+			log.Errorf("unmarshal ResourceKind error: %v", err)
+			continue
+		}
+		serviceOption.Resources = append(serviceOption.Resources, &SvcResources{Kind: resKind.Kind, Name: resKind.Metadata.Name})
+	}
+
 	return serviceOption, nil
 }
 

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -188,7 +188,8 @@ func GetServiceOption(args *commonmodels.Service, log *zap.SugaredLogger) (*Serv
 			log.Errorf("unmarshal ResourceKind error: %v", err)
 			continue
 		}
-		serviceOption.Resources = append(serviceOption.Resources, &SvcResources{Kind: resKind.Kind, Name: resKind.Metadata.Name})
+		log.Infof("the reskind data is %v", *resKind)
+		serviceOption.Resources = append(serviceOption.Resources, &SvcResources{Kind: resKind.Kind})
 	}
 
 	return serviceOption, nil

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -189,11 +189,9 @@ func GetServiceOption(args *commonmodels.Service, log *zap.SugaredLogger) (*Serv
 			continue
 		}
 		if resKind == nil {
-			log.Infof("resKind is nil, raw data: %s", string(yamlData))
 			continue
 		}
-		log.Infof("the reskind data is %v", *resKind)
-		serviceOption.Resources = append(serviceOption.Resources, &SvcResources{Kind: resKind.Kind})
+		serviceOption.Resources = append(serviceOption.Resources, &SvcResources{Kind: resKind.Kind, Name: resKind.Metadata.Name})
 	}
 
 	return serviceOption, nil

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -188,6 +188,10 @@ func GetServiceOption(args *commonmodels.Service, log *zap.SugaredLogger) (*Serv
 			log.Errorf("unmarshal ResourceKind error: %v", err)
 			continue
 		}
+		if resKind == nil {
+			log.Infof("resKind is nil, raw data: %s", string(yamlData))
+			continue
+		}
 		log.Infof("the reskind data is %v", *resKind)
 		serviceOption.Resources = append(serviceOption.Resources, &SvcResources{Kind: resKind.Kind})
 	}

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -180,6 +180,9 @@ func GetServiceOption(args *commonmodels.Service, log *zap.SugaredLogger) (*Serv
 	if err != nil {
 		log.Errorf("failed to render k8s svc yaml: %s/%s, err: %s", args.ProductName, args.ServiceName, err)
 	}
+	renderedYaml = config.ServiceNameAlias.ReplaceAllLiteralString(renderedYaml, args.ServiceName)
+	renderedYaml = config.ProductNameAlias.ReplaceAllLiteralString(renderedYaml, args.ProductName)
+
 	renderedYaml = util.ReplaceWrapLine(renderedYaml)
 	yamlDataArray := util.SplitYaml(renderedYaml)
 	for _, yamlData := range yamlDataArray {

--- a/pkg/tool/git/gitlab/repo.go
+++ b/pkg/tool/git/gitlab/repo.go
@@ -19,6 +19,7 @@ package gitlab
 import (
 	"encoding/base64"
 	"strings"
+	"sync"
 
 	"github.com/27149chen/afero"
 	"github.com/xanzy/go-gitlab"
@@ -143,19 +144,30 @@ func (c *Client) GetYAMLContents(owner, repo, path, branch string, isDir, split 
 		return nil, err
 	}
 
+	loadMutex := sync.Mutex{}
+	var loadErr error = nil
+	wg := sync.WaitGroup{}
+
 	for _, tn := range treeNodes {
 		if tn.Type != "blob" {
 			continue
 		}
-		r, err := c.GetYAMLContents(owner, repo, tn.Path, branch, false, split)
-		if err != nil {
-			return nil, err
-		}
-
-		res = append(res, r...)
+		go func() {
+			wg.Add(1)
+			defer wg.Done()
+			r, err := c.GetYAMLContents(owner, repo, tn.Path, branch, false, split)
+			loadMutex.Lock()
+			defer loadMutex.Unlock()
+			if err != nil {
+				loadErr = err
+				return
+			}
+			res = append(res, r...)
+		}()
 	}
+	wg.Wait()
 
-	return res, nil
+	return res, loadErr
 }
 
 // GetTreeContents recursively gets all file contents under the given path, and writes to an in-memory file system.

--- a/pkg/tool/git/gitlab/repo.go
+++ b/pkg/tool/git/gitlab/repo.go
@@ -154,8 +154,8 @@ func (c *Client) GetYAMLContents(owner, repo, path, branch string, isDir, split 
 		if tn.Type != "blob" {
 			continue
 		}
+		wg.Add(1)
 		go func(tn *gitlab.TreeNode) {
-			wg.Add(1)
 			defer wg.Done()
 			log.Infof("---- start load data from %s", tn.Path)
 			r, err := c.GetYAMLContents(owner, repo, tn.Path, branch, false, split)

--- a/pkg/tool/git/gitlab/repo.go
+++ b/pkg/tool/git/gitlab/repo.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/koderover/zadig/pkg/tool/log"
-
 	"github.com/27149chen/afero"
 	"github.com/xanzy/go-gitlab"
 
@@ -157,7 +155,6 @@ func (c *Client) GetYAMLContents(owner, repo, path, branch string, isDir, split 
 		wg.Add(1)
 		go func(tn *gitlab.TreeNode) {
 			defer wg.Done()
-			log.Infof("---- start load data from %s", tn.Path)
 			r, err := c.GetYAMLContents(owner, repo, tn.Path, branch, false, split)
 			loadMutex.Lock()
 			defer loadMutex.Unlock()
@@ -166,12 +163,9 @@ func (c *Client) GetYAMLContents(owner, repo, path, branch string, isDir, split 
 				return
 			}
 			res = append(res, r...)
-			log.Infof("---- finished load data from %s", tn.Path)
 		}(tn)
 	}
 	wg.Wait()
-
-	log.Infof("load files in dir %s, total %d", path, len(res))
 
 	return res, loadErr
 }

--- a/pkg/tool/git/gitlab/repo.go
+++ b/pkg/tool/git/gitlab/repo.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/koderover/zadig/pkg/tool/log"
+
 	"github.com/27149chen/afero"
 	"github.com/xanzy/go-gitlab"
 
@@ -144,7 +146,7 @@ func (c *Client) GetYAMLContents(owner, repo, path, branch string, isDir, split 
 		return nil, err
 	}
 
-	loadMutex := sync.Mutex{}
+	loadMutex := &sync.Mutex{}
 	var loadErr error = nil
 	wg := sync.WaitGroup{}
 
@@ -152,9 +154,10 @@ func (c *Client) GetYAMLContents(owner, repo, path, branch string, isDir, split 
 		if tn.Type != "blob" {
 			continue
 		}
-		go func() {
+		go func(tn *gitlab.TreeNode) {
 			wg.Add(1)
 			defer wg.Done()
+			log.Infof("---- start load data from %s", tn.Path)
 			r, err := c.GetYAMLContents(owner, repo, tn.Path, branch, false, split)
 			loadMutex.Lock()
 			defer loadMutex.Unlock()
@@ -163,9 +166,12 @@ func (c *Client) GetYAMLContents(owner, repo, path, branch string, isDir, split 
 				return
 			}
 			res = append(res, r...)
-		}()
+			log.Infof("---- finished load data from %s", tn.Path)
+		}(tn)
 	}
 	wg.Wait()
+
+	log.Infof("load files in dir %s, total %d", path, len(res))
 
 	return res, loadErr
 }


### PR DESCRIPTION
### What this PR does / Why we need it:
add resoruce list of service when fetching service info
add concurrency when fetching files from git repo

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 80f7c91</samp>

*  Define a new type `SvcResources` to store Kubernetes resource information ([link](https://github.com/koderover/zadig/pull/3077/files?diff=unified&w=0#diff-fcfbf6b1c510bcc0aac99a96af3adfab8a03337a991e91e0b1a7f79b0faac5f0R62-R66))
*  Add a `Resources` field to the `ServiceOption` type to store the rendered resources ([link](https://github.com/koderover/zadig/pull/3077/files?diff=unified&w=0#diff-fcfbf6b1c510bcc0aac99a96af3adfab8a03337a991e91e0b1a7f79b0faac5f0R74))
*  Render the service template YAML with the given variables and split it into resources ([link](https://github.com/koderover/zadig/pull/3077/files?diff=unified&w=0#diff-fcfbf6b1c510bcc0aac99a96af3adfab8a03337a991e91e0b1a7f79b0faac5f0R177-R193))
*  Extract the kind and name of each resource and append them to the `Resources` field ([link](https://github.com/koderover/zadig/pull/3077/files?diff=unified&w=0#diff-fcfbf6b1c510bcc0aac99a96af3adfab8a03337a991e91e0b1a7f79b0faac5f0R177-R193))
*  Remove the unnecessary call to `getTemplateMergedVariables` ([link](https://github.com/koderover/zadig/pull/3077/files?diff=unified&w=0#diff-fcfbf6b1c510bcc0aac99a96af3adfab8a03337a991e91e0b1a7f79b0faac5f0L164))
*  Modify the `GetYAMLContents` function in `repo.go` to use goroutines to concurrently fetch the YAML contents of the blobs ([link](https://github.com/koderover/zadig/pull/3077/files?diff=unified&w=0#diff-d250ac5b12f12a26a0bbc1a5b6fe8d6fe77521f80c9f8a4b5061ee731125eeacL146-R170))
*  Use a mutex to protect the shared variables `res` and `loadErr` ([link](https://github.com/koderover/zadig/pull/3077/files?diff=unified&w=0#diff-d250ac5b12f12a26a0bbc1a5b6fe8d6fe77521f80c9f8a4b5061ee731125eeacL146-R170))
*  Use a wait group to wait for all the goroutines to finish ([link](https://github.com/koderover/zadig/pull/3077/files?diff=unified&w=0#diff-d250ac5b12f12a26a0bbc1a5b6fe8d6fe77521f80c9f8a4b5061ee731125eeacL146-R170))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
