### PR TITLE
change logic of generating OPA bundle

### DIFF
--- a/pkg/microservice/policy/core/handler/bundle.go
+++ b/pkg/microservice/policy/core/handler/bundle.go
@@ -24,16 +24,9 @@ import (
 
 	"github.com/koderover/zadig/pkg/config"
 	"github.com/koderover/zadig/pkg/microservice/policy/core/service/bundle"
-	"github.com/koderover/zadig/pkg/tool/log"
 )
 
 func DownloadBundle(c *gin.Context) {
-	if err := bundle.GenerateOPABundle(); err != nil {
-		log.Errorf("Failed to generate OPA bundle, err: %s", err)
-		c.String(http.StatusInternalServerError, "bundle generation failure, err: %s", err)
-		return
-	}
-
 	revision := bundle.GetRevision()
 	matching := c.GetHeader("If-None-Match")
 	if revision != "" && revision == matching {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fc39788</samp>

Refactored the OPA policy bundle generation and download logic. Moved the bundle generation logic from the `core` package to the `bundle` package and removed the redundant calls and imports from the `DownloadBundle` function.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fc39788</samp>

*  Refactored the bundle controller logic from the `core` package to the `bundle` package ([link](https://github.com/koderover/zadig/pull/3178/files?diff=unified&w=0#diff-a74fa9c9aa31979c0e1634097c1a6b3e84ea13e0686ad037178b5d1208e9f9deL76), [link](https://github.com/koderover/zadig/pull/3178/files?diff=unified&w=0#diff-a74fa9c9aa31979c0e1634097c1a6b3e84ea13e0686ad037178b5d1208e9f9deL90-R91), [link](https://github.com/koderover/zadig/pull/3178/files?diff=unified&w=0#diff-a74fa9c9aa31979c0e1634097c1a6b3e84ea13e0686ad037178b5d1208e9f9deL178-R177), [link](https://github.com/koderover/zadig/pull/3178/files?diff=unified&w=0#diff-a74fa9c9aa31979c0e1634097c1a6b3e84ea13e0686ad037178b5d1208e9f9deR230-R244), [link](https://github.com/koderover/zadig/pull/3178/files?diff=unified&w=0#diff-f0774551807a4f40ff967c85c832ad5d69f7dd3a7244d0524251603b4758e628L27-R29))
  * Removed the `bundleController` field from the `Service` struct in `pkg/microservice/aslan/core/service.go` ([link](https://github.com/koderover/zadig/pull/3178/files?diff=unified&w=0#diff-a74fa9c9aa31979c0e1634097c1a6b3e84ea13e0686ad037178b5d1208e9f9deL76))
  * Removed the `bundleController` entry from the `controllerWorkers` and `controllers` maps in the `StartControllers` function in `pkg/microservice/aslan/core/service.go` ([link](https://github.com/koderover/zadig/pull/3178/files?diff=unified&w=0#diff-a74fa9c9aa31979c0e1634097c1a6b3e84ea13e0686ad037178b5d1208e9f9deL90-R91))
  * Removed the `policybundle.GenerateOPABundle()` function call from the `Start` function in `pkg/microservice/aslan/core/service.go` ([link](https://github.com/koderover/zadig/pull/3178/files?diff=unified&w=0#diff-a74fa9c9aa31979c0e1634097c1a6b3e84ea13e0686ad037178b5d1208e9f9deL178-R177))
  * Added the `initBundleGenerator()` function to the `core` package in `pkg/microservice/aslan/core/service.go` ([link](https://github.com/koderover/zadig/pull/3178/files?diff=unified&w=0#diff-a74fa9c9aa31979c0e1634097c1a6b3e84ea13e0686ad037178b5d1208e9f9deR230-R244))
  * Removed the `log` import and the `bundle.GenerateOPABundle()` function call from the `DownloadBundle` function in `pkg/microservice/policy/core/handler/bundle.go` ([link](https://github.com/koderover/zadig/pull/3178/files?diff=unified&w=0#diff-f0774551807a4f40ff967c85c832ad5d69f7dd3a7244d0524251603b4758e628L27-R29))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
