### PR TITLE
refactor: distribute image use docker cli

### DIFF
--- a/pkg/microservice/jobexecutor/core/service/step/step_distribute_image.go
+++ b/pkg/microservice/jobexecutor/core/service/step/step_distribute_image.go
@@ -125,7 +125,7 @@ func (s *DistributeImageStep) Run(ctx context.Context) error {
 }
 
 func (s *DistributeImageStep) loginSourceRegistry() error {
-	fmt.Println("Logining Docker Source Registry.")
+	log.Info("Logining Docker Source Registry.")
 	startTimeDockerLogin := time.Now()
 	loginCmd := dockerLogin(s.spec.SourceRegistry.AccessKey, s.spec.SourceRegistry.SecretKey, s.spec.SourceRegistry.RegAddr)
 	var out bytes.Buffer
@@ -134,12 +134,12 @@ func (s *DistributeImageStep) loginSourceRegistry() error {
 	if err := loginCmd.Run(); err != nil {
 		return fmt.Errorf("failed to login docker registry: %s %s", err, out.String())
 	}
-	fmt.Printf("Login ended. Duration: %.2f seconds.\n", time.Since(startTimeDockerLogin).Seconds())
+	log.Infof("Login ended. Duration: %.2f seconds.", time.Since(startTimeDockerLogin).Seconds())
 	return nil
 }
 
 func (s *DistributeImageStep) loginTargetRegistry() error {
-	fmt.Println("Logining Docker Target Registry.")
+	log.Info("Logining Docker Target Registry.")
 	startTimeDockerLogin := time.Now()
 	loginCmd := dockerLogin(s.spec.TargetRegistry.AccessKey, s.spec.TargetRegistry.SecretKey, s.spec.TargetRegistry.RegAddr)
 	var out bytes.Buffer
@@ -148,7 +148,7 @@ func (s *DistributeImageStep) loginTargetRegistry() error {
 	if err := loginCmd.Run(); err != nil {
 		return fmt.Errorf("failed to login docker registry: %s %s", err, out.String())
 	}
-	fmt.Printf("Login ended. Duration: %.2f seconds.\n", time.Since(startTimeDockerLogin).Seconds())
+	log.Infof("Login ended. Duration: %.2f seconds.", time.Since(startTimeDockerLogin).Seconds())
 	return nil
 }
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a50701</samp>

Refactored image distribution step to use shell commands instead of `regclient` package. This improves the speed and stability of copying images across different registries in the `jobexecutor` service.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a50701</samp>

* Rewrote `Run` function in `DistributeImageStep` struct to use shell commands for image distribution ([link](https://github.com/koderover/zadig/pull/3122/files?diff=unified&w=0#diff-e1f71f941c08e9460dc2b1125a6b5a4b38e9566c2413926d5f0c0d51f718b661L61-R150))
* Modified import statements in `step` package to remove unused dependencies and add new ones ([link](https://github.com/koderover/zadig/pull/3122/files?diff=unified&w=0#diff-e1f71f941c08e9460dc2b1125a6b5a4b38e9566c2413926d5f0c0d51f718b661L20-R28))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
