### PR TITLE
fix product workflow cache for build, testing and scanning

### DIFF
--- a/pkg/microservice/reaper/core/service/reaper/reaper.go
+++ b/pkg/microservice/reaper/core/service/reaper/reaper.go
@@ -114,7 +114,7 @@ func (r *Reaper) CompressCache(storageURI string) error {
 	cacheDir := r.ActiveWorkspace
 	if r.Ctx.CacheDirType == types.UserDefinedCacheDir {
 		// Note: Product supports using environment variables, so we need to parsing the directory path here.
-		cacheDir = r.renderUserEnv(fmt.Sprintf("%s/%s", "/workspace", r.Ctx.CacheUserDir))
+		cacheDir = r.renderUserEnv(r.Ctx.CacheUserDir)
 	}
 
 	log.Infof("Data in `%s` will be cached.", cacheDir)

--- a/pkg/microservice/warpdrive/core/service/taskplugin/build.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/build.go
@@ -121,6 +121,9 @@ func (p *BuildTaskPlugin) SetBuildStatusCompleted(status config.Status) {
 
 // TODO: Binded Archive File logic
 func (p *BuildTaskPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipelineCtx *task.PipelineCtx, serviceName string) {
+	// since a prefix of $WORKSPACE is added to the user path in the product, we add this prefix to the cacheUserDir parameter
+	pipelineCtx.CacheUserDir = fmt.Sprintf("%s/%s", "/workspace", p.Task.CacheUserDir)
+
 	if p.Task.CacheEnable && !pipelineTask.ConfigPayload.ResetCache {
 		pipelineCtx.CacheEnable = true
 		pipelineCtx.Cache = p.Task.Cache

--- a/pkg/microservice/warpdrive/core/service/taskplugin/scanning.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/scanning.go
@@ -209,20 +209,23 @@ func (p *ScanPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipelineC
 	reaperContext.Scripts = append(reaperContext.Scripts, strings.Split(replaceWrapLine(p.Task.Script), "\n")...)
 
 	if p.Task.CacheEnable {
+		// since a prefix of $WORKSPACE is added to the user path in the product, we add this prefix to the cacheUserDir parameter
+		cacheDir := fmt.Sprintf("%s/%s", "/workspace", p.Task.CacheUserDir)
+
 		// job creation usage
 		pipelineCtx.CacheEnable = true
 		pipelineCtx.Cache = p.Task.Cache
 		pipelineCtx.CacheDirType = p.Task.CacheDirType
-		pipelineCtx.CacheUserDir = p.Task.CacheUserDir
+		pipelineCtx.CacheUserDir = cacheDir
 		// job usage
-		reaperContext.CacheEnable = p.Task.CacheEnable
+		reaperContext.CacheEnable = true
 		reaperContext.CacheDirType = p.Task.CacheDirType
-		reaperContext.CacheUserDir = p.Task.CacheUserDir
+		reaperContext.CacheUserDir = cacheDir
 		reaperContext.Cache = p.Task.Cache
 
 		// Since we allow users to use custom environment variables, variable resolution is required.
 		if pipelineCtx.CacheEnable && pipelineCtx.Cache.MediumType == types.NFSMedium {
-			pipelineCtx.CacheUserDir = p.renderEnv(pipelineCtx.CacheUserDir, envVars)
+			pipelineCtx.CacheUserDir = p.renderEnv(cacheDir, envVars)
 			pipelineCtx.Cache.NFSProperties.Subpath = p.renderEnv(pipelineCtx.Cache.NFSProperties.Subpath, envVars)
 		}
 	}

--- a/pkg/microservice/warpdrive/core/service/taskplugin/testing.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/testing.go
@@ -104,6 +104,9 @@ func (p *TestPlugin) TaskTimeout() int {
 }
 
 func (p *TestPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipelineCtx *task.PipelineCtx, serviceName string) {
+	// since a prefix of $WORKSPACE is added to the user path in the product, we add this prefix to the cacheUserDir parameter
+	pipelineCtx.CacheUserDir = fmt.Sprintf("%s/%s", "/workspace", p.Task.CacheUserDir)
+
 	if p.Task.CacheEnable && !pipelineTask.ConfigPayload.ResetCache {
 		pipelineCtx.CacheEnable = true
 		pipelineCtx.Cache = p.Task.Cache

--- a/pkg/microservice/warpdrive/core/service/taskplugin/testing.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/testing.go
@@ -104,14 +104,12 @@ func (p *TestPlugin) TaskTimeout() int {
 }
 
 func (p *TestPlugin) Run(ctx context.Context, pipelineTask *task.Task, pipelineCtx *task.PipelineCtx, serviceName string) {
-	// since a prefix of $WORKSPACE is added to the user path in the product, we add this prefix to the cacheUserDir parameter
-	pipelineCtx.CacheUserDir = fmt.Sprintf("%s/%s", "/workspace", p.Task.CacheUserDir)
-
 	if p.Task.CacheEnable && !pipelineTask.ConfigPayload.ResetCache {
 		pipelineCtx.CacheEnable = true
 		pipelineCtx.Cache = p.Task.Cache
 		pipelineCtx.CacheDirType = p.Task.CacheDirType
-		pipelineCtx.CacheUserDir = p.Task.CacheUserDir
+		// since a prefix of $WORKSPACE is added to the user path in the product, we add this prefix to the cacheUserDir parameter
+		pipelineCtx.CacheUserDir = fmt.Sprintf("%s/%s", "/workspace", p.Task.CacheUserDir)
 	} else {
 		pipelineCtx.CacheEnable = false
 	}


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5bee7b6</samp>

This pull request fixes a bug in the reaper service and adds the `/workspace` prefix to the `CacheUserDir` value in the pipeline context for the build, scanning, and testing task plugins. This ensures the consistency and correctness of the cache key generation and compression for pipeline tasks.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5bee7b6</samp>

*  Fix a bug in the reaper service that caused cache compression to fail by removing the unnecessary `/workspace` prefix from the cache directory path ([link](https://github.com/koderover/zadig/pull/3206/files?diff=unified&w=0#diff-81665bd0249cbf747d030b652b84195780e796e1bbaaaf95494615816933a776L117-R117))
*  Add the `/workspace` prefix to the `CacheUserDir` value in the pipeline context for the build, scanning, and testing task plugins, to make it consistent with the product logic and the reaper service ([link](https://github.com/koderover/zadig/pull/3206/files?diff=unified&w=0#diff-f5d40817e0b50e462d685039df2072b1273509b9b00061eda543c40da81e9131R124-R126), [link](https://github.com/koderover/zadig/pull/3206/files?diff=unified&w=0#diff-011710bf487b419f6cd001735c3d510d5e6b07037b3b5d80f716fb35f7aaba8fL212-R228), [link](https://github.com/koderover/zadig/pull/3206/files?diff=unified&w=0#diff-732be4389deb4fd5211363e19cc7541153c8575e300f2aa3ce7f83e4c022bd1cR107-R109))
*  Use a local variable `cacheDir` to store the prefixed `CacheUserDir` value in the scanning task plugin, to avoid repeating the same concatenation operation ([link](https://github.com/koderover/zadig/pull/3206/files?diff=unified&w=0#diff-011710bf487b419f6cd001735c3d510d5e6b07037b3b5d80f716fb35f7aaba8fL212-R228))
*  Pass the prefixed `CacheUserDir` value to the reaper context for the scanning task plugin, to ensure the correct cache key is generated and passed to the reaper service ([link](https://github.com/koderover/zadig/pull/3206/files?diff=unified&w=0#diff-011710bf487b419f6cd001735c3d510d5e6b07037b3b5d80f716fb35f7aaba8fL212-R228))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
