### PR TITLE
fix sonar openapi problem

### DIFF
--- a/pkg/microservice/aslan/core/workflow/testing/service/types.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/types.go
@@ -55,8 +55,10 @@ type OpenAPICreateScanningReq struct {
 	ScannerType string                    `json:"scanner_type"`
 	ImageName   string                    `json:"image_name"`
 	RepoInfo    []*types.OpenAPIRepoInput `json:"repo_info"`
+	SonarSystem string                    `json:"sonar_system"`
 	// FIMXE: currently only one sonar system is required, so we just fill in the default sonar ID.
 	Addons            []*commonmodels.Item          `json:"addons"`
+	PrelaunchScript   string                        `json:"prelaunch_script"`
 	SonarParameter    string                        `json:"sonar_parameter"`
 	Script            string                        `json:"script"`
 	EnableQualityGate bool                          `json:"enable_quality_gate"`


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3eba704</samp>

The changes allow specifying the sonar system name for openapi scanning and improve the logic of finding the sonar integration ID. The changes also rename and set some fields of the scanning module and request type for clarity.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3eba704</samp>

*  Add `SonarSystem` field to `OpenAPICreateScanningReq` type and rename `Script` field to `PrelaunchScript` ([link](https://github.com/koderover/zadig/pull/3100/files?diff=unified&w=0#diff-c76ce97d0bbad006a475686268fd2e1bab3ea25b780e963aaf9fa3e7182b61bcL58-R61)) in `types.go`

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
