### PR TITLE
fix active users issue

### DIFF
--- a/pkg/microservice/user/core/repository/orm/user_login.go
+++ b/pkg/microservice/user/core/repository/orm/user_login.go
@@ -82,9 +82,9 @@ func UpdateUserLogin(uid string, userLogin *models.UserLogin, db *gorm.DB) error
 	return nil
 }
 
-func CountActiveUser(db *gorm.DB) (int64, error) {
+func CountActiveUser(signatureUpdatedAt int64, db *gorm.DB) (int64, error) {
 	var count int64
-	err := db.Model(&models.UserLogin{}).Select("count(*)").Where("last_login_time > 0").Find(&count).Error
+	err := db.Model(&models.UserLogin{}).Select("count(*)").Where("last_login_time > ?", signatureUpdatedAt).Find(&count).Error
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/microservice/user/core/service/login/local.go
+++ b/pkg/microservice/user/core/service/login/local.go
@@ -62,13 +62,18 @@ type CheckSignatureRes struct {
 }
 
 func CheckSignature(ifLoggedIn bool, logger *zap.SugaredLogger) error {
-	userNum, err := orm.CountActiveUser(repository.DB)
+	vendorClient := plutusvendor.New()
+	err := vendorClient.Health()
 	if err != nil {
 		return err
 	}
-	vendorClient := plutusvendor.New()
 
-	err = vendorClient.Health()
+	status, checkErr := vendorClient.CheckZadigXLicenseStatus()
+	if checkErr != nil {
+		return checkErr
+	}
+
+	userNum, err := orm.CountActiveUser(status.UpdatedAt, repository.DB)
 	if err != nil {
 		return err
 	}

--- a/pkg/shared/client/plutusvendor/plutusvendor.go
+++ b/pkg/shared/client/plutusvendor/plutusvendor.go
@@ -51,6 +51,8 @@ type ZadigXLicenseStatus struct {
 	CurrentVersion   string   `json:"current_version"`
 	Features         []string `json:"features"`
 	ImprovementPlan  bool     `json:"improvement_plan"`
+	CreatedAt        int64    `json:"created_time"`
+	UpdatedAt        int64    `json:"updated_time"`
 }
 
 func (c *Client) CheckZadigXLicenseStatus() (*ZadigXLicenseStatus, error) {

--- a/pkg/tool/cache/redis_cache.go
+++ b/pkg/tool/cache/redis_cache.go
@@ -76,3 +76,7 @@ func (c *RedisCache) GetString(key string) (string, error) {
 func (c *RedisCache) Delete(key string) error {
 	return c.redisClient.Del(context.TODO(), key).Err()
 }
+
+func (c *RedisCache) FlushDBAsync() error {
+	return c.redisClient.FlushDBAsync(context.TODO()).Err()
+}


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5488b48</samp>

This pull request implements the feature to check the license status and limit the active user number for Zadig X based on the license signature. It modifies the `user`, `orm`, `login`, `plutusvendor`, and `cache` packages to use the `plutusvendor` client and the signature update time to filter and count the active users.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5488b48</samp>

*  Add `FlushDBAsync` method to `RedisCache` type to clear the redis database asynchronously ([link](https://github.com/koderover/zadig/pull/3148/files?diff=unified&w=0#diff-2679b655022bd144afe8198668bb94d83a2f5a206dde8efe4e8afa29cf2587deR79-R82))
*  Modify `ZadigXLicenseStatus` type to include `CreatedAt` and `UpdatedAt` fields for the license signature ([link](https://github.com/koderover/zadig/pull/3148/files?diff=unified&w=0#diff-dc647553163be176b091e99b6f71a7c1093cabdc6cdfc55c3dbdace59a5113c8R54-R55))
*  Modify `CheckSignature` function in `login` package to call `CheckZadigXLicenseStatus` method of `plutusvendor` client and pass the signature update time to `CountActiveUser` function ([link](https://github.com/koderover/zadig/pull/3148/files?diff=unified&w=0#diff-6edc8543c3f426bae078caf11911512ccec56b3c70e9e89d19db91b4d56eefc7L65-R76))
*  Modify `GetUserCount` function in `user` package to call `CheckZadigXLicenseStatus` method of `plutusvendor` client and pass the signature update time to `CountActiveUser` function ([link](https://github.com/koderover/zadig/pull/3148/files?diff=unified&w=0#diff-a122d70189cd7678bf0b0e34711cb98db75b0397dd59aa334e216616a513e32aL696-R709))
*  Modify `CountActiveUser` function in `orm` package to accept a `signatureUpdatedAt` parameter and filter the user login records by the last update time of the signature ([link](https://github.com/koderover/zadig/pull/3148/files?diff=unified&w=0#diff-75c9f57ff419b19844268c60da57bfbe5d1b42fa78f9bab34dec02fc7e3f4dd7L85-R87))
*  Import `plutusvendor` package in `user` package to use the `plutusvendor` client ([link](https://github.com/koderover/zadig/pull/3148/files?diff=unified&w=0#diff-a122d70189cd7678bf0b0e34711cb98db75b0397dd59aa334e216616a513e32aR44))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
