### PR TITLE
fix helm chart deploy job panic

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/helm.go
+++ b/pkg/microservice/aslan/core/common/service/kube/helm.go
@@ -248,7 +248,7 @@ func UpgradeHelmRelease(product *commonmodels.Product, productSvc *commonmodels.
 	} else {
 		releaseName = productSvc.ReleaseName
 		svcTemp = &commonmodels.Service{
-			ServiceName: productSvc.ReleaseName,
+			ServiceName: releaseName,
 			ProductName: product.ProductName,
 			HelmChart: &commonmodels.HelmChart{
 				Name:    chartInfo.ChartName,

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_chart_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_chart_deploy.go
@@ -96,7 +96,7 @@ func (c *HelmChartDeployJobCtl) Run(ctx context.Context) {
 		}
 	}
 
-	chartInfo, ok := productInfo.GetChartRenderMap()[deploy.ReleaseName]
+	chartInfo, ok := productInfo.GetChartDeployRenderMap()[deploy.ReleaseName]
 	if !ok {
 		chartInfo = &template.ServiceRender{
 			ReleaseName:       deploy.ReleaseName,

--- a/pkg/microservice/aslan/core/delivery/service/version.go
+++ b/pkg/microservice/aslan/core/delivery/service/version.go
@@ -811,13 +811,10 @@ func CreateHelmDeliveryVersion(args *CreateHelmDeliveryVersionArgs, logger *zap.
 // validate chartInfo, make sure service is in environment
 // prepare data set for chart delivery
 func prepareChartData(chartDatas []*CreateHelmDeliveryVersionChartData, productInfo *commonmodels.Product) (map[string]*DeliveryChartData, error) {
-	chartMap := make(map[string]*template.ServiceRender)
-	for _, rChart := range productInfo.GetChartRenderMap() {
-		chartMap[rChart.ServiceName] = rChart
-	}
-
-	chartDataMap := make(map[string]*DeliveryChartData)
 	serviceMap := productInfo.GetServiceMap()
+	chartMap := productInfo.GetChartRenderMap()
+	chartDataMap := make(map[string]*DeliveryChartData)
+
 	for _, chartData := range chartDatas {
 		if productService, ok := serviceMap[chartData.ServiceName]; ok {
 			serviceObj, err := commonrepo.NewServiceColl().Find(&commonrepo.ServiceFindOption{


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fbe3297</samp>

This pull request fixes a bug, improves code readability, and adds debug logging in various functions related to helm release management in the `aslan` microservice. The affected files are `helm.go`, `job_helm_chart_deploy.go`, `version.go`, and `environment.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fbe3297</samp>

*  Add nil check for chartInfo variable in UpgradeHelmRelease function to prevent potential nil pointer dereference error ([link](https://github.com/koderover/zadig/pull/3090/files?diff=unified&w=0#diff-622e96cd3987393e3ae95185c4555f59f3b3ace6292ef497487eb0e7b383a722R247-R249))
*  Use releaseName variable instead of productSvc.ReleaseName field to access chartInfo map in UpgradeHelmRelease function for consistency and simplicity ([link](https://github.com/koderover/zadig/pull/3090/files?diff=unified&w=0#diff-622e96cd3987393e3ae95185c4555f59f3b3ace6292ef497487eb0e7b383a722L253-R262))
*  Use GetChartDeployRenderMap method instead of GetChartRenderMap method to get chartInfo variable in Run function of `job_helm_chart_deploy.go` file to match deployment configuration ([link](https://github.com/koderover/zadig/pull/3090/files?diff=unified&w=0#diff-d0104fe88492ea4119b685c64edf287a1e0ddc568984d78c1e814eae010fce52L99-R99))
*  Simplify code and avoid creating unnecessary chartMap variable in prepareChartData function of `version.go` file by accessing productInfo.GetChartRenderMap method directly ([link](https://github.com/koderover/zadig/pull/3090/files?diff=unified&w=0#diff-320244f3b12a280f137a071697ee8bb4bbf6d888da488025f7e7cfc06bb8a064L814-R817))
*  Add debug logging statements to proceedHelmRelease function of `environment.go` file to help troubleshoot and diagnose helm release issues ([link](https://github.com/koderover/zadig/pull/3090/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24R2830-R2833))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
