### PR TITLE
add portal service feature for share env

### DIFF
--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -784,6 +784,7 @@ func ListWorkloadDetails(envName, clusterID, namespace, productName string, perP
 		return 0, resp, e.ErrListGroups.AddDesc(err.Error())
 	}
 
+	// @note helm
 	hostInfos := make([]resource.HostInfo, 0)
 	if kubeclient.VersionLessThan122(version) {
 		ingresses, err := getter.ListExtensionsV1Beta1Ingresses(nil, informer)

--- a/pkg/microservice/aslan/core/common/service/kube/apply.go
+++ b/pkg/microservice/aslan/core/common/service/kube/apply.go
@@ -271,7 +271,7 @@ func removeResources(currentItems, newItems []*unstructured.Unstructured, namesp
 	return errList.ErrorOrNil()
 }
 
-func manifestToUnstructured(manifest string) ([]*unstructured.Unstructured, error) {
+func ManifestToUnstructured(manifest string) ([]*unstructured.Unstructured, error) {
 	if len(manifest) == 0 {
 		return nil, nil
 	}
@@ -299,13 +299,13 @@ func CreateOrPatchResource(applyParam *ResourceApplyParam, log *zap.SugaredLogge
 	kubeClient := applyParam.KubeClient
 	istioClient := applyParam.IstioClient
 
-	curResources, err := manifestToUnstructured(applyParam.CurrentResourceYaml)
+	curResources, err := ManifestToUnstructured(applyParam.CurrentResourceYaml)
 	if err != nil {
 		log.Errorf("Failed to convert currently deplyed resource yaml to Unstructured, manifest is\n%s\n, error: %v", applyParam.CurrentResourceYaml, err)
 		return nil, err
 	}
 
-	resources, err := manifestToUnstructured(applyParam.UpdateResourceYaml)
+	resources, err := ManifestToUnstructured(applyParam.UpdateResourceYaml)
 	if err != nil {
 		log.Errorf("Failed to convert yaml to Unstructured, manifest is\n%s\n, error: %v", applyParam.UpdateResourceYaml, err)
 		return nil, err

--- a/pkg/microservice/aslan/core/common/service/kube/share_env.go
+++ b/pkg/microservice/aslan/core/common/service/kube/share_env.go
@@ -504,7 +504,6 @@ func EnsureZadigServiceByManifest(ctx context.Context, productName, namespace, m
 		return nil
 	}
 
-	// @note helm
 	svcNames, err := util.GetSvcNamesFromManifest(manifest)
 	if err != nil {
 		return fmt.Errorf("failed to get Service names from manifest: %s", err)

--- a/pkg/microservice/aslan/core/common/service/kube/share_env.go
+++ b/pkg/microservice/aslan/core/common/service/kube/share_env.go
@@ -504,6 +504,7 @@ func EnsureZadigServiceByManifest(ctx context.Context, productName, namespace, m
 		return nil
 	}
 
+	// @note helm
 	svcNames, err := util.GetSvcNamesFromManifest(manifest)
 	if err != nil {
 		return fmt.Errorf("failed to get Service names from manifest: %s", err)

--- a/pkg/microservice/aslan/core/common/util/enviroment.go
+++ b/pkg/microservice/aslan/core/common/util/enviroment.go
@@ -209,3 +209,7 @@ func UpdateProductImage(envName, productName, serviceName string, targets map[st
 
 	return nil
 }
+
+func GenIstioGatewayName(serviceName string) string {
+	return fmt.Sprintf("%s-gateway-%s", "zadig", serviceName)
+}

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -269,8 +269,8 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		environments.POST("/:name/share/enable", EnableBaseEnv)
 		environments.DELETE("/:name/share/enable", DisableBaseEnv)
 		environments.GET("/:name/check/sharenv/:op/ready", CheckShareEnvReady)
-		environments.POST("/:name/share/setupPortal/:serviceName", SetupPortalService)
-		environments.GET("/:name/share/gatewayAddress", GetIstioGatewayAddress)
+		environments.GET("/:name/share/portal/:serviceName", GetPortalService)
+		environments.POST("/:name/share/portal/:serviceName", SetupPortalService)
 
 		environments.GET("/:name/services/:serviceName/pmexec", ConnectSshPmExec)
 

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -270,6 +270,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		environments.DELETE("/:name/share/enable", DisableBaseEnv)
 		environments.GET("/:name/check/sharenv/:op/ready", CheckShareEnvReady)
 		environments.POST("/:name/share/setupPortal/:serviceName", SetupPortalService)
+		environments.GET("/:name/share/gatewayAddress", GetIstioGatewayAddress)
 
 		environments.GET("/:name/services/:serviceName/pmexec", ConnectSshPmExec)
 

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -269,6 +269,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		environments.POST("/:name/share/enable", EnableBaseEnv)
 		environments.DELETE("/:name/share/enable", DisableBaseEnv)
 		environments.GET("/:name/check/sharenv/:op/ready", CheckShareEnvReady)
+		environments.POST("/:name/share/setupPortal/:serviceName", SetupPortalService)
 
 		environments.GET("/:name/services/:serviceName/pmexec", ConnectSshPmExec)
 

--- a/pkg/microservice/aslan/core/environment/handler/share_env.go
+++ b/pkg/microservice/aslan/core/environment/handler/share_env.go
@@ -162,6 +162,50 @@ func CheckShareEnvReady(c *gin.Context) {
 	ctx.Resp, ctx.Err = service.CheckShareEnvReady(c, envName, c.Param("op"), projectKey)
 }
 
+// @Summary Get Portal Service for Share Env
+// @Description Get Portal Service for Share Env
+// @Tags 	environment
+// @Accept 	json
+// @Produce json
+// @Param 	projectName		query		string									true	"project name"
+// @Param 	name			path		string									true	"env name"
+// @Param 	serviceName		path		string									true	"service name"
+// @Success 200 			{object} 	service.GetPortalServiceResponse
+// @Router /api/aslan/environment/environments/{name}/share/portal/{serviceName} [get]
+func GetPortalService(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	envName := c.Param("name")
+	serviceName := c.Param("serviceName")
+	projectKey := c.Query("projectName")
+
+	// authorization checks
+	if !ctx.Resources.IsSystemAdmin {
+		if _, ok := ctx.Resources.ProjectAuthInfo[projectKey]; !ok {
+			ctx.UnAuthorized = true
+			return
+		}
+		if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin &&
+			!ctx.Resources.ProjectAuthInfo[projectKey].Env.EditConfig {
+			permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, projectKey, types.ResourceTypeEnvironment, envName, types.EnvActionEditConfig)
+			if err != nil || !permitted {
+				ctx.UnAuthorized = true
+				return
+			}
+		}
+	}
+
+	ctx.Resp, ctx.Err = service.GetPortalService(c, projectKey, envName, serviceName)
+	return
+}
+
 // @Summary Setup Portal Service for Share Env
 // @Description Setup Portal Service for Share Env
 // @Tags 	environment
@@ -172,7 +216,7 @@ func CheckShareEnvReady(c *gin.Context) {
 // @Param 	serviceName		path		string									true	"service name"
 // @Param 	body 			body 		[]service.SetupPortalServiceRequest 	true 	"body"
 // @Success 200
-// @Router /api/aslan/environment/environments/{name}/share/setupPortal/{serviceName} [post]
+// @Router /api/aslan/environment/environments/{name}/share/portal/{serviceName} [post]
 func SetupPortalService(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
@@ -211,47 +255,5 @@ func SetupPortalService(c *gin.Context) {
 	}
 
 	ctx.Err = service.SetupPortalService(c, projectKey, envName, serviceName, req)
-	return
-}
-
-// @Summary Get Istio Gateway Address for Share Env
-// @Description Get Istio Gateway Address for Share Env
-// @Tags 	environment
-// @Accept 	json
-// @Produce json
-// @Param 	projectName		query		string									true	"project name"
-// @Param 	name			path		string									true	"env name"
-// @Success 200 		{object} 	service.GetIstioGatewayAddressResponse
-// @Router /api/aslan/environment/environments/{name}/share/gatewayAddress [get]
-func GetIstioGatewayAddress(c *gin.Context) {
-	ctx, err := internalhandler.NewContextWithAuthorization(c)
-	defer func() { internalhandler.JSONResponse(c, ctx) }()
-
-	if err != nil {
-		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
-		ctx.UnAuthorized = true
-		return
-	}
-
-	envName := c.Param("name")
-	projectKey := c.Query("projectName")
-
-	// authorization checks
-	if !ctx.Resources.IsSystemAdmin {
-		if _, ok := ctx.Resources.ProjectAuthInfo[projectKey]; !ok {
-			ctx.UnAuthorized = true
-			return
-		}
-		if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin &&
-			!ctx.Resources.ProjectAuthInfo[projectKey].Env.EditConfig {
-			permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, projectKey, types.ResourceTypeEnvironment, envName, types.EnvActionEditConfig)
-			if err != nil || !permitted {
-				ctx.UnAuthorized = true
-				return
-			}
-		}
-	}
-
-	ctx.Resp, ctx.Err = service.GetIstioGatewayAddress(c, projectKey, envName)
 	return
 }

--- a/pkg/microservice/aslan/core/environment/handler/share_env.go
+++ b/pkg/microservice/aslan/core/environment/handler/share_env.go
@@ -219,6 +219,8 @@ func SetupPortalService(c *gin.Context) {
 // @Tags 	environment
 // @Accept 	json
 // @Produce json
+// @Param 	projectName		query		string									true	"project name"
+// @Param 	name			path		string									true	"env name"
 // @Success 200 		{object} 	service.GetIstioGatewayAddressResponse
 // @Router /api/aslan/environment/environments/{name}/share/gatewayAddress [get]
 func GetIstioGatewayAddress(c *gin.Context) {

--- a/pkg/microservice/aslan/core/environment/handler/share_env.go
+++ b/pkg/microservice/aslan/core/environment/handler/share_env.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/gin-gonic/gin"
+	e "github.com/koderover/zadig/pkg/tool/errors"
 	"github.com/koderover/zadig/pkg/types"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/environment/service"
@@ -32,7 +33,6 @@ func CheckWorkloadsK8sServices(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	if err != nil {
-
 		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
 		ctx.UnAuthorized = true
 		return
@@ -65,7 +65,6 @@ func EnableBaseEnv(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	if err != nil {
-
 		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
 		ctx.UnAuthorized = true
 		return
@@ -100,7 +99,6 @@ func DisableBaseEnv(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	if err != nil {
-
 		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
 		ctx.UnAuthorized = true
 		return
@@ -137,7 +135,6 @@ func CheckShareEnvReady(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	if err != nil {
-
 		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
 		ctx.UnAuthorized = true
 		return
@@ -163,4 +160,56 @@ func CheckShareEnvReady(c *gin.Context) {
 	}
 
 	ctx.Resp, ctx.Err = service.CheckShareEnvReady(c, envName, c.Param("op"), projectKey)
+}
+
+// @Summary Setup Portal Service for Share Env
+// @Description Setup Portal Service for Share Env
+// @Tags 	environment
+// @Accept 	json
+// @Produce json
+// @Param 	projectName		query		string									true	"project name"
+// @Param 	name			path		string									true	"env name"
+// @Param 	serviceName		path		string									true	"service name"
+// @Param 	body 			body 		[]service.SetupPortalServiceRequest 	true 	"body"
+// @Success 200
+// @Router /api/aslan/environment/environments/{name}/share/setupPortal/{serviceName} [post]
+func SetupPortalService(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	envName := c.Param("name")
+	serviceName := c.Param("serviceName")
+	projectKey := c.Query("projectName")
+
+	// authorization checks
+	if !ctx.Resources.IsSystemAdmin {
+		if _, ok := ctx.Resources.ProjectAuthInfo[projectKey]; !ok {
+			ctx.UnAuthorized = true
+			return
+		}
+		if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin &&
+			!ctx.Resources.ProjectAuthInfo[projectKey].Env.EditConfig {
+			permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, projectKey, types.ResourceTypeEnvironment, envName, types.EnvActionEditConfig)
+			if err != nil || !permitted {
+				ctx.UnAuthorized = true
+				return
+			}
+		}
+	}
+
+	req := []service.SetupPortalServiceRequest{}
+	err = c.ShouldBindJSON(&req)
+	if err != nil {
+		ctx.Err = e.ErrInvalidParam.AddErr(err)
+		return
+	}
+
+	ctx.Err = service.SetupPortalService(c, projectKey, envName, serviceName, req)
+	return
 }

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2024,7 +2024,6 @@ func deleteK8sProductServices(productInfo *commonmodels.Product, serviceNames []
 		}
 
 		selector := labels.Set{setting.ProductLabel: productInfo.ProductName, setting.ServiceLabel: name}.AsSelector()
-
 		err = EnsureDeleteZadigService(ctx, productInfo, selector, kclient, istioClient)
 		if err != nil {
 			// Only record and do not block subsequent traversals.

--- a/pkg/microservice/aslan/core/environment/service/k8s.go
+++ b/pkg/microservice/aslan/core/environment/service/k8s.go
@@ -307,6 +307,7 @@ func (k *K8sService) listGroupServices(allServices []*commonmodels.ProductServic
 		return nil
 	}
 
+	// @note k8s
 	hostInfos := make([]resource.HostInfo, 0)
 	version, err := cls.Discovery().ServerVersion()
 	if err != nil {

--- a/pkg/microservice/aslan/core/environment/service/k8s.go
+++ b/pkg/microservice/aslan/core/environment/service/k8s.go
@@ -17,6 +17,7 @@ limitations under the License.
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -24,15 +25,16 @@ import (
 	"sync"
 	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-
 	"github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	versionedclient "istio.io/client-go/pkg/clientset/versioned"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,6 +56,7 @@ import (
 	"github.com/koderover/zadig/pkg/tool/kube/informer"
 	"github.com/koderover/zadig/pkg/tool/kube/serializer"
 	"github.com/koderover/zadig/pkg/tool/log"
+	zadigtypes "github.com/koderover/zadig/pkg/types"
 )
 
 type K8sService struct {
@@ -307,7 +310,6 @@ func (k *K8sService) listGroupServices(allServices []*commonmodels.ProductServic
 		return nil
 	}
 
-	// @note k8s
 	hostInfos := make([]resource.HostInfo, 0)
 	version, err := cls.Discovery().ServerVersion()
 	if err != nil {
@@ -332,6 +334,27 @@ func (k *K8sService) listGroupServices(allServices []*commonmodels.ProductServic
 		} else {
 			log.Warnf("Failed to list ingresses, the error is: %s", err)
 		}
+	}
+
+	restConfig, err := kubeclient.GetRESTConfig(config.HubServerAddress(), productInfo.ClusterID)
+	if err != nil {
+		log.Errorf("failed to get rest config: %s", err)
+		return nil
+	}
+	istioClient, err := versionedclient.NewForConfig(restConfig)
+	if err != nil {
+		log.Errorf("failed to new istio client: %s", err)
+		return nil
+	}
+	zadigLabels := map[string]string{
+		zadigtypes.ZadigLabelKeyGlobalOwner: zadigtypes.Zadig,
+	}
+	gwObjs, err := istioClient.NetworkingV1alpha3().Gateways(productInfo.Namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labels.FormatLabels(zadigLabels),
+	})
+	if err != nil {
+		log.Errorf("failed to list gateways in ns `%s`: %s", productInfo.Namespace, err)
+		return nil
 	}
 
 	// get all services
@@ -387,6 +410,10 @@ func (k *K8sService) listGroupServices(allServices []*commonmodels.ProductServic
 
 			} else {
 				gp.Status = setting.ClusterUnknown
+			}
+
+			gp.IstioGateway = &commonservice.IstioGatewayInfo{
+				Servers: commonservice.FindServiceFromIstioGateway(gwObjs, service.ServiceName),
 			}
 
 			mutex.Lock()

--- a/pkg/microservice/aslan/core/environment/service/share_env.go
+++ b/pkg/microservice/aslan/core/environment/service/share_env.go
@@ -1328,15 +1328,15 @@ func SetupPortalService(ctx context.Context, productName, envName, serviceName s
 
 	kclient, err := kubeclient.GetKubeClient(config.HubServerAddress(), clusterID)
 	if err != nil {
-		return fmt.Errorf("failed to get kube client: %s", err)
+		return e.ErrSetupPortalService.AddErr(fmt.Errorf("failed to get kube client: %s", err))
 	}
 	restConfig, err := kubeclient.GetRESTConfig(config.HubServerAddress(), clusterID)
 	if err != nil {
-		return fmt.Errorf("failed to get rest config: %s", err)
+		return e.ErrSetupPortalService.AddErr(fmt.Errorf("failed to get rest config: %s", err))
 	}
 	istioClient, err := versionedclient.NewForConfig(restConfig)
 	if err != nil {
-		return fmt.Errorf("failed to new istio client: %s", err)
+		return e.ErrSetupPortalService.AddErr(fmt.Errorf("failed to new istio client: %s", err))
 	}
 	gatewayName := fmt.Sprintf("zadig-gateway-%s", serviceName)
 
@@ -1501,9 +1501,47 @@ func SetupPortalService(ctx context.Context, productName, envName, serviceName s
 		}
 		_, err = istioClient.NetworkingV1alpha3().VirtualServices(ns).Update(ctx, vsObj, metav1.UpdateOptions{})
 		if err != nil {
-			e.ErrSetupPortalService.AddErr(fmt.Errorf("failed to update virtualservice %s in namespace %s, err: %v", vsName, ns, err))
+			return e.ErrSetupPortalService.AddErr(fmt.Errorf("failed to update virtualservice %s in namespace %s, err: %v", vsName, ns, err))
 		}
 	}
 
 	return nil
+}
+
+type GetIstioGatewayAddressResponse struct {
+	DefaultGatewayIP string `json:"default_gateway_ip"`
+}
+
+func GetIstioGatewayAddress(ctx context.Context, productName, envName string) (GetIstioGatewayAddressResponse, error) {
+	resp := GetIstioGatewayAddressResponse{}
+	env, err := commonrepo.NewProductColl().Find(&commonrepo.ProductFindOptions{
+		Name:    productName,
+		EnvName: envName,
+	})
+	if err != nil {
+		return resp, e.ErrGetIstioGatewayAddress.AddErr(fmt.Errorf("failed to query env %s of product %s: %s", envName, productName, err))
+	}
+	if !env.ShareEnv.Enable && !env.ShareEnv.IsBase {
+		return resp, e.ErrGetIstioGatewayAddress.AddDesc("%s doesn't enable share environment or is not base environment")
+	}
+
+	clusterID := env.ClusterID
+	kclient, err := kubeclient.GetKubeClient(config.HubServerAddress(), clusterID)
+	if err != nil {
+		return resp, e.ErrGetIstioGatewayAddress.AddErr(fmt.Errorf("failed to get kube client: %s", err))
+	}
+
+	gatewaySvc := &corev1.Service{}
+	err = kclient.Get(ctx, client.ObjectKey{
+		Name:      "istio-ingressgateway",
+		Namespace: "istio-system",
+	}, gatewaySvc)
+	if len(gatewaySvc.Status.LoadBalancer.Ingress) == 0 {
+		return resp, e.ErrGetIstioGatewayAddress.AddDesc("istio default gateway's lb doesn't have ip address")
+	}
+	for _, ing := range gatewaySvc.Status.LoadBalancer.Ingress {
+		resp.DefaultGatewayIP = ing.IP
+	}
+
+	return resp, nil
 }

--- a/pkg/microservice/aslan/core/environment/service/share_env.go
+++ b/pkg/microservice/aslan/core/environment/service/share_env.go
@@ -1335,6 +1335,72 @@ func CheckServicesDeployedInSubEnvs(ctx context.Context, productName, envName st
 	return svcsInSubEnvs, nil
 }
 
+type GetPortalServiceResponse struct {
+	DefaultGatewayIP string                      `json:"default_gateway_ip"`
+	Servers          []SetupPortalServiceRequest `json:"servers"`
+}
+
+func GetPortalService(ctx context.Context, productName, envName, serviceName string) (GetPortalServiceResponse, error) {
+	resp := GetPortalServiceResponse{}
+	env, err := commonrepo.NewProductColl().Find(&commonrepo.ProductFindOptions{
+		Name:    productName,
+		EnvName: envName,
+	})
+	if err != nil {
+		return resp, e.ErrSetupPortalService.AddErr(fmt.Errorf("failed to query env %s of product %s: %s", envName, productName, err))
+	}
+	if !env.ShareEnv.Enable && !env.ShareEnv.IsBase {
+		return resp, e.ErrSetupPortalService.AddDesc("%s doesn't enable share environment or is not base environment")
+	}
+
+	ns := env.Namespace
+	clusterID := env.ClusterID
+
+	kclient, err := kubeclient.GetKubeClient(config.HubServerAddress(), clusterID)
+	if err != nil {
+		return resp, e.ErrSetupPortalService.AddErr(fmt.Errorf("failed to get kube client: %s", err))
+	}
+	restConfig, err := kubeclient.GetRESTConfig(config.HubServerAddress(), clusterID)
+	if err != nil {
+		return resp, e.ErrSetupPortalService.AddErr(fmt.Errorf("failed to get rest config: %s", err))
+	}
+	istioClient, err := versionedclient.NewForConfig(restConfig)
+	if err != nil {
+		return resp, e.ErrSetupPortalService.AddErr(fmt.Errorf("failed to new istio client: %s", err))
+	}
+
+	gatewayName := genGatewayName(serviceName)
+	gatewaySvc := &corev1.Service{}
+	err = kclient.Get(ctx, client.ObjectKey{
+		Name:      "istio-ingressgateway",
+		Namespace: "istio-system",
+	}, gatewaySvc)
+	if len(gatewaySvc.Status.LoadBalancer.Ingress) == 0 {
+		return resp, e.ErrGetIstioGatewayAddress.AddDesc("istio default gateway's lb doesn't have ip address")
+	}
+	for _, ing := range gatewaySvc.Status.LoadBalancer.Ingress {
+	resp.DefaultGatewayIP = ing.IP
+	}
+
+	gwObj, err := istioClient.NetworkingV1alpha3().Gateways(ns).Get(ctx, gatewayName, metav1.GetOptions{})
+	if err != nil {
+		return resp, e.ErrSetupPortalService.AddErr(fmt.Errorf("failed to get gateway %s in namespace %s, err: %w", gatewayName, ns, err))
+	}
+
+	for _, server := range gwObj.Spec.Servers {
+		if len(server.Hosts) == 0 {
+			return resp, e.ErrSetupPortalService.AddDesc("can't find any host in istio gateway")
+		}
+		resp.Servers = append(resp.Servers, SetupPortalServiceRequest{
+			Host:         server.Hosts[0],
+			PortNumber:   server.Port.Number,
+			PortProtocol: server.Port.Protocol,
+		})
+	}
+
+	return resp, nil
+}
+
 type SetupPortalServiceRequest struct {
 	Host         string `json:"host"`
 	PortNumber   uint32 `json:"port_number"`
@@ -1439,7 +1505,6 @@ func SetupPortalService(ctx context.Context, productName, envName, serviceName s
 	// 3. change the related virtualservice
 	svcs := []*corev1.Service{}
 	deployType := templateProd.ProductFeature.GetDeployType()
-	log.Debugf("deployType: %v", deployType)
 	if deployType == setting.K8SDeployType {
 		prodSvc := env.GetServiceMap()[serviceName]
 		if prodSvc == nil {
@@ -1542,42 +1607,4 @@ func SetupPortalService(ctx context.Context, productName, envName, serviceName s
 	}
 
 	return nil
-}
-
-type GetIstioGatewayAddressResponse struct {
-	DefaultGatewayIP string `json:"default_gateway_ip"`
-}
-
-func GetIstioGatewayAddress(ctx context.Context, productName, envName string) (GetIstioGatewayAddressResponse, error) {
-	resp := GetIstioGatewayAddressResponse{}
-	env, err := commonrepo.NewProductColl().Find(&commonrepo.ProductFindOptions{
-		Name:    productName,
-		EnvName: envName,
-	})
-	if err != nil {
-		return resp, e.ErrGetIstioGatewayAddress.AddErr(fmt.Errorf("failed to query env %s of product %s: %s", envName, productName, err))
-	}
-	if !env.ShareEnv.Enable && !env.ShareEnv.IsBase {
-		return resp, e.ErrGetIstioGatewayAddress.AddDesc("%s doesn't enable share environment or is not base environment")
-	}
-
-	clusterID := env.ClusterID
-	kclient, err := kubeclient.GetKubeClient(config.HubServerAddress(), clusterID)
-	if err != nil {
-		return resp, e.ErrGetIstioGatewayAddress.AddErr(fmt.Errorf("failed to get kube client: %s", err))
-	}
-
-	gatewaySvc := &corev1.Service{}
-	err = kclient.Get(ctx, client.ObjectKey{
-		Name:      "istio-ingressgateway",
-		Namespace: "istio-system",
-	}, gatewaySvc)
-	if len(gatewaySvc.Status.LoadBalancer.Ingress) == 0 {
-		return resp, e.ErrGetIstioGatewayAddress.AddDesc("istio default gateway's lb doesn't have ip address")
-	}
-	for _, ing := range gatewaySvc.Status.LoadBalancer.Ingress {
-		resp.DefaultGatewayIP = ing.IP
-	}
-
-	return resp, nil
 }

--- a/pkg/microservice/aslan/server/rest/doc/docs.go
+++ b/pkg/microservice/aslan/server/rest/doc/docs.go
@@ -779,9 +779,9 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/aslan/environment/environments/{name}/share/gatewayAddress": {
+        "/api/aslan/environment/environments/{name}/share/portal/{serviceName}": {
             "get": {
-                "description": "Get Istio Gateway Address for Share Env",
+                "description": "Get Portal Service for Share Env",
                 "consumes": [
                     "application/json"
                 ],
@@ -791,7 +791,7 @@ const docTemplate = `{
                 "tags": [
                     "environment"
                 ],
-                "summary": "Get Istio Gateway Address for Share Env",
+                "summary": "Get Portal Service for Share Env",
                 "parameters": [
                     {
                         "type": "string",
@@ -806,19 +806,24 @@ const docTemplate = `{
                         "name": "name",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "service name",
+                        "name": "serviceName",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/service.GetIstioGatewayAddressResponse"
+                            "$ref": "#/definitions/service.GetPortalServiceResponse"
                         }
                     }
                 }
-            }
-        },
-        "/api/aslan/environment/environments/{name}/share/setupPortal/{serviceName}": {
+            },
             "post": {
                 "description": "Setup Portal Service for Share Env",
                 "consumes": [
@@ -6895,11 +6900,17 @@ const docTemplate = `{
                 }
             }
         },
-        "service.GetIstioGatewayAddressResponse": {
+        "service.GetPortalServiceResponse": {
             "type": "object",
             "properties": {
                 "default_gateway_ip": {
                     "type": "string"
+                },
+                "servers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/service.SetupPortalServiceRequest"
+                    }
                 }
             }
         },

--- a/pkg/microservice/aslan/server/rest/doc/docs.go
+++ b/pkg/microservice/aslan/server/rest/doc/docs.go
@@ -7074,6 +7074,31 @@ const docTemplate = `{
                 }
             }
         },
+        "service.IstioGatewayInfo": {
+            "type": "object",
+            "properties": {
+                "servers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/service.IstioGatewayServer"
+                    }
+                }
+            }
+        },
+        "service.IstioGatewayServer": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string"
+                },
+                "port_number": {
+                    "type": "integer"
+                },
+                "port_protocol": {
+                    "type": "string"
+                }
+            }
+        },
         "service.JiraProjectsResp": {
             "type": "object",
             "properties": {
@@ -7707,6 +7732,9 @@ const docTemplate = `{
                 },
                 "is_helm_chart_deploy": {
                     "type": "boolean"
+                },
+                "istio_gateway": {
+                    "$ref": "#/definitions/service.IstioGatewayInfo"
                 },
                 "product_name": {
                     "type": "string"

--- a/pkg/microservice/aslan/server/rest/doc/docs.go
+++ b/pkg/microservice/aslan/server/rest/doc/docs.go
@@ -779,6 +779,29 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/aslan/environment/environments/{name}/share/gatewayAddress": {
+            "get": {
+                "description": "Get Istio Gateway Address for Share Env",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Get Istio Gateway Address for Share Env",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.GetIstioGatewayAddressResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/aslan/environment/environments/{name}/share/setupPortal/{serviceName}": {
             "post": {
                 "description": "Setup Portal Service for Share Env",
@@ -6853,6 +6876,14 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "service.GetIstioGatewayAddressResponse": {
+            "type": "object",
+            "properties": {
+                "default_gateway_ip": {
+                    "type": "string"
                 }
             }
         },

--- a/pkg/microservice/aslan/server/rest/doc/docs.go
+++ b/pkg/microservice/aslan/server/rest/doc/docs.go
@@ -779,6 +779,61 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/aslan/environment/environments/{name}/share/setupPortal/{serviceName}": {
+            "post": {
+                "description": "Setup Portal Service for Share Env",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Setup Portal Service for Share Env",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "service name",
+                        "name": "serviceName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/service.SetupPortalServiceRequest"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/api/aslan/environment/environments/{name}/sleep": {
             "post": {
                 "description": "Environment Sleep",
@@ -7580,6 +7635,9 @@ const docTemplate = `{
                         "$ref": "#/definitions/models.EnvStatus"
                     }
                 },
+                "error": {
+                    "type": "string"
+                },
                 "images": {
                     "type": "array",
                     "items": {
@@ -7628,6 +7686,20 @@ const docTemplate = `{
                 },
                 "zadigx_release_type": {
                     "description": "ZadigXReleaseType represents the service contain created by zadigx release workflow\nfrontend should limit some operations on these services",
+                    "type": "string"
+                }
+            }
+        },
+        "service.SetupPortalServiceRequest": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string"
+                },
+                "port_number": {
+                    "type": "integer"
+                },
+                "port_protocol": {
                     "type": "string"
                 }
             }

--- a/pkg/microservice/aslan/server/rest/doc/docs.go
+++ b/pkg/microservice/aslan/server/rest/doc/docs.go
@@ -792,6 +792,22 @@ const docTemplate = `{
                     "environment"
                 ],
                 "summary": "Get Istio Gateway Address for Share Env",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/pkg/microservice/aslan/server/rest/doc/swagger.json
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.json
@@ -770,6 +770,61 @@
                 }
             }
         },
+        "/api/aslan/environment/environments/{name}/share/setupPortal/{serviceName}": {
+            "post": {
+                "description": "Setup Portal Service for Share Env",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Setup Portal Service for Share Env",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "service name",
+                        "name": "serviceName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/service.SetupPortalServiceRequest"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/api/aslan/environment/environments/{name}/sleep": {
             "post": {
                 "description": "Environment Sleep",
@@ -7571,6 +7626,9 @@
                         "$ref": "#/definitions/models.EnvStatus"
                     }
                 },
+                "error": {
+                    "type": "string"
+                },
                 "images": {
                     "type": "array",
                     "items": {
@@ -7619,6 +7677,20 @@
                 },
                 "zadigx_release_type": {
                     "description": "ZadigXReleaseType represents the service contain created by zadigx release workflow\nfrontend should limit some operations on these services",
+                    "type": "string"
+                }
+            }
+        },
+        "service.SetupPortalServiceRequest": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string"
+                },
+                "port_number": {
+                    "type": "integer"
+                },
+                "port_protocol": {
                     "type": "string"
                 }
             }

--- a/pkg/microservice/aslan/server/rest/doc/swagger.json
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.json
@@ -770,9 +770,9 @@
                 }
             }
         },
-        "/api/aslan/environment/environments/{name}/share/gatewayAddress": {
+        "/api/aslan/environment/environments/{name}/share/portal/{serviceName}": {
             "get": {
-                "description": "Get Istio Gateway Address for Share Env",
+                "description": "Get Portal Service for Share Env",
                 "consumes": [
                     "application/json"
                 ],
@@ -782,7 +782,7 @@
                 "tags": [
                     "environment"
                 ],
-                "summary": "Get Istio Gateway Address for Share Env",
+                "summary": "Get Portal Service for Share Env",
                 "parameters": [
                     {
                         "type": "string",
@@ -797,19 +797,24 @@
                         "name": "name",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "service name",
+                        "name": "serviceName",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/service.GetIstioGatewayAddressResponse"
+                            "$ref": "#/definitions/service.GetPortalServiceResponse"
                         }
                     }
                 }
-            }
-        },
-        "/api/aslan/environment/environments/{name}/share/setupPortal/{serviceName}": {
+            },
             "post": {
                 "description": "Setup Portal Service for Share Env",
                 "consumes": [
@@ -6886,11 +6891,17 @@
                 }
             }
         },
-        "service.GetIstioGatewayAddressResponse": {
+        "service.GetPortalServiceResponse": {
             "type": "object",
             "properties": {
                 "default_gateway_ip": {
                     "type": "string"
+                },
+                "servers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/service.SetupPortalServiceRequest"
+                    }
                 }
             }
         },

--- a/pkg/microservice/aslan/server/rest/doc/swagger.json
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.json
@@ -7065,6 +7065,31 @@
                 }
             }
         },
+        "service.IstioGatewayInfo": {
+            "type": "object",
+            "properties": {
+                "servers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/service.IstioGatewayServer"
+                    }
+                }
+            }
+        },
+        "service.IstioGatewayServer": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string"
+                },
+                "port_number": {
+                    "type": "integer"
+                },
+                "port_protocol": {
+                    "type": "string"
+                }
+            }
+        },
         "service.JiraProjectsResp": {
             "type": "object",
             "properties": {
@@ -7698,6 +7723,9 @@
                 },
                 "is_helm_chart_deploy": {
                     "type": "boolean"
+                },
+                "istio_gateway": {
+                    "$ref": "#/definitions/service.IstioGatewayInfo"
                 },
                 "product_name": {
                     "type": "string"

--- a/pkg/microservice/aslan/server/rest/doc/swagger.json
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.json
@@ -770,6 +770,29 @@
                 }
             }
         },
