### PR TITLE
add proudction svc structure support

### DIFF
--- a/pkg/microservice/aslan/core/service/service/production_service.go
+++ b/pkg/microservice/aslan/core/service/service/production_service.go
@@ -75,7 +75,7 @@ func ListProductionServices(productName string, log *zap.SugaredLogger) (*servic
 	return resp, nil
 }
 
-func GetProductionK8sService(serviceName, productName string, log *zap.SugaredLogger) (*commonmodels.Service, error) {
+func GetProductionK8sService(serviceName, productName string, log *zap.SugaredLogger) (*commonservice.TemplateSvcResp, error) {
 	serviceObject, err := repository.QueryTemplateService(&commonrepo.ServiceFindOption{
 		ServiceName: serviceName,
 		ProductName: productName,
@@ -86,7 +86,11 @@ func GetProductionK8sService(serviceName, productName string, log *zap.SugaredLo
 		log.Errorf("Failed to list services by %+v, err: %s", serviceName, err)
 		return nil, e.ErrGetTemplate.AddDesc(err.Error())
 	}
-	return serviceObject, nil
+	resp := &commonservice.TemplateSvcResp{
+		Service:   serviceObject,
+		Resources: commonservice.GeneSvcStructure(serviceObject),
+	}
+	return resp, nil
 }
 
 func GetProductionK8sServiceOption(serviceName, productName string, log *zap.SugaredLogger) (*ServiceOption, error) {


### PR DESCRIPTION
### What this PR does / Why we need it:
add production svc structure parse logic 

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c865286</samp>

*  Refactor the logic of generating the service structure from the rendered YAML into a separate function `GeneSvcStructure` to improve readability and modularity ([link](https://github.com/koderover/zadig/pull/3087/files?diff=unified&w=0#diff-618d57a8566d51373f92b52b30ac5462a808b5cc1f1f06a8ad48e750fa986092L386-R415))
* Move the function `GetProductionK8sService` from the `service` package to the `commonservice` package to reuse it in both the service and the workflow packages ([link](https://github.com/koderover/zadig/pull/3087/files?diff=unified&w=0#diff-8f5643e5004520c1ff20a8af90399a5adf97c4624d15d083314aa8238fd18f8bL78-R78))
* Change the return type of `GetProductionK8sService` from `*commonmodels.Service` to `*commonservice.TemplateSvcResp` to include the service structure in the response data ([link](https://github.com/koderover/zadig/pull/3087/files?diff=unified&w=0#diff-8f5643e5004520c1ff20a8af90399a5adf97c4624d15d083314aa8238fd18f8bL78-R78))
* Call the `GeneSvcStructure` function in `GetProductionK8sService` to generate and assign the service structure to the `Resources` field of the `TemplateSvcResp` object ([link](https://github.com/koderover/zadig/pull/3087/files?diff=unified&w=0#diff-8f5643e5004520c1ff20a8af90399a5adf97c4624d15d083314aa8238fd18f8bL89-R93))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
