### PR TITLE
set branch info for test tasks triggerd by webhook

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/workflow.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow.go
@@ -234,6 +234,7 @@ type TestTaskArgs struct {
 	RepoNamespace  string `bson:"repo_namespace"   json:"repo_namespace"`
 	RepoName       string `bson:"repo_name"        json:"repo_name"`
 	Ref            string `bson:"ref" json:"ref"`
+	Branch         string `bson:"branch" json:"branch"`
 	EventType      string `bson:"event_type" json:"event_type"`
 }
 

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_testing_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_testing_task.go
@@ -224,7 +224,6 @@ func TriggerTestByGitlabEvent(event interface{}, baseURI, requestID string, log 
 					args.RepoNamespace = item.MainRepo.GetRepoNamespace()
 					args.RepoName = item.MainRepo.RepoName
 					args.Branch = item.MainRepo.Branch
-					log.Infof("-------- branch name is %v", args.Branch)
 
 					// 3. create task with args
 					if resp, err := testingservice.CreateTestTask(args, log); err != nil {

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_testing_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_testing_task.go
@@ -169,7 +169,7 @@ func TriggerTestByGitlabEvent(event interface{}, baseURI, requestID string, log 
 					mErr = multierror.Append(mErr, err)
 				} else if matches {
 					log.Infof("event match hook %v of %s", item.MainRepo, testing.Name)
-					var mergeRequestID, commitID, branch, ref, eventType string
+					var mergeRequestID, commitID, ref, eventType string
 					var prID int
 					autoCancelOpt := &AutoCancelOpt{
 						TaskType: config.TestType,
@@ -181,7 +181,6 @@ func TriggerTestByGitlabEvent(event interface{}, baseURI, requestID string, log 
 						eventType = EventTypePR
 						mergeRequestID = strconv.Itoa(ev.ObjectAttributes.IID)
 						commitID = ev.ObjectAttributes.LastCommit.ID
-						branch = ev.ObjectAttributes.TargetBranch
 						prID = ev.ObjectAttributes.IID
 						autoCancelOpt.MergeRequestID = mergeRequestID
 						autoCancelOpt.CommitID = commitID

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_testing_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_testing_task.go
@@ -169,7 +169,7 @@ func TriggerTestByGitlabEvent(event interface{}, baseURI, requestID string, log 
 					mErr = multierror.Append(mErr, err)
 				} else if matches {
 					log.Infof("event match hook %v of %s", item.MainRepo, testing.Name)
-					var mergeRequestID, commitID, ref, eventType string
+					var mergeRequestID, commitID, branch, ref, eventType string
 					var prID int
 					autoCancelOpt := &AutoCancelOpt{
 						TaskType: config.TestType,
@@ -181,6 +181,7 @@ func TriggerTestByGitlabEvent(event interface{}, baseURI, requestID string, log 
 						eventType = EventTypePR
 						mergeRequestID = strconv.Itoa(ev.ObjectAttributes.IID)
 						commitID = ev.ObjectAttributes.LastCommit.ID
+						branch = ev.ObjectAttributes.TargetBranch
 						prID = ev.ObjectAttributes.IID
 						autoCancelOpt.MergeRequestID = mergeRequestID
 						autoCancelOpt.CommitID = commitID
@@ -223,6 +224,7 @@ func TriggerTestByGitlabEvent(event interface{}, baseURI, requestID string, log 
 					args.RepoOwner = item.MainRepo.RepoOwner
 					args.RepoNamespace = item.MainRepo.GetRepoNamespace()
 					args.RepoName = item.MainRepo.RepoName
+					log.Infof("------- the target br is %s, ref is %v", item.MainRepo.Branch, ref)
 
 					// 3. create task with args
 					if resp, err := testingservice.CreateTestTask(args, log); err != nil {

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_testing_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_testing_task.go
@@ -223,7 +223,8 @@ func TriggerTestByGitlabEvent(event interface{}, baseURI, requestID string, log 
 					args.RepoOwner = item.MainRepo.RepoOwner
 					args.RepoNamespace = item.MainRepo.GetRepoNamespace()
 					args.RepoName = item.MainRepo.RepoName
-					log.Infof("------- the target br is %s, ref is %v", item.MainRepo.Branch, ref)
+					args.Branch = item.MainRepo.Branch
+					log.Infof("-------- branch name is %v", args.Branch)
 
 					// 3. create task with args
 					if resp, err := testingservice.CreateTestTask(args, log); err != nil {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
@@ -742,8 +742,8 @@ func TestArgsToTestSubtask(args *commonmodels.TestTaskArgs, pt *task.Task, log *
 						if pr != 0 {
 							testArg.Builds[i].PRs = []int{pr}
 						}
-						if args.Ref != "" {
-							testArg.Builds[i].Branch = args.Ref
+						if args.Branch != "" {
+							testArg.Builds[i].Branch = args.Branch
 						}
 					}
 				}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/pipeline_task.go
@@ -742,6 +742,9 @@ func TestArgsToTestSubtask(args *commonmodels.TestTaskArgs, pt *task.Task, log *
 						if pr != 0 {
 							testArg.Builds[i].PRs = []int{pr}
 						}
+						if args.Ref != "" {
+							testArg.Builds[i].Branch = args.Ref
+						}
 					}
 				}
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5465034</samp>

Added support for Gitlab tag events in webhook and test tasks. Used the `args.Ref` parameter to get the branch or tag name from the webhook payload and pass it to the test argument. Modified `gitlab_testing_task.go` and `pipeline_task.go` to handle different ref formats.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5465034</samp>

*  Add support for triggering tests by Gitlab tag events ([link](https://github.com/koderover/zadig/pull/3101/files?diff=unified&w=0#diff-2808ff8ab1c1e64c7d43a23b4d498dd252454b67c915d41d5ca82329093bc031L172-R172), [link](https://github.com/koderover/zadig/pull/3101/files?diff=unified&w=0#diff-2808ff8ab1c1e64c7d43a23b4d498dd252454b67c915d41d5ca82329093bc031R184), [link](https://github.com/koderover/zadig/pull/3101/files?diff=unified&w=0#diff-2808ff8ab1c1e64c7d43a23b4d498dd252454b67c915d41d5ca82329093bc031R227), [link](https://github.com/koderover/zadig/pull/3101/files?diff=unified&w=0#diff-3a9aed32d3722a7eb3a76d79dfd8c1a994acb4f875829cb8f1f80ebaf367b8abR745-R747))
  - Declare a `branch` variable to store the target branch of a Gitlab merge request event in `gitlab_testing_task.go` ([link](https://github.com/koderover/zadig/pull/3101/files?diff=unified&w=0#diff-2808ff8ab1c1e64c7d43a23b4d498dd252454b67c915d41d5ca82329093bc031L172-R172))
  - Assign the `branch` variable the value of the target branch from the Gitlab event object attributes ([link](https://github.com/koderover/zadig/pull/3101/files?diff=unified&w=0#diff-2808ff8ab1c1e64c7d43a23b4d498dd252454b67c915d41d5ca82329093bc031R184))
  - Log the target branch and the ref of the Gitlab event for debugging purposes ([link](https://github.com/koderover/zadig/pull/3101/files?diff=unified&w=0#diff-2808ff8ab1c1e64c7d43a23b4d498dd252454b67c915d41d5ca82329093bc031R227))
  - Check if the `args.Ref` parameter is not empty in `pipeline_task.go`, and if so, assign it to the `testArg.Builds[i].Branch` field ([link](https://github.com/koderover/zadig/pull/3101/files?diff=unified&w=0#diff-3a9aed32d3722a7eb3a76d79dfd8c1a994acb4f875829cb8f1f80ebaf367b8abR745-R747))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
