### PR TITLE
fixing caching error when using object storage cache in product workflow

### DIFF
--- a/pkg/microservice/reaper/core/service/reaper/reaper.go
+++ b/pkg/microservice/reaper/core/service/reaper/reaper.go
@@ -114,7 +114,7 @@ func (r *Reaper) CompressCache(storageURI string) error {
 	cacheDir := r.ActiveWorkspace
 	if r.Ctx.CacheDirType == types.UserDefinedCacheDir {
 		// Note: Product supports using environment variables, so we need to parsing the directory path here.
-		cacheDir = r.renderUserEnv(r.Ctx.CacheUserDir)
+		cacheDir = r.renderUserEnv(fmt.Sprintf("%s/%s", "$WORKSPACE", r.Ctx.CacheUserDir))
 	}
 
 	log.Infof("Data in `%s` will be cached.", cacheDir)

--- a/pkg/microservice/reaper/core/service/reaper/reaper.go
+++ b/pkg/microservice/reaper/core/service/reaper/reaper.go
@@ -114,7 +114,7 @@ func (r *Reaper) CompressCache(storageURI string) error {
 	cacheDir := r.ActiveWorkspace
 	if r.Ctx.CacheDirType == types.UserDefinedCacheDir {
 		// Note: Product supports using environment variables, so we need to parsing the directory path here.
-		fmt.Println(11111111111111111111111)
+		fmt.Println("11111111111111111111111")
 		cacheDir = r.renderUserEnv(fmt.Sprintf("%s/%s", "/workspace", r.Ctx.CacheUserDir))
 	}
 

--- a/pkg/microservice/reaper/core/service/reaper/reaper.go
+++ b/pkg/microservice/reaper/core/service/reaper/reaper.go
@@ -114,7 +114,6 @@ func (r *Reaper) CompressCache(storageURI string) error {
 	cacheDir := r.ActiveWorkspace
 	if r.Ctx.CacheDirType == types.UserDefinedCacheDir {
 		// Note: Product supports using environment variables, so we need to parsing the directory path here.
-		fmt.Println("11111111111111111111111")
 		cacheDir = r.renderUserEnv(fmt.Sprintf("%s/%s", "/workspace", r.Ctx.CacheUserDir))
 	}
 

--- a/pkg/microservice/reaper/core/service/reaper/reaper.go
+++ b/pkg/microservice/reaper/core/service/reaper/reaper.go
@@ -114,7 +114,7 @@ func (r *Reaper) CompressCache(storageURI string) error {
 	cacheDir := r.ActiveWorkspace
 	if r.Ctx.CacheDirType == types.UserDefinedCacheDir {
 		// Note: Product supports using environment variables, so we need to parsing the directory path here.
-		cacheDir = r.renderUserEnv(fmt.Sprintf("%s/%s", "$WORKSPACE", r.Ctx.CacheUserDir))
+		cacheDir = r.renderUserEnv(fmt.Sprintf("%s/%s", "/workspace", r.Ctx.CacheUserDir))
 	}
 
 	log.Infof("Data in `%s` will be cached.", cacheDir)

--- a/pkg/microservice/reaper/core/service/reaper/reaper.go
+++ b/pkg/microservice/reaper/core/service/reaper/reaper.go
@@ -114,6 +114,7 @@ func (r *Reaper) CompressCache(storageURI string) error {
 	cacheDir := r.ActiveWorkspace
 	if r.Ctx.CacheDirType == types.UserDefinedCacheDir {
 		// Note: Product supports using environment variables, so we need to parsing the directory path here.
+		fmt.Println(11111111111111111111111)
 		cacheDir = r.renderUserEnv(fmt.Sprintf("%s/%s", "/workspace", r.Ctx.CacheUserDir))
 	}
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 00defbf</samp>

Allow users to customize cache directory for builds. Modify `cacheDir` in `reaper.go` to use `$WORKSPACE` as the base path.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 00defbf</samp>

* Prepend `$WORKSPACE` to user-defined cache directory ([link](https://github.com/koderover/zadig/pull/3198/files?diff=unified&w=0#diff-81665bd0249cbf747d030b652b84195780e796e1bbaaaf95494615816933a776L117-R117))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
