### PR TITLE
fix template workflow issue

### DIFF
--- a/pkg/microservice/aslan/core/templatestore/handler/workflow.go
+++ b/pkg/microservice/aslan/core/templatestore/handler/workflow.go
@@ -54,11 +54,6 @@ func GetWorkflowTemplateByID(c *gin.Context) {
 		}
 	}
 
-	if err = commonutil.CheckZadigXLicenseStatus(); err != nil {
-		ctx.Err = err
-		return
-	}
-
 	resp, err := templateservice.GetWorkflowTemplateByID(c.Param("id"), ctx.Logger)
 	if err != nil {
 		c.JSON(e.ErrorMessage(err))


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b23fdb</samp>

Removed ZadigX license check from `GetWorkflowTemplateByID` function in `workflow.go`. This is part of a larger refactor to simplify the code and reduce technical debt.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5b23fdb</samp>

* Remove ZadigX license check from `GetWorkflowTemplateByID` function ([link](https://github.com/koderover/zadig/pull/3149/files?diff=unified&w=0#diff-f2c47871850d34d336afe2636c8558af02a279ca4655c4af43c0c359a78678f9L57-L61)). This is part of a larger refactor to remove the ZadigX license feature from the codebase, as ZadigX is no longer a separate product. The file `pkg/microservice/aslan/core/templatestore/handler/workflow.go` contains the handler for workflow template operations.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
