### PR TITLE
add oci registry support

### DIFF
--- a/pkg/microservice/aslan/core/system/service/helm.go
+++ b/pkg/microservice/aslan/core/system/service/helm.go
@@ -19,9 +19,9 @@ package service
 import (
 	"go.uber.org/zap"
 
-	commonutil "github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
 	commonmodels "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/pkg/microservice/aslan/core/common/repository/mongodb"
+	commonutil "github.com/koderover/zadig/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/pkg/tool/helmclient"
 )
 

--- a/pkg/tool/helmclient/helmclient.go
+++ b/pkg/tool/helmclient/helmclient.go
@@ -643,12 +643,14 @@ func (hClient *HelmClient) DownloadChart(repoEntry *repo.Entry, chartRef string,
 
 	// download chart from ocr registry
 	if registry.IsOCI(repoEntry.URL) {
-		log.Infof("start download chart from oci registry")
+		log.Infof("start download chart from oci registry, chartRef: %s", chartRef)
 		chartNameStr := strings.Split(chartRef, "/")
 		if len(chartNameStr) < 2 {
 			return fmt.Errorf("chart name is not valid")
 		}
-		return hClient.DownloadOCIChart(repoEntry, chartNameStr[len(chartNameStr)-1], chartVersion, destDir, unTar)
+		chartRef = fmt.Sprintf("%s/%s", repoEntry.URL, chartNameStr[len(chartNameStr)-1])
+		log.Infof("final chart ref is %s", chartRef)
+		return hClient.DownloadOCIChart(repoEntry, chartRef, chartVersion, destDir, unTar)
 	}
 
 	_, err := hClient.UpdateChartRepo(repoEntry)

--- a/pkg/tool/helmclient/helmclient.go
+++ b/pkg/tool/helmclient/helmclient.go
@@ -643,6 +643,7 @@ func (hClient *HelmClient) DownloadChart(repoEntry *repo.Entry, chartRef string,
 
 	// download chart from ocr registry
 	if registry.IsOCI(repoEntry.URL) {
+		log.Infof("start download chart from oci registry")
 		chartNameStr := strings.Split(chartRef, "/")
 		if len(chartNameStr) < 2 {
 			return fmt.Errorf("chart name is not valid")
@@ -667,9 +668,6 @@ func (hClient *HelmClient) DownloadChart(repoEntry *repo.Entry, chartRef string,
 }
 
 func (hClient *HelmClient) DownloadOCIChart(repoEntry *repo.Entry, chartRef string, chartVersion string, destDir string, unTar bool) error {
-	hClient.lock.Lock()
-	defer hClient.lock.Unlock()
-
 	pullConfig := &action.Configuration{}
 	var err error
 	pullConfig.RegistryClient, err = registry.NewClient(
@@ -733,9 +731,6 @@ func (hClient *HelmClient) pushChartMuseum(repoEntry *repo.Entry, chartPath stri
 }
 
 func (hClient *HelmClient) pushOCIRegistry(repoEntry *repo.Entry, chartPath string) error {
-	hClient.lock.Lock()
-	defer hClient.lock.Unlock()
-
 	pushConfig := &action.Configuration{}
 	var err error
 	pushConfig.RegistryClient, err = registry.NewClient(

--- a/pkg/tool/helmclient/helmclient.go
+++ b/pkg/tool/helmclient/helmclient.go
@@ -72,8 +72,8 @@ var generalSettings *cli.EnvSettings
 
 // enable support of oci registry
 func init() {
-	os.Setenv("HELM_EXPERIMENTAL_OCI", "1")
-	os.Setenv("HELM_PLUGINS", HelmPluginsDirectory)
+	_ = os.Setenv("HELM_EXPERIMENTAL_OCI", "1")
+	_ = os.Setenv("HELM_PLUGINS", HelmPluginsDirectory)
 	repoInfo = &repo.File{}
 	generalSettings = cli.New()
 	generalSettings.PluginsDirectory = HelmPluginsDirectory
@@ -589,8 +589,8 @@ func (hClient *HelmClient) UpdateChartRepo(repoEntry *repo.Entry) (string, error
 	}
 	if repoUrl.Scheme == "acr" {
 		// export envionment-variables for ali acr chart repo
-		os.Setenv("HELM_REPO_USERNAME", repoEntry.Username)
-		os.Setenv("HELM_REPO_PASSWORD", repoEntry.Password)
+		_ = os.Setenv("HELM_REPO_USERNAME", repoEntry.Username)
+		_ = os.Setenv("HELM_REPO_PASSWORD", repoEntry.Password)
 	}
 
 	// update repo info
@@ -648,7 +648,7 @@ func (hClient *HelmClient) DownloadChart(repoEntry *repo.Entry, chartRef string,
 			return fmt.Errorf("chart name is not valid")
 		}
 		chartRef = fmt.Sprintf("%s/%s", repoEntry.URL, chartNameStr[len(chartNameStr)-1])
-		return hClient.DownloadOCIChart(repoEntry, chartRef, chartVersion, destDir, unTar)
+		return hClient.downloadOCIChart(repoEntry, chartRef, chartVersion, destDir, unTar)
 	}
 
 	_, err := hClient.UpdateChartRepo(repoEntry)
@@ -667,7 +667,7 @@ func (hClient *HelmClient) DownloadChart(repoEntry *repo.Entry, chartRef string,
 	return err
 }
 
-func (hClient *HelmClient) DownloadOCIChart(repoEntry *repo.Entry, chartRef string, chartVersion string, destDir string, unTar bool) error {
+func (hClient *HelmClient) downloadOCIChart(repoEntry *repo.Entry, chartRef string, chartVersion string, destDir string, unTar bool) error {
 	pullConfig := &action.Configuration{}
 	var err error
 	pullConfig.RegistryClient, err = registry.NewClient(

--- a/pkg/tool/helmclient/helmclient.go
+++ b/pkg/tool/helmclient/helmclient.go
@@ -32,8 +32,6 @@ import (
 	"strings"
 	"sync"
 
-	"helm.sh/helm/v3/pkg/registry"
-
 	cm "github.com/chartmuseum/helm-push/pkg/chartmuseum"
 	hc "github.com/mittwald/go-helm-client"
 	"helm.sh/helm/v3/pkg/action"
@@ -42,6 +40,7 @@ import (
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/downloader"
 	"helm.sh/helm/v3/pkg/plugin"
+	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	"helm.sh/helm/v3/pkg/repo"

--- a/pkg/tool/helmclient/helmclient.go
+++ b/pkg/tool/helmclient/helmclient.go
@@ -649,7 +649,6 @@ func (hClient *HelmClient) DownloadChart(repoEntry *repo.Entry, chartRef string,
 			return fmt.Errorf("chart name is not valid")
 		}
 		chartRef = fmt.Sprintf("%s/%s", repoEntry.URL, chartNameStr[len(chartNameStr)-1])
-		log.Infof("final chart ref is %s", chartRef)
 		return hClient.DownloadOCIChart(repoEntry, chartRef, chartVersion, destDir, unTar)
 	}
 
@@ -733,6 +732,7 @@ func (hClient *HelmClient) pushChartMuseum(repoEntry *repo.Entry, chartPath stri
 }
 
 func (hClient *HelmClient) pushOCIRegistry(repoEntry *repo.Entry, chartPath string) error {
+	log.Infof("------- push chart to oci registry: %s/%s", repoEntry.URL, chartPath)
 	pushConfig := &action.Configuration{}
 	var err error
 	pushConfig.RegistryClient, err = registry.NewClient(
@@ -742,6 +742,7 @@ func (hClient *HelmClient) pushOCIRegistry(repoEntry *repo.Entry, chartPath stri
 	)
 
 	hostUrl := strings.TrimPrefix(repoEntry.URL, fmt.Sprintf("%s://", registry.OCIScheme))
+	log.Infof("------ host url : %s", hostUrl)
 	err = pushConfig.RegistryClient.Login(hostUrl, registry.LoginOptBasicAuth(repoEntry.Username, repoEntry.Password))
 	if err != nil {
 		return err
@@ -787,6 +788,7 @@ func (hClient *HelmClient) PushChart(repoEntry *repo.Entry, chartPath string) er
 	if err != nil {
 		return fmt.Errorf("failed to parse repo url: %s, err: %w", repoEntry.URL, err)
 	}
+	log.Infof("----- chart repo schema: %s", repoUrl.Scheme)
 	if repoUrl.Scheme == "acr" {
 		return hClient.pushAcrChart(repoEntry, chartPath)
 	} else if repoUrl.Scheme == registry.OCIScheme {

--- a/pkg/tool/helmclient/helmclient.go
+++ b/pkg/tool/helmclient/helmclient.go
@@ -617,7 +617,9 @@ func (hClient *HelmClient) FetchIndexYaml(repoEntry *repo.Entry) (*repo.IndexFil
 	defer hClient.lock.Unlock()
 
 	if registry.IsOCI(repoEntry.URL) {
-		return nil, nil
+		return &repo.IndexFile{
+			Entries: make(map[string]repo.ChartVersions),
+		}, nil
 	}
 
 	indexFilePath, err := hClient.UpdateChartRepo(repoEntry)

--- a/pkg/tool/helmclient/helmclient.go
+++ b/pkg/tool/helmclient/helmclient.go
@@ -780,10 +780,6 @@ func handlePushResponse(resp *http.Response) error {
 func (hClient *HelmClient) PushChart(repoEntry *repo.Entry, chartPath string) error {
 	hClient.lock.Lock()
 	defer hClient.lock.Unlock()
-	_, err := hClient.UpdateChartRepo(repoEntry)
-	if err != nil {
-		return nil
-	}
 	repoUrl, err := url.Parse(repoEntry.URL)
 	if err != nil {
 		return fmt.Errorf("failed to parse repo url: %s, err: %w", repoEntry.URL, err)
@@ -794,6 +790,10 @@ func (hClient *HelmClient) PushChart(repoEntry *repo.Entry, chartPath string) er
 	} else if repoUrl.Scheme == registry.OCIScheme {
 		return hClient.pushOCIRegistry(repoEntry, chartPath)
 	} else {
+		_, err := hClient.UpdateChartRepo(repoEntry)
+		if err != nil {
+			return err
+		}
 		return hClient.pushChartMuseum(repoEntry, chartPath)
 	}
 }

--- a/pkg/tool/helmclient/helmclient.go
+++ b/pkg/tool/helmclient/helmclient.go
@@ -615,6 +615,11 @@ func (hClient *HelmClient) UpdateChartRepo(repoEntry *repo.Entry) (string, error
 func (hClient *HelmClient) FetchIndexYaml(repoEntry *repo.Entry) (*repo.IndexFile, error) {
 	hClient.lock.Lock()
 	defer hClient.lock.Unlock()
+
+	if registry.IsOCI(repoEntry.URL) {
+		return nil, nil
+	}
+
 	indexFilePath, err := hClient.UpdateChartRepo(repoEntry)
 	if err != nil {
 		return nil, err

--- a/pkg/tool/helmclient/helmclient.go
+++ b/pkg/tool/helmclient/helmclient.go
@@ -732,7 +732,6 @@ func (hClient *HelmClient) pushChartMuseum(repoEntry *repo.Entry, chartPath stri
 }
 
 func (hClient *HelmClient) pushOCIRegistry(repoEntry *repo.Entry, chartPath string) error {
-	log.Infof("------- push chart to oci registry: %s/%s", repoEntry.URL, chartPath)
 	pushConfig := &action.Configuration{}
 	var err error
 	pushConfig.RegistryClient, err = registry.NewClient(
@@ -742,7 +741,6 @@ func (hClient *HelmClient) pushOCIRegistry(repoEntry *repo.Entry, chartPath stri
 	)
 
 	hostUrl := strings.TrimPrefix(repoEntry.URL, fmt.Sprintf("%s://", registry.OCIScheme))
-	log.Infof("------ host url : %s", hostUrl)
 	err = pushConfig.RegistryClient.Login(hostUrl, registry.LoginOptBasicAuth(repoEntry.Username, repoEntry.Password))
 	if err != nil {
 		return err
@@ -784,7 +782,6 @@ func (hClient *HelmClient) PushChart(repoEntry *repo.Entry, chartPath string) er
 	if err != nil {
 		return fmt.Errorf("failed to parse repo url: %s, err: %w", repoEntry.URL, err)
 	}
-	log.Infof("----- chart repo schema: %s", repoUrl.Scheme)
 	if repoUrl.Scheme == "acr" {
 		return hClient.pushAcrChart(repoEntry, chartPath)
 	} else if repoUrl.Scheme == registry.OCIScheme {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 55fc1f7</samp>

This change enables HelmClient to work with OCI registries as chart sources and destinations. It leverages the existing `registry` package to handle the OCI protocol for chart operations. This allows users to use any OCI-compatible registry as a Helm repository.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 55fc1f7</samp>

*  Add support for working with OCI registries for Helm charts ([link](https://github.com/koderover/zadig/pull/3207/files?diff=unified&w=0#diff-43a9dce56755d1a350cdaddec8b11f9b7c4e7fa8fc7f7aa5204cbaddbb9c3869R35-R36), [link](https://github.com/koderover/zadig/pull/3207/files?diff=unified&w=0#diff-43a9dce56755d1a350cdaddec8b11f9b7c4e7fa8fc7f7aa5204cbaddbb9c3869L634-R648), [link](https://github.com/koderover/zadig/pull/3207/files?diff=unified&w=0#diff-43a9dce56755d1a350cdaddec8b11f9b7c4e7fa8fc7f7aa5204cbaddbb9c3869R662-R687), [link](https://github.com/koderover/zadig/pull/3207/files?diff=unified&w=0#diff-43a9dce56755d1a350cdaddec8b11f9b7c4e7fa8fc7f7aa5204cbaddbb9c3869R728-R751), [link](https://github.com/koderover/zadig/pull/3207/files?diff=unified&w=0#diff-43a9dce56755d1a350cdaddec8b11f9b7c4e7fa8fc7f7aa5204cbaddbb9c3869R788-R789))
  * Import the `registry` package from `helm.sh/helm/v3/pkg/registry` in `helmclient.go` ([link](https://github.com/koderover/zadig/pull/3207/files?diff=unified&w=0#diff-43a9dce56755d1a350cdaddec8b11f9b7c4e7fa8fc7f7aa5204cbaddbb9c3869R35-R36))
  * Modify the `DownloadChart` function to handle OCI registry URLs and call the `DownloadOCIChart` function in that case ([link](https://github.com/koderover/zadig/pull/3207/files?diff=unified&w=0#diff-43a9dce56755d1a350cdaddec8b11f9b7c4e7fa8fc7f7aa5204cbaddbb9c3869L634-R648))
  * Add the `DownloadOCIChart` function to the `HelmClient` struct, which uses the `registry` package to create a registry client, configure the authentication and pull options, and run the pull action to download the chart ([link](https://github.com/koderover/zadig/pull/3207/files?diff=unified&w=0#diff-43a9dce56755d1a350cdaddec8b11f9b7c4e7fa8fc7f7aa5204cbaddbb9c3869R662-R687))
  * Add the `pushOCIRegistry` function to the `HelmClient` struct, which uses the `registry` package to create a registry client, configure the authentication and push options, and run the push action to upload the chart ([link](https://github.com/koderover/zadig/pull/3207/files?diff=unified&w=0#diff-43a9dce56755d1a350cdaddec8b11f9b7c4e7fa8fc7f7aa5204cbaddbb9c3869R728-R751))
  * Modify the `PushChart` function to handle OCI registry URLs and call the `pushOCIRegistry` function in that case ([link](https://github.com/koderover/zadig/pull/3207/files?diff=unified&w=0#diff-43a9dce56755d1a350cdaddec8b11f9b7c4e7fa8fc7f7aa5204cbaddbb9c3869R788-R789))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
