### PR TITLE
add transaction support for env service operation

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/env_svc_version.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/env_svc_version.go
@@ -32,13 +32,18 @@ import (
 
 type EnvVersionColl struct {
 	*mongo.Collection
-
+	mongo.Session
 	coll string
 }
 
 func NewEnvServiceVersionColl() *EnvVersionColl {
 	name := models.EnvServiceVersion{}.TableName()
 	return &EnvVersionColl{Collection: mongotool.Database(config.MongoDatabase()).Collection(name), coll: name}
+}
+
+func NewEnvServiceVersionCollWithSession(session mongo.Session) *EnvVersionColl {
+	name := models.EnvServiceVersion{}.TableName()
+	return &EnvVersionColl{Collection: mongotool.Database(config.MongoDatabase()).Collection(name), Session: session, coll: name}
 }
 
 func (c *EnvVersionColl) GetCollectionName() string {
@@ -180,7 +185,7 @@ func (c *EnvVersionColl) DeleteRevisions(productName, envName, serviceName strin
 		query["service.service_name"] = serviceName
 	}
 
-	_, err := c.DeleteMany(context.TODO(), query)
+	_, err := c.DeleteMany(mongotool.SessionContext(context.TODO(), c.Session), query)
 
 	return err
 }
@@ -194,7 +199,7 @@ func (c *EnvVersionColl) Create(args *models.EnvServiceVersion) error {
 	now := time.Now().Unix()
 	args.CreateTime = now
 	args.UpdateTime = now
-	_, err := c.InsertOne(context.TODO(), args)
+	_, err := c.InsertOne(mongotool.SessionContext(context.TODO(), c.Session), args)
 
 	return err
 }

--- a/pkg/microservice/aslan/core/common/repository/mongodb/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/product.go
@@ -381,7 +381,7 @@ func (c *ProductColl) UpdateGlobalVariable(args *models.Product) error {
 		"global_variables": args.GlobalVariables,
 	}
 	change := bson.M{"$set": changePayload}
-	_, err := c.UpdateOne(context.TODO(), query, change)
+	_, err := c.UpdateOne(mongotool.SessionContext(context.TODO(), c.Session), query, change)
 	return err
 }
 
@@ -409,7 +409,7 @@ func (c *ProductColl) Update(args *models.Product) error {
 		changePayload["pre_sleep_status"] = args.PreSleepStatus
 	}
 	change := bson.M{"$set": changePayload}
-	_, err := c.UpdateOne(context.TODO(), query, change)
+	_, err := c.UpdateOne(mongotool.SessionContext(context.TODO(), c.Session), query, change)
 	return err
 }
 
@@ -440,7 +440,7 @@ func (c *ProductColl) UpdateGroup(envName, productName string, groupIndex int, g
 		serviceGroup:  group,
 	}
 
-	_, err := c.UpdateOne(context.TODO(), query, bson.M{"$set": change})
+	_, err := c.UpdateOne(mongotool.SessionContext(context.TODO(), c.Session), query, bson.M{"$set": change})
 
 	return err
 }
@@ -471,7 +471,7 @@ func (c *ProductColl) UpdateDeployStrategy(envName, productName string, deploySt
 		"service_deploy_strategy": deployStrategy,
 	}
 
-	_, err := c.UpdateOne(context.TODO(), query, bson.M{"$set": change})
+	_, err := c.UpdateOne(mongotool.SessionContext(context.TODO(), c.Session), query, bson.M{"$set": change})
 
 	return err
 }

--- a/pkg/microservice/aslan/core/common/repository/mongodb/production_service.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/production_service.go
@@ -36,6 +36,7 @@ import (
 
 type ProductionServiceColl struct {
 	*mongo.Collection
+	mongo.Session
 	coll string
 }
 
@@ -43,6 +44,15 @@ func NewProductionServiceColl() *ProductionServiceColl {
 	name := "production_template_service"
 	return &ProductionServiceColl{
 		Collection: mongotool.Database(config.MongoDatabase()).Collection(name),
+		coll:       name,
+	}
+}
+
+func NewProductionServiceCollWithSession(session mongo.Session) *ProductionServiceColl {
+	name := "production_template_service"
+	return &ProductionServiceColl{
+		Collection: mongotool.Database(config.MongoDatabase()).Collection(name),
+		Session:    session,
 		coll:       name,
 	}
 }
@@ -270,7 +280,7 @@ func (c *ProductionServiceColl) Update(args *models.Service) error {
 		changeMap["env_statuses"] = args.EnvStatuses
 	}
 	change := bson.M{"$set": changeMap}
-	_, err := c.UpdateOne(context.TODO(), query, change)
+	_, err := c.UpdateOne(mongotool.SessionContext(context.TODO(), c.Session), query, change)
 	return err
 }
 

