### PR TITLE
fix: warpdrive ServiceRender field type

### DIFF
--- a/pkg/microservice/warpdrive/core/service/types/task/model.go
+++ b/pkg/microservice/warpdrive/core/service/types/task/model.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sync"
 
+	templatemodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/template"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/config"
 	"github.com/koderover/zadig/pkg/microservice/warpdrive/core/service/common"
 	"github.com/koderover/zadig/pkg/setting"
@@ -291,14 +292,14 @@ type ArtifactPackageTaskArgs struct {
 }
 
 type ProductService struct {
-	ServiceName string           `bson:"service_name"               json:"service_name"`
-	ProductName string           `bson:"product_name"               json:"product_name"`
-	Type        string           `bson:"type"                       json:"type"`
-	Revision    int64            `bson:"revision"                   json:"revision"`
-	Containers  []*Container     `bson:"containers"                 json:"containers,omitempty"`
-	Configs     []*ServiceConfig `bson:"configs,omitempty"          json:"configs,omitempty"`
-	Render      *RenderInfo      `bson:"render,omitempty"           json:"render,omitempty"` // 记录每个服务render信息 便于更新单个服务
-	EnvConfigs  []*EnvConfig     `bson:"-"                          json:"env_configs,omitempty"`
+	ServiceName string                        `bson:"service_name"               json:"service_name"`
+	ProductName string                        `bson:"product_name"               json:"product_name"`
+	Type        string                        `bson:"type"                       json:"type"`
+	Revision    int64                         `bson:"revision"                   json:"revision"`
+	Containers  []*Container                  `bson:"containers"                 json:"containers,omitempty"`
+	Configs     []*ServiceConfig              `bson:"configs,omitempty"          json:"configs,omitempty"`
+	Render      *templatemodels.ServiceRender `bson:"render,omitempty"           json:"render,omitempty"` // 记录每个服务render信息 便于更新单个服务
+	EnvConfigs  []*EnvConfig                  `bson:"-"                          json:"env_configs,omitempty"`
 }
 
 type Container struct {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eb4e256</samp>

Refactor the render logic of product services in `warpdrive` by reusing the `ServiceRender` type from `aslan`. This enhances code readability and maintainability.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eb4e256</samp>

*  Refactor the render logic and data structure of product services by using the `ServiceRender` type from the `templatemodels` package ([link](https://github.com/koderover/zadig/pull/3107/files?diff=unified&w=0#diff-76a4f150309e850e4d0886a028a1d589899155e4a05dcf5930708f26b179ef4eL294-R302))
* Import the `templatemodels` package from the `aslan` microservice to access the `ServiceRender` type definition ([link](https://github.com/koderover/zadig/pull/3107/files?diff=unified&w=0#diff-76a4f150309e850e4d0886a028a1d589899155e4a05dcf5930708f26b179ef4eR24))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
