### PR TITLE
merge insight, delivery version and release plan

### DIFF
--- a/pkg/microservice/aslan/core/delivery/handler/version.go
+++ b/pkg/microservice/aslan/core/delivery/handler/version.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
+	commonutil "github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
 	deliveryservice "github.com/koderover/zadig/pkg/microservice/aslan/core/delivery/service"
 	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
 	e "github.com/koderover/zadig/pkg/tool/errors"
@@ -132,6 +133,12 @@ func ListDeliveryVersion(c *gin.Context) {
 	}
 	if len(args.Verbosity) == 0 {
 		args.Verbosity = deliveryservice.VerbosityDetailed
+	}
+
+	err = commonutil.CheckZadigXLicenseStatus()
+	if err != nil {
+		ctx.Err = err
+		return
 	}
 
 	ctx.Resp, ctx.Err = deliveryservice.ListDeliveryVersion(args, ctx.Logger)
@@ -279,6 +286,12 @@ func DeleteDeliveryVersion(c *gin.Context) {
 			ctx.UnAuthorized = true
 			return
 		}
+	}
+
+	err = commonutil.CheckZadigXLicenseStatus()
+	if err != nil {
+		ctx.Err = err
+		return
 	}
 
 	//params validate

--- a/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	commonutil "github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/release_plan/service"
 	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
 	e "github.com/koderover/zadig/pkg/tool/errors"
@@ -54,6 +55,12 @@ func ListReleasePlans(c *gin.Context) {
 		return
 	}
 
+	err = commonutil.CheckZadigXLicenseStatus()
+	if err != nil {
+		ctx.Err = err
+		return
+	}
+
 	ctx.Resp, ctx.Err = service.ListReleasePlans(opt.PageNum, opt.PageSize)
 }
 
@@ -73,6 +80,12 @@ func GetReleasePlan(c *gin.Context) {
 		return
 	}
 
+	err = commonutil.CheckZadigXLicenseStatus()
+	if err != nil {
+		ctx.Err = err
+		return
+	}
+
 	ctx.Resp, ctx.Err = service.GetReleasePlan(c.Param("id"))
 }
 
@@ -89,6 +102,12 @@ func GetReleasePlanLogs(c *gin.Context) {
 
 	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.ReleasePlan.View {
 		ctx.UnAuthorized = true
+		return
+	}
+
+	err = commonutil.CheckZadigXLicenseStatus()
+	if err != nil {
+		ctx.Err = err
 		return
 	}
 
@@ -116,6 +135,13 @@ func CreateReleasePlan(c *gin.Context) {
 		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
 		return
 	}
+
+	err = commonutil.CheckZadigXLicenseStatus()
+	if err != nil {
+		ctx.Err = err
+		return
+	}
+
 	ctx.Err = service.CreateReleasePlan(ctx, req)
 }
 
@@ -135,6 +161,12 @@ func UpdateReleasePlan(c *gin.Context) {
 		return
 	}
 
