### PR TITLE
fix distribute image parse image name bug

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/stepcontroller/step_distribute_image.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/stepcontroller/step_distribute_image.go
@@ -25,6 +25,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/koderover/zadig/pkg/types/job"
 	"github.com/koderover/zadig/pkg/types/step"
 )
@@ -55,14 +56,18 @@ func (s *distributeImageCtl) PreRun(ctx context.Context) error {
 		if target.SourceImage == "" {
 			return fmt.Errorf("source image is empty")
 		}
+		log.Debugf("1 sourceImage: %s, targetImage: %s", target.SourceImage, target.TargetImage)
 		sourceImageName := strings.Split(target.SourceImage, ":")[0]
 		if idx := strings.LastIndex(sourceImageName, "/"); idx != -1 {
 			sourceImageName = sourceImageName[idx+1:]
 		}
+		log.Debugf("2 sourceImage: %s, targetImage: %s", target.SourceImage, target.TargetImage)
 		target.TargetImage = getImage(sourceImageName, target.TargetTag, s.distributeImageSpec.TargetRegistry)
 		if !target.UpdateTag {
 			target.TargetImage = getImage(sourceImageName, getImageTag(target.SourceImage), s.distributeImageSpec.TargetRegistry)
+			log.Debugf("3 sourceImage: %s, targetImage: %s", target.SourceImage, target.TargetImage)
 		}
+		log.Debugf("4 sourceImage: %s, targetImage: %s", target.SourceImage, target.TargetImage)
 	}
 	s.step.Spec = s.distributeImageSpec
 	return nil

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/stepcontroller/step_distribute_image.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/stepcontroller/step_distribute_image.go
@@ -25,7 +25,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
-	"github.com/koderover/zadig/pkg/tool/log"
 	"github.com/koderover/zadig/pkg/types/job"
 	"github.com/koderover/zadig/pkg/types/step"
 )
@@ -56,18 +55,21 @@ func (s *distributeImageCtl) PreRun(ctx context.Context) error {
 		if target.SourceImage == "" {
 			return fmt.Errorf("source image is empty")
 		}
-		log.Debugf("1 sourceImage: %s, targetImage: %s", target.SourceImage, target.TargetImage)
+
+		// for exmaple, target.SourceImage = koderover.tencentcloudcr.com/test/service1:20231026142000-6-main
 		sourceImageName := strings.Split(target.SourceImage, ":")[0]
+		count := strings.Count(target.SourceImage, ":")
+		if count == 2 {
+			// for exmaple, target.SourceImage = 2.192.49.92:9392/test/service1:20231026142000-6-main
+			sourceImageName = strings.Split(target.SourceImage, ":")[1]
+		}
 		if idx := strings.LastIndex(sourceImageName, "/"); idx != -1 {
 			sourceImageName = sourceImageName[idx+1:]
 		}
-		log.Debugf("2 sourceImage: %s, targetImage: %s", target.SourceImage, target.TargetImage)
 		target.TargetImage = getImage(sourceImageName, target.TargetTag, s.distributeImageSpec.TargetRegistry)
 		if !target.UpdateTag {
 			target.TargetImage = getImage(sourceImageName, getImageTag(target.SourceImage), s.distributeImageSpec.TargetRegistry)
-			log.Debugf("3 sourceImage: %s, targetImage: %s", target.SourceImage, target.TargetImage)
 		}
-		log.Debugf("4 sourceImage: %s, targetImage: %s", target.SourceImage, target.TargetImage)
 	}
 	s.step.Spec = s.distributeImageSpec
 	return nil


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a805350</samp>

Added debug logs to image distribution step in workflow controller. The logs help to troubleshoot how the `PreRun` function handles the image tag and registry settings in `step_distribute_image.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a805350</samp>

*  Add debug logs to `PreRun` function in `step_distribute_image.go` ([link](https://github.com/koderover/zadig/pull/3165/files?diff=unified&w=0#diff-0256e52a1295a0f9e95a380c144aaa4065b3637e0db1fb711f7bc3d6eeb80594R28), [link](https://github.com/koderover/zadig/pull/3165/files?diff=unified&w=0#diff-0256e52a1295a0f9e95a380c144aaa4065b3637e0db1fb711f7bc3d6eeb80594L58-R70))
  - Import log package to enable logging ([link](https://github.com/koderover/zadig/pull/3165/files?diff=unified&w=0#diff-0256e52a1295a0f9e95a380c144aaa4065b3637e0db1fb711f7bc3d6eeb80594R28))
  - Log the source and target images before and after applying tag and registry transformations ([link](https://github.com/koderover/zadig/pull/3165/files?diff=unified&w=0#diff-0256e52a1295a0f9e95a380c144aaa4065b3637e0db1fb711f7bc3d6eeb80594L58-R70))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
