### PR TITLE
remove enterprise check for pod file download api

### DIFF
--- a/pkg/microservice/aslan/core/environment/handler/kube.go
+++ b/pkg/microservice/aslan/core/environment/handler/kube.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	commonutil "github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core/environment/service"
 	"github.com/koderover/zadig/pkg/setting"
 	internalhandler "github.com/koderover/zadig/pkg/shared/handler"
@@ -125,11 +124,6 @@ func DownloadFileFromPod(c *gin.Context) {
 	}
 	if len(filePath) == 0 {
 		ctx.Err = e.ErrInvalidParam.AddDesc("file path can't be nil")
-		return
-	}
-
-	if err := commonutil.CheckZadigXLicenseStatus(); err != nil {
-		ctx.Err = err
 		return
 	}
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5d96b1d</samp>

Refactored `handler` package in environment service by removing unused and redundant code. This makes the package cleaner and faster.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5d96b1d</samp>

* Remove unused import of `commonutil` package from `kube.go` ([link](https://github.com/koderover/zadig/pull/3201/files?diff=unified&w=0#diff-a5cea4826aa345a878ca29c2d24b4c6777b2656c91c9e150efba27388e4d08edL26))
* Simplify logic of `DownloadFileFromPod` function by removing irrelevant check of ZadigX license status ([link](https://github.com/koderover/zadig/pull/3201/files?diff=unified&w=0#diff-a5cea4826aa345a878ca29c2d24b4c6777b2656c91c9e150efba27388e4d08edL131-L135))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
