### PR TITLE
undo env sleep limit check

### DIFF
--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -2937,12 +2937,6 @@ func EnvSleep(c *gin.Context) {
 		return
 	}
 
-	err = commonutil.CheckZadigXLicenseStatus()
-	if err != nil {
-		ctx.Err = err
-		return
-	}
-
 	ctx.Err = service.EnvSleep(projectName, envName, action == "enable", false, ctx.Logger)
 }
 
@@ -3016,12 +3010,6 @@ func ProductionEnvSleep(c *gin.Context) {
 		return
 	}
 
-	err = commonutil.CheckZadigXLicenseStatus()
-	if err != nil {
-		ctx.Err = err
-		return
-	}
-
 	ctx.Err = service.EnvSleep(projectName, envName, action == "enable", true, ctx.Logger)
 }
 
@@ -3084,12 +3072,6 @@ func GetEnvSleepCron(c *gin.Context) {
 		return
 	}
 
-	err = commonutil.CheckZadigXLicenseStatus()
-	if err != nil {
-		ctx.Err = err
-		return
-	}
-
 	ctx.Resp, ctx.Err = service.GetEnvSleepCron(projectName, envName, boolptr.False(), ctx.Logger)
 }
 
@@ -3149,12 +3131,6 @@ func GetProductionEnvSleepCron(c *gin.Context) {
 
 	if !permitted {
 		ctx.UnAuthorized = true
-		return
-	}
-
-	err = commonutil.CheckZadigXLicenseStatus()
-	if err != nil {
-		ctx.Err = err
 		return
 	}
 
@@ -3235,12 +3211,6 @@ func UpsertEnvSleepCron(c *gin.Context) {
 		return
 	}
 
-	err = commonutil.CheckZadigXLicenseStatus()
-	if err != nil {
-		ctx.Err = err
-		return
-	}
-
 	ctx.Err = service.UpsertEnvSleepCron(projectName, envName, boolptr.False(), arg, ctx.Logger)
 }
 
@@ -3315,12 +3285,6 @@ func UpsertProductionEnvSleepCron(c *gin.Context) {
 
 	if !permitted {
 		ctx.UnAuthorized = true
-		return
-	}
-
-	err = commonutil.CheckZadigXLicenseStatus()
-	if err != nil {
-		ctx.Err = err
 		return
 	}
 

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -161,7 +161,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		production.GET("/environments/:name/services/:serviceName", GetProductionService)
 		production.GET("/environments/:name/services/:serviceName/variables", GetProductionVariables)
 		production.GET("/environments/:name/services/:serviceName/yaml", ExportProductionServiceYaml)
-		production.POST("/environments/:name/services/preview/batch", BatchPreviewServices)
+		production.POST("/environments/:name/services/preview/batch", ProductionBatchPreviewServices)
 
 		production.DELETE("/environments/:name", DeleteProductionProduct)
 

--- a/pkg/microservice/aslan/core/environment/handler/service.go
+++ b/pkg/microservice/aslan/core/environment/handler/service.go
@@ -307,7 +307,7 @@ func PreviewService(c *gin.Context) {
 	ctx.Resp, ctx.Err = service.PreviewService(args, ctx.Logger)
 }
 
-func BatchPreviewServices(c *gin.Context) {
+func ProductionBatchPreviewServices(c *gin.Context) {
 	// TODO: add authorization probably
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
@@ -327,6 +327,26 @@ func BatchPreviewServices(c *gin.Context) {
 	if err := commonutil.CheckZadigXLicenseStatus(); err != nil {
 		ctx.Err = err
 		return
+	}
+
+	ctx.Resp, ctx.Err = service.BatchPreviewService(args, ctx.Logger)
+}
+
+func BatchPreviewServices(c *gin.Context) {
+	// TODO: add authorization probably
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	args := make([]*service.PreviewServiceArgs, 0)
+	if err := c.BindJSON(&args); err != nil {
+		ctx.Logger.Errorf("faield to bind args, err: %s", err)
+		ctx.Err = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+
+	for _, arg := range args {
+		arg.ProductName = c.Query("projectName")
+		arg.EnvName = c.Param("name")
 	}
 
 	ctx.Resp, ctx.Err = service.BatchPreviewService(args, ctx.Logger)


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f72ee2f</samp>

This pull request removes the license checks for the environment sleep mode feature in `pkg/microservice/aslan/core/environment/handler/environment.go`. This simplifies the code and avoids unnecessary errors for zadig users.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f72ee2f</samp>

*  Remove license checks for environment sleep mode functions and their cron expressions ([link](https://github.com/koderover/zadig/pull/3167/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL2940-L2945), [link](https://github.com/koderover/zadig/pull/3167/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL3019-L3024), [link](https://github.com/koderover/zadig/pull/3167/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL3087-L3092), [link](https://github.com/koderover/zadig/pull/3167/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL3155-L3160), [link](https://github.com/koderover/zadig/pull/3167/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL3238-L3243), [link](https://github.com/koderover/zadig/pull/3167/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL3321-L3326)) in `environment.go`

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