+	err = commonutil.CheckZadigXLicenseStatus()
+	if err != nil {
+		ctx.Err = err
+		return
+	}
+
 	req := new(service.UpdateReleasePlanArgs)
 	if err := c.ShouldBindJSON(req); err != nil {
 		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
@@ -148,7 +180,6 @@ func DeleteReleasePlan(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	if err != nil {
-
 		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
 		ctx.UnAuthorized = true
 		return
@@ -159,6 +190,12 @@ func DeleteReleasePlan(c *gin.Context) {
 		return
 	}
 
+	err = commonutil.CheckZadigXLicenseStatus()
+	if err != nil {
+		ctx.Err = err
+		return
+	}
+
 	ctx.Err = service.DeleteReleasePlan(c, ctx.UserName, c.Param("id"))
 }
 
@@ -166,9 +203,14 @@ func ExecuteReleaseJob(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 	if err != nil {
-
 		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
 		ctx.UnAuthorized = true
+		return
+	}
+
+	err = commonutil.CheckZadigXLicenseStatus()
+	if err != nil {
+		ctx.Err = err
 		return
 	}
 
@@ -193,6 +235,12 @@ func UpdateReleaseJobStatus(c *gin.Context) {
 		return
 	}
 
+	err = commonutil.CheckZadigXLicenseStatus()
+	if err != nil {
+		ctx.Err = err
+		return
+	}
+
 	// only release plan manager can execute release job
 	// so no need to check authorization there
 	ctx.Err = service.UpdateReleasePlanStatus(ctx, c.Param("id"), c.Param("status"))
@@ -202,9 +250,14 @@ func ApproveReleasePlan(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 	if err != nil {
-
 		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
 		ctx.UnAuthorized = true
+		return
+	}
+
+	err = commonutil.CheckZadigXLicenseStatus()
+	if err != nil {
+		ctx.Err = err
 		return
 	}
 

--- a/pkg/microservice/aslan/core/stat/handler/stat_v2.go
+++ b/pkg/microservice/aslan/core/stat/handler/stat_v2.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	commonutil "github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/stat/service"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/stat/service/ai"
 	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
@@ -36,6 +37,12 @@ func CreateStatDashboardConfig(c *gin.Context) {
 	args := new(service.StatDashboardConfig)
 	if err := c.BindJSON(args); err != nil {
 		ctx.Err = e.ErrInvalidParam.AddErr(err)
+		return
+	}
+
+	err := commonutil.CheckZadigXLicenseStatus()
+	if err != nil {
+		ctx.Err = err
 		return
 	}
 
@@ -67,12 +74,24 @@ func UpdateStatDashboardConfig(c *gin.Context) {
 		return
 	}
 
+	err := commonutil.CheckZadigXLicenseStatus()
+	if err != nil {
+		ctx.Err = err
+		return
+	}
+
 	ctx.Err = service.UpdateStatDashboardConfig(c.Param("id"), args, ctx.Logger)
 }
 
 func DeleteStatDashboardConfig(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	err := commonutil.CheckZadigXLicenseStatus()
+	if err != nil {
+		ctx.Err = err
+		return
+	}
 
 	ctx.Err = service.DeleteStatDashboardConfig(c.Param("id"), ctx.Logger)
 }
@@ -96,6 +115,12 @@ func GetStatsDashboard(c *gin.Context) {
 		return
 	}
 
+	err := commonutil.CheckZadigXLicenseStatus()
+	if err != nil {
+		ctx.Err = err
+		return
+	}
+
 	resp, err := service.GetStatsDashboard(args.StartTime, args.EndTime, nil, ctx.Logger)
 
 	ctx.Resp = getStatDashboardResp{resp}
@@ -109,6 +134,12 @@ func GetStatsDashboardGeneralData(c *gin.Context) {
 	args := new(getStatDashboardReq)
 	if err := c.ShouldBindQuery(args); err != nil {
 		ctx.Err = e.ErrInvalidParam.AddErr(err)
+		return
+	}
+
+	err := commonutil.CheckZadigXLicenseStatus()
+	if err != nil {
+		ctx.Err = err
 		return
 	}
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 562d919</samp>

This pull request adds license validation for the ZadigX edition of the product in various handler packages. It uses a common utility function `CheckZadigXLicenseStatus` to check the license status before performing operations on delivery versions, release plans, and stat dashboards. It affects the files `version.go`, `release_plan.go`, and `stat_v2.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 562d919</samp>

*  Add license check for ZadigX edition features in delivery, release plan, and stat handlers ([link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-65c52204665c81226b726dd24d9fe6176eb7932ac8c176fc4b44ba080db5048bR29), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-65c52204665c81226b726dd24d9fe6176eb7932ac8c176fc4b44ba080db5048bR138-R143), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-65c52204665c81226b726dd24d9fe6176eb7932ac8c176fc4b44ba080db5048bR291-R296), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R25), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R58-R63), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R83-R88), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R108-R113), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R138-R144), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R164-R169), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R193-R198), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R211-R216), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R238-R243), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R258-R263), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-5478768a28a707945f52431616288f7ca31592e0bfc2dbe62c478eb4945d319cR25), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-5478768a28a707945f52431616288f7ca31592e0bfc2dbe62c478eb4945d319cR43-R48), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-5478768a28a707945f52431616288f7ca31592e0bfc2dbe62c478eb4945d319cR77-R82), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-5478768a28a707945f52431616288f7ca31592e0bfc2dbe62c478eb4945d319cR90-R95), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-5478768a28a707945f52431616288f7ca31592e0bfc2dbe62c478eb4945d319cR118-R123), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-5478768a28a707945f52431616288f7ca31592e0bfc2dbe62c478eb4945d319cR140-R145))
  * Import `commonutil` package from `core/common/util` directory in `version.go`, `release_plan.go`, and `stat_v2.go` files ([link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-65c52204665c81226b726dd24d9fe6176eb7932ac8c176fc4b44ba080db5048bR29), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R25), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-5478768a28a707945f52431616288f7ca31592e0bfc2dbe62c478eb4945d319cR25))
  * Call `CheckZadigXLicenseStatus` function from `commonutil` package before performing any operations on delivery versions, release plans, or stat dashboard configs in the respective handlers ([link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-65c52204665c81226b726dd24d9fe6176eb7932ac8c176fc4b44ba080db5048bR138-R143), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-65c52204665c81226b726dd24d9fe6176eb7932ac8c176fc4b44ba080db5048bR291-R296), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R58-R63), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R83-R88), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R108-R113), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R138-R144), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R164-R169), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R193-R198), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R211-R216), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R238-R243), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9R258-R263), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-5478768a28a707945f52431616288f7ca31592e0bfc2dbe62c478eb4945d319cR43-R48), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-5478768a28a707945f52431616288f7ca31592e0bfc2dbe62c478eb4945d319cR77-R82), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-5478768a28a707945f52431616288f7ca31592e0bfc2dbe62c478eb4945d319cR90-R95), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-5478768a28a707945f52431616288f7ca31592e0bfc2dbe62c478eb4945d319cR118-R123), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-5478768a28a707945f52431616288f7ca31592e0bfc2dbe62c478eb4945d319cR140-R145))
* Remove empty lines from `release_plan.go` file ([link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9L151), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9L169), [link](https://github.com/koderover/zadig/pull/3129/files?diff=unified&w=0#diff-7d213fcab6790a0a6103cf3f3dfb4790f0aa40d061b49ac36e4fd02080f69de9L205))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
Signed-off-by: Patrick Zhao <zhaoyu@koderover.com>