### PR TITLE
fix helm repo management action alias

### DIFF
--- a/pkg/microservice/user/core/service/permission/resource.go
+++ b/pkg/microservice/user/core/service/permission/resource.go
@@ -49,7 +49,7 @@ var systemResourceActionAliasMap = map[string]string{
 	"VMManagement":        "主机管理",
 	"RegistryManagement":  "镜像仓库",
 	"S3StorageManagement": "对象存储",
-	"HelmRepoManagement":  "Chart仓库",
+	"HelmRepoManagement":  "Chart 仓库",
 }
 
 var systemResourceSequence = []string{


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6d90db8</samp>

Fixed a spacing issue in the HelmRepoManagement permission name. This permission name is used in `resource.go` to define the resources that users can access or manage in Zadig.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6d90db8</samp>

*  Add a space between "Chart" and "仓库" in the permission name for Helm repo management ([link](https://github.com/koderover/zadig/pull/3109/files?diff=unified&w=0#diff-2b9e607730627613bc1ba0bc3f6c3fd61d7e3432231ab570772f06d192155c89L52-R52))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
