### PR TITLE
cp 3122

### DIFF
--- a/pkg/microservice/jobexecutor/core/service/step/step_distribute_image.go
+++ b/pkg/microservice/jobexecutor/core/service/step/step_distribute_image.go
@@ -17,17 +17,15 @@ limitations under the License.
 package step
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"strings"
+	"os/exec"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/regclient/regclient"
-	"github.com/regclient/regclient/config"
-	"github.com/regclient/regclient/types/ref"
-	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
 	"github.com/koderover/zadig/pkg/tool/log"
@@ -58,59 +56,119 @@ func (s *DistributeImageStep) Run(ctx context.Context) error {
 	if s.spec.SourceRegistry == nil || s.spec.TargetRegistry == nil {
 		return errors.New("image registry infos are missing")
 	}
-	hostsOpt := regclient.WithConfigHosts([]config.Host{getDockerHost(s.spec.SourceRegistry), getDockerHost(s.spec.TargetRegistry)})
-	logger := logrus.New()
-	logger.SetLevel(logrus.DebugLevel)
-	client := regclient.New(hostsOpt, regclient.WithLog(logger))
+
+	if err := s.loginSourceRegistry(); err != nil {
+		return err
+	}
 
 	errList := new(multierror.Error)
+	errLock := sync.Mutex{}
+	appendError := func(err error) {
+		errLock.Lock()
+		defer errLock.Unlock()
+		errList = multierror.Append(errList, err)
+	}
+
 	wg := sync.WaitGroup{}
 	for _, target := range s.spec.DistributeTarget {
 		wg.Add(1)
 		go func(target *step.DistributeTaskTarget) {
 			defer wg.Done()
-			if err := copyImage(target, client); err != nil {
-				errList = multierror.Append(errList, err)
+			pullCmd := dockerPullCmd(target.SourceImage)
+			out := bytes.Buffer{}
+			pullCmd.Stdout = &out
+			pullCmd.Stderr = &out
+			if err := pullCmd.Run(); err != nil {
+				errMsg := fmt.Sprintf("failed to pull image: %s %s", err, out.String())
+				appendError(errors.New(errMsg))
+				return
 			}
+			log.Infof("pull source image [%s] succeed", target.SourceImage)
+
+			tagCmd := dockerTagCmd(target.SourceImage, target.TargetImage)
+			out = bytes.Buffer{}
+			tagCmd.Stdout = &out
+			tagCmd.Stderr = &out
+			if err := tagCmd.Run(); err != nil {
+				errMsg := fmt.Sprintf("failed to tag image: %s %s", err, out.String())
+				appendError(errors.New(errMsg))
+				return
+			}
+			log.Infof("tag image [%s] to [%s] succeed", target.SourceImage, target.TargetImage)
 		}(target)
 	}
 	wg.Wait()
 	if err := errList.ErrorOrNil(); err != nil {
-		return fmt.Errorf("copy images error: %v", err)
+		return fmt.Errorf("prepare source images error: %v", err)
 	}
+	log.Infof("Finish prepare source images.")
+
+	if err := s.loginTargetRegistry(); err != nil {
+		return err
+	}
+	for _, target := range s.spec.DistributeTarget {
+		wg.Add(1)
+		go func(target *step.DistributeTaskTarget) {
+			defer wg.Done()
+			pushCmd := dockerPush(target.TargetImage)
+			out := bytes.Buffer{}
+			pushCmd.Stdout = &out
+			pushCmd.Stderr = &out
+			if err := pushCmd.Run(); err != nil {
+				errMsg := fmt.Sprintf("failed to push image: %s %s", err, out.String())
+				appendError(errors.New(errMsg))
+				return
+			}
+			log.Infof("push image [%s] succeed", target.TargetImage)
+		}(target)
+	}
+	wg.Wait()
+	if err := errList.ErrorOrNil(); err != nil {
+		return fmt.Errorf("push target images error: %v", err)
+	}
+
 	log.Info("Finish distribute images.")
 	return nil
 }
 
-func copyImage(target *step.DistributeTaskTarget, client *regclient.RegClient) error {
-	sourceRef, err := ref.New(target.SourceImage)
-	if err != nil {
-		errMsg := fmt.Sprintf("parse source image: %s error: %v", target.SourceImage, err)
-		return errors.New(errMsg)
+func (s *DistributeImageStep) loginSourceRegistry() error {
+	log.Info("Logining Docker Source Registry.")
+	startTimeDockerLogin := time.Now()
+	loginCmd := dockerLogin(s.spec.SourceRegistry.AccessKey, s.spec.SourceRegistry.SecretKey, s.spec.SourceRegistry.RegAddr)
+	var out bytes.Buffer
+	loginCmd.Stdout = &out
+	loginCmd.Stderr = &out
+	if err := loginCmd.Run(); err != nil {
+		return fmt.Errorf("failed to login docker registry: %s %s", err, out.String())
 	}
-	targetRef, err := ref.New(target.TargetImage)
-	if err != nil {
-		errMsg := fmt.Sprintf("parse target image: %s error: %v", target.TargetImage, err)
-		return errors.New(errMsg)
-	}
-	if err := client.ImageCopy(context.Background(), sourceRef, targetRef); err != nil {
-		errMsg := fmt.Sprintf("copy image failed: %v", err)
-		return errors.New(errMsg)
-	}
-	log.Infof("copy image from [%s] to [%s] succeed", target.SourceImage, target.TargetImage)
+	log.Infof("Login ended. Duration: %.2f seconds.", time.Since(startTimeDockerLogin).Seconds())
 	return nil
 }
 
-func getDockerHost(reg *step.RegistryNamespace) config.Host {
-	host := config.HostNewName(reg.RegAddr)
-	host.User = reg.AccessKey
-	host.Pass = reg.SecretKey
-	host.RegCert = reg.TLSCert
-	if !reg.TLSEnabled {
-		host.TLS = config.TLSInsecure
+func (s *DistributeImageStep) loginTargetRegistry() error {
+	log.Info("Logining Docker Target Registry.")
+	startTimeDockerLogin := time.Now()
+	loginCmd := dockerLogin(s.spec.TargetRegistry.AccessKey, s.spec.TargetRegistry.SecretKey, s.spec.TargetRegistry.RegAddr)
+	var out bytes.Buffer
+	loginCmd.Stdout = &out
+	loginCmd.Stderr = &out
+	if err := loginCmd.Run(); err != nil {
+		return fmt.Errorf("failed to login docker registry: %s %s", err, out.String())
 	}
-	if strings.HasPrefix(reg.RegAddr, "http://") {
-		host.TLS = config.TLSDisabled
-	}
-	return *host
+	log.Infof("Login ended. Duration: %.2f seconds.", time.Since(startTimeDockerLogin).Seconds())
+	return nil
+}
+
+func dockerPullCmd(fullImage string) *exec.Cmd {
+	args := []string{"-c"}
+	dockerPushCommand := "docker pull " + fullImage
+	args = append(args, dockerPushCommand)
+	return exec.Command("sh", args...)
+}
+
+func dockerTagCmd(sourceImage, targetImage string) *exec.Cmd {
+	args := []string{"-c"}
+	dockerPushCommand := fmt.Sprintf("docker tag %s %s", sourceImage, targetImage)
+	args = append(args, dockerPushCommand)
+	return exec.Command("sh", args...)
 }


### PR DESCRIPTION
* refactor: distribute image use docker cli

### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8f695d8</samp>

Refactored the `DistributeImageStep` to use docker commands instead of the `regclient` package for image distribution. Improved the readability and maintainability of the code in `step_distribute_image.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8f695d8</samp>

*  Replace `regclient` package with docker commands to copy images between registries ([link](https://github.com/koderover/zadig/pull/3123/files?diff=unified&w=0#diff-e1f71f941c08e9460dc2b1125a6b5a4b38e9566c2413926d5f0c0d51f718b661L20-R28), [link](https://github.com/koderover/zadig/pull/3123/files?diff=unified&w=0#diff-e1f71f941c08e9460dc2b1125a6b5a4b38e9566c2413926d5f0c0d51f718b661L61-R71), [link](https://github.com/koderover/zadig/pull/3123/files?diff=unified&w=0#diff-e1f71f941c08e9460dc2b1125a6b5a4b38e9566c2413926d5f0c0d51f718b661L72-R174))
  - Remove unused imports and add new ones in `step_distribute_image.go` ([link](https://github.com/koderover/zadig/pull/3123/files?diff=unified&w=0#diff-e1f71f941c08e9460dc2b1125a6b5a4b38e9566c2413926d5f0c0d51f718b661L20-R28))
  - Remove `client`, `hostsOpt` and `logger` variables and `copyImage` and `getDockerHost` functions in `DistributeImageStep` struct ([link](https://github.com/koderover/zadig/pull/3123/files?diff=unified&w=0#diff-e1f71f941c08e9460dc2b1125a6b5a4b38e9566c2413926d5f0c0d51f718b661L61-R71), [link](https://github.com/koderover/zadig/pull/3123/files?diff=unified&w=0#diff-e1f71f941c08e9460dc2b1125a6b5a4b38e9566c2413926d5f0c0d51f718b661L72-R174))
  - Add helper functions to create `exec.Cmd` structs for docker commands: `dockerPullCmd`, `dockerTagCmd`, `dockerPushCmd` and `dockerLoginCmd` ([link](https://github.com/koderover/zadig/pull/3123/files?diff=unified&w=0#diff-e1f71f941c08e9460dc2b1125a6b5a4b38e9566c2413926d5f0c0d51f718b661L72-R174))
  - Modify `Run` function to use helper functions to login to source and target registries, pull and tag source images, and push target images in parallel ([link](https://github.com/koderover/zadig/pull/3123/files?diff=unified&w=0#diff-e1f71f941c08e9460dc2b1125a6b5a4b38e9566c2413926d5f0c0d51f718b661L61-R71))
  - Use a mutex to append errors to a `multierror.Error` variable in `Run` function ([link](https://github.com/koderover/zadig/pull/3123/files?diff=unified&w=0#diff-e1f71f941c08e9460dc2b1125a6b5a4b38e9566c2413926d5f0c0d51f718b661L61-R71))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
