### PR TITLE
add missing err

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/1190.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/1190.go
@@ -112,6 +112,7 @@ func V1180ToV1190() error {
 	log.Infof("-------- start migrate renderset info --------")
 	if err := migrateRendersets(); err != nil {
 		log.Infof("migrateRendersets err: %v", err)
+		return err
 	}
 
 	log.Infof("-------- start migrate infrastructure filed in build & build template module and general job --------")


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1948db5</samp>

Fix error handling in data migration function for Zadig 1.19.0. Add missing `return err` statement to `V1180ToV1190` in `pkg/cli/upgradeassistant/cmd/migrate/1190.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1948db5</samp>

* Add error return statement to `V1180ToV1190` function to handle migration failures ([link](https://github.com/koderover/zadig/pull/3143/files?diff=unified&w=0#diff-801df8491afb56024402917f8633f318f503e7d7970e88cf71ffe476a0245c5cR115))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
