### PR TITLE
cherry pick fix scale and update default values bug (#3163) to 2.0.0

### DIFF
--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -1001,13 +1000,6 @@ func UpdateHelmProductDefaultValues(c *gin.Context) {
 	if err != nil {
 		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
 		ctx.UnAuthorized = true
-		return
-	}
-
-	// license checks
-	err = util.CheckZadigXLicenseStatus()
-	if err != nil {
-		ctx.Err = err
 		return
 	}
 

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -189,7 +189,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		production.POST("/environments/:name/services/:serviceName/restartNew", RestartProductionWorkload)
 
 		// k8s resources operations
-		production.POST("/environments/:name/services/:serviceName/scaleNew", ScaleNewService)
+		production.POST("/environments/:name/services/:serviceName/scaleNew", ScaleNewProductionService)
 		production.POST("/image/deployment/:envName", UpdateProductionDeploymentContainerImage)
 
 		production.GET("/rendersets/variables", GetProductionServiceVariables)


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2d4bf7d</samp>

This pull request refactors the aslan microservice to improve the code quality and modularity. It removes unused and redundant code, splits the `service.go` file into two files, and renames a function to better reflect its functionality.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2d4bf7d</samp>

*  Remove unused import of `util` package from `handler` package ([link](https://github.com/koderover/zadig/pull/3164/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL30))
*  Rename `ScaleNewService` function to `ScaleNewProductionService` in `router.go` file ([link](https://github.com/koderover/zadig/pull/3164/files?diff=unified&w=0#diff-bc855cdae7fd5951f2dd616071a0a85b20273c7a89fc1725f032de2b17ff7bd7L192-R192))
*  Add `ScaleNewProductionService` function to `service.go` file to handle scaling of services in production environments ([link](https://github.com/koderover/zadig/pull/3164/files?diff=unified&w=0#diff-1f1a96ca5c17bda66614fbd3686bed9b70e571ce337083b0b1c81d025ba01109R614-R673))
*  Remove license check logic from `UpdateHelmProductDefaultValues` function in `environment.go` file as part of a larger refactor to move license check to hub microservice ([link](https://github.com/koderover/zadig/pull/3164/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL1007-L1013))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
