### PR TITLE
cherry pick #3184 to 2.0.0

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2037,11 +2037,12 @@ func deleteK8sProductServices(productInfo *commonmodels.Product, serviceNames []
 			KubeClient:          kclient,
 			CurrentResourceYaml: serviceRelatedYaml[name],
 			Uninstall:           true,
+			WaitForUninstall:    true,
 		}
 		_, err = kube.CreateOrPatchResource(param, log)
 		if err != nil {
 			// Only record and do not block subsequent traversals.
-			log.Errorf("failed to remove k8s resources when deleting ervice: %s, err: %s", name, err)
+			log.Errorf("failed to remove k8s resources when deleting service: %s, err: %s", name, err)
 		}
 	}
 

--- a/pkg/microservice/aslan/core/multicluster/service/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/service/clusters.go
@@ -548,8 +548,8 @@ func UpdateCluster(id string, args *K8SCluster, logger *zap.SugaredLogger) (*com
 	// If the user chooses to use dynamically generated storage resources, the system automatically creates the PVC.
 	// TODO: If the PVC is not successfully bound to the PV, it is necessary to consider how to expose this abnormal information.
 	//       Depends on product design.
+	// TODO: Currently can't change cluster to right config, if previous config is wrong.
 	if args.Cache.MediumType == types.NFSMedium && args.Cache.NFSProperties.ProvisionType == types.DynamicProvision {
-
 		if id == setting.LocalClusterID {
 			args.DindCfg = nil
 		}

--- a/pkg/util/pointer.go
+++ b/pkg/util/pointer.go
@@ -28,6 +28,10 @@ func GetInt32Pointer(data int32) *int32 {
 	return &data
 }
 
+func GetInt64Pointer(data int64) *int64 {
+	return &data
+}
+
 func GetBoolFromPointer(source *bool) bool {
 	if source == nil {
 		return false


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f7a93c7</samp>

This pull request adds a feature to the `kube` package that allows waiting for the deletion of the old Kubernetes resources before applying the new ones. It also updates the `environment` package to use this feature when deleting a service, adds a TODO comment to the `multicluster` package, and adds a helper function to the `util` package.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f7a93c7</samp>

*  Add a new feature to wait for the deletion of the old resources before applying the new ones in the `kube` package ([link](https://github.com/koderover/zadig/pull/3202/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L32-R38), [link](https://github.com/koderover/zadig/pull/3202/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050R77), [link](https://github.com/koderover/zadig/pull/3202/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L170-R174), [link](https://github.com/koderover/zadig/pull/3202/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L193-R268), [link](https://github.com/koderover/zadig/pull/3202/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L255-R330), [link](https://github.com/koderover/zadig/pull/3202/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L262-R337))
  * Import `metav1` and `watch` packages to create and use watch interfaces for different Kubernetes resources ([link](https://github.com/koderover/zadig/pull/3202/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L32-R38))
  * Add a new field, `WaitForUninstall`, to the `ResourceApplyParam` type to indicate whether to wait for the deletion ([link](https://github.com/koderover/zadig/pull/3202/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050R77))
  * Modify the signature of the `removeResources` function to accept `waitForDelete` and `clientSet` parameters ([link](https://github.com/koderover/zadig/pull/3202/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L170-R174))
  * Implement the logic of waiting for the deletion using a switch statement, a for loop, and a select statement in the `removeResources` function ([link](https://github.com/koderover/zadig/pull/3202/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L193-R268))
  * Pass the `WaitForUninstall` field and the `clientSet` variable to the `removeResources` function call in the `CreateOrPatchResource` function ([link](https://github.com/koderover/zadig/pull/3202/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L255-R330), [link](https://github.com/koderover/zadig/pull/3202/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L262-R337))
* Use the new feature of waiting for the deletion in the `environment` package when deleting a service ([link](https://github.com/koderover/zadig/pull/3202/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L2040-R2045))
  * Pass the `WaitForUninstall` field to the `CreateOrPatchResource` function call in the `deleteK8sProductServices` function ([link](https://github.com/koderover/zadig/pull/3202/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L2040-R2045))
  * Fix a typo in the log message ([link](https://github.com/koderover/zadig/pull/3202/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L2040-R2045))
* Add a new helper function, `GetInt64Pointer`, to the `util` package to create a pointer to an int64 value ([link](https://github.com/koderover/zadig/pull/3202/files?diff=unified&w=0#diff-ce2f6267ac90e59f180836b5832268c3c3154d8a7d0810c52032d9494cd7aa1cR31-R34))
  * Use the function to create a pointer to the `GracePeriodSeconds` field of the `DeleteOptions` struct in the `removeResources` function ([link](https://github.com/koderover/zadig/pull/3202/files?diff=unified&w=0#diff-ce2f6267ac90e59f180836b5832268c3c3154d8a7d0810c52032d9494cd7aa1cR31-R34))
* Add a TODO comment to the `UpdateCluster` function in the `multicluster` package to indicate a potential issue with changing the cluster configuration ([link](https://github.com/koderover/zadig/pull/3202/files?diff=unified&w=0#diff-4e85c1af9762124c9c31e475d7a54712ffc81a99054ebef0ea2d97cd73ca6a8cL551-R552))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
