### PR TITLE
remove Render filed from common product

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/1180_vars.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/1180_vars.go
@@ -26,6 +26,8 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	uamodel "github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/repository/models"
+	uamongo "github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/repository/mongodb"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
@@ -457,8 +459,14 @@ func migrateTestProductVariables() error {
 			}
 			product.Render.Name = renderInfo.Name
 			product.Render.Revision = renderInfo.Revision
+			uaRenderInfo := &uamodel.RenderInfo{
+				Name:        product.Render.Name,
+				Revision:    product.Render.Revision,
+				ProductTmpl: product.Render.ProductTmpl,
+				Description: product.Render.Description,
+			}
 
-			err = mongodb.NewProductColl().UpdateRender(product.EnvName, product.ProductName, product.Render)
+			err = uamongo.NewProductColl().UpdateRender(product.EnvName, product.ProductName, uaRenderInfo)
 			if err != nil {
 				return errors.Wrapf(err, "failed to update product info: %s/%s", product.ProductName, product.EnvName)
 			}
@@ -620,7 +628,13 @@ func migrateProductionProductVariables() error {
 			product.Render.Name = renderInfo.Name
 			product.Render.Revision = renderInfo.Revision
 
-			err = mongodb.NewProductColl().UpdateRender(product.EnvName, product.ProductName, product.Render)
+			uaRenderInfo := &uamodel.RenderInfo{
+				Name:        product.Render.Name,
+				Revision:    product.Render.Revision,
+				ProductTmpl: product.Render.ProductTmpl,
+				Description: product.Render.Description,
+			}
+			err = uamongo.NewProductColl().UpdateRender(product.EnvName, product.ProductName, uaRenderInfo)
 			if err != nil {
 				return errors.Wrapf(err, "failed to update product info: %s/%s", product.ProductName, product.EnvName)
 			}

--- a/pkg/cli/upgradeassistant/internal/repository/mongodb/product.go
+++ b/pkg/cli/upgradeassistant/internal/repository/mongodb/product.go
@@ -148,3 +148,13 @@ func (c *ProductColl) UpdateProductRender(product *models.Product) error {
 	_, err := c.Collection.UpdateOne(context.TODO(), query, change)
 	return err
 }
+
+func (c *ProductColl) UpdateRender(envName, productName string, render *models.RenderInfo) error {
+	query := bson.M{"env_name": envName, "product_name": productName}
+	change := bson.M{"$set": bson.M{
+		"render": render,
+	}}
+	_, err := c.UpdateOne(context.TODO(), query, change)
+
+	return err
+}

--- a/pkg/microservice/aslan/core/common/repository/models/product.go
+++ b/pkg/microservice/aslan/core/common/repository/models/product.go
@@ -39,7 +39,7 @@ type Product struct {
 	UpdateBy       string                          `bson:"update_by"                 json:"update_by"`
 	Visibility     string                          `bson:"-"                         json:"visibility"`
 	Services       [][]*ProductService             `bson:"services"                  json:"services"`
-	Render         *RenderInfo                     `bson:"render"                    json:"render"` // Deprecated in 1.19.0, will be removed in 1.10.0
+	Render         *RenderInfo                     `bson:"-"                         json:"render"` // Deprecated in 1.19.0, will be removed in 1.20.0
 	Error          string                          `bson:"error"                     json:"error"`
 	ServiceRenders []*templatemodels.ServiceRender `bson:"-"                         json:"chart_infos,omitempty"`
 	IsPublic       bool                            `bson:"is_public"                 json:"isPublic"`

--- a/pkg/microservice/aslan/core/common/repository/mongodb/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/product.go
@@ -352,16 +352,6 @@ func (c *ProductColl) UpdateRegistry(envName, productName, registryId string) er
 	return err
 }
 
-func (c *ProductColl) UpdateRender(envName, productName string, render *models.RenderInfo) error {
-	query := bson.M{"env_name": envName, "product_name": productName}
-	change := bson.M{"$set": bson.M{
-		"render": render,
-	}}
-	_, err := c.UpdateOne(context.TODO(), query, change)
-
-	return err
-}
-
 func (c *ProductColl) Delete(owner, productName string) error {
 	query := bson.M{"env_name": owner, "product_name": productName}
 	_, err := c.DeleteOne(context.TODO(), query)


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 166d57d</samp>

This pull request migrates product variables from the old format to the new format using the `uamongo` package. It also updates the `mongodb` and `aslan` packages to support and remove the old format respectively.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 166d57d</samp>

* Import the `uamongo` package to handle the migration of product variables from the old format to the new format in the `migrate` package ([link](https://github.com/koderover/zadig/pull/3120/files?diff=unified&w=0#diff-7f92727841734ff4c923f21299d3d777ec262cabd615736547cc8ae01eb0c1deR29))
* Replace the `mongodb` package with the `uamongo` package in the `migrateTestProductVariables` and `migrateProductionProductVariables` functions to use the correct collection and model for the product variables ([link](https://github.com/koderover/zadig/pull/3120/files?diff=unified&w=0#diff-7f92727841734ff4c923f21299d3d777ec262cabd615736547cc8ae01eb0c1deL461-R462), [link](https://github.com/koderover/zadig/pull/3120/files?diff=unified&w=0#diff-7f92727841734ff4c923f21299d3d777ec262cabd615736547cc8ae01eb0c1deL623-R624))
* Import the `commonmodels` package to define the new format for the product variables in the `mongodb` package ([link](https://github.com/koderover/zadig/pull/3120/files?diff=unified&w=0#diff-3af817a3399f2d0b014161a238a96c064412e5cf25b055fbafef660f70d474a0R28))
* Add the `UpdateRender` function to the `ProductColl` struct in the `mongodb` package to update the render information of a product with the new format ([link](https://github.com/koderover/zadig/pull/3120/files?diff=unified&w=0#diff-3af817a3399f2d0b014161a238a96c064412e5cf25b055fbafef660f70d474a0R152-R161))
* Remove the `UpdateRender` function from the `ProductColl` struct in the `pkg/microservice/aslan/core/common/repository/mongodb/product.go` file, as it is no longer needed after the migration ([link](https://github.com/koderover/zadig/pull/3120/files?diff=unified&w=0#diff-150810b9b9a9ae4e2d85ea333a4ca97a7ca4ca8c02b80ff11d17cc853f75ba14L355-L364))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
