### PR TITLE
cherry pick #3192 #3205 to 2.0.0

### DIFF
--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -17,6 +17,7 @@ limitations under the License.
 package service
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -29,7 +30,10 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
+	"istio.io/client-go/pkg/apis/networking/v1alpha3"
+	versionedclient "istio.io/client-go/pkg/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -55,6 +59,7 @@ import (
 	"github.com/koderover/zadig/pkg/tool/kube/getter"
 	"github.com/koderover/zadig/pkg/tool/kube/informer"
 	"github.com/koderover/zadig/pkg/tool/log"
+	zadigtypes "github.com/koderover/zadig/pkg/types"
 	"github.com/koderover/zadig/pkg/util"
 	jsonutil "github.com/koderover/zadig/pkg/util/json"
 )
@@ -80,17 +85,18 @@ func FillProductTemplateValuesYamls(tmpl *templatemodels.Product, production boo
 }
 
 type ServiceResp struct {
-	ServiceName        string       `json:"service_name"`
-	ReleaseName        string       `json:"release_name"`
-	IsHelmChartDeploy  bool         `json:"is_helm_chart_deploy"`
-	ServiceDisplayName string       `json:"service_display_name"`
-	Type               string       `json:"type"`
-	Status             string       `json:"status"`
-	Error              string       `json:"error"`
-	Images             []string     `json:"images,omitempty"`
-	ProductName        string       `json:"product_name"`
-	EnvName            string       `json:"env_name"`
-	Ingress            *IngressInfo `json:"ingress"`
+	ServiceName        string            `json:"service_name"`
+	ReleaseName        string            `json:"release_name"`
+	IsHelmChartDeploy  bool              `json:"is_helm_chart_deploy"`
+	ServiceDisplayName string            `json:"service_display_name"`
+	Type               string            `json:"type"`
+	Status             string            `json:"status"`
+	Error              string            `json:"error"`
+	Images             []string          `json:"images,omitempty"`
+	ProductName        string            `json:"product_name"`
+	EnvName            string            `json:"env_name"`
+	Ingress            *IngressInfo      `json:"ingress"`
+	IstioGateway       *IstioGatewayInfo `json:"istio_gateway"`
 	//deprecated
 	Ready          string              `json:"ready"`
 	EnvStatuses    []*models.EnvStatus `json:"env_statuses,omitempty"`
@@ -107,6 +113,16 @@ type ServiceResp struct {
 
 type IngressInfo struct {
 	HostInfo []resource.HostInfo `json:"host_info"`
+}
+
+type IstioGatewayInfo struct {
+	Servers []IstioGatewayServer `json:"servers"`
+}
+
+type IstioGatewayServer struct {
+	Host         string `json:"host"`
+	PortProtocol string `json:"port_protocol"`
+	PortNumber   uint32 `json:"port_number"`
 }
 
 func UnMarshalSourceDetail(source interface{}) (*models.CreateFromRepo, error) {
@@ -664,10 +680,15 @@ func fillServiceName(envName, productName string, workloads []*Workload) error {
 	if err != nil {
 		return err
 	}
+	releaseServiceNameMap, err := commonutil.GetReleaseNameToServiceNameMap(productInfo)
+	if err != nil {
+		return err
+	}
 	for _, wl := range workloads {
 		if chartRelease, ok := wl.Annotation[setting.HelmReleaseNameAnnotation]; ok {
 			wl.ReleaseName = chartRelease
 			wl.ChartName = releaseChartNameMap[wl.ReleaseName]
+			wl.ServiceName = releaseServiceNameMap[wl.ReleaseName]
 		}
 	}
 	return nil
@@ -778,6 +799,15 @@ func ListWorkloadDetails(envName, clusterID, namespace, productName string, perP
 		log.Errorf("Failed to get server version info for cluster: %s, the error is: %s", clusterID, err)
 		return 0, resp, e.ErrListGroups.AddDesc(err.Error())
 	}
+	restConfig, err := kubeclient.GetRESTConfig(config.HubServerAddress(), clusterID)
+	if err != nil {
+		return 0, resp, e.ErrListGroups.AddErr(fmt.Errorf("failed to get rest config: %s", err))
+	}
+	istioClient, err := versionedclient.NewForConfig(restConfig)
+	if err != nil {
+		return 0, resp, e.ErrListGroups.AddErr(fmt.Errorf("failed to new istio client: %s", err))
+	}
+
 	count, workLoads, err := ListWorkloads(envName, productName, perPage, page, informer, version, log, filter...)
 	if err != nil {
 		log.Errorf("failed to list workloads, [%s][%s], error: %v", namespace, envName, err)
@@ -803,6 +833,16 @@ func ListWorkloadDetails(envName, clusterID, namespace, productName string, perP
 		} else {
 			log.Warnf("Failed to list ingresses, the error is: %s", err)
 		}
+	}
+
+	zadigLabels := map[string]string{
+		zadigtypes.ZadigLabelKeyGlobalOwner: zadigtypes.Zadig,
+	}
+	gwObjs, err := istioClient.NetworkingV1alpha3().Gateways(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labels.FormatLabels(zadigLabels),
+	})
+	if err != nil {
+		return 0, resp, e.ErrListGroups.AddErr(fmt.Errorf("failed to list gateways in ns `%s`: %s", namespace, err))
 	}
 
 	// get all services
@@ -835,6 +875,9 @@ func ListWorkloadDetails(envName, clusterID, namespace, productName string, perP
 			productRespInfo.Status, productRespInfo.Ready, productRespInfo.Images = kube.GetSelectedPodsInfo(selector, informer, workload.Images, log)
 			productRespInfo.Ingress = &IngressInfo{
 				HostInfo: FindServiceFromIngress(hostInfos, workload, allServices),
+			}
+			productRespInfo.IstioGateway = &IstioGatewayInfo{
+				Servers: FindServiceFromIstioGateway(gwObjs, workload.ServiceName),
 			}
 		} else if workload.Type == setting.CronJob {
 			productRespInfo.Status = workload.Status
@@ -873,6 +916,33 @@ func FindServiceFromIngress(hostInfos []resource.HostInfo, currentWorkload *Work
 			}
 		}
 	}
+	return resp
+}
+
+func FindServiceFromIstioGateway(gwObjs *v1alpha3.GatewayList, serviceName string) []IstioGatewayServer {
+	resp := []IstioGatewayServer{}
+	if len(gwObjs.Items) == 0 {
+		return resp
+	}
+	gatewayName := commonutil.GenIstioGatewayName(serviceName)
+	for _, gwObj := range gwObjs.Items {
+		if gwObj.Name == gatewayName {
+			for _, serverObj := range gwObj.Spec.Servers {
+				if len(serverObj.Hosts) == 0 {
+					continue
+				}
+
+				server := IstioGatewayServer{
+					Host:         serverObj.Hosts[0],
+					PortProtocol: serverObj.Port.Protocol,
+					PortNumber:   serverObj.Port.Number,
+				}
+				resp = append(resp, server)
+			}
+			break
+		}
+	}
+
 	return resp
 }
 

--- a/pkg/microservice/aslan/core/common/service/kube/apply.go
+++ b/pkg/microservice/aslan/core/common/service/kube/apply.go
@@ -196,7 +196,7 @@ func removeResources(currentItems, newItems []*unstructured.Unstructured, namesp
 	return errList.ErrorOrNil()
 }
 
-func manifestToUnstructured(manifest string) ([]*unstructured.Unstructured, error) {
+func ManifestToUnstructured(manifest string) ([]*unstructured.Unstructured, error) {
 	if len(manifest) == 0 {
 		return nil, nil
 	}
@@ -224,13 +224,13 @@ func CreateOrPatchResource(applyParam *ResourceApplyParam, log *zap.SugaredLogge
 	kubeClient := applyParam.KubeClient
 	istioClient := applyParam.IstioClient
 
-	curResources, err := manifestToUnstructured(applyParam.CurrentResourceYaml)
+	curResources, err := ManifestToUnstructured(applyParam.CurrentResourceYaml)
 	if err != nil {
 		log.Errorf("Failed to convert currently deplyed resource yaml to Unstructured, manifest is\n%s\n, error: %v", applyParam.CurrentResourceYaml, err)
 		return nil, err
 	}
 
-	resources, err := manifestToUnstructured(applyParam.UpdateResourceYaml)
+	resources, err := ManifestToUnstructured(applyParam.UpdateResourceYaml)
 	if err != nil {
 		log.Errorf("Failed to convert yaml to Unstructured, manifest is\n%s\n, error: %v", applyParam.UpdateResourceYaml, err)
 		return nil, err

--- a/pkg/microservice/aslan/core/common/util/enviroment.go
+++ b/pkg/microservice/aslan/core/common/util/enviroment.go
@@ -209,3 +209,7 @@ func UpdateProductImage(envName, productName, serviceName string, targets map[st
 
 	return nil
 }
+
+func GenIstioGatewayName(serviceName string) string {
+	return fmt.Sprintf("%s-gateway-%s", "zadig", serviceName)
+}

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -269,6 +269,8 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		environments.POST("/:name/share/enable", EnableBaseEnv)
 		environments.DELETE("/:name/share/enable", DisableBaseEnv)
 		environments.GET("/:name/check/sharenv/:op/ready", CheckShareEnvReady)
+		environments.GET("/:name/share/portal/:serviceName", GetPortalService)
+		environments.POST("/:name/share/portal/:serviceName", SetupPortalService)
 
 		environments.GET("/:name/services/:serviceName/pmexec", ConnectSshPmExec)
 

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2024,7 +2024,6 @@ func deleteK8sProductServices(productInfo *commonmodels.Product, serviceNames []
 		}
 
 		selector := labels.Set{setting.ProductLabel: productInfo.ProductName, setting.ServiceLabel: name}.AsSelector()
-
 		err = EnsureDeleteZadigService(ctx, productInfo, selector, kclient, istioClient)
 		if err != nil {
 			// Only record and do not block subsequent traversals.

--- a/pkg/microservice/aslan/core/environment/service/k8s.go
+++ b/pkg/microservice/aslan/core/environment/service/k8s.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"context"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -32,7 +33,9 @@ import (
 	"go.uber.org/zap"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	versionedclient "istio.io/client-go/pkg/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,6 +57,7 @@ import (
 	"github.com/koderover/zadig/pkg/tool/kube/informer"
 	"github.com/koderover/zadig/pkg/tool/kube/serializer"
 	"github.com/koderover/zadig/pkg/tool/log"
+	zadigtypes "github.com/koderover/zadig/pkg/types"
 )
 
 type K8sService struct {
@@ -333,6 +337,27 @@ func (k *K8sService) listGroupServices(allServices []*commonmodels.ProductServic
 		}
 	}
 
+	restConfig, err := kubeclient.GetRESTConfig(config.HubServerAddress(), productInfo.ClusterID)
+	if err != nil {
+		log.Errorf("failed to get rest config: %s", err)
+		return nil
+	}
+	istioClient, err := versionedclient.NewForConfig(restConfig)
+	if err != nil {
+		log.Errorf("failed to new istio client: %s", err)
+		return nil
+	}
+	zadigLabels := map[string]string{
+		zadigtypes.ZadigLabelKeyGlobalOwner: zadigtypes.Zadig,
+	}
+	gwObjs, err := istioClient.NetworkingV1alpha3().Gateways(productInfo.Namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labels.FormatLabels(zadigLabels),
+	})
+	if err != nil {
+		log.Errorf("failed to list gateways in ns `%s`: %s", productInfo.Namespace, err)
+		return nil
+	}
+
 	// get all services
 	k8sServices, err := getter.ListServicesWithCache(nil, informer)
 	if err != nil {
@@ -386,6 +411,10 @@ func (k *K8sService) listGroupServices(allServices []*commonmodels.ProductServic
 
 			} else {
 				gp.Status = setting.ClusterUnknown
+			}
+
+			gp.IstioGateway = &commonservice.IstioGatewayInfo{
+				Servers: commonservice.FindServiceFromIstioGateway(gwObjs, service.ServiceName),
 			}
 
 			mutex.Lock()

--- a/pkg/microservice/aslan/server/rest/doc/docs.go
+++ b/pkg/microservice/aslan/server/rest/doc/docs.go
@@ -779,6 +779,105 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/aslan/environment/environments/{name}/share/portal/{serviceName}": {
+            "get": {
+                "description": "Get Portal Service for Share Env",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Get Portal Service for Share Env",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "service name",
+                        "name": "serviceName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.GetPortalServiceResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Setup Portal Service for Share Env",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Setup Portal Service for Share Env",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "service name",
+                        "name": "serviceName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/service.SetupPortalServiceRequest"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/api/aslan/environment/environments/{name}/sleep": {
             "post": {
                 "description": "Environment Sleep",
@@ -6801,6 +6900,20 @@ const docTemplate = `{
                 }
             }
         },
+        "service.GetPortalServiceResponse": {
+            "type": "object",
+            "properties": {
+                "default_gateway_ip": {
+                    "type": "string"
+                },
+                "servers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/service.SetupPortalServiceRequest"
+                    }
+                }
+            }
+        },
         "service.GetReleaseInstanceDeployStatusResponse": {
             "type": "object",
             "properties": {
@@ -6958,6 +7071,31 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/resource.HostInfo"
                     }
+                }
+            }
+        },
+        "service.IstioGatewayInfo": {
+            "type": "object",
+            "properties": {
+                "servers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/service.IstioGatewayServer"
+                    }
+                }
+            }
+        },
+        "service.IstioGatewayServer": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string"
+                },
+                "port_number": {
+                    "type": "integer"
+                },
+                "port_protocol": {
+                    "type": "string"
                 }
             }
         },
@@ -7580,6 +7718,9 @@ const docTemplate = `{
                         "$ref": "#/definitions/models.EnvStatus"
                     }
                 },
+                "error": {
+                    "type": "string"
+                },
                 "images": {
                     "type": "array",
                     "items": {
@@ -7591,6 +7732,9 @@ const docTemplate = `{
                 },
                 "is_helm_chart_deploy": {
                     "type": "boolean"
+                },
+                "istio_gateway": {
+                    "$ref": "#/definitions/service.IstioGatewayInfo"
                 },
                 "product_name": {
                     "type": "string"
@@ -7628,6 +7772,20 @@ const docTemplate = `{
                 },
                 "zadigx_release_type": {
                     "description": "ZadigXReleaseType represents the service contain created by zadigx release workflow\nfrontend should limit some operations on these services",
+                    "type": "string"
+                }
+            }
+        },
+        "service.SetupPortalServiceRequest": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string"
+                },
+                "port_number": {
+                    "type": "integer"
+                },
+                "port_protocol": {
                     "type": "string"
                 }
             }

--- a/pkg/microservice/aslan/server/rest/doc/swagger.json
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.json
@@ -770,6 +770,105 @@
                 }
             }
         },
+        "/api/aslan/environment/environments/{name}/share/portal/{serviceName}": {
+            "get": {
+                "description": "Get Portal Service for Share Env",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Get Portal Service for Share Env",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "service name",
+                        "name": "serviceName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.GetPortalServiceResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Setup Portal Service for Share Env",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "environment"
+                ],
+                "summary": "Setup Portal Service for Share Env",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "project name",
+                        "name": "projectName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "env name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "service name",
+                        "name": "serviceName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/service.SetupPortalServiceRequest"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/api/aslan/environment/environments/{name}/sleep": {
             "post": {
                 "description": "Environment Sleep",
@@ -6792,6 +6891,20 @@
                 }
             }
         },
+        "service.GetPortalServiceResponse": {
+            "type": "object",
+            "properties": {
+                "default_gateway_ip": {
+                    "type": "string"
+                },
+                "servers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/service.SetupPortalServiceRequest"
+                    }
+                }
+            }
+        },
         "service.GetReleaseInstanceDeployStatusResponse": {
             "type": "object",
             "properties": {
@@ -6949,6 +7062,31 @@
                     "items": {
                         "$ref": "#/definitions/resource.HostInfo"
                     }
+                }
+            }
+        },
+        "service.IstioGatewayInfo": {
+            "type": "object",
+            "properties": {
+                "servers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/service.IstioGatewayServer"
+                    }
+                }
+            }
+        },
+        "service.IstioGatewayServer": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string"
+                },
+                "port_number": {
+                    "type": "integer"
+                },
+                "port_protocol": {
+                    "type": "string"
                 }
             }
         },
