### PR TITLE
fix update project template's auto deploy bug

### DIFF
--- a/pkg/microservice/aslan/core/project/handler/product.go
+++ b/pkg/microservice/aslan/core/project/handler/product.go
@@ -29,8 +29,8 @@ import (
 	commonservice "github.com/koderover/zadig/pkg/microservice/aslan/core/common/service"
 	commontypes "github.com/koderover/zadig/pkg/microservice/aslan/core/common/types"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
+	commonutil "github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
 	projectservice "github.com/koderover/zadig/pkg/microservice/aslan/core/project/service"
-	"github.com/koderover/zadig/pkg/shared/client/plutusvendor"
 	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 	"github.com/koderover/zadig/pkg/tool/log"
@@ -161,13 +161,9 @@ func UpdateProductTemplate(c *gin.Context) {
 		}
 	}
 
-	licenseStatus, err := plutusvendor.New().CheckZadigXLicenseStatus()
+	err = commonutil.CheckZadigXLicenseStatus()
 	if err != nil {
-		ctx.Err = fmt.Errorf("failed to validate zadig license status, error: %s", err)
-		return
-	}
-	if args.AutoDeploy.Enable == true {
-		if !(licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional && licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
+		if args.AutoDeploy.Enable == true {
 			ctx.Err = e.ErrLicenseInvalid
 			return
 		}
@@ -264,6 +260,14 @@ func UpdateProject(c *gin.Context) {
 		}
 		if !ctx.Resources.ProjectAuthInfo[productName].IsProjectAdmin {
 			ctx.UnAuthorized = true
+			return
+		}
+	}
+
+	err = commonutil.CheckZadigXLicenseStatus()
+	if err != nil {
+		if args.AutoDeploy.Enable == true {
+			ctx.Err = e.ErrLicenseInvalid
 			return
 		}
 	}

--- a/pkg/microservice/aslan/core/templatestore/handler/workflow.go
+++ b/pkg/microservice/aslan/core/templatestore/handler/workflow.go
@@ -32,7 +32,6 @@ func GetWorkflowTemplateByID(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 
 	if err != nil {
-
 		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
 		ctx.UnAuthorized = true
 		internalhandler.JSONResponse(c, ctx)
@@ -55,6 +54,11 @@ func GetWorkflowTemplateByID(c *gin.Context) {
 		}
 	}
 
+	if err = commonutil.CheckZadigXLicenseStatus(); err != nil {
+		ctx.Err = err
+		return
+	}
+
 	resp, err := templateservice.GetWorkflowTemplateByID(c.Param("id"), ctx.Logger)
 	if err != nil {
 		c.JSON(e.ErrorMessage(err))
@@ -69,7 +73,6 @@ func ListWorkflowTemplate(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	if err != nil {
-
 		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
 		ctx.UnAuthorized = true
 		return
@@ -89,6 +92,11 @@ func ListWorkflowTemplate(c *gin.Context) {
 				return
 			}
 		}
+	}
+
+	if err = commonutil.CheckZadigXLicenseStatus(); err != nil {
+		ctx.Err = err
+		return
 	}
 
 	excludeBuildIn := false

--- a/pkg/microservice/aslan/core/workflow/testing/handler/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/handler/scanning.go
@@ -111,8 +111,10 @@ func CreateScanningModule(c *gin.Context) {
 	}
 
 	if err = commonutil.CheckZadigXLicenseStatus(); err != nil {
-		ctx.Err = err
-		return
+		if args.CheckQualityGate == true || len(args.AdvancedSetting.NotifyCtls) != 0 {
+			ctx.Err = err
+			return
+		}
 	}
 
 	ctx.Err = service.CreateScanningModule(ctx.UserName, args, ctx.Logger)
@@ -161,8 +163,10 @@ func UpdateScanningModule(c *gin.Context) {
 	}
 
 	if err = commonutil.CheckZadigXLicenseStatus(); err != nil {
-		ctx.Err = err
-		return
+		if args.CheckQualityGate == true || len(args.AdvancedSetting.NotifyCtls) != 0 {
+			ctx.Err = err
+			return
+		}
 	}
 
 	ctx.Err = service.UpdateScanningModule(id, ctx.UserName, args, ctx.Logger)
@@ -228,11 +232,6 @@ func ListScanningModule(c *gin.Context) {
 		return
 	}
 
-	if err = commonutil.CheckZadigXLicenseStatus(); err != nil {
-		ctx.Err = err
-		return
-	}
-
 	resp, _, err := service.ListScanningModule(projectKey, ctx.Logger)
 	ctx.Resp = resp
 	ctx.Err = err
@@ -272,11 +271,6 @@ func GetScanningModule(c *gin.Context) {
 			ctx.UnAuthorized = true
 			return
 		}
-	}
-
-	if err = commonutil.CheckZadigXLicenseStatus(); err != nil {
-		ctx.Err = err
-		return
 	}
 
 	ctx.Resp = resp
@@ -360,11 +354,6 @@ func CreateScanningTask(c *gin.Context) {
 		}
 	}
 
-	if err = commonutil.CheckZadigXLicenseStatus(); err != nil {
-		ctx.Err = err
-		return
-	}
-
 	resp, err := service.CreateScanningTask(scanningID, req, "", ctx.UserName, ctx.Logger)
 	if err != nil {
 		ctx.Err = err
@@ -403,11 +392,6 @@ func ListScanningTask(c *gin.Context) {
 			ctx.UnAuthorized = true
 			return
 		}
-	}
-
-	if err = commonutil.CheckZadigXLicenseStatus(); err != nil {
-		ctx.Err = err
-		return
 	}
 
 	// Query Verification
@@ -450,11 +434,6 @@ func GetScanningTask(c *gin.Context) {
 	taskIDStr := c.Param("scan_id")
 	if taskIDStr == "" {
 		ctx.Err = fmt.Errorf("scan_id must be provided")
-		return
-	}
-
-	if err = commonutil.CheckZadigXLicenseStatus(); err != nil {
-		ctx.Err = err
 		return
 	}
 
@@ -507,11 +486,6 @@ func CancelScanningTask(c *gin.Context) {
 		}
 	}
 
-	if err = commonutil.CheckZadigXLicenseStatus(); err != nil {
-		ctx.Err = err
-		return
-	}
-
 	ctx.Err = service.CancelScanningTask(ctx.UserName, scanningID, taskID, config.ScanningType, ctx.RequestID, ctx.Logger)
 }
 
