### PR TITLE
fix share env issues

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2037,11 +2037,12 @@ func deleteK8sProductServices(productInfo *commonmodels.Product, serviceNames []
 			KubeClient:          kclient,
 			CurrentResourceYaml: serviceRelatedYaml[name],
 			Uninstall:           true,
+			WaitForUninstall:    true,
 		}
 		_, err = kube.CreateOrPatchResource(param, log)
 		if err != nil {
 			// Only record and do not block subsequent traversals.
-			log.Errorf("failed to remove k8s resources when deleting ervice: %s, err: %s", name, err)
+			log.Errorf("failed to remove k8s resources when deleting service: %s, err: %s", name, err)
 		}
 	}
 

--- a/pkg/microservice/aslan/core/multicluster/service/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/service/clusters.go
@@ -548,8 +548,8 @@ func UpdateCluster(id string, args *K8SCluster, logger *zap.SugaredLogger) (*com
 	// If the user chooses to use dynamically generated storage resources, the system automatically creates the PVC.
 	// TODO: If the PVC is not successfully bound to the PV, it is necessary to consider how to expose this abnormal information.
 	//       Depends on product design.
+	// TODO: Currently can't change cluster to right config, if previous config is wrong.
 	if args.Cache.MediumType == types.NFSMedium && args.Cache.NFSProperties.ProvisionType == types.DynamicProvision {
-
 		if id == setting.LocalClusterID {
 			args.DindCfg = nil
 		}

--- a/pkg/util/pointer.go
+++ b/pkg/util/pointer.go
@@ -28,6 +28,10 @@ func GetInt32Pointer(data int32) *int32 {
 	return &data
 }
 
+func GetInt64Pointer(data int64) *int64 {
+	return &data
+}
+
 func GetBoolFromPointer(source *bool) bool {
 	if source == nil {
 		return false


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 626970a</samp>

This pull request updates the `go.mod` file to use newer and more relevant Go modules for the project. It also adds a TODO comment in the `clusters.go` file to mark a limitation in the cluster update logic that needs to be fixed. These changes aim to improve the dependency management and the cluster management features of the `koderover/zadig` project.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 626970a</samp>

*  Update various Go module dependencies to newer versions ([link](https://github.com/koderover/zadig/pull/3184/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L29-R29), [link](https://github.com/koderover/zadig/pull/3184/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L87-R91), [link](https://github.com/koderover/zadig/pull/3184/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L99-R109), [link](https://github.com/koderover/zadig/pull/3184/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L138-R137), [link](https://github.com/koderover/zadig/pull/3184/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L156-R157), [link](https://github.com/koderover/zadig/pull/3184/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L173-R175), [link](https://github.com/koderover/zadig/pull/3184/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L261-R262), [link](https://github.com/koderover/zadig/pull/3184/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L284-R285), [link](https://github.com/koderover/zadig/pull/3184/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L295-R299), [link](https://github.com/koderover/zadig/pull/3184/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L306-R313))
*  Add new Go module dependencies for Google Cloud Compute Engine, OpenAPI models, and Enterprise Certificate Proxy ([link](https://github.com/koderover/zadig/pull/3184/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L115-R116), [link](https://github.com/koderover/zadig/pull/3184/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L186-R190), [link](https://github.com/koderover/zadig/pull/3184/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L197-R198))
*  Remove unused Go module dependencies for URL and character manipulation ([link](https://github.com/koderover/zadig/pull/3184/files?diff=unified&w=0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L126-L127))
*  Add a TODO comment to document a limitation in the `UpdateCluster` function in `clusters.go` ([link](https://github.com/koderover/zadig/pull/3184/files?diff=unified&w=0#diff-4e85c1af9762124c9c31e475d7a54712ffc81a99054ebef0ea2d97cd73ca6a8cL551-R552))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
