### PR TITLE
fix registry permission bug

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/template/product.go
+++ b/pkg/microservice/aslan/core/common/repository/models/template/product.go
@@ -167,6 +167,18 @@ type ProductFeature struct {
 	CreateEnvType string `bson:"create_env_type"           json:"create_env_type"`
 }
 
+func (p *ProductFeature) GetDeployType() string {
+	var deployType string
+	if p.CreateEnvType == "external" {
+		deployType = "external"
+	} else if p.BasicFacility == "cloud_host" {
+		deployType = "cloud_host"
+	} else {
+		deployType = p.DeployType
+	}
+	return deployType
+}
+
 type ForkProject struct {
 	EnvName      string           `json:"env_name"`
 	WorkflowName string           `json:"workflow_name"`

--- a/pkg/microservice/aslan/core/common/repository/mongodb/template/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/template/product.go
@@ -28,21 +28,20 @@ import (
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/template"
+	templatemodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/template"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/types"
 	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
 )
 
 type ProjectInfo struct {
-	Name          string `bson:"product_name"`
-	Alias         string `bson:"project_name"`
-	Desc          string `bson:"description"`
-	UpdatedAt     int64  `bson:"update_time"`
-	UpdatedBy     string `bson:"update_by"`
-	OnboardStatus int    `bson:"onboarding_status"`
-	Public        bool   `bson:"public"`
-	DeployType    string `bson:"deploy_type"`
-	CreateEnvType string `bson:"create_env_type"`
-	BasicFacility string `bson:"basic_facility"`
+	Name           string                         `bson:"product_name"`
+	Alias          string                         `bson:"project_name"`
+	Desc           string                         `bson:"description"`
+	UpdatedAt      int64                          `bson:"update_time"`
+	UpdatedBy      string                         `bson:"update_by"`
+	OnboardStatus  int                            `bson:"onboarding_status"`
+	Public         bool                           `bson:"public"`
+	ProductFeature *templatemodels.ProductFeature `bson:"product_feature"`
 }
 
 type ProductColl struct {
@@ -173,9 +172,10 @@ func (c *ProductColl) PageListProjectByFilter(opt ProductListByFilterOpt) ([]*Pr
 		"update_by":         "$update_by",
 		"onboarding_status": "$onboarding_status",
 		"public":            "$public",
-		"deploy_type":       "$product_feature.deploy_type",
-		"create_env_type":   "$product_feature.create_env_type",
-		"basic_facility":    "$product_feature.basic_facility",
+		"product_feature":   "$product_feature",
+		// "deploy_type":       "$product_feature.deploy_type",
+		// "create_env_type":   "$product_feature.create_env_type",
+		// "basic_facility":    "$product_feature.basic_facility",
 	}
 	pipeline := []bson.M{
 		{

--- a/pkg/microservice/aslan/core/project/service/bizdir.go
+++ b/pkg/microservice/aslan/core/project/service/bizdir.go
@@ -76,7 +76,7 @@ func GetBizDirProject() ([]GroupDetail, error) {
 			projectDetail := *&commonmodels.ProjectDetail{
 				ProjectName:       project.ProjectName,
 				ProjectKey:        project.ProductName,
-				ProjectDeployType: project.ProductFeature.DeployType,
+				ProjectDeployType: project.ProductFeature.GetDeployType(),
 			}
 			ungrouped.Projects = append(ungrouped.Projects, &projectDetail)
 		}
@@ -145,7 +145,7 @@ func SearchBizDirByProject(projectKeyword string) ([]GroupDetail, error) {
 		projectDetail := &commonmodels.ProjectDetail{
 			ProjectKey:        project.Name,
 			ProjectName:       project.Alias,
-			ProjectDeployType: project.DeployType,
+			ProjectDeployType: project.ProductFeature.GetDeployType(),
 		}
 		if projectGroupMap[project.Name] != "" {
 			groupProjectMap[projectGroupMap[project.Name]] = append(groupProjectMap[projectGroupMap[project.Name]], projectDetail)

--- a/pkg/microservice/aslan/core/project/service/bizdir.go
+++ b/pkg/microservice/aslan/core/project/service/bizdir.go
@@ -221,9 +221,9 @@ func SearchBizDirByService(serviceName string) ([]*SearchBizDirByServiceGroup, e
 		if elem, ok := projectMap[service.ProductName]; !ok {
 			project := &SearchBizDirByServiceProject{
 				Project: &commonmodels.ProjectDetail{
-					ProjectKey:        templateProjectMap[service.ServiceName].ProductName,
-					ProjectName:       templateProjectMap[service.ServiceName].ProjectName,
-					ProjectDeployType: templateProjectMap[service.ServiceName].ProductFeature.DeployType,
+					ProjectKey:        templateProjectMap[service.ProductName].ProductName,
+					ProjectName:       templateProjectMap[service.ProductName].ProjectName,
+					ProjectDeployType: templateProjectMap[service.ProductName].ProductFeature.DeployType,
 				},
 				Services: []string{service.ServiceName},
 			}

--- a/pkg/microservice/aslan/core/project/service/product.go
+++ b/pkg/microservice/aslan/core/project/service/product.go
@@ -1443,7 +1443,7 @@ func GetProjectGroupRelation(name string, logger *zap.SugaredLogger) (resp *Proj
 			resp.Projects = append(resp.Projects, &ProjectGroupRelation{
 				ProjectKey:  project.Name,
 				ProjectName: project.Alias,
-				DeployType:  project.DeployType,
+				DeployType:  project.ProductFeature.GetDeployType(),
 				Enabled:     false,
 			})
 		}

--- a/pkg/microservice/aslan/core/project/service/project.go
+++ b/pkg/microservice/aslan/core/project/service/project.go
@@ -172,14 +172,7 @@ func listDetailedProjectInfos(opts *ProjectListOptions, logger *zap.SugaredLogge
 		}
 
 		info := nameMap[name]
-		var deployType string
-		if info.CreateEnvType == "external" {
-			deployType = "external"
-		} else if info.BasicFacility == "cloud_host" {
-			deployType = "cloud_host"
-		} else {
-			deployType = info.DeployType
-		}
+		deployType := info.ProductFeature.GetDeployType()
 		representation = append(representation, &ProjectDetailedRepresentation{
 			ProjectBriefRepresentation: &ProjectBriefRepresentation{
 				ProjectMinimalRepresentation: &ProjectMinimalRepresentation{Name: name},


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5339a79</samp>

Improved security and access control for `ListImages` handler in `registry.go`. Added project-level authorization and validation for registries using a new package.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5339a79</samp>

* Require authorization and project name for listing images in a registry ([link](https://github.com/koderover/zadig/pull/3083/files?diff=unified&w=0#diff-19b41d62129e62f812f57327c25629c825112f2a06085d1ee9f795c12bfbae9fL281-R307))
* Check user's access to the project and the registry using `sets.String` ([link](https://github.com/koderover/zadig/pull/3083/files?diff=unified&w=0#diff-19b41d62129e62f812f57327c25629c825112f2a06085d1ee9f795c12bfbae9fL26-R31), [link](https://github.com/koderover/zadig/pull/3083/files?diff=unified&w=0#diff-19b41d62129e62f812f57327c25629c825112f2a06085d1ee9f795c12bfbae9fL281-R307))
* Validate project name against the registry's project list or all-projects flag ([link](https://github.com/koderover/zadig/pull/3083/files?diff=unified&w=0#diff-19b41d62129e62f812f57327c25629c825112f2a06085d1ee9f795c12bfbae9fR319-R324))
* Return error if project name is invalid or unauthorized ([link](https://github.com/koderover/zadig/pull/3083/files?diff=unified&w=0#diff-19b41d62129e62f812f57327c25629c825112f2a06085d1ee9f795c12bfbae9fR319-R324))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
