### PR TITLE
optimize ua logic

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/1160_vars.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/1160_vars.go
@@ -30,7 +30,6 @@ import (
 	templaterepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb/template"
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/tool/log"
-	"github.com/koderover/zadig/pkg/util"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"gopkg.in/yaml.v3"
@@ -296,117 +295,117 @@ func adjustProductRenderInfo() error {
 		projectNames = append(projectNames, v.ProductName)
 	}
 
-	products, err := uamongo.NewProductColl().List(&uamongo.ProductListOptions{ExcludeStatus: setting.ProductStatusDeleting, InProjects: projectNames})
-	if err != nil && !mongodb.IsErrNoDocuments(err) {
-		log.Errorf("adjustProductRenderInfo list product error: %s", err)
-		return fmt.Errorf("adjustProductRenderInfo list product error: %s", err)
-	}
+	//products, err := uamongo.NewProductColl().List(&uamongo.ProductListOptions{ExcludeStatus: setting.ProductStatusDeleting, InProjects: projectNames})
+	//if err != nil && !mongodb.IsErrNoDocuments(err) {
+	//	log.Errorf("adjustProductRenderInfo list product error: %s", err)
+	//	return fmt.Errorf("adjustProductRenderInfo list product error: %s", err)
+	//}
 
-	for _, product := range products {
-		err = adjustSingleProductRender(product)
-		if err != nil {
-			return err
-		}
-	}
+	//for _, product := range products {
+	//	err = adjustSingleProductRender(product)
+	//	if err != nil {
+	//		return err
+	//	}
+	//}
 	return nil
 }
 
 // used product.render instead of product.service[].render
 // convert current kvs in render into global data
