### PR TITLE
fix init s3 storage don't belong to any project

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/s3.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/s3.go
@@ -263,6 +263,7 @@ func (c *S3StorageColl) InitData() error {
 		Endpoint:  minioEndpoint,
 		Bucket:    config.S3StorageBucket(),
 		IsDefault: setDefault,
+		Projects:  []string{setting.AllProjects},
 		Insecure:  true,
 		Provider:  0,
 	}


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f89b7ec</samp>

Added a `Projects` field to `S3Storage` struct to support project-level S3 configuration. Updated the initialization of the struct to include all projects by default.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f89b7ec</samp>

*  Add `Projects` field to `S3Storage` struct to store S3 configuration for different projects ([link](https://github.com/koderover/zadig/pull/3104/files?diff=unified&w=0#diff-5c461b780690625313db199bb31c46ad94ffb57311d0a8128f584636228d91e7R266))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