--- a/pkg/microservice/aslan/core/common/service/kube/helm.go
+++ b/pkg/microservice/aslan/core/common/service/kube/helm.go
@@ -25,12 +25,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/koderover/zadig/pkg/tool/mongo"
-
-	"go.uber.org/zap"
-
 	helmclient "github.com/mittwald/go-helm-client"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	versionedclient "istio.io/client-go/pkg/clientset/versioned"
@@ -52,6 +49,7 @@ import (
 	helmtool "github.com/koderover/zadig/pkg/tool/helmclient"
 	kubeutil "github.com/koderover/zadig/pkg/tool/kube/util"
 	"github.com/koderover/zadig/pkg/tool/log"
+	"github.com/koderover/zadig/pkg/tool/mongo"
 	"github.com/koderover/zadig/pkg/types"
 	"github.com/koderover/zadig/pkg/util"
 	"github.com/koderover/zadig/pkg/util/fs"

--- a/pkg/microservice/aslan/core/common/service/repository/service.go
+++ b/pkg/microservice/aslan/core/common/service/repository/service.go
@@ -19,6 +19,7 @@ package repository
 import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 func QueryTemplateService(option *mongodb.ServiceFindOption, production bool) (*models.Service, error) {
@@ -88,6 +89,14 @@ func Update(service *models.Service, production bool) error {
 		return mongodb.NewServiceColl().Update(service)
 	} else {
 		return mongodb.NewProductionServiceColl().Update(service)
+	}
+}
+
+func UpdateWithSession(service *models.Service, production bool, session mongo.Session) error {
+	if !production {
+		return mongodb.NewServiceCollWithSession(session).Update(service)
+	} else {
+		return mongodb.NewProductionServiceCollWithSession(session).Update(service)
 	}
 }
 

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_env.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_env.go
@@ -21,11 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/koderover/zadig/pkg/tool/mongo"
-
 	"github.com/pkg/errors"
-
-	"github.com/koderover/zadig/pkg/util/converter"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/template"
@@ -36,6 +32,8 @@ import (
 	commonutil "github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/tool/log"
+	"github.com/koderover/zadig/pkg/tool/mongo"
+	"github.com/koderover/zadig/pkg/util/converter"
 )
 
 type ProductServiceDeployInfo struct {

--- a/pkg/microservice/aslan/core/common/util/enviroment.go
+++ b/pkg/microservice/aslan/core/common/util/enviroment.go
@@ -1,9 +1,12 @@
 package util
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
+
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
@@ -170,9 +173,17 @@ func UpdateProductImage(envName, productName, serviceName string, targets map[st
 		}
 	}
 
+	session := mongotool.Session()
+	defer session.EndSession(context.TODO())
+
+	err = session.StartTransaction()
+	if err != nil {
+		return err
+	}
+
 	service := prod.GetServiceMap()[serviceName]
 	if service != nil {
-		err = CreateEnvServiceVersion(prod, service, userName, log.SugaredLogger())
+		err = CreateEnvServiceVersion(prod, service, userName, session, log.SugaredLogger())
 		if err != nil {
 			log.Errorf("CreateK8SEnvServiceVersion error: %v", err)
 		}
@@ -180,8 +191,9 @@ func UpdateProductImage(envName, productName, serviceName string, targets map[st
 		log.Errorf("service %s not found in prod %s/%s", serviceName, prod.ProductName, prod.EnvName)
 	}
 
-	templateProject, err := templaterepo.NewProductColl().Find(productName)
+	templateProject, err := templaterepo.NewProductCollWithSess(session).Find(productName)
 	if err != nil {
+		session.AbortTransaction(context.TODO())
 		return fmt.Errorf("find template project %s error: %v", productName, err)
 	}
 
@@ -191,21 +203,24 @@ func UpdateProductImage(envName, productName, serviceName string, targets map[st
 			ProductName: productName,
 		}, prod.Production)
 		if err != nil {
+			session.AbortTransaction(context.TODO())
 			return fmt.Errorf("find template service %s/%s, production %v, error: %v", productName, serviceName, prod.Production, err)
 		}
 
 		tmplSvc.DeployTime = time.Now().Unix()
-		err = repository.Update(tmplSvc, prod.Production)
+		err = repository.UpdateWithSession(tmplSvc, prod.Production, session)
 		if err != nil {
+			session.AbortTransaction(context.TODO())
 			return fmt.Errorf("update template service %s/%s, production %v, error: %v", productName, serviceName, prod.Production, err)
 		}
 	}
 
-	if err := commonrepo.NewProductColl().Update(prod); err != nil {
+	if err := commonrepo.NewProductCollWithSession(session).Update(prod); err != nil {
 		errMsg := fmt.Sprintf("[%s][%s] update product image error: %v", prod.EnvName, prod.ProductName, err)
 		logger.Errorf(errMsg)
+		session.AbortTransaction(context.TODO())
 		return errors.New(errMsg)
 	}
 
-	return nil
+	return session.CommitTransaction(context.TODO())
 }

--- a/pkg/microservice/aslan/core/common/util/enviroment.go
+++ b/pkg/microservice/aslan/core/common/util/enviroment.go
@@ -6,18 +6,18 @@ import (
 	"fmt"
 	"time"
 
-	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	templaterepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb/template"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/repository"
 	"github.com/koderover/zadig/pkg/tool/log"
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
 	"github.com/koderover/zadig/pkg/util"
 	"github.com/koderover/zadig/pkg/util/converter"
-	"go.uber.org/zap"
-	"gopkg.in/yaml.v2"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func IsServiceVarsWildcard(serviceVars []string) bool {

--- a/pkg/microservice/aslan/core/common/util/version.go
+++ b/pkg/microservice/aslan/core/common/util/version.go
@@ -3,6 +3,8 @@ package util
 import (
 	"fmt"
 
+	"go.mongodb.org/mongo-driver/mongo"
+
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
@@ -12,12 +14,12 @@ import (
 	"go.uber.org/zap"
 )
 
-func GenerateEnvServiceNextRevision(projectName, envName, serviceName string, isHelmChart bool) (int64, error) {
+func GenerateEnvServiceNextRevision(projectName, envName, serviceName string, isHelmChart bool, session mongo.Session) (int64, error) {
 	counterName := fmt.Sprintf(setting.EnvServiceVersionCounterName, projectName, envName, serviceName, isHelmChart)
-	return commonrepo.NewCounterColl().GetNextSeq(counterName)
+	return commonrepo.NewCounterCollWithSession(session).GetNextSeq(counterName)
 }
 
-func CreateEnvServiceVersion(env *models.Product, prodSvc *models.ProductService, createBy string, log *zap.SugaredLogger) error {
+func CreateEnvServiceVersion(env *models.Product, prodSvc *models.ProductService, createBy string, session mongo.Session, log *zap.SugaredLogger) error {
 	name := prodSvc.ServiceName
 	isHelmChart := !prodSvc.FromZadig()
 	if isHelmChart {
@@ -36,11 +38,12 @@ func CreateEnvServiceVersion(env *models.Product, prodSvc *models.ProductService
 		prodSvc.ReleaseName = releaseName
 	}
 
-	revision, err := GenerateEnvServiceNextRevision(env.ProductName, env.EnvName, name, isHelmChart)
+	revision, err := GenerateEnvServiceNextRevision(env.ProductName, env.EnvName, name, isHelmChart, session)
 	if err != nil {
 		return fmt.Errorf("failed to generate service %s/%s/%s revision, error: %v", env.ProductName, env.EnvName, name, err)
 	}
 
+	svcVersionColl := mongodb.NewEnvServiceVersionCollWithSession(session)
 	version := &models.EnvServiceVersion{
 		ProductName:     env.ProductName,
 		EnvName:         env.EnvName,
@@ -53,7 +56,7 @@ func CreateEnvServiceVersion(env *models.Product, prodSvc *models.ProductService
 		YamlData:        env.YamlData,
 		CreateBy:        createBy,
 	}
-	err = mongodb.NewEnvServiceVersionColl().Create(version)
+	err = svcVersionColl.Create(version)
 	if err != nil {
 		return fmt.Errorf("failed to create service %s/%s/%s version %d, error: %v", env.ProductName, env.EnvName, name, revision, err)
 	}
@@ -62,7 +65,7 @@ func CreateEnvServiceVersion(env *models.Product, prodSvc *models.ProductService
 
 	if revision > 20 {
 		// delete old version
-		err = mongodb.NewEnvServiceVersionColl().DeleteRevisions(env.ProductName, env.EnvName, name, isHelmChart, env.Production, revision-20)
+		err = svcVersionColl.DeleteRevisions(env.ProductName, env.EnvName, name, isHelmChart, env.Production, revision-20)
 		if err != nil {
 			log.Errorf("failed to delete service %s/%s/%s version less equal than %d, error: %v", env.ProductName, env.EnvName, name, revision-20, err)
 		}

--- a/pkg/microservice/aslan/core/common/util/version.go
+++ b/pkg/microservice/aslan/core/common/util/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.uber.org/zap"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
@@ -11,7 +12,6 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/repository"
 	"github.com/koderover/zadig/pkg/setting"
 	"github.com/koderover/zadig/pkg/util"
-	"go.uber.org/zap"
 )
 
 func GenerateEnvServiceNextRevision(projectName, envName, serviceName string, isHelmChart bool, session mongo.Session) (int64, error) {

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -28,13 +28,8 @@ import (
 	"sync"
 	"time"
 
-	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
-
-	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/render"
-
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/go-multierror"
-	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/msg_queue"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.uber.org/zap"
@@ -52,6 +47,7 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/ai"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/msg_queue"
 	templatemodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models/template"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
@@ -63,6 +59,7 @@ import (
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/imnotify"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/kube"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/notify"
+	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/render"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/repository"
 	commontypes "github.com/koderover/zadig/pkg/microservice/aslan/core/common/types"
 	commonutil "github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
@@ -76,6 +73,7 @@ import (
 	"github.com/koderover/zadig/pkg/tool/kube/serializer"
 	"github.com/koderover/zadig/pkg/tool/kube/updater"
 	"github.com/koderover/zadig/pkg/tool/log"
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
 	"github.com/koderover/zadig/pkg/types"
 	"github.com/koderover/zadig/pkg/util"
 	"github.com/koderover/zadig/pkg/util/boolptr"

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -28,6 +28,8 @@ import (
 	"sync"
 	"time"
 
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
+
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/common/service/render"
 
 	"github.com/cenkalti/backoff/v4"
@@ -376,6 +378,14 @@ func updateProductImpl(updateRevisionSvcs []string, deployStrategy map[string]st
 		return e.ErrUpdateEnv.AddDesc(err.Error())
 	}
 
+	session := mongotool.Session()
+	defer session.EndSession(context.TODO())
+
+	err = session.StartTransaction()
+	if err != nil {
+		return e.ErrUpdateEnv.AddErr(err)
+	}
+
 	// 遍历产品环境和产品模板交叉对比的结果
 	// 四个状态：待删除，待添加，待更新，无需更新
 	//var deletedServices []string
@@ -408,6 +418,7 @@ func updateProductImpl(updateRevisionSvcs []string, deployStrategy map[string]st
 
 	if err := commonrepo.NewProductColl().UpdateStatus(envName, productName, setting.ProductStatusUpdating); err != nil {
 		log.Errorf("[%s][P:%s] Product.UpdateStatus error: %v", envName, productName, err)
+		session.AbortTransaction(context.TODO())
 		return e.ErrUpdateEnv.AddDesc(e.UpdateEnvStatusErrMsg)
 	}
 
@@ -475,7 +486,7 @@ func updateProductImpl(updateRevisionSvcs []string, deployStrategy map[string]st
 						service.Error = ""
 					}
 
-					err = commonutil.CreateEnvServiceVersion(updateProd, service, user, log)
+					err = commonutil.CreateEnvServiceVersion(updateProd, service, user, session, log)
 					if err != nil {
 						log.Errorf("CreateK8SEnvServiceVersion error: %v", err)
 					}
@@ -485,18 +496,20 @@ func updateProductImpl(updateRevisionSvcs []string, deployStrategy map[string]st
 		}
 		wg.Wait()
 
-		err = commonrepo.NewProductColl().UpdateGroup(envName, productName, groupIndex, groupSvcs)
+		err = commonrepo.NewProductCollWithSession(session).UpdateGroup(envName, productName, groupIndex, groupSvcs)
 		if err != nil {
 			log.Errorf("Failed to update collection - service group %d. Error: %v", groupIndex, err)
 			err = e.ErrUpdateEnv.AddDesc(err.Error())
+			session.AbortTransaction(context.TODO())
 			return
 		}
 	}
 
-	err = commonrepo.NewProductColl().UpdateGlobalVariable(updateProd)
+	err = commonrepo.NewProductCollWithSession(session).UpdateGlobalVariable(updateProd)
 	if err != nil {
 		log.Errorf("failed to update product globalvariable error: %v", err)
 		err = e.ErrUpdateEnv.AddDesc(err.Error())
+		session.AbortTransaction(context.TODO())
 		return
 	}
 
@@ -509,15 +522,16 @@ func updateProductImpl(updateRevisionSvcs []string, deployStrategy map[string]st
 				existedProd.ServiceDeployStrategy[k] = v
 			}
 		}
-		err = commonrepo.NewProductColl().UpdateDeployStrategy(envName, productName, existedProd.ServiceDeployStrategy)
+		err = commonrepo.NewProductCollWithSession(session).UpdateDeployStrategy(envName, productName, existedProd.ServiceDeployStrategy)
 		if err != nil {
 			log.Errorf("Failed to update deploy strategy data, error: %v", err)
 			err = e.ErrUpdateEnv.AddDesc(err.Error())
+			session.AbortTransaction(context.TODO())
 			return
 		}
 	}
 
-	return nil
+	return session.CommitTransaction(context.TODO())
 }
 
 func UpdateProductRegistry(envName, productName, registryID string, log *zap.SugaredLogger) (err error) {
@@ -2765,13 +2779,22 @@ func findRenderChartFromList(svc *commonmodels.ProductService, renderCharts []*t
 // @todo merge with UpgradeHelmRelease
 func proceedHelmRelease(productResp *commonmodels.Product, helmClient *helmtool.HelmClient, filter svcUpgradeFilter, user string, log *zap.SugaredLogger) error {
 	productName, envName := productResp.ProductName, productResp.EnvName
+
+	session := mongotool.Session()
+	defer session.EndSession(context.TODO())
+
+	err := session.StartTransaction()
+	if err != nil {
+		return err
+	}
+
 	handler := func(param *kube.ReleaseInstallParam, isRetry bool, log *zap.SugaredLogger) (err error) {
 		defer func() {
 			if param.ProdService != nil {
 				if err != nil {
 					param.ProdService.Error = err.Error()
 				} else {
-					err = commonutil.CreateEnvServiceVersion(productResp, param.ProdService, user, log)
+					err = commonutil.CreateEnvServiceVersion(productResp, param.ProdService, user, session, log)
 					if err != nil {
 						log.Errorf("failed to create service version, err: %v", err)
 					}
@@ -2829,6 +2852,7 @@ func proceedHelmRelease(productResp *commonmodels.Product, helmClient *helmtool.
 			param, err := buildInstallParam(productResp.DefaultValues, productResp, chartInfo, prodSvc)
 			if err != nil {
 				log.Errorf("failed to generate install param, service: %s, namespace: %s, err: %s", prodSvc.ServiceName, productResp.Namespace, err)
+				session.AbortTransaction(context.TODO())
 				return err
 			}
 			prodSvc.Render = chartInfo
@@ -2839,11 +2863,16 @@ func proceedHelmRelease(productResp *commonmodels.Product, helmClient *helmtool.
 		if groupServiceErr != nil {
 			errList = multierror.Append(errList, groupServiceErr...)
 		}
-		err := commonrepo.NewProductColl().UpdateGroup(envName, productName, groupIndex, groupServices)
+		err := commonrepo.NewProductCollWithSession(session).UpdateGroup(envName, productName, groupIndex, groupServices)
 		if err != nil {
 			log.Errorf("Failed to update service group %d. Error: %v", groupIndex, err)
+			session.AbortTransaction(context.TODO())
 			return err
 		}
+	}
+	err = session.CommitTransaction(context.TODO())
+	if err != nil {
+		return err
 	}
 	return errList.ErrorOrNil()
 }

--- a/pkg/microservice/aslan/core/environment/service/image.go
+++ b/pkg/microservice/aslan/core/environment/service/image.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
-
 	"go.uber.org/zap"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
@@ -37,6 +35,7 @@ import (
 	e "github.com/koderover/zadig/pkg/tool/errors"
 	"github.com/koderover/zadig/pkg/tool/kube/updater"
 	"github.com/koderover/zadig/pkg/tool/log"
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
 )
 
 type UpdateContainerImageArgs struct {

--- a/pkg/microservice/aslan/core/environment/service/k8s.go
+++ b/pkg/microservice/aslan/core/environment/service/k8s.go
@@ -25,17 +25,14 @@ import (
 	"sync"
 	"time"
 
-	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
-
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-
 	"github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	versionedclient "istio.io/client-go/pkg/clientset/versioned"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,6 +54,7 @@ import (
 	"github.com/koderover/zadig/pkg/tool/kube/informer"
 	"github.com/koderover/zadig/pkg/tool/kube/serializer"
 	"github.com/koderover/zadig/pkg/tool/log"
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
 )
 
 type K8sService struct {

--- a/pkg/microservice/aslan/core/environment/service/k8s.go
+++ b/pkg/microservice/aslan/core/environment/service/k8s.go
@@ -17,12 +17,15 @@ limitations under the License.
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -225,22 +228,34 @@ func (k *K8sService) updateService(args *SvcOptArgs) error {
 
 	exitedProd.ServiceDeployStrategy = commonutil.SetServiceDeployStrategyDepoly(exitedProd.ServiceDeployStrategy, args.ServiceName)
 
+	session := mongotool.Session()
+	defer session.EndSession(context.Background())
+
+	err = session.StartTransaction()
+	if err != nil {
+		return e.ErrUpdateProduct.AddErr(err)
+	}
+
+	productColl := commonrepo.NewProductCollWithSession(session)
+
 	// Note update logic need to be optimized since we only need to update one service
-	if err := commonrepo.NewProductColl().Update(exitedProd); err != nil {
+	if err := productColl.Update(exitedProd); err != nil {
 		k.log.Errorf("[%s][%s] Product.Update error: %v", args.EnvName, args.ProductName, err)
-		return e.ErrUpdateProduct
+		session.AbortTransaction(context.Background())
+		return e.ErrUpdateProduct.AddErr(err)
 	}
 
-	if err := commonrepo.NewProductColl().UpdateGlobalVariable(exitedProd); err != nil {
+	if err := productColl.UpdateGlobalVariable(exitedProd); err != nil {
 		k.log.Errorf("[%s][%s] Product.UpdateGlobalVariable error: %v", args.EnvName, args.ProductName, err)
-		return e.ErrUpdateProduct
+		session.AbortTransaction(context.Background())
+		return e.ErrUpdateProduct.AddErr(err)
 	}
 
-	if err := commonutil.CreateEnvServiceVersion(exitedProd, newProductSvc, args.UpdateBy, k.log); err != nil {
+	if err := commonutil.CreateEnvServiceVersion(exitedProd, newProductSvc, args.UpdateBy, session, k.log); err != nil {
 		k.log.Errorf("[%s][%s] Product.CreateEnvServiceVersion for service %s error: %v", args.EnvName, args.ProductName, args.ServiceName, err)
 	}
 
-	return nil
+	return session.CommitTransaction(context.Background())
 }
 
 func (k *K8sService) calculateProductStatus(productInfo *commonmodels.Product, informer informers.SharedInformerFactory) (string, error) {
@@ -645,7 +660,7 @@ func (k *K8sService) createGroup(username string, product *commonmodels.Product,
 				lock.Unlock()
 			}
 
-			err = commonutil.CreateEnvServiceVersion(product, svc, username, k.log)
+			err = commonutil.CreateEnvServiceVersion(product, svc, username, nil, k.log)
 			if err != nil {
 				log.Errorf("failed to create env service version for service %s/%s, error: %v", product.EnvName, svc.ServiceName, err)
 			}

--- a/pkg/microservice/aslan/core/environment/service/version.go
+++ b/pkg/microservice/aslan/core/environment/service/version.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
-
 	"go.uber.org/zap"
 	versionedclient "istio.io/client-go/pkg/clientset/versioned"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -38,6 +36,7 @@ import (
 	e "github.com/koderover/zadig/pkg/tool/errors"
 	helmtool "github.com/koderover/zadig/pkg/tool/helmclient"
 	"github.com/koderover/zadig/pkg/tool/kube/informer"
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
 )
 
 type ListEnvServiceVersionsResponse struct {

--- a/pkg/microservice/aslan/core/environment/service/version.go
+++ b/pkg/microservice/aslan/core/environment/service/version.go
@@ -17,7 +17,10 @@ limitations under the License.
 package service
 
 import (
+	"context"
 	"fmt"
+
+	mongotool "github.com/koderover/zadig/pkg/tool/mongo"
 
 	"go.uber.org/zap"
 	versionedclient "istio.io/client-go/pkg/clientset/versioned"
@@ -241,7 +244,15 @@ func RollbackEnvServiceVersion(ctx *internalhandler.Context, projectName, envNam
 			return e.ErrRollbackEnvServiceVersion.AddErr(fmt.Errorf("failed to create or patch resource for env %s, service %s, revision %d, error: %v", envSvcVersion.EnvName, envSvcVersion.Service.ServiceName, envSvcVersion.Service.Revision, err))
 		}
 
-		err = commonutil.CreateEnvServiceVersion(env, envSvcVersion.Service, ctx.UserName, log)
+		session := mongotool.Session()
+		defer session.EndSession(context.Background())
+
+		err = session.StartTransaction()
+		if err != nil {
+			return e.ErrRollbackEnvServiceVersion.AddErr(err)
+		}
+
+		err = commonutil.CreateEnvServiceVersion(env, envSvcVersion.Service, ctx.UserName, session, log)
 		if err != nil {
 			log.Errorf("failed to create env service version for service %s/%s, error: %v", envSvcVersion.EnvName, envSvcVersion.Service.ServiceName, err)
 		}
@@ -262,12 +273,14 @@ func RollbackEnvServiceVersion(ctx *internalhandler.Context, projectName, envNam
 			}
 		}
 		if groupIndex < 0 || svcIndex < 0 {
+			session.AbortTransaction(context.Background())
 			return e.ErrRollbackEnvServiceVersion.AddErr(fmt.Errorf("failed to find service %s in env %s/%s, isProudction %v", envSvcVersion.Service.ServiceName, envSvcVersion.ProductName, envSvcVersion.EnvName, envSvcVersion.Production))
 		}
 
 		env.Services[groupIndex][svcIndex] = envSvcVersion.Service
-		err = commonrepo.NewProductColl().UpdateGroup(envName, projectName, groupIndex, env.Services[groupIndex])
+		err = commonrepo.NewProductCollWithSession(session).UpdateGroup(envName, projectName, groupIndex, env.Services[groupIndex])
 		if err != nil {
+			session.AbortTransaction(context.Background())
 			return e.ErrRollbackEnvServiceVersion.AddErr(fmt.Errorf("failed to update service %s in env %s/%s, isProudction %v", envSvcVersion.Service.ServiceName, envSvcVersion.ProductName, envSvcVersion.EnvName, envSvcVersion.Production))
 		}
 
@@ -278,9 +291,14 @@ func RollbackEnvServiceVersion(ctx *internalhandler.Context, projectName, envNam
 			}
 			globalKV.RelatedServices = relatedServiceSet.List()
 		}
-		err = commonrepo.NewProductColl().UpdateGlobalVariable(env)
+		err = commonrepo.NewProductCollWithSession(session).UpdateGlobalVariable(env)
 		if err != nil {
+			session.AbortTransaction(context.Background())
 			return e.ErrRollbackEnvServiceVersion.AddErr(fmt.Errorf("failed to update global variables in env %s/%s, isProudction %v", envSvcVersion.ProductName, envSvcVersion.EnvName, envSvcVersion.Production))
+		}
+		err = session.CommitTransaction(context.Background())
+		if err != nil {
+			return e.ErrRollbackEnvServiceVersion.AddErr(err)
 		}
 	} else if envSvcVersion.Service.Type == setting.HelmDeployType || envSvcVersion.Service.Type == setting.HelmChartDeployType {
 		var svcTmpl *commonmodels.Service


### PR DESCRIPTION
### What this PR does / Why we need it:
add transaction support for env service operation

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f152de</samp>

*  Add `mongo.Session` fields to various collection types to support MongoDB transactions ([link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-723a1bcc96cd9e49c61752790ae3c12b4faaa8efde2bced05c54010ce2951a7bL34-R34), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-ea1d5cac2e6e037dcc9246907bafd09cce7eab723c7dca9e43a08a220644c68fL35-R35), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-1ad3c4da0aa92f32013570e108079300e5a06f5d09f98bd82a07d860ac08d8dcR39))
*  Add functions to create collection instances with a given session ([link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-723a1bcc96cd9e49c61752790ae3c12b4faaa8efde2bced05c54010ce2951a7bR46-R54), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-ea1d5cac2e6e037dcc9246907bafd09cce7eab723c7dca9e43a08a220644c68fR44-R48), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-1ad3c4da0aa92f32013570e108079300e5a06f5d09f98bd82a07d860ac08d8dcR51-R59))
*  Modify database operations to use session contexts instead of background contexts ([link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-723a1bcc96cd9e49c61752790ae3c12b4faaa8efde2bced05c54010ce2951a7bL62-R71), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-ea1d5cac2e6e037dcc9246907bafd09cce7eab723c7dca9e43a08a220644c68fL183-R188), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-ea1d5cac2e6e037dcc9246907bafd09cce7eab723c7dca9e43a08a220644c68fL197-R202), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-150810b9b9a9ae4e2d85ea333a4ca97a7ca4ca8c02b80ff11d17cc853f75ba14L384-R384), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-150810b9b9a9ae4e2d85ea333a4ca97a7ca4ca8c02b80ff11d17cc853f75ba14L412-R412), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-150810b9b9a9ae4e2d85ea333a4ca97a7ca4ca8c02b80ff11d17cc853f75ba14L443-R443), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-150810b9b9a9ae4e2d85ea333a4ca97a7ca4ca8c02b80ff11d17cc853f75ba14L474-R474), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-1ad3c4da0aa92f32013570e108079300e5a06f5d09f98bd82a07d860ac08d8dcL273-R283))
*  Import `mongo` and `context` packages to use `mongo.Session` type and `context` functions ([link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-622e96cd3987393e3ae95185c4555f59f3b3ace6292ef497487eb0e7b383a722R28-R29), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-85d85a4e1e87ca8b020ba4e490c1ea1f5440c40d9193e4cc121af19b5e42a774R22), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-595392e64f1b99c3b9a86378055f808d9fcc8dac2db18369742bd4a8b31af07aL20-R25), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-f47c0a20e012ef2548ef6631ca90301c9eb29005eab5ff1269c4fe4df14997c1L4-R10), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-b03f222a39be8927774718b859444ce55ef162576d7b994ea20771b2a7fca3d8R6-R7), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24R31-R32), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-ec03ae2e652b194c605abd596fd18e1dc1696d9d51d0c3145137b483806f0436L20-R25), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136R20), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136R28-R29), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-c282f3a3ba6b7c450a15a42671e0eb40be4bdcb38d32311d3f3fc606d51e6ac2L20-R24))
*  Add `UpdateWithSession` function to update a service with a session and production flag ([link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-85d85a4e1e87ca8b020ba4e490c1ea1f5440c40d9193e4cc121af19b5e42a774R95-R102))
*  Modify `GenerateEnvServiceNextRevision` and `CreateEnvServiceVersion` functions to accept a session parameter and use collections with the session ([link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-b03f222a39be8927774718b859444ce55ef162576d7b994ea20771b2a7fca3d8L15-R22), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-b03f222a39be8927774718b859444ce55ef162576d7b994ea20771b2a7fca3d8L39-R46), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-b03f222a39be8927774718b859444ce55ef162576d7b994ea20771b2a7fca3d8L56-R59), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-b03f222a39be8927774718b859444ce55ef162576d7b994ea20771b2a7fca3d8L65-R68))
*  Modify `UpgradeHelmRelease` function to create a session and a transaction before updating the product and service versions, and to abort or commit the transaction depending on the outcome ([link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-622e96cd3987393e3ae95185c4555f59f3b3ace6292ef497487eb0e7b383a722L315-R336), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-622e96cd3987393e3ae95185c4555f59f3b3ace6292ef497487eb0e7b383a722L345-R364))
*  Modify `UpdateProductServiceDeployInfo` function to create a session and a transaction before updating the product and service versions, and to abort or commit the transaction depending on the outcome ([link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-595392e64f1b99c3b9a86378055f808d9fcc8dac2db18369742bd4a8b31af07aR123-R130), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-595392e64f1b99c3b9a86378055f808d9fcc8dac2db18369742bd4a8b31af07aL149-R165), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-595392e64f1b99c3b9a86378055f808d9fcc8dac2db18369742bd4a8b31af07aL169-R182), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-595392e64f1b99c3b9a86378055f808d9fcc8dac2db18369742bd4a8b31af07aL200-R218))
*  Modify `UpdateProductImage` function to create a session and a transaction before updating the product and service versions, and to abort or commit the transaction depending on the outcome ([link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-f47c0a20e012ef2548ef6631ca90301c9eb29005eab5ff1269c4fe4df14997c1L173-R186), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-f47c0a20e012ef2548ef6631ca90301c9eb29005eab5ff1269c4fe4df14997c1L183-R196), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-f47c0a20e012ef2548ef6631ca90301c9eb29005eab5ff1269c4fe4df14997c1L194-R225))
*  Modify `updateProductImpl` function to create a session and a transaction before updating the product and service versions, and to abort or commit the transaction depending on the outcome ([link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24R381-R388), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24R421), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L478-R489), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L488-R512), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L512-R534))
*  Modify `proceedHelmRelease` function to create a session and a transaction before updating the product and service versions, and to abort or commit the transaction depending on the outcome ([link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24R2782-R2790), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L2774-R2797), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24R2855), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L2842-R2876))
*  Modify `UpdateContainerImage` function to create a session and a transaction before updating the product and service versions, and to abort or commit the transaction depending on the outcome ([link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-ec03ae2e652b194c605abd596fd18e1dc1696d9d51d0c3145137b483806f0436L162-R183))
*  Modify `updateService` function to create a session and a transaction before updating the product and service versions, and to abort or commit the transaction depending on the outcome ([link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136L228-R258))
*  Modify `createGroup` function to pass a nil session to `CreateEnvServiceVersion` function, since it does not need a transaction ([link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136L648-R663))
*  Modify `RollbackEnvServiceVersion` function to create a session and a transaction before creating the service version and updating the product info, and to abort or commit the transaction depending on the outcome ([link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-c282f3a3ba6b7c450a15a42671e0eb40be4bdcb38d32311d3f3fc606d51e6ac2L244-R256), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-c282f3a3ba6b7c450a15a42671e0eb40be4bdcb38d32311d3f3fc606d51e6ac2L265-R283), [link](https://github.com/koderover/zadig/pull/3194/files?diff=unified&w=0#diff-c282f3a3ba6b7c450a15a42671e0eb40be4bdcb38d32311d3f3fc606d51e6ac2L281-R302))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
