### PR TITLE
cherry pick #3171 to 2.0.0

### DIFF
--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -86,6 +86,7 @@ type ServiceResp struct {
 	ServiceDisplayName string       `json:"service_display_name"`
 	Type               string       `json:"type"`
 	Status             string       `json:"status"`
+	Error              string       `json:"error"`
 	Images             []string     `json:"images,omitempty"`
 	ProductName        string       `json:"product_name"`
 	EnvName            string       `json:"env_name"`

--- a/pkg/microservice/aslan/core/environment/service/k8s.go
+++ b/pkg/microservice/aslan/core/environment/service/k8s.go
@@ -350,6 +350,7 @@ func (k *K8sService) listGroupServices(allServices []*commonmodels.ProductServic
 				EnvName:        envName,
 				DeployStrategy: service.DeployStrategy,
 				Updatable:      service.Updatable,
+				Error:          service.Error,
 			}
 			serviceTmpl, err := repository.QueryTemplateService(&commonrepo.ServiceFindOption{
 				ServiceName: service.ServiceName,


### PR DESCRIPTION
* add error to list group func
* add render check before upsertService

---------

### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 70d69db</samp>

This pull request enhances the error handling and reporting of the service operations for updating Kubernetes resources of a product environment. It adds a new `Error` field to the `ServiceResp` type and assigns it the value of the `Error` field of the `Service` type, which is populated by the render check function. It also improves the logic of the environment update function in `environment_update.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 70d69db</samp>

*  Add `Error` field to `ServiceResp` type to store service operation error messages ([link](https://github.com/koderover/zadig/pull/3181/files?diff=unified&w=0#diff-43b4a5df02ef75087654902b8d4afc32745599d35053d171a5b950a94d012960R89))
*  Update `updateK8sProduct` function to handle service errors and return them as part of the product response ([link](https://github.com/koderover/zadig/pull/3181/files?diff=unified&w=0#diff-32522f742768b025f50f0278e3483c42f49374f507116c80571b6fcb806b80d1R429-R474))
   * Remove redundant assignment of error message to `productErrMsg` variable ([link](https://github.com/koderover/zadig/pull/3181/files?diff=unified&w=0#diff-32522f742768b025f50f0278e3483c42f49374f507116c80571b6fcb806b80d1L439))
*  Assign service error field to service response error field in `k8s.go` to return render check errors to caller ([link](https://github.com/koderover/zadig/pull/3181/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136R353))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
