### PR TITLE
support special character in workflow view

### DIFF
--- a/pkg/microservice/aslan/core/workflow/handler/router.go
+++ b/pkg/microservice/aslan/core/workflow/handler/router.go
@@ -248,7 +248,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		view.POST("", CreateWorkflowView)
 		view.GET("", ListWorkflowViewNames)
 		view.GET("/preset", GetWorkflowViewPreset)
-		view.DELETE("/:projectName/:viewName", DeleteWorkflowView)
+		view.DELETE("", DeleteWorkflowView)
 		view.PUT("", UpdateWorkflowView)
 	}
 

--- a/pkg/microservice/aslan/core/workflow/handler/workflow_view.go
+++ b/pkg/microservice/aslan/core/workflow/handler/workflow_view.go
@@ -144,13 +144,13 @@ func DeleteWorkflowView(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	if err != nil {
-
 		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
 		ctx.UnAuthorized = true
 		return
 	}
 
 	projectKey := c.Query("projectName")
+	viewName := c.Query("viewName")
 
 	// authorization check
 	if !ctx.Resources.IsSystemAdmin {
@@ -166,5 +166,5 @@ func DeleteWorkflowView(c *gin.Context) {
 		}
 	}
 
-	ctx.Err = workflowservice.DeleteWorkflowView(projectKey, c.Param("viewName"), ctx.Logger)
+	ctx.Err = workflowservice.DeleteWorkflowView(projectKey, viewName, ctx.Logger)
 }


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a7d5059</samp>

Changed the API for deleting workflow views to use query parameters instead of path parameters. This improves the consistency and clarity of the API and avoids potential routing issues.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a7d5059</samp>

*  Changed the `DeleteWorkflowView` route to use query parameters instead of path parameters for consistency and to avoid conflicts ([link](https://github.com/koderover/zadig/pull/3199/files?diff=unified&w=0#diff-fd8d832ab541e6bdd527d9eb797a280356448994200abf5bf794925ffcaff834L251-R251))
*  Updated the `DeleteWorkflowView` function to obtain the `projectName` and `viewName` from the query parameters instead of the path parameters ([link](https://github.com/koderover/zadig/pull/3199/files?diff=unified&w=0#diff-a38ae1ee3ef15108a3a5ba0eb63063a833870b6746f5d5cb1ac83cd3ef279a8eL147), [link](https://github.com/koderover/zadig/pull/3199/files?diff=unified&w=0#diff-a38ae1ee3ef15108a3a5ba0eb63063a833870b6746f5d5cb1ac83cd3ef279a8eR153), [link](https://github.com/koderover/zadig/pull/3199/files?diff=unified&w=0#diff-a38ae1ee3ef15108a3a5ba0eb63063a833870b6746f5d5cb1ac83cd3ef279a8eL169-R169))
*  Modified the call to the `workflowservice.DeleteWorkflowView` function to use the `viewName` variable instead of the `c.Param("viewName")` argument ([link](https://github.com/koderover/zadig/pull/3199/files?diff=unified&w=0#diff-a38ae1ee3ef15108a3a5ba0eb63063a833870b6746f5d5cb1ac83cd3ef279a8eL169-R169))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
