### PR TITLE
modify get yaml service structure lgoic

### DIFF
--- a/pkg/microservice/aslan/core/service/handler/service.go
+++ b/pkg/microservice/aslan/core/service/handler/service.go
@@ -128,7 +128,7 @@ func GetServiceTemplate(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam.AddDesc("invalid revision number")
 		return
 	}
-	ctx.Resp, ctx.Err = commonservice.GetServiceTemplate(c.Param("name"), c.Param("type"), projectName, setting.ProductStatusDeleting, revision, ctx.Logger)
+	ctx.Resp, ctx.Err = commonservice.GetServiceTemplateWithStructure(c.Param("name"), c.Param("type"), projectName, setting.ProductStatusDeleting, revision, ctx.Logger)
 }
 
 func GetServiceTemplateOption(c *gin.Context) {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at af19411</samp>

This pull request refactors the code related to service templates and resources in the `aslan` microservice. It introduces a new function and types in the `service` package to return more information about the service template structure and the Kubernetes resources it contains. It also simplifies the `service` service package and the `service` handler package to use the new function and types.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at af19411</samp>

*  Define new types `SvcResources` and `TemplateSvcResp` to represent Kubernetes resources and service templates with structure ([link](https://github.com/koderover/zadig/pull/3082/files?diff=unified&w=0#diff-618d57a8566d51373f92b52b30ac5462a808b5cc1f1f06a8ad48e750fa986092R140-R149))
* Add new function `GetServiceTemplateWithStructure` to render and parse service YAML template and return a `TemplateSvcResp` object ([link](https://github.com/koderover/zadig/pull/3082/files?diff=unified&w=0#diff-618d57a8566d51373f92b52b30ac5462a808b5cc1f1f06a8ad48e750fa986092R377-R412))
* Modify handler function `GetServiceTemplate` to use `GetServiceTemplateWithStructure` and return more information to the frontend ([link](https://github.com/koderover/zadig/pull/3082/files?diff=unified&w=0#diff-e30959853a932ff64364968244d50a3c90686daae12f30161913bebcded55fc9L131-R131))
* Remove unused code and types from the `service` service package, such as `SvcResources`, `Resources` field, and YAML rendering and parsing logic ([link](https://github.com/koderover/zadig/pull/3082/files?diff=unified&w=0#diff-fcfbf6b1c510bcc0aac99a96af3adfab8a03337a991e91e0b1a7f79b0faac5f0L62-L66), [link](https://github.com/koderover/zadig/pull/3082/files?diff=unified&w=0#diff-fcfbf6b1c510bcc0aac99a96af3adfab8a03337a991e91e0b1a7f79b0faac5f0L74), [link](https://github.com/koderover/zadig/pull/3082/files?diff=unified&w=0#diff-fcfbf6b1c510bcc0aac99a96af3adfab8a03337a991e91e0b1a7f79b0faac5f0L178-L199), [link](https://github.com/koderover/zadig/pull/3082/files?diff=unified&w=0#diff-618d57a8566d51373f92b52b30ac5462a808b5cc1f1f06a8ad48e750fa986092L377))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
