### PR TITLE
fix: update cluster createDynamicPVC

### DIFF
--- a/pkg/microservice/aslan/core/multicluster/service/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/service/clusters.go
@@ -507,6 +507,25 @@ func UpdateCluster(id string, args *K8SCluster, logger *zap.SugaredLogger) (*com
 		return nil, err
 	}
 
+	// If the user chooses to use dynamically generated storage resources, the system automatically creates the PVC.
+	// TODO: If the PVC is not successfully bound to the PV, it is necessary to consider how to expose this abnormal information.
+	//       Depends on product design.
+	if args.Cache.MediumType == types.NFSMedium && args.Cache.NFSProperties.ProvisionType == types.DynamicProvision {
+
+		if id == setting.LocalClusterID {
+			args.DindCfg = nil
+		}
+
+		if err := createDynamicPVC(id, "cache", &args.Cache.NFSProperties, logger); err != nil {
+			return nil, err
+		}
+	}
+	if args.ShareStorage.MediumType == types.NFSMedium && args.ShareStorage.NFSProperties.ProvisionType == types.DynamicProvision {
+		if err := createDynamicPVC(id, "share-storage", &args.ShareStorage.NFSProperties, logger); err != nil {
+			return nil, err
+		}
+	}
+
 	cluster := &commonmodels.K8SCluster{
 		Name:           args.Name,
 		Description:    args.Description,
@@ -526,25 +545,6 @@ func UpdateCluster(id string, args *K8SCluster, logger *zap.SugaredLogger) (*com
 	// if we don't need this cluster to schedule workflow, we don't need to upgrade hub-agent
 	if cluster.AdvancedConfig != nil && !cluster.AdvancedConfig.ScheduleWorkflow {
 		return cluster, nil
-	}
-
-	// If the user chooses to use dynamically generated storage resources, the system automatically creates the PVC.
-	// TODO: If the PVC is not successfully bound to the PV, it is necessary to consider how to expose this abnormal information.
-	//       Depends on product design.
-	if args.Cache.MediumType == types.NFSMedium && args.Cache.NFSProperties.ProvisionType == types.DynamicProvision {
-
-		if id == setting.LocalClusterID {
-			args.DindCfg = nil
-		}
-
-		if err := createDynamicPVC(id, "cache", &args.Cache.NFSProperties, logger); err != nil {
-			return nil, err
-		}
-	}
-	if args.ShareStorage.MediumType == types.NFSMedium && args.ShareStorage.NFSProperties.ProvisionType == types.DynamicProvision {
-		if err := createDynamicPVC(id, "share-storage", &args.ShareStorage.NFSProperties, logger); err != nil {
-			return nil, err
-		}
 	}
 
 	return cluster, UpgradeAgent(id, logger)


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5bd5d6b</samp>

This pull request refactors the code for dynamic NFS provision in `clusters.go` by removing duplication and reusing the `CreateCluster` function. This improves the readability and maintainability of the code.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5bd5d6b</samp>

*  Remove duplicated code for creating dynamic PVCs for cluster storage ([link](https://github.com/koderover/zadig/pull/3099/files?diff=unified&w=0#diff-4e85c1af9762124c9c31e475d7a54712ffc81a99054ebef0ea2d97cd73ca6a8cL531-L549))
*  Add code for creating dynamic PVCs for cluster storage when updating cluster ([link](https://github.com/koderover/zadig/pull/3099/files?diff=unified&w=0#diff-4e85c1af9762124c9c31e475d7a54712ffc81a99054ebef0ea2d97cd73ca6a8cR510-R528))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