@@ -7571,6 +7709,9 @@
                         "$ref": "#/definitions/models.EnvStatus"
                     }
                 },
+                "error": {
+                    "type": "string"
+                },
                 "images": {
                     "type": "array",
                     "items": {
@@ -7582,6 +7723,9 @@
                 },
                 "is_helm_chart_deploy": {
                     "type": "boolean"
+                },
+                "istio_gateway": {
+                    "$ref": "#/definitions/service.IstioGatewayInfo"
                 },
                 "product_name": {
                     "type": "string"
@@ -7619,6 +7763,20 @@
                 },
                 "zadigx_release_type": {
                     "description": "ZadigXReleaseType represents the service contain created by zadigx release workflow\nfrontend should limit some operations on these services",
+                    "type": "string"
+                }
+            }
+        },
+        "service.SetupPortalServiceRequest": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string"
+                },
+                "port_number": {
+                    "type": "integer"
+                },
+                "port_protocol": {
                     "type": "string"
                 }
             }

--- a/pkg/microservice/aslan/server/rest/doc/swagger.yaml
+++ b/pkg/microservice/aslan/server/rest/doc/swagger.yaml
@@ -1500,6 +1500,15 @@ definitions:
           type: string
         type: array
     type: object
+  service.GetPortalServiceResponse:
+    properties:
+      default_gateway_ip:
+        type: string
+      servers:
+        items:
+          $ref: '#/definitions/service.SetupPortalServiceRequest'
+        type: array
+    type: object
   service.GetReleaseInstanceDeployStatusResponse:
     properties:
       chart_name:
