### PR TITLE
fix authentication & authorization errors

### DIFF
--- a/pkg/microservice/aslan/core/templatestore/handler/workflow.go
+++ b/pkg/microservice/aslan/core/templatestore/handler/workflow.go
@@ -77,7 +77,7 @@ func ListWorkflowTemplate(c *gin.Context) {
 	// authorization check
 	if !ctx.Resources.IsSystemAdmin {
 		if !ctx.Resources.SystemActions.Template.View {
-			projectKey := c.Param("projectName")
+			projectKey := c.Query("projectName")
 			if _, ok := ctx.Resources.ProjectAuthInfo[projectKey]; !ok {
 				ctx.UnAuthorized = true
 				return

--- a/pkg/microservice/user/core/service/permission/authn.go
+++ b/pkg/microservice/user/core/service/permission/authn.go
@@ -57,7 +57,15 @@ func IsPublicURL(reqPath, method string) bool {
 		return true
 	}
 
+	if realPath == "/api/v1/reset" && method == http.MethodPost {
+		return true
+	}
+
 	if realPath == "/api/aslan/system/initialization/status" && method == http.MethodGet {
+		return true
+	}
+
+	if realPath == "/api/aslan/system/registry" && method == http.MethodGet {
 		return true
 	}
 

--- a/pkg/microservice/user/core/service/permission/authn.go
+++ b/pkg/microservice/user/core/service/permission/authn.go
@@ -65,7 +65,7 @@ func IsPublicURL(reqPath, method string) bool {
 		return true
 	}
 
-	if realPath == "/api/aslan/system/registry" && method == http.MethodGet {
+	if realPath == "/api/aslan/system/registry/project" && method == http.MethodGet {
 		return true
 	}
 

--- a/pkg/shared/client/aslan/registries.go
+++ b/pkg/shared/client/aslan/registries.go
@@ -19,7 +19,7 @@ package aslan
 import "github.com/koderover/zadig/pkg/tool/httpclient"
 
 func (c *Client) ListRegistries() ([]*RegistryInfo, error) {
-	url := "/system/registry"
+	url := "/system/registry/project"
 	res := make([]*RegistryInfo, 0)
 
 	_, err := c.Get(url, httpclient.SetResult(&res))


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f55fc2</samp>

This pull request enhances the external authorization service for Envoy, fixes a bug in the workflow template listing, and adds two new public URLs to the user service. These changes improve the security, usability, and functionality of the Zadig platform.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f55fc2</samp>

* Fix a bug in `ListWorkflowTemplate` that caused permission check failure ([link](https://github.com/koderover/zadig/pull/3098/files?diff=unified&w=0#diff-f2c47871850d34d336afe2636c8558af02a279ca4655c4af43c0c359a78678f9L80-R80))
* Add two new public URLs to bypass authentication and authorization checks ([link](https://github.com/koderover/zadig/pull/3098/files?diff=unified&w=0#diff-a183a10cb2bc26193bb8bfd0c8b78551dc357620da224f0b692c93c5cabe5c12L60-R71))
* Refactor and extend `Check` function in `grpc` package to support different ways of passing user token and handle malformed URL ([link](https://github.com/koderover/zadig/pull/3098/files?diff=unified&w=0#diff-be92193ee06b006922b7b2f0190330386f4ca38412d7bb0bde35973eca73ff09R23), [link](https://github.com/koderover/zadig/pull/3098/files?diff=unified&w=0#diff-be92193ee06b006922b7b2f0190330386f4ca38412d7bb0bde35973eca73ff09L52-R57), [link](https://github.com/koderover/zadig/pull/3098/files?diff=unified&w=0#diff-be92193ee06b006922b7b2f0190330386f4ca38412d7bb0bde35973eca73ff09L82-R109), [link](https://github.com/koderover/zadig/pull/3098/files?diff=unified&w=0#diff-be92193ee06b006922b7b2f0190330386f4ca38412d7bb0bde35973eca73ff09L119-R144), [link](https://github.com/koderover/zadig/pull/3098/files?diff=unified&w=0#diff-be92193ee06b006922b7b2f0190330386f4ca38412d7bb0bde35973eca73ff09L134-R167))
* Add `userToken` to log message when request is allowed in `Check` function ([link](https://github.com/koderover/zadig/pull/3098/files?diff=unified&w=0#diff-be92193ee06b006922b7b2f0190330386f4ca38412d7bb0bde35973eca73ff09L134-R167))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
