### PR TITLE
[DON'T MERGE] Debug log list workflow cost time

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/workflow_task_v4.go
@@ -80,6 +80,7 @@ func (c *WorkflowTaskv4Coll) EnsureIndex(ctx context.Context) error {
 				bson.E{Key: "workflow_name", Value: 1},
 				bson.E{Key: "is_archived", Value: 1},
 				bson.E{Key: "is_deleted", Value: 1},
+				bson.E{Key: "create_time", Value: 1},
 			},
 			Options: options.Index().SetUnique(false),
 		},

--- a/pkg/microservice/aslan/core/common/repository/mongodb/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/workflow_task_v4.go
@@ -22,13 +22,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/koderover/zadig/pkg/microservice/aslan/config"
-	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
-	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/koderover/zadig/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/pkg/tool/log"
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
 )
 
 type ListWorkflowTaskV4Option struct {
@@ -125,10 +127,12 @@ func (c *WorkflowTaskv4Coll) List(opt *ListWorkflowTaskV4Option) ([]*models.Work
 		}
 		query["create_time"] = bson.M{comparison: opt.CreateTime}
 	}
+	t := time.Now()
 	count, err := c.CountDocuments(context.TODO(), query)
 	if err != nil {
 		return nil, 0, err
 	}
+	log.Infof("count cost: %v", time.Since(t))
 
 	findOption := options.Find()
 	if opt.Limit > 0 {
@@ -145,6 +149,7 @@ func (c *WorkflowTaskv4Coll) List(opt *ListWorkflowTaskV4Option) ([]*models.Work
 	if err != nil {
 		return nil, 0, err
 	}
+	log.Infof("find cost: %v", time.Since(t))
 	return resp, count, nil
 }
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -411,11 +411,17 @@ func ListWorkflowV4(projectName, viewName, userID string, names, v4Names []strin
 	for _, name := range workflowList {
 		wg.Add(1)
 		go func(workflowName string) {
+			logger.Infof("go func cost %s", time.Since(t))
+			t2 := time.Now()
+			defer func() {
+				logger.Infof("ListWorkflowV4 db all cost: %v", time.Since(t2))
+			}()
 			defer wg.Done()
 			resp, _, err2 := commonrepo.NewworkflowTaskv4Coll().List(&commonrepo.ListWorkflowTaskV4Option{
 				WorkflowName: workflowName,
 				Limit:        10,
 			})
+			logger.Infof("ListWorkflowV4 db cost: %v workflowName: %s", time.Since(t2), workflowName)
 			if err2 != nil {
 				err = err2
 				return


### PR DESCRIPTION
Signed-off-by: M-Cosmosss <yuzhou@koderover.com>### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5406913</samp>

Added time measurement and structured logging to workflow v4 functions and operations. This helps to monitor and improve the performance and reliability of the workflow v4 logic in `pkg/microservice/aslan/core/workflow`. The changes mainly affect `handler/workflow_v4.go` and `service/workflow/workflow_v4.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5406913</samp>

*  Add `time` package to import list of `handler` package to enable measuring execution time of some functions ([link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-0f8a8ee855a0910d9a79938a5d3fe54e784aa806d54f11d14dcc7ec3968f32b2L24-R30))
*  Create `log` variable to store sugared logger with some fields and use it instead of `ctx.Logger` in some places to provide more consistent and structured logging ([link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-0f8a8ee855a0910d9a79938a5d3fe54e784aa806d54f11d14dcc7ec3968f32b2L185-R190), [link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-0f8a8ee855a0910d9a79938a5d3fe54e784aa806d54f11d14dcc7ec3968f32b2R237), [link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-0f8a8ee855a0910d9a79938a5d3fe54e784aa806d54f11d14dcc7ec3968f32b2L240-R250))
*  Measure and log time cost of `NewContextWithAuthorization` function and `ListWorkflowV4` function using `log` variable and `t` variable ([link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-0f8a8ee855a0910d9a79938a5d3fe54e784aa806d54f11d14dcc7ec3968f32b2L194-R200), [link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-0f8a8ee855a0910d9a79938a5d3fe54e784aa806d54f11d14dcc7ec3968f32b2L194-R200))
*  Log user role and filter status in `ListWorkflowV4` function using `log` variable ([link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-0f8a8ee855a0910d9a79938a5d3fe54e784aa806d54f11d14dcc7ec3968f32b2R215))
*  Measure and log time cost of `ListAuthorizedWorkflows` function using `log` variable and `t2` variable ([link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-0f8a8ee855a0910d9a79938a5d3fe54e784aa806d54f11d14dcc7ec3968f32b2L215-R226))
*  Log length of names and v4Names slices and policyFound and viewName variables in `DeleteWorkflowV4` function ([link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R340))
*  Measure and log time cost and length of names and v4Names slices of `filterWorkflowNamesByView` function in `ListWorkflowV4` function ([link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R353), [link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114L363-R369))
*  Measure and log time cost and length of workflowV4List slice of `NewWorkflowV4Coll().List` function in `ListWorkflowV4` function ([link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114L363-R369), [link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R378))
*  Measure and log time cost and length of workflow slice of `ListWorkflows` function in `ListWorkflowV4` function ([link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114L380-R390))
*  Measure and log time cost of `collaboration.GetWorkflowCMMap` function in `ListWorkflowV4` function ([link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114L391-R403))
*  Measure and log time cost of `ListWorkflowTaskV4s` function in `ListWorkflowV4` function ([link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R410), [link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114L422-R448))
*  Measure and log time cost of `NewFavoriteColl().List` function in `ListWorkflowV4` function ([link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114L422-R448))
*  Measure and log time cost of `getWorkflowStatMap` function in `ListWorkflowV4` function ([link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114L422-R448))
*  Measure and log time cost of iterating over workflowV4List slice in `ListWorkflowV4` function ([link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114L422-R448), [link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R488))
*  Log length of baseRefs slice in `ListWorkflowV4` function ([link](https://github.com/koderover/zadig/pull/3079/files?diff=unified&w=0#diff-457a9b90aabad0df747627bdeb2219fd063e51123f44900bc0fb93e655d70114R463))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
