### PR TITLE
allow to create empty env for testing

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2336,10 +2336,6 @@ func preCreateProduct(envName string, args *commonmodels.Product, kubeClient cli
 	for _, group := range args.Services {
 		serviceCount = serviceCount + len(group)
 	}
-	if serviceCount == 0 && !args.Production {
-		log.Errorf("[%s][P:%s] not service found", envName, args.ProductName)
-		return e.ErrCreateEnv.AddDesc(e.FindProductServiceErrMsg)
-	}
 	args.Revision = productTmpl.Revision
 
 	opt := &commonrepo.ProductFindOptions{Name: args.ProductName, EnvName: envName}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_helm_chart_deploy.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_helm_chart_deploy.go
@@ -23,6 +23,7 @@ import (
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	templaterepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb/template"
+	"github.com/koderover/zadig/pkg/setting"
 )
 
 type HelmChartDeployJob struct {
@@ -113,6 +114,10 @@ func (j *HelmChartDeployJob) ToJobs(taskID int64) ([]*commonmodels.JobTask, erro
 		return resp, fmt.Errorf("cannot find product %s: %w", j.workflow.Project, err)
 	}
 	timeout := templateProduct.Timeout * 60
+
+	if templateProduct.ProductFeature.DeployType != setting.HelmDeployType {
+		return resp, fmt.Errorf("product %s deploy type is not helm", j.workflow.Project)
+	}
 
 	for _, deploy := range j.spec.DeployHelmCharts {
 		jobTaskSpec := &commonmodels.JobTaskHelmChartDeploySpec{


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b390118</samp>

This pull request adds support for `helm` deploy type in the workflow engine, which allows creating and deploying products with helm charts. It modifies the `job` and `environment` packages to handle the new deploy type and remove unnecessary checks.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b390118</samp>

*  Add support for helm deploy type in the workflow engine
  * Check the deploy type of the product in the `ToJobs` function and return an error if it is not `HelmDeployType` ([link](https://github.com/koderover/zadig/pull/3088/files?diff=unified&w=0#diff-e67653ce8bfe907653ae8afbd507df9f18b9f170c6bd2457aa78a9eb63fe3c59R118-R121))
  * Import the `setting` package to use the constant `HelmDeployType` ([link](https://github.com/koderover/zadig/pull/3088/files?diff=unified&w=0#diff-e67653ce8bfe907653ae8afbd507df9f18b9f170c6bd2457aa78a9eb63fe3c59R26))
  * Remove the check for service count and production flag in the `preCreateProduct` function to allow creating products without services and deploying them with helm charts ([link](https://github.com/koderover/zadig/pull/3088/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L2339-L2342))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
