### PR TITLE
fix: prepare retry workflow data should ignore skipped job

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -540,6 +540,9 @@ func RetryWorkflowTaskV4(workflowName string, taskID int64, logger *zap.SugaredL
 	jobTaskMap := make(map[string]*commonmodels.JobTask)
 	for _, stage := range task.WorkflowArgs.Stages {
 		for _, job := range stage.Jobs {
+			if job.Skipped {
+				continue
+			}
 			jobCtl, err := jobctl.InitJobCtl(job, task.WorkflowArgs)
 			if err != nil {
 				return errors.Errorf("init jobCtl %s error: %s", job.Name, err)


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4cb5314</samp>

Skip retry logic for skipped workflow tasks. This improves the performance and user experience of the workflow engine by avoiding redundant retries for `workflow_task_v4.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4cb5314</samp>

*  Skip retry logic for skipped workflow tasks ([link](https://github.com/koderover/zadig/pull/3091/files?diff=unified&w=0#diff-5a9b5157a24d6d74d66a54b3d6b2a961d0b468af078c53b04301e590ab97e165R543-R545))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