@@ -551,11 +525,6 @@ func GetScanningTaskSSE(c *gin.Context) {
 	taskID, err := strconv.ParseInt(taskIDStr, 10, 64)
 	if err != nil {
 		ctx.Err = e.ErrInvalidParam.AddDesc(fmt.Sprintf("invalid task id: %s", err))
-		return
-	}
-
-	if err = commonutil.CheckZadigXLicenseStatus(); err != nil {
-		ctx.Err = err
 		return
 	}
 

--- a/pkg/microservice/systemconfig/core/codehost/handler/codehost.go
+++ b/pkg/microservice/systemconfig/core/codehost/handler/codehost.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	commonutil "github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/pkg/microservice/systemconfig/core/codehost/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/systemconfig/core/codehost/service"
 	"github.com/koderover/zadig/pkg/setting"
-	"github.com/koderover/zadig/pkg/shared/client/plutusvendor"
 	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
 	e "github.com/koderover/zadig/pkg/tool/errors"
 )
@@ -52,17 +52,14 @@ func CreateSystemCodeHost(c *gin.Context) {
 		return
 	}
 
-	licenseStatus, err := plutusvendor.New().CheckZadigXLicenseStatus()
+	err = commonutil.CheckZadigXLicenseStatus()
 	if err != nil {
-		ctx.Err = fmt.Errorf("failed to validate zadig license status, error: %s", err)
-		return
-	}
-	if req.Type == setting.SourceFromGiteeEE {
-		if !(licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional && licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
+		if req.Type == setting.SourceFromGiteeEE {
 			ctx.Err = e.ErrLicenseInvalid
 			return
 		}
 	}
+
 	ctx.Resp, ctx.Err = service.CreateSystemCodeHost(req, ctx.Logger)
 }
 
@@ -191,13 +188,9 @@ func UpdateSystemCodeHost(c *gin.Context) {
 	}
 	req.ID = id
 
-	licenseStatus, err := plutusvendor.New().CheckZadigXLicenseStatus()
+	err = commonutil.CheckZadigXLicenseStatus()
 	if err != nil {
-		ctx.Err = fmt.Errorf("failed to validate zadig license status, error: %s", err)
-		return
-	}
-	if req.Type == setting.SourceFromGiteeEE {
-		if !(licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional && licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
+		if req.Type == setting.SourceFromGiteeEE {
 			ctx.Err = e.ErrLicenseInvalid
 			return
 		}


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 55b2d51</samp>

Refactor product template update handler to use a common function for license validation. Reduce code duplication and complexity in `product.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 55b2d51</samp>

*  Simplify the logic of checking the Zadig X license status by using a common utility function ([link](https://github.com/koderover/zadig/pull/3140/files?diff=unified&w=0#diff-5218f5d9e0657625e795150301a8a3b707cdd4a95de1533ab00e2430510dbb44R32), [link](https://github.com/koderover/zadig/pull/3140/files?diff=unified&w=0#diff-5218f5d9e0657625e795150301a8a3b707cdd4a95de1533ab00e2430510dbb44L168-R171))
  - Import the `commonutil` package from the same project, which provides some common utility functions for the handlers ([link](https://github.com/koderover/zadig/pull/3140/files?diff=unified&w=0#diff-5218f5d9e0657625e795150301a8a3b707cdd4a95de1533ab00e2430510dbb44R32))
  - Replace the original logic of validating the license type and status with a single call to the `commonutil.CheckZadigXLicenseStatus` function, which returns an error if the license is invalid or expired ([link](https://github.com/koderover/zadig/pull/3140/files?diff=unified&w=0#diff-5218f5d9e0657625e795150301a8a3b707cdd4a95de1533ab00e2430510dbb44L168-R171))
  - Remove the unnecessary check of the license type and status, which are already handled by the `commonutil` function ([link](https://github.com/koderover/zadig/pull/3140/files?diff=unified&w=0#diff-5218f5d9e0657625e795150301a8a3b707cdd4a95de1533ab00e2430510dbb44L168-R171))
  - Only check the error and the `AutoDeploy` flag, which determines whether the product template can be updated with auto-deploy enabled ([link](https://github.com/koderover/zadig/pull/3140/files?diff=unified&w=0#diff-5218f5d9e0657625e795150301a8a3b707cdd4a95de1533ab00e2430510dbb44L168-R171))
  - Handle the error by returning a bad request response with the error message ([link](https://github.com/koderover/zadig/pull/3140/files?diff=unified&w=0#diff-5218f5d9e0657625e795150301a8a3b707cdd4a95de1533ab00e2430510dbb44L168-R171))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