@@ -1603,6 +1612,22 @@ definitions:
         items:
           $ref: '#/definitions/resource.HostInfo'
         type: array
+    type: object
+  service.IstioGatewayInfo:
+    properties:
+      servers:
+        items:
+          $ref: '#/definitions/service.IstioGatewayServer'
+        type: array
+    type: object
+  service.IstioGatewayServer:
+    properties:
+      host:
+        type: string
+      port_number:
+        type: integer
+      port_protocol:
+        type: string
     type: object
   service.JiraProjectsResp:
     properties:
@@ -2007,6 +2032,8 @@ definitions:
         items:
           $ref: '#/definitions/models.EnvStatus'
         type: array
+      error:
+        type: string
       images:
         items:
           type: string
@@ -2015,6 +2042,8 @@ definitions:
         $ref: '#/definitions/service.IngressInfo'
       is_helm_chart_deploy:
         type: boolean
+      istio_gateway:
+        $ref: '#/definitions/service.IstioGatewayInfo'
       product_name:
         type: string
       ready:
@@ -2042,6 +2071,15 @@ definitions:
         description: |-
           ZadigXReleaseType represents the service contain created by zadigx release workflow
           frontend should limit some operations on these services
+        type: string
+    type: object
+  service.SetupPortalServiceRequest:
+    properties:
+      host:
+        type: string
+      port_number:
+        type: integer
+      port_protocol:
         type: string
     type: object
   service.SvcDiffResult:
