### PR TITLE
add error to list group func

### DIFF
--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -86,6 +86,7 @@ type ServiceResp struct {
 	ServiceDisplayName string       `json:"service_display_name"`
 	Type               string       `json:"type"`
 	Status             string       `json:"status"`
+	Error              string       `json:"error"`
 	Images             []string     `json:"images,omitempty"`
 	ProductName        string       `json:"product_name"`
 	EnvName            string       `json:"env_name"`

--- a/pkg/microservice/aslan/core/environment/service/k8s.go
+++ b/pkg/microservice/aslan/core/environment/service/k8s.go
@@ -350,6 +350,7 @@ func (k *K8sService) listGroupServices(allServices []*commonmodels.ProductServic
 				EnvName:        envName,
 				DeployStrategy: service.DeployStrategy,
 				Updatable:      service.Updatable,
+				Error:          service.Error,
 			}
 			serviceTmpl, err := repository.QueryTemplateService(&commonrepo.ServiceFindOption{
 				ServiceName: service.ServiceName,


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at de2301e</samp>

Added an `Error` field to the `ServiceResp` type to store and return any service operation error message. This allows the frontend to show the error message to the user when listing the group environments and their services.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at de2301e</samp>

*  Add `Error` field to `ServiceResp` type to store service operation error messages ([link](https://github.com/koderover/zadig/pull/3171/files?diff=unified&w=0#diff-43b4a5df02ef75087654902b8d4afc32745599d35053d171a5b950a94d012960R89))
*  Assign `Error` field of `ServiceResp` to `service` variable in `listGroupServices` function ([link](https://github.com/koderover/zadig/pull/3171/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136R353))
*  Return `Error` field of `service` variable to `ListGroups` handler in `environment` package ([link](https://github.com/koderover/zadig/pull/3171/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136R353))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
