### PR TITLE
Feature/remove sleep time

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/200.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/200.go
@@ -744,7 +744,6 @@ func migrateRendersets() error {
 					// ensure render is set, technically this should not happen
 					if svc.Render == nil {
 						log.Infof("migrateRendersets failed to find service render for product: %s/%s, service: %s, render info: %v/%v", env.ProductName, env.EnvName, svc.ServiceName, curRender.Name, curRender.Revision)
-						time.Sleep(time.Second * 1)
 						svc.Render = svc.GetServiceRender()
 					}
 				}


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a881c3</samp>

Removed `time.Sleep` from renderset migration loop in `pkg/cli/upgradeassistant/cmd/migrate/200.go`. This improves the performance and efficiency of the upgrade assistant feature for Zadig 1.6.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a881c3</samp>

*  Removed unnecessary delays from the migration loop (`[link](https://github.com/koderover/zadig/pull/3182/files?diff=unified&w=0#diff-7ec06042579da80c009448a3749eb09b67bd83e81dcb2f38f92ab9eddeb9e165L747)`). This improves the performance and efficiency of the upgrade assistant feature that helps users to upgrade their Zadig projects from version 1.5 to 1.6. The loop is located in the file `pkg/cli/upgradeassistant/cmd/migrate/200.go`.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