@@ -2927,6 +2965,73 @@ paths:
           schema:
             $ref: '#/definitions/service.SvcDiffResult'
       summary: Preview service
+      tags:
+      - environment
+  /api/aslan/environment/environments/{name}/share/portal/{serviceName}:
+    get:
+      consumes:
+      - application/json
+      description: Get Portal Service for Share Env
+      parameters:
+      - description: project name
+        in: query
+        name: projectName
+        required: true
+        type: string
+      - description: env name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: service name
+        in: path
+        name: serviceName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/service.GetPortalServiceResponse'
+      summary: Get Portal Service for Share Env
+      tags:
+      - environment
+    post:
+      consumes:
+      - application/json
+      description: Setup Portal Service for Share Env
+      parameters:
+      - description: project name
+        in: query
+        name: projectName
+        required: true
+        type: string
+      - description: env name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: service name
+        in: path
+        name: serviceName
+        required: true
+        type: string
+      - description: body
+        in: body
+        name: body
+        required: true
+        schema:
+          items:
+            $ref: '#/definitions/service.SetupPortalServiceRequest'
+          type: array
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Setup Portal Service for Share Env
       tags:
       - environment
   /api/aslan/environment/environments/{name}/sleep:

--- a/pkg/tool/errors/http_errors.go
+++ b/pkg/tool/errors/http_errors.go
@@ -177,6 +177,8 @@ var (
 	ErrListEnvServiceVersions    = NewHTTPError(6079, "列出环境服务版本失败")
 	ErrDiffEnvServiceVersions    = NewHTTPError(6079, "Diff环境服务版本失败")
 	ErrRollbackEnvServiceVersion = NewHTTPError(6079, "回滚环境服务版本失败")
+	ErrSetupPortalService        = NewHTTPError(6079, "设置入口服务失败")
+	ErrGetPortalService          = NewHTTPError(6079, "获取入口服务配置失败")
 
 	//-----------------------------------------------------------------------------------------------
 	// Product Service APIs Range: 6080 - 6099 AND 6150 -6199


### PR DESCRIPTION
* add portal service feature for share env



* add remove portal service function



* add get istio gateway address function



* add delete istio gateway function



* add get portal service function



* add istio gateway info to listGroups and listWorkloads api



---------

### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 18e3312</samp>

This pull request adds the portal service feature to the aslan microservice, which allows users to configure and access Istio gateways for their services. It modifies the environment, service, and kube packages to support the istio gateway integration and adds new handlers, routes, schemas, and endpoints to the rest and doc packages. It also updates the swagger files and the error constants.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 18e3312</samp>

*  Add the GetPortalService and SetupPortalService endpoints to handle the requests for getting and setting the portal service configuration for a share environment ([link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-bc855cdae7fd5951f2dd616071a0a85b20273c7a89fc1725f032de2b17ff7bd7R272-R273), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-26dddb32e101161b1f0e05ef51f67d0cccec1f24f45b218835be1ebc2dce461fR164-R259), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-22190d4add8462b956413294f5d90b8d79a762060450aba68aca2311dc71ce1dR1334-R1611), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62R782-R880), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216R773-R871), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2R2970-R3036))
*  Add the IstioGatewayInfo field to the ServiceResp struct and schema to store the istio gateway information for a service in the environment response ([link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-43b4a5df02ef75087654902b8d4afc32745599d35053d171a5b950a94d012960L83-R99), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62R6903-R6916), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62R7077-R7101), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-71a25ee683f3a4e1bc83df7ab843a5cfd17b51d582f82b6ec8ccf9ea2c329f62R7736-R7738), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216R6894-R6907), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216R7068-R7092), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-38fdd86d14a10f659e7743269c9dc50922a165792323f816a3f51f4b46470216R7727-R7729), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2R1503-R1511), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2R1616-R1631), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-ff717b5b25142637404aeb7bb75e7a972f2d87d18f08c048dda0952b9f9607e2R2045-R2046))
*  Add the logic to create and manipulate istio resources such as gateways and virtual services using the istio client package and the metav1 package ([link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-43b4a5df02ef75087654902b8d4afc32745599d35053d171a5b950a94d012960L32-R36), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-43b4a5df02ef75087654902b8d4afc32745599d35053d171a5b950a94d012960R62), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-43b4a5df02ef75087654902b8d4afc32745599d35053d171a5b950a94d012960R838-R847), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-43b4a5df02ef75087654902b8d4afc32745599d35053d171a5b950a94d012960R879-R881), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-43b4a5df02ef75087654902b8d4afc32745599d35053d171a5b950a94d012960R922-R948), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-f47c0a20e012ef2548ef6631ca90301c9eb29005eab5ff1269c4fe4df14997c1R212-R215), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136R26), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136L35-R38), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136R60), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136R340-R360), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136R416-R419), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-22190d4add8462b956413294f5d90b8d79a762060450aba68aca2311dc71ce1dR34), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-22190d4add8462b956413294f5d90b8d79a762060450aba68aca2311dc71ce1dL39-R47), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-22190d4add8462b956413294f5d90b8d79a762060450aba68aca2311dc71ce1dL179-R192), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-22190d4add8462b956413294f5d90b8d79a762060450aba68aca2311dc71ce1dR817-R841), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-51c90b89590bb0a556310c234b9577d723f86e920197bafac172048e2e6a3ebfR243-R258))
*  Add the logic to fill the service name for a workload based on the release name to service name map from the product info ([link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-43b4a5df02ef75087654902b8d4afc32745599d35053d171a5b950a94d012960L667-R691))
*  Export the ManifestToUnstructured function to be used by other packages ([link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L199-R199), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L227-R227), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050L233-R233))
*  Add the error constants for the portal service functions to the errors package ([link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-754ac2982cab78c22f57f226133df3f1092fc72a6d1133a1331864479a935773R180-R181))
*  Remove some empty lines in the handler package ([link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-26dddb32e101161b1f0e05ef51f67d0cccec1f24f45b218835be1ebc2dce461fL35), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-26dddb32e101161b1f0e05ef51f67d0cccec1f24f45b218835be1ebc2dce461fL68), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-26dddb32e101161b1f0e05ef51f67d0cccec1f24f45b218835be1ebc2dce461fL103), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-26dddb32e101161b1f0e05ef51f67d0cccec1f24f45b218835be1ebc2dce461fL140))
*  Update the comments and the step numbers for the DisableBaseEnv function ([link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-22190d4add8462b956413294f5d90b8d79a762060450aba68aca2311dc71ce1dL185-R198), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-22190d4add8462b956413294f5d90b8d79a762060450aba68aca2311dc71ce1dL191-R204), [link](https://github.com/koderover/zadig/pull/3203/files?diff=unified&w=0#diff-22190d4add8462b956413294f5d90b8d79a762060450aba68aca2311dc71ce1dL197-R210))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
