### PR TITLE
fix create/update cluster validate

### DIFF
--- a/pkg/microservice/aslan/core/multicluster/service/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/service/clusters.go
@@ -110,16 +110,27 @@ func (args *K8SCluster) Validate() error {
 		if args.Provider == config.ClusterProviderTKEServerless || args.Production {
 			return e.ErrLicenseInvalid
 		}
-		for _, scheduleStrategy := range args.AdvancedConfig.ScheduleStrategy {
-			if scheduleStrategy.Strategy == setting.RequiredSchedule || scheduleStrategy.Tolerations != "" {
-				return e.ErrLicenseInvalid
+		if args.AdvancedConfig != nil {
+			for _, scheduleStrategy := range args.AdvancedConfig.ScheduleStrategy {
+				if scheduleStrategy.Strategy == setting.RequiredSchedule || scheduleStrategy.Tolerations != "" {
+					return e.ErrLicenseInvalid
+				}
 			}
 		}
-		if args.DindCfg.Replicas != 1 || args.DindCfg.Resources.Limits.CPU != 4000 || args.DindCfg.Resources.Limits.Memory != 8192 {
-			return e.ErrLicenseInvalid
+		if args.DindCfg != nil {
+			if args.DindCfg.Replicas != 1 {
+				return e.ErrLicenseInvalid
+			}
+			if args.DindCfg.Resources != nil {
+				if args.DindCfg.Resources.Limits != nil {
+					if args.DindCfg.Resources.Limits.CPU != 4000 || args.DindCfg.Resources.Limits.Memory != 8192 {
+						return e.ErrLicenseInvalid
+					}
+				}
+			}
 		}
-
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6830fc9</samp>

Fixed a bug in `Validate` function of `clusters.go` that could cause panics when validating cluster arguments. Added nil checks for `args.AdvancedConfig` and `args.DindCfg` fields.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6830fc9</samp>

*  Prevent potential panics in `Validate` function by checking for nil pointers ([link](https://github.com/koderover/zadig/pull/3146/files?diff=unified&w=0#diff-4e85c1af9762124c9c31e475d7a54712ffc81a99054ebef0ea2d97cd73ca6a8cL113-R126))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
