### PR TITLE
fix codehost refresh token bug for project integration

### DIFF
--- a/pkg/microservice/systemconfig/core/codehost/handler/codehost.go
+++ b/pkg/microservice/systemconfig/core/codehost/handler/codehost.go
@@ -176,5 +176,5 @@ func UpdateSystemCodeHost(c *gin.Context) {
 		return
 	}
 	req.ID = id
-	ctx.Resp, ctx.Err = service.UpdateSystemCodeHost(req, ctx.Logger)
+	ctx.Resp, ctx.Err = service.UpdateCodeHost(req, ctx.Logger)
 }

--- a/pkg/microservice/systemconfig/core/codehost/repository/mongodb/codehost.go
+++ b/pkg/microservice/systemconfig/core/codehost/repository/mongodb/codehost.go
@@ -261,10 +261,9 @@ func (c *CodehostColl) deleteCodeHost(query bson.M) error {
 	return nil
 }
 
-func (c *CodehostColl) UpdateSystemCodeHost(host *models.CodeHost) (*models.CodeHost, error) {
+func (c *CodehostColl) UpdateCodeHost(host *models.CodeHost) (*models.CodeHost, error) {
 	query := bson.M{
 		"id":                host.ID,
-		"integration_level": setting.IntegrationLevelSystem,
 		"deleted_at":        0,
 	}
 

--- a/pkg/microservice/systemconfig/core/codehost/service/codehost.go
+++ b/pkg/microservice/systemconfig/core/codehost/service/codehost.go
@@ -134,7 +134,7 @@ func DeleteCodeHost(id int, _ *zap.SugaredLogger) error {
 	return mongodb.NewCodehostColl().DeleteSystemCodeHostByID(id)
 }
 
-func UpdateSystemCodeHost(host *models.CodeHost, _ *zap.SugaredLogger) (*models.CodeHost, error) {
+func UpdateCodeHost(host *models.CodeHost, _ *zap.SugaredLogger) (*models.CodeHost, error) {
 	if host.Type == setting.SourceFromGerrit {
 		host.AccessToken = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", host.Username, host.Password)))
 	}
@@ -150,7 +150,7 @@ func UpdateSystemCodeHost(host *models.CodeHost, _ *zap.SugaredLogger) (*models.
 		}
 	}
 
-	return mongodb.NewCodehostColl().UpdateSystemCodeHost(host)
+	return mongodb.NewCodehostColl().UpdateCodeHost(host)
 }
 
 func UpdateCodeHostToken(host *models.CodeHost, _ *zap.SugaredLogger) (*models.CodeHost, error) {

--- a/pkg/shared/client/systemconfig/codehost.go
+++ b/pkg/shared/client/systemconfig/codehost.go
@@ -174,7 +174,7 @@ func (c *Client) UpdateCodeHost(id int, codehost *CodeHost) error {
 		UpdatedAt:          codehost.UpdatedAt,
 	}
 
-	_, err := codehostservice.UpdateSystemCodeHost(arg, log.SugaredLogger())
+	_, err := codehostservice.UpdateCodeHost(arg, log.SugaredLogger())
 	return err
 }
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a38a12d</samp>

Renamed and refactored code host functions to remove the integration level distinction between system and project code hosts. This simplifies the code and the API for managing code hosts.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a38a12d</samp>

*  Rename `UpdateSystemCodeHost` to `UpdateCodeHost` in handler, service, repository, and client functions to remove integration level distinction between system and project code hosts ([link](https://github.com/koderover/zadig/pull/3092/files?diff=unified&w=0#diff-8d2774c44f378636140a88a1644bcb6ff92f8ebc1b2cb1d50881d9cd205a0355L179-R179), [link](https://github.com/koderover/zadig/pull/3092/files?diff=unified&w=0#diff-5c934ca0076f385b4c69664a27b51f475c8a6e18b57b8a26ee849d88c57685fdL264-R266), [link](https://github.com/koderover/zadig/pull/3092/files?diff=unified&w=0#diff-e01793883739b931d8eb70dfebbb51ccbbe23e396b4d756101098b69ad2a23c4L137-R137), [link](https://github.com/koderover/zadig/pull/3092/files?diff=unified&w=0#diff-86c6c6531a07c11aa911d2fb4cae738466109ef6e4257391351f9a875b928b2eL177-R177))
* Simplify query filter in repository function `UpdateCodeHost` to remove integration level condition ([link](https://github.com/koderover/zadig/pull/3092/files?diff=unified&w=0#diff-5c934ca0076f385b4c69664a27b51f475c8a6e18b57b8a26ee849d88c57685fdL264-R266))
* Update service function `UpdateCodeHost` to call renamed repository function `UpdateCodeHost` ([link](https://github.com/koderover/zadig/pull/3092/files?diff=unified&w=0#diff-e01793883739b931d8eb70dfebbb51ccbbe23e396b4d756101098b69ad2a23c4L153-R153))
* Update client function `UpdateCodeHost` to call renamed service function `UpdateCodeHost` ([link](https://github.com/koderover/zadig/pull/3092/files?diff=unified&w=0#diff-86c6c6531a07c11aa911d2fb4cae738466109ef6e4257391351f9a875b928b2eL177-R177))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
