### PR TITLE
fix env svc version default values bug for helm project

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/version.go
+++ b/pkg/microservice/aslan/core/environment/service/version.go
@@ -382,6 +382,7 @@ func RollbackEnvServiceVersion(ctx *internalhandler.Context, projectName, envNam
 
 		envSvcVersion.Service.GetServiceRender().OverrideYaml.YamlContent = mergedValues
 		envSvcVersion.Service.GetServiceRender().OverrideValues = ""
+		env.DefaultValues = ""
 		// }
 
 		err = kube.UpgradeHelmRelease(env, envSvcVersion.Service, svcTmpl, nil, 0, ctx.UserName)


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at afef255</samp>

Fix a bug in environment rollback that could cause default values mismatch. Reset the default values of the environment to an empty string in `version.go` when rolling back the service version.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at afef255</samp>

*  Reset default environment values when rolling back service version ([link](https://github.com/koderover/zadig/pull/3111/files?diff=unified&w=0#diff-c282f3a3ba6b7c450a15a42671e0eb40be4bdcb38d32311d3f3fc606d51e6ac2R385))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