-func adjustSingleProductRender(product *uamodel.Product) error {
-
-	var maxVersionRender *uamodel.RenderInfo = nil
-	for _, svc := range product.GetServiceMap() {
-		if svc.Render != nil && (maxVersionRender == nil || svc.Render.Revision > maxVersionRender.Revision) {
-			maxVersionRender = svc.Render
-		}
-	}
-	if product.Render != nil && (maxVersionRender == nil || product.Render.Revision > maxVersionRender.Revision) {
-		maxVersionRender = product.Render
-	}
-
-	if maxVersionRender == nil {
-		return nil
-	}
-
-	renderSet, err := uamongo.NewRenderSetColl().Find(&uamongo.RenderSetFindOption{
-		ProductTmpl: product.ProductName,
-		EnvName:     product.EnvName,
-		IsDefault:   false,
-		Revision:    maxVersionRender.Revision,
-		Name:        maxVersionRender.Name,
-	})
-	if err != nil {
-		log.Errorf("failed to find renderset info: %v/%v, product: %v/%v", maxVersionRender.Name, maxVersionRender.Revision, product.ProductName, product.EnvName)
-		return err
-	}
-	// the render set has been handled
-	if len(renderSet.DefaultValues) > 0 {
-		return nil
-	}
-
-	// set variable kv default value
-	usedSvcVariables := make(map[string]string)
-	for _, kv := range renderSet.KVs {
-		usedSvcVariables[kv.Key] = kv.Value
-	}
-
-	rendersetMap := make(map[int64]*uamodel.RenderSet)
-
-	for _, svc := range product.GetServiceMap() {
-		if svc.Render == nil {
-			continue
-		}
-
-		renderSet, ok := rendersetMap[svc.Render.Revision]
-		if !ok {
-			var err error
-			renderSet, err = uamongo.NewRenderSetColl().Find(&uamongo.RenderSetFindOption{
-				ProductTmpl: product.ProductName,
-				EnvName:     product.EnvName,
-				IsDefault:   false,
-				Revision:    svc.Render.Revision,
-				Name:        svc.Render.Name,
-			})
-			if err != nil {
-				log.Errorf("failed to find renderset info %v/%v for service: %s , product: %v/%v", maxVersionRender.Name, maxVersionRender.Revision, svc.ServiceName, product.ProductName, product.EnvName)
-				continue
-			}
-			rendersetMap[svc.Render.Revision] = renderSet
-		}
-
-		if len(renderSet.DefaultValues) > 0 {
-			return nil
-		}
-
-		if len(renderSet.KVs) == 0 {
-			continue
-		}
-		for _, kv := range renderSet.KVs {
-			if util.InStringArray(svc.ServiceName, kv.Services) {
-				usedSvcVariables[kv.Key] = kv.Value
-			}
-		}
-	}
-
-	valuesYaml, _ := yaml.Marshal(usedSvcVariables)
-
-	log.Infof("handling single render set: %s:%v, generated variable yaml %s", maxVersionRender.Name, maxVersionRender.Revision, string(valuesYaml))
-
-	// turn current kv info into global variable-yaml
-	renderSet.DefaultValues = string(valuesYaml)
-	if len(usedSvcVariables) == 0 {
-		renderSet.DefaultValues = ""
-	}
-
-	log.Infof("setting default values for renderset: %v/%v, values: %v", renderSet.Name, renderSet.Revision, renderSet.DefaultValues)
-	err = uamongo.NewRenderSetColl().UpdateDefaultValues(renderSet)
-	if err != nil {
-		return err
-	}
-
-	return setProductRender(product, maxVersionRender)
-}
+//func adjustSingleProductRender(product *uamodel.Product) error {
+//
+//	var maxVersionRender *uamodel.RenderInfo = nil
+//	for _, svc := range product.GetServiceMap() {
+//		if svc.Render != nil && (maxVersionRender == nil || svc.Render.Revision > maxVersionRender.Revision) {
+//			maxVersionRender = svc.Render
+//		}
+//	}
+//	if product.Render != nil && (maxVersionRender == nil || product.Render.Revision > maxVersionRender.Revision) {
+//		maxVersionRender = product.Render
+//	}
+//
+//	if maxVersionRender == nil {
+//		return nil
+//	}
+//
+//	renderSet, err := uamongo.NewRenderSetColl().Find(&uamongo.RenderSetFindOption{
+//		ProductTmpl: product.ProductName,
+//		EnvName:     product.EnvName,
+//		IsDefault:   false,
+//		Revision:    maxVersionRender.Revision,
+//		Name:        maxVersionRender.Name,
+//	})
+//	if err != nil {
+//		log.Errorf("failed to find renderset info: %v/%v, product: %v/%v", maxVersionRender.Name, maxVersionRender.Revision, product.ProductName, product.EnvName)
+//		return err
+//	}
+//	// the render set has been handled
+//	if len(renderSet.DefaultValues) > 0 {
+//		return nil
+//	}
+//
+//	// set variable kv default value
+//	usedSvcVariables := make(map[string]string)
+//	for _, kv := range renderSet.KVs {
+//		usedSvcVariables[kv.Key] = kv.Value
+//	}
+//
+//	rendersetMap := make(map[int64]*uamodel.RenderSet)
+//
+//	for _, svc := range product.GetServiceMap() {
+//		if svc.Render == nil {
+//			continue
+//		}
+//
+//		renderSet, ok := rendersetMap[svc.Render.Revision]
+//		if !ok {
+//			var err error
+//			renderSet, err = uamongo.NewRenderSetColl().Find(&uamongo.RenderSetFindOption{
+//				ProductTmpl: product.ProductName,
+//				EnvName:     product.EnvName,
+//				IsDefault:   false,
+//				Revision:    svc.Render.Revision,
+//				Name:        svc.Render.Name,
+//			})
+//			if err != nil {
+//				log.Errorf("failed to find renderset info %v/%v for service: %s , product: %v/%v", maxVersionRender.Name, maxVersionRender.Revision, svc.ServiceName, product.ProductName, product.EnvName)
+//				continue
+//			}
+//			rendersetMap[svc.Render.Revision] = renderSet
+//		}
+//
+//		if len(renderSet.DefaultValues) > 0 {
+//			return nil
+//		}
+//
+//		if len(renderSet.KVs) == 0 {
+//			continue
+//		}
+//		for _, kv := range renderSet.KVs {
+//			if util.InStringArray(svc.ServiceName, kv.Services) {
+//				usedSvcVariables[kv.Key] = kv.Value
+//			}
+//		}
+//	}
+//
+//	valuesYaml, _ := yaml.Marshal(usedSvcVariables)
+//
+//	log.Infof("handling single render set: %s:%v, generated variable yaml %s", maxVersionRender.Name, maxVersionRender.Revision, string(valuesYaml))
+//
+//	// turn current kv info into global variable-yaml
+//	renderSet.DefaultValues = string(valuesYaml)
+//	if len(usedSvcVariables) == 0 {
+//		renderSet.DefaultValues = ""
+//	}
+//
+//	log.Infof("setting default values for renderset: %v/%v, values: %v", renderSet.Name, renderSet.Revision, renderSet.DefaultValues)
+//	err = uamongo.NewRenderSetColl().UpdateDefaultValues(renderSet)
+//	if err != nil {
+//		return err
+//	}
+//
+//	return setProductRender(product, maxVersionRender)
+//}
 
 func setProductRender(product *uamodel.Product, maxVersionRender *uamodel.RenderInfo) error {
 	// revisions of product.render and product.service[].render are the same

--- a/pkg/cli/upgradeassistant/cmd/migrate/1160_vars.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/1160_vars.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"strings"
 
-	uamodel "github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/repository/models"
 	uamongo "github.com/koderover/zadig/pkg/cli/upgradeassistant/internal/repository/mongodb"
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
@@ -407,12 +406,12 @@ func adjustProductRenderInfo() error {
 //	return setProductRender(product, maxVersionRender)
 //}
 
-func setProductRender(product *uamodel.Product, maxVersionRender *uamodel.RenderInfo) error {
-	// revisions of product.render and product.service[].render are the same
-	if product.Render != nil && product.Render.Revision == maxVersionRender.Revision {
-		return nil
-	}
-	log.Infof("setting product render: %s from revision: %d to revision: %d", product.Render.Name, product.Revision, maxVersionRender.Revision)
-	product.Render = maxVersionRender
-	return uamongo.NewProductColl().UpdateProductRender(product)
-}
+//func setProductRender(product *uamodel.Product, maxVersionRender *uamodel.RenderInfo) error {
+//	// revisions of product.render and product.service[].render are the same
+//	if product.Render != nil && product.Render.Revision == maxVersionRender.Revision {
+//		return nil
+//	}
+//	log.Infof("setting product render: %s from revision: %d to revision: %d", product.Render.Name, product.Revision, maxVersionRender.Revision)
+//	product.Render = maxVersionRender
+//	return uamongo.NewProductColl().UpdateProductRender(product)
+//}

--- a/pkg/cli/upgradeassistant/cmd/migrate/200.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/200.go
@@ -727,6 +727,9 @@ func migrateRendersets() error {
 			for _, svcGroup := range env.Services {
 				for _, svc := range svcGroup {
 					if project.IsHelmProduct() {
+						if svc.Render != nil && (svc.Render.OverrideYaml != nil && len(svc.Render.OverrideYaml.YamlContent) > 0 || len(svc.Render.OverrideValues) > 0) {
+							continue
+						}
 						if svc.FromZadig() {
 							svc.Render = curRender.GetChartRenderMap()[svc.ServiceName]
 						} else {

--- a/pkg/cli/upgradeassistant/cmd/migrate/200.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/200.go
@@ -686,7 +686,7 @@ func migrateRendersets() error {
 
 		log.Infof("migrating render set for project: %s", project.ProductName)
 
-		envs, err := mongodb.NewProductColl().List(&mongodb.ProductListOptions{Name: project.ProductName})
+		envs, err := internaldb.NewProductColl().List(&internaldb.ProductListOptions{Name: project.ProductName})
 		if err != nil {
 			return errors.Wrapf(err, "failed to list envs of project: %s", project.ProductName)
 		}
@@ -750,7 +750,7 @@ func migrateRendersets() error {
 				}
 			}
 
-			err = mongodb.NewProductColl().Update(env)
+			err = internaldb.NewProductColl().Update(env)
 			if err != nil {
 				return errors.Wrapf(err, "failed to update render for product: %v/%v", env.ProductName, env.EnvName)
 			}

--- a/pkg/cli/upgradeassistant/internal/repository/models/product.go
+++ b/pkg/cli/upgradeassistant/internal/repository/models/product.go
@@ -42,7 +42,7 @@ type Product struct {
 	UpdateBy       string                          `bson:"update_by"                 json:"update_by"`
 	Visibility     string                          `bson:"-"                         json:"visibility"`
 	Services       [][]*models.ProductService      `bson:"services"                  json:"services"`
-	Render         *RenderInfo                     `bson:"render"                    json:"render"` // Deprecated in 1.19.0, will be removed in 1.20.0
+	Render         *models.RenderInfo              `bson:"render"                    json:"render"`
 	Error          string                          `bson:"error"                     json:"error"`
 	ServiceRenders []*templatemodels.ServiceRender `bson:"-"                         json:"chart_infos,omitempty"`
 	IsPublic       bool                            `bson:"is_public"                 json:"isPublic"`

--- a/pkg/cli/upgradeassistant/internal/repository/models/product.go
+++ b/pkg/cli/upgradeassistant/internal/repository/models/product.go
@@ -17,6 +17,8 @@ limitations under the License.
 package models
 
 import (
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
+	commontypes "github.com/koderover/zadig/pkg/microservice/aslan/core/common/types"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	templatemodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/template"
@@ -27,30 +29,61 @@ type ProductPermission string
 
 // Vars do not save, only input parameters
 type Product struct {
-	ID              primitive.ObjectID         `bson:"_id,omitempty"             json:"id,omitempty"`
-	ProductName     string                     `bson:"product_name"              json:"product_name"`
-	CreateTime      int64                      `bson:"create_time"               json:"create_time"`
-	UpdateTime      int64                      `bson:"update_time"               json:"update_time"`
-	Namespace       string                     `bson:"namespace,omitempty"       json:"namespace,omitempty"`
-	Status          string                     `bson:"status"                    json:"status"`
-	Revision        int64                      `bson:"revision"                  json:"revision"`
-	Enabled         bool                       `bson:"enabled"                   json:"enabled"`
-	EnvName         string                     `bson:"env_name"                  json:"env_name"`
-	UpdateBy        string                     `bson:"update_by"                 json:"update_by"`
-	Auth            []*ProductAuth             `bson:"auth"                      json:"auth"`
-	Visibility      string                     `bson:"-"                         json:"visibility"`
-	Services        [][]*ProductService        `bson:"services"                  json:"services"`
-	Render          *RenderInfo                `bson:"render"                    json:"render"`
-	Error           string                     `bson:"error"                     json:"error"`
-	Vars            []*templatemodels.RenderKV `bson:"vars,omitempty"            json:"vars,omitempty"`
-	IsPublic        bool                       `bson:"is_public"                 json:"isPublic"`
-	RoleIDs         []int64                    `bson:"role_ids"                  json:"roleIds"`
-	ClusterID       string                     `bson:"cluster_id,omitempty"      json:"cluster_id,omitempty"`
-	RecycleDay      int                        `bson:"recycle_day"               json:"recycle_day"`
-	Source          string                     `bson:"source"                    json:"source"`
-	IsOpenSource    bool                       `bson:"is_opensource"             json:"is_opensource"`
-	RegistryID      string                     `bson:"registry_id"               json:"registry_id"`
-	IsForkedProduct bool                       `bson:"-"                         json:"-"`
+	ID             primitive.ObjectID              `bson:"_id,omitempty"             json:"id,omitempty"`
+	ProductName    string                          `bson:"product_name"              json:"product_name"`
+	CreateTime     int64                           `bson:"create_time"               json:"create_time"`
+	UpdateTime     int64                           `bson:"update_time"               json:"update_time"`
+	Namespace      string                          `bson:"namespace,omitempty"       json:"namespace,omitempty"`
+	Status         string                          `bson:"status"                    json:"status"`
+	Revision       int64                           `bson:"revision"                  json:"revision"`
+	Enabled        bool                            `bson:"enabled"                   json:"enabled"`
+	EnvName        string                          `bson:"env_name"                  json:"env_name"`
+	BaseEnvName    string                          `bson:"-"                         json:"base_env_name"`
+	UpdateBy       string                          `bson:"update_by"                 json:"update_by"`
+	Visibility     string                          `bson:"-"                         json:"visibility"`
+	Services       [][]*models.ProductService      `bson:"services"                  json:"services"`
+	Render         *RenderInfo                     `bson:"render"                    json:"render"` // Deprecated in 1.19.0, will be removed in 1.20.0
+	Error          string                          `bson:"error"                     json:"error"`
+	ServiceRenders []*templatemodels.ServiceRender `bson:"-"                         json:"chart_infos,omitempty"`
+	IsPublic       bool                            `bson:"is_public"                 json:"isPublic"`
+	RoleIDs        []int64                         `bson:"role_ids"                  json:"roleIds"`
+	ClusterID      string                          `bson:"cluster_id,omitempty"      json:"cluster_id,omitempty"`
+	RecycleDay     int                             `bson:"recycle_day"               json:"recycle_day"`
+	Source         string                          `bson:"source"                    json:"source"`
+	IsOpenSource   bool                            `bson:"is_opensource"             json:"is_opensource"`
+	RegistryID     string                          `bson:"registry_id"               json:"registry_id"`
+	BaseName       string                          `bson:"base_name"                 json:"base_name"`
+	// IsExisted is true if this environment is created from an existing one
+	IsExisted bool `bson:"is_existed"                json:"is_existed"`
+	// TODO: Deprecated: temp flag
+	IsForkedProduct bool `bson:"-" json:"-"`
+
+	// New Since v1.11.0.
+	//ShareEnv ProductShareEnv `bson:"share_env" json:"share_env"`
+
+	// New Since v1.13.0.
+	//EnvConfigs []*CreateUpdateCommonEnvCfgArgs `bson:"-"   json:"env_configs,omitempty"`
+
+	// New Since v1.16.0, used to determine whether to install resources
+	ServiceDeployStrategy map[string]string `bson:"service_deploy_strategy" json:"service_deploy_strategy"`
+
+	// New Since v.1.18.0, env configs
+	//AnalysisConfig      *AnalysisConfig       `bson:"analysis_config"      json:"analysis_config"`
+	//NotificationConfigs []*NotificationConfig `bson:"notification_configs" json:"notification_configs"`
+
+	// New Since v1.19.0, env sleep configs
+	PreSleepStatus map[string]int `bson:"pre_sleep_status" json:"pre_sleep_status"`
+
+	// New Since v1.19.0, for env global variables
+	// GlobalValues for helm projects
+	DefaultValues string                     `bson:"default_values,omitempty"       json:"default_values,omitempty"`
+	YamlData      *templatemodels.CustomYaml `bson:"yaml_data,omitempty"            json:"yaml_data,omitempty"`
+	// GlobalValues for k8s projects
+	GlobalVariables []*commontypes.GlobalVariableKV `bson:"global_variables,omitempty"     json:"global_variables,omitempty"`
+
+	// For production environment
+	Production bool   `json:"production" bson:"production"`
+	Alias      string `json:"alias" bson:"alias"`
 }
 
 type RenderInfo struct {
@@ -91,8 +124,9 @@ type ProductService struct {
 	Type        string       `bson:"type"                       json:"type"`
 	Revision    int64        `bson:"revision"                   json:"revision"`
 	Containers  []*Container `bson:"containers"                 json:"containers,omitempty"`
-	Render      *RenderInfo  `bson:"render,omitempty"           json:"render,omitempty"` // Record the render information of each service to facilitate the update of a single service
-	EnvConfigs  []*EnvConfig `bson:"-"                          json:"env_configs,omitempty"`
+	//Render      *RenderInfo  `bson:"render,omitempty"           json:"render,omitempty"` // Record the render information of each service to facilitate the update of a single service
+	Render     *models.RenderInfo `bson:"render"`
+	EnvConfigs []*EnvConfig       `bson:"-"                          json:"env_configs,omitempty"`
 }
 
 type ServiceConfig struct {
@@ -104,13 +138,13 @@ func (*Product) TableName() string {
 	return "product"
 }
 
-func (p *Product) GetServiceMap() map[string]*ProductService {
-	ret := make(map[string]*ProductService)
-	for _, group := range p.Services {
-		for _, svc := range group {
-			ret[svc.ServiceName] = svc
-		}
-	}
-
-	return ret
-}
+//func (p *Product) GetServiceMap() map[string]*ProductService {
+//	ret := make(map[string]*ProductService)
+//	for _, group := range p.Services {
+//		for _, svc := range group {
+//			ret[svc.ServiceName] = svc
+//		}
+//	}
+//
+//	return ret
+//}

--- a/pkg/cli/upgradeassistant/internal/repository/mongodb/product.go
+++ b/pkg/cli/upgradeassistant/internal/repository/mongodb/product.go
@@ -18,6 +18,7 @@ package mongodb
 
 import (
 	"context"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -156,5 +157,28 @@ func (c *ProductColl) UpdateRender(envName, productName string, render *models.R
 	}}
 	_, err := c.UpdateOne(context.TODO(), query, change)
 
+	return err
+}
+
+func (c *ProductColl) Update(args *models.Product) error {
+	query := bson.M{"env_name": args.EnvName, "product_name": args.ProductName}
+	changePayload := bson.M{
+		"update_time":      time.Now().Unix(),
+		"services":         args.Services,
+		"global_variables": args.GlobalVariables,
+		"default_values":   args.DefaultValues,
+		"yaml_data":        args.YamlData,
+	}
+	if len(args.Source) > 0 {
+		changePayload["source"] = args.Source
+	}
+	if args.ServiceDeployStrategy != nil {
+		changePayload["service_deploy_strategy"] = args.ServiceDeployStrategy
+	}
+	if args.PreSleepStatus != nil {
+		changePayload["pre_sleep_status"] = args.PreSleepStatus
+	}
+	change := bson.M{"$set": changePayload}
+	_, err := c.UpdateOne(context.TODO(), query, change)
 	return err
 }

--- a/pkg/microservice/aslan/core/common/repository/models/product.go
+++ b/pkg/microservice/aslan/core/common/repository/models/product.go
@@ -39,7 +39,7 @@ type Product struct {
 	UpdateBy       string                          `bson:"update_by"                 json:"update_by"`
 	Visibility     string                          `bson:"-"                         json:"visibility"`
 	Services       [][]*ProductService             `bson:"services"                  json:"services"`
-	Render         *RenderInfo                     `bson:"-"                         json:"render"` // Deprecated in 1.19.0, will be removed in 1.20.0
+	Render         *RenderInfo                     `bson:"render"                    json:"render"` // Deprecated in 1.19.0, will be removed in 1.20.0
 	Error          string                          `bson:"error"                     json:"error"`
 	ServiceRenders []*templatemodels.ServiceRender `bson:"-"                         json:"chart_infos,omitempty"`
 	IsPublic       bool                            `bson:"is_public"                 json:"isPublic"`

--- a/pkg/microservice/aslan/core/common/repository/models/product.go
+++ b/pkg/microservice/aslan/core/common/repository/models/product.go
@@ -39,7 +39,7 @@ type Product struct {
 	UpdateBy       string                          `bson:"update_by"                 json:"update_by"`
 	Visibility     string                          `bson:"-"                         json:"visibility"`
 	Services       [][]*ProductService             `bson:"services"                  json:"services"`
-	Render         *RenderInfo                     `bson:"render"                    json:"render"` // Deprecated in 1.19.0, will be removed in 1.20.0
+	Render         *RenderInfo                     `bson:"-"                         json:"render"` // Deprecated in 1.19.0, will be removed in 2.0.1
 	Error          string                          `bson:"error"                     json:"error"`
 	ServiceRenders []*templatemodels.ServiceRender `bson:"-"                         json:"chart_infos,omitempty"`
 	IsPublic       bool                            `bson:"is_public"                 json:"isPublic"`


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 48ab754</samp>

This file implements the logic for migrating render sets to the new format, which is compatible with the latest version of Zadig. It handles the conversion of environment and service variables, and retries the migration in case of MongoDB replication issues.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 48ab754</samp>

*  Migrate render sets from separate documents to embedded fields in environment documents ([link](https://github.com/koderover/zadig/pull/3172/files?diff=unified&w=0#diff-7ec06042579da80c009448a3749eb09b67bd83e81dcb2f38f92ab9eddeb9e165L698-R712), [link](https://github.com/koderover/zadig/pull/3172/files?diff=unified&w=0#diff-7ec06042579da80c009448a3749eb09b67bd83e81dcb2f38f92ab9eddeb9e165L721-R725), [link](https://github.com/koderover/zadig/pull/3172/files?diff=unified&w=0#diff-7ec06042579da80c009448a3749eb09b67bd83e81dcb2f38f92ab9eddeb9e165L734-R744), [link](https://github.com/koderover/zadig/pull/3172/files?diff=unified&w=0#diff-7ec06042579da80c009448a3749eb09b67bd83e81dcb2f38f92ab9eddeb9e165R756))
  - Skip migration if environment has any default values, yaml data, or global variables to preserve user's customizations ([link](https://github.com/koderover/zadig/pull/3172/files?diff=unified&w=0#diff-7ec06042579da80c009448a3749eb09b67bd83e81dcb2f38f92ab9eddeb9e165L698-R712), [link](https://github.com/koderover/zadig/pull/3172/files?diff=unified&w=0#diff-7ec06042579da80c009448a3749eb09b67bd83e81dcb2f38f92ab9eddeb9e165L721-R725))
  - Skip migration for service renders with override yaml variables to preserve user's customizations ([link](https://github.com/koderover/zadig/pull/3172/files?diff=unified&w=0#diff-7ec06042579da80c009448a3749eb09b67bd83e81dcb2f38f92ab9eddeb9e165L734-R744))
  - Log and retry migration if service render is nil, which should not happen but is a possible edge case ([link](https://github.com/koderover/zadig/pull/3172/files?diff=unified&w=0#diff-7ec06042579da80c009448a3749eb09b67bd83e81dcb2f38f92ab9eddeb9e165L734-R744))
  - Add a sleep of 30 seconds to wait for MongoDB replication to finish before proceeding to the next step ([link](https://github.com/koderover/zadig/pull/3172/files?diff=unified&w=0#diff-7ec06042579da80c009448a3749eb09b67bd83e81dcb2f38f92ab9eddeb9e165R756))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
