### PR TITLE
fix merge bugs

### DIFF
--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -1880,11 +1880,6 @@ func GetProductionEnv(c *gin.Context) {
 		}
 	}
 
-	if err := commonutil.CheckZadigXLicenseStatus(); err != nil {
-		ctx.Err = err
-		return
-	}
-
 	ctx.Resp, ctx.Err = service.GetProduct(ctx.UserName, envName, projectKey, ctx.Logger)
 }
 

--- a/pkg/microservice/aslan/core/environment/handler/kube.go
+++ b/pkg/microservice/aslan/core/environment/handler/kube.go
@@ -358,12 +358,6 @@ func GetResourceDeployStatus(c *gin.Context) {
 		return
 	}
 
-	err = commonutil.CheckZadigXLicenseStatus()
-	if err != nil {
-		ctx.Err = err
-		return
-	}
-
 	ctx.Resp, ctx.Err = service.GetResourceDeployStatus(c.Query("projectName"), request, ctx.Logger)
 }
 
@@ -375,12 +369,6 @@ func GetReleaseDeployStatus(c *gin.Context) {
 	err := c.BindJSON(request)
 	if err != nil {
 		ctx.Err = e.ErrInvalidParam.AddErr(err)
-		return
-	}
-
-	err = commonutil.CheckZadigXLicenseStatus()
-	if err != nil {
-		ctx.Err = err
 		return
 	}
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9fb2722</samp>

This pull request removes the license check for some features of Zadig that are related to viewing the deployment status and the production environment. This is to make Zadig more open source friendly and accessible for users.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9fb2722</samp>

*  Remove license check for getting production environment information ([link](https://github.com/koderover/zadig/pull/3137/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL1883-L1887))
*  Remove license check for getting resource and release deployment status in `kube.go` ([link](https://github.com/koderover/zadig/pull/3137/files?diff=unified&w=0#diff-a5cea4826aa345a878ca29c2d24b4c6777b2656c91c9e150efba27388e4d08edL361-L366), [link](https://github.com/koderover/zadig/pull/3137/files?diff=unified&w=0#diff-a5cea4826aa345a878ca29c2d24b4c6777b2656c91c9e150efba27388e4d08edL381-L386))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
