### PR TITLE
update amazon eks cluster

### DIFF
--- a/pkg/microservice/aslan/config/consts.go
+++ b/pkg/microservice/aslan/config/consts.go
@@ -436,6 +436,7 @@ const (
 type ClusterProvider int
 
 const (
+	ClusterProviderAmazonEKS     = 4
 	ClusterProviderTKEServerless = 5
 )
 

--- a/pkg/microservice/aslan/core/multicluster/service/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/service/clusters.go
@@ -107,7 +107,7 @@ func (args *K8SCluster) Validate() error {
 		return fmt.Errorf("failed to validate zadig license status, error: %s", err)
 	}
 	if !(licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional && licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
-		if args.Provider == config.ClusterProviderTKEServerless || args.Production {
+		if args.Provider == config.ClusterProviderTKEServerless || args.Provider == config.ClusterProviderAmazonEKS || args.Production {
 			return e.ErrLicenseInvalid
 		}
 		if args.AdvancedConfig != nil {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0a6f7a3</samp>

This pull request adds support for Amazon EKS as a cluster provider option for Zadig, and enforces the license requirement for using it. It introduces a new constant `ClusterProviderAmazonEKS` in `consts.go`, and modifies the validation logic in `clusters.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0a6f7a3</samp>

*  Add a new cluster provider option for Amazon EKS ([link](https://github.com/koderover/zadig/pull/3151/files?diff=unified&w=0#diff-b75a929528a6cc3d65392ca838a5f63796ed0a4ec0f239f69a4e8c4bf61ba04cR439))
*  Validate license status when creating a cluster with Amazon EKS ([link](https://github.com/koderover/zadig/pull/3151/files?diff=unified&w=0#diff-4e85c1af9762124c9c31e475d7a54712ffc81a99054ebef0ea2d97cd73ca6a8cL110-R110))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
