### PR TITLE
fix ua missing data change error

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/1190.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/1190.go
@@ -737,7 +737,7 @@ func migrateRendersets() error {
 				return errors.Wrapf(err, "failed to find render info for product: %s/%s, render info: %s/%d", env.ProductName, curRender.EnvName, env.Render.Name, env.Render.Revision)
 			}
 
-			if len(curRender.DefaultValues) == 0 && len(curRender.GlobalVariables) == 0 && len(env.GetServiceMap()) == 0 {
+			if len(curRender.DefaultValues) == 0 && len(curRender.GlobalVariables) == 0 && len(env.GetAllSvcRenders()) == 0 {
 				continue
 			}
 			log.Infof("migrating render set for product: %s/%s", project.ProductName, env.EnvName)

--- a/pkg/cli/upgradeassistant/cmd/migrate/1190.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/1190.go
@@ -737,9 +737,6 @@ func migrateRendersets() error {
 				return errors.Wrapf(err, "failed to find render info for product: %s/%s, render info: %s/%d", env.ProductName, curRender.EnvName, env.Render.Name, env.Render.Revision)
 			}
 
-			if len(curRender.DefaultValues) == 0 && len(curRender.GlobalVariables) == 0 && len(env.GetAllSvcRenders()) == 0 {
-				continue
-			}
 			log.Infof("migrating render set for product: %s/%s", project.ProductName, env.EnvName)
 
 			env.DefaultValues = curRender.DefaultValues


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 371d8fa</samp>

Migrate service renders from old format to new format in `pkg/cli/upgradeassistant/cmd/migrate/1190.go`. This change updates the `migrateRendersets` function to use the new `SvcRenders` field instead of the old `ServiceMap` field.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 371d8fa</samp>

*  Migrate the rendersets of services from the old format to the new format ([link](https://github.com/koderover/zadig/pull/3110/files?diff=unified&w=0#diff-801df8491afb56024402917f8633f318f503e7d7970e88cf71ffe476a0245c5cL740-R740))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