+        "/api/aslan/environment/environments/{name}/share/gatewayAddress": {
+            "get": {
+                "description": "Get Istio Gateway Address for Share Env",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Get Istio Gateway Address for Share Env",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.GetIstioGatewayAddressResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/aslan/environment/environments/{name}/share/setupPortal/{serviceName}": {
             "post": {
                 "description": "Setup Portal Service for Share Env",
@@ -6844,6 +6867,14 @@
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "service.GetIstioGatewayAddressResponse": {
+            "type": "object",
+            "properties": {
+                "default_gateway_ip": {
+                    "type": "string"
                 }
             }
         },

--- a/pkg/microservice/aslan/server/rest/doc/swagger.json
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.json
@@ -783,6 +783,22 @@
                     "environment"
                 ],
                 "summary": "Get Istio Gateway Address for Share Env",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/pkg/microservice/aslan/server/rest/doc/swagger.yaml
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.yaml
@@ -2007,6 +2007,8 @@ definitions:
         items:
           $ref: '#/definitions/models.EnvStatus'
         type: array
+      error:
+        type: string
       images:
         items:
           type: string
@@ -2042,6 +2044,15 @@ definitions:
         description: |-
           ZadigXReleaseType represents the service contain created by zadigx release workflow
           frontend should limit some operations on these services
+        type: string
+    type: object
+  service.SetupPortalServiceRequest:
+    properties:
+      host:
+        type: string
+      port_number:
+        type: integer
+      port_protocol:
         type: string
     type: object
   service.SvcDiffResult:
@@ -2927,6 +2938,43 @@ paths:
           schema:
             $ref: '#/definitions/service.SvcDiffResult'
       summary: Preview service
+      tags:
+      - environment
+  /api/aslan/environment/environments/{name}/share/setupPortal/{serviceName}:
+    post:
+      consumes:
+      - application/json
+      description: Setup Portal Service for Share Env
+      parameters:
+      - description: project name
+        in: query
+        name: projectName
+        required: true
+        type: string
+      - description: env name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: service name
+        in: path
+        name: serviceName
+        required: true
+        type: string
+      - description: body
+        in: body
+        name: body
+        required: true
+        schema:
+          items:
+            $ref: '#/definitions/service.SetupPortalServiceRequest'
+          type: array
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Setup Portal Service for Share Env
       tags:
       - environment
   /api/aslan/environment/environments/{name}/sleep:

--- a/pkg/microservice/aslan/server/rest/doc/swagger.yaml
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.yaml
@@ -1500,6 +1500,11 @@ definitions:
           type: string
         type: array
     type: object
+  service.GetIstioGatewayAddressResponse:
+    properties:
+      default_gateway_ip:
+        type: string
+    type: object
   service.GetReleaseInstanceDeployStatusResponse:
     properties:
       chart_name:
@@ -2938,6 +2943,21 @@ paths:
           schema:
             $ref: '#/definitions/service.SvcDiffResult'
       summary: Preview service
+      tags:
+      - environment
+  /api/aslan/environment/environments/{name}/share/gatewayAddress:
+    get:
+      consumes:
+      - application/json
+      description: Get Istio Gateway Address for Share Env
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/service.GetIstioGatewayAddressResponse'
+      summary: Get Istio Gateway Address for Share Env
       tags:
       - environment
   /api/aslan/environment/environments/{name}/share/setupPortal/{serviceName}:

--- a/pkg/microservice/aslan/server/rest/doc/swagger.yaml
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.yaml
@@ -1500,10 +1500,14 @@ definitions:
           type: string
         type: array
     type: object
-  service.GetIstioGatewayAddressResponse:
+  service.GetPortalServiceResponse:
     properties:
       default_gateway_ip:
         type: string
+      servers:
+        items:
+          $ref: '#/definitions/service.SetupPortalServiceRequest'
+        type: array
     type: object
   service.GetReleaseInstanceDeployStatusResponse:
     properties:
@@ -2945,11 +2949,11 @@ paths:
       summary: Preview service
       tags:
       - environment
-  /api/aslan/environment/environments/{name}/share/gatewayAddress:
+  /api/aslan/environment/environments/{name}/share/portal/{serviceName}:
     get:
       consumes:
       - application/json
-      description: Get Istio Gateway Address for Share Env
+      description: Get Portal Service for Share Env
       parameters:
       - description: project name
         in: query
@@ -2961,17 +2965,21 @@ paths:
         name: name
         required: true
         type: string
+      - description: service name
+        in: path
+        name: serviceName
+        required: true
+        type: string
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/service.GetIstioGatewayAddressResponse'
-      summary: Get Istio Gateway Address for Share Env
+            $ref: '#/definitions/service.GetPortalServiceResponse'
+      summary: Get Portal Service for Share Env
       tags:
       - environment
-  /api/aslan/environment/environments/{name}/share/setupPortal/{serviceName}:
     post:
       consumes:
       - application/json

--- a/pkg/microservice/aslan/server/rest/doc/swagger.yaml
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.yaml
@@ -2950,6 +2950,17 @@ paths:
       consumes:
       - application/json
       description: Get Istio Gateway Address for Share Env
+      parameters:
+      - description: project name
+        in: query
+        name: projectName
+        required: true
+        type: string
+      - description: env name
+        in: path
+        name: name
+        required: true
+        type: string
       produces:
       - application/json
       responses:

--- a/pkg/microservice/aslan/server/rest/doc/swagger.yaml
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.yaml
@@ -1613,6 +1613,22 @@ definitions:
           $ref: '#/definitions/resource.HostInfo'
         type: array
     type: object
+  service.IstioGatewayInfo:
+    properties:
+      servers:
+        items:
+          $ref: '#/definitions/service.IstioGatewayServer'
+        type: array
+    type: object
+  service.IstioGatewayServer:
+    properties:
+      host:
+        type: string
+      port_number:
+        type: integer
+      port_protocol:
+        type: string
+    type: object
   service.JiraProjectsResp:
     properties:
       key:
@@ -2026,6 +2042,8 @@ definitions:
         $ref: '#/definitions/service.IngressInfo'
       is_helm_chart_deploy:
         type: boolean
+      istio_gateway:
+        $ref: '#/definitions/service.IstioGatewayInfo'
       product_name:
         type: string
       ready:

--- a/pkg/tool/errors/http_errors.go
+++ b/pkg/tool/errors/http_errors.go
@@ -178,6 +178,7 @@ var (
 	ErrDiffEnvServiceVersions    = NewHTTPError(6079, "Diff环境服务版本失败")
 	ErrRollbackEnvServiceVersion = NewHTTPError(6079, "回滚环境服务版本失败")
 	ErrSetupPortalService        = NewHTTPError(6079, "设置入口服务失败")
+	ErrGetIstioGatewayAddress    = NewHTTPError(6079, "获取Istio Gateway地址失败")
 
 	//-----------------------------------------------------------------------------------------------
 	// Product Service APIs Range: 6080 - 6099 AND 6150 -6199

--- a/pkg/tool/errors/http_errors.go
+++ b/pkg/tool/errors/http_errors.go
@@ -177,6 +177,7 @@ var (
 	ErrListEnvServiceVersions    = NewHTTPError(6079, "列出环境服务版本失败")
 	ErrDiffEnvServiceVersions    = NewHTTPError(6079, "Diff环境服务版本失败")
 	ErrRollbackEnvServiceVersion = NewHTTPError(6079, "回滚环境服务版本失败")
+	ErrSetupPortalService        = NewHTTPError(6079, "设置入口服务失败")
 
 	//-----------------------------------------------------------------------------------------------
 	// Product Service APIs Range: 6080 - 6099 AND 6150 -6199

--- a/pkg/tool/errors/http_errors.go
+++ b/pkg/tool/errors/http_errors.go
@@ -178,7 +178,7 @@ var (
 	ErrDiffEnvServiceVersions    = NewHTTPError(6079, "Diff环境服务版本失败")
 	ErrRollbackEnvServiceVersion = NewHTTPError(6079, "回滚环境服务版本失败")
 	ErrSetupPortalService        = NewHTTPError(6079, "设置入口服务失败")
-	ErrGetIstioGatewayAddress    = NewHTTPError(6079, "获取Istio Gateway地址失败")
+	ErrGetPortalService          = NewHTTPError(6079, "获取入口服务配置失败")
 
 	//-----------------------------------------------------------------------------------------------
 	// Product Service APIs Range: 6080 - 6099 AND 6150 -6199


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 56411cd</samp>

Added a new feature to set up portal service for share environment. This feature allows users to configure the portal service settings for a given project, environment and service. Exported a function to convert YAML manifests to Kubernetes unstructured objects. Refactored and documented some existing code. Added a new API endpoint, route, and error for the feature.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 56411cd</samp>

*  Rename `manifestToUnstructured` to `ManifestToUnstructured` and update function calls ([link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L274-R274), [link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L302-R302), [link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L308-R308))
*  Add a new route for setting up portal service for share environment ([link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-bc855cdae7fd5951f2dd616071a0a85b20273c7a89fc1725f032de2b17ff7bd7R272))
*  Add a new function `SetupPortalService` to handle the logic of setting up portal service for share environment ([link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-26dddb32e101161b1f0e05ef51f67d0cccec1f24f45b218835be1ebc2dce461fR164-R215), [link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-22190d4add8462b956413294f5d90b8d79a762060450aba68aca2311dc71ce1dR1301-R1485))
*  Add a new HTTP handler for the `SetupPortalService` function ([link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-26dddb32e101161b1f0e05ef51f67d0cccec1f24f45b218835be1ebc2dce461fL103))
*  Add a new HTTP error for setting up portal service ([link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-754ac2982cab78c22f57f226133df3f1092fc72a6d1133a1331864479a935773R180))
*  Add a new API definition for the `SetupPortalService` endpoint ([link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62R782-R836), [link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62R7693-R7706), [link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216R773-R827), [link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216R7684-R7697), [link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2R2010-R2011), [link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2R2049-R2057), [link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2R2943-R2979))
*  Add a new error field to the `commonmodels.Response` struct ([link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62R7638-R7640), [link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216R7629-R7631), [link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2R2010-R2011))
*  Add a comment to indicate the helm deployment code ([link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-cc7fb5841e25af5acc225a53fd6c59207d13b470ca23d89feadd724c4e8a48bdR507))
*  Remove some empty lines for code style consistency ([link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-26dddb32e101161b1f0e05ef51f67d0cccec1f24f45b218835be1ebc2dce461fL35), [link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-26dddb32e101161b1f0e05ef51f67d0cccec1f24f45b218835be1ebc2dce461fL68), [link](https://github.com/koderover/zadig/pull/3192/files?diff=unified&w=0#diff-26dddb32e101161b1f0e05ef51f67d0cccec1f24f45b218835be1ebc2dce461fL140))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
