### PR TITLE
fix build data check logic

### DIFF
--- a/pkg/microservice/aslan/core/build/service/build.go
+++ b/pkg/microservice/aslan/core/build/service/build.go
@@ -612,21 +612,23 @@ func correctFields(build *commonmodels.Build) error {
 		}
 	}
 
-	if build.PreBuild == nil {
-		return fmt.Errorf("build prebuild is nil")
-	} else {
-		if build.PreBuild.ClusterID == "" {
-			return fmt.Errorf("build prebuild clusterid is empty")
-		}
-		if build.PreBuild.StrategyID == "" {
-			buildTemplate, err := commonrepo.NewBuildTemplateColl().Find(&commonrepo.BuildTemplateQueryOption{
-				ID: build.TemplateID,
-			})
-			if err != nil {
-				return fmt.Errorf("failed to find build template with id: %s, err: %s", build.TemplateID, err)
+	if build.TemplateID == "" {
+		if build.PreBuild == nil {
+			return fmt.Errorf("build prebuild is nil")
+		} else {
+			if build.PreBuild.ClusterID == "" {
+				return fmt.Errorf("build prebuild clusterid is empty")
 			}
-			if buildTemplate.PreBuild != nil {
-				build.PreBuild.StrategyID = buildTemplate.PreBuild.StrategyID
+			if build.PreBuild.StrategyID == "" {
+				buildTemplate, err := commonrepo.NewBuildTemplateColl().Find(&commonrepo.BuildTemplateQueryOption{
+					ID: build.TemplateID,
+				})
+				if err != nil {
+					return fmt.Errorf("failed to find build template with id: %s, err: %s", build.TemplateID, err)
+				}
+				if buildTemplate.PreBuild != nil {
+					build.PreBuild.StrategyID = buildTemplate.PreBuild.StrategyID
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1a658f7</samp>

Fix a bug in the build service that caused a panic when the `build.TemplateID` was empty. Modify the `correctFields` function in `build.go` to skip validating the `build.PreBuild` fields if the `build.TemplateID` is empty.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1a658f7</samp>

*  Validate `build.PreBuild` fields only if `build.TemplateID` is not empty to avoid panic ([link](https://github.com/koderover/zadig/pull/3200/files?diff=unified&w=0#diff-98035dca197ab8b7d8f219a434cea6798a900a7795634e465c1119efd2faa1d2L615-R631))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
