### PR TITLE
cherry pick #3186 to 2.0.0

### DIFF
--- a/pkg/microservice/aslan/core/environment/handler/kube.go
+++ b/pkg/microservice/aslan/core/environment/handler/kube.go
@@ -85,11 +85,6 @@ func DeletePod(c *gin.Context) {
 	envName := c.Query("envName")
 	productName := c.Query("projectName")
 
-	if err := commonutil.CheckZadigXLicenseStatus(); err != nil {
-		ctx.Err = err
-		return
-	}
-
 	internalhandler.InsertDetailedOperationLog(c, ctx.UserName, c.Query("projectName"), setting.OperationSceneEnv,
 		"重启", "环境-服务实例", fmt.Sprintf("环境名称:%s,pod名称:%s",
 			c.Query("envName"), c.Param("podName")), "", ctx.Logger, envName)


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bcb1af9</samp>

Removed ZadigX license check from `DeletePod` function in `kube.go`. This simplifies the pod deletion logic and improves performance.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bcb1af9</samp>

*  Remove license check from `DeletePod` function ([link](https://github.com/koderover/zadig/pull/3187/files?diff=unified&w=0#diff-a5cea4826aa345a878ca29c2d24b4c6777b2656c91c9e150efba27388e4d08edL88-L92)). This simplifies the logic and avoids unnecessary calls to the license service when deleting pods by name and namespace.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
