### PR TITLE
remove authorization checks for listing codehosts in project

### DIFF
--- a/pkg/microservice/aslan/core/project/handler/integration.go
+++ b/pkg/microservice/aslan/core/project/handler/integration.go
@@ -106,17 +106,18 @@ func ListProjectCodeHost(c *gin.Context) {
 		return
 	}
 
+	// TODO: Authorization leaks
 	// authorization checks
-	if !ctx.Resources.IsSystemAdmin {
-		if _, ok := ctx.Resources.ProjectAuthInfo[projectKey]; !ok {
-			ctx.UnAuthorized = true
-			return
-		}
-		if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin {
-			ctx.UnAuthorized = true
-			return
-		}
-	}
+	//if !ctx.Resources.IsSystemAdmin {
+	//	if _, ok := ctx.Resources.ProjectAuthInfo[projectKey]; !ok {
+	//		ctx.UnAuthorized = true
+	//		return
+	//	}
+	//	if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin {
+	//		ctx.UnAuthorized = true
+	//		return
+	//	}
+	//}
 
 	encryptedKey := c.Query("encryptedKey")
 	if len(encryptedKey) == 0 {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 947b751</samp>

Temporarily disabled authorization checks for listing code hosts in `integration.go`. This was a workaround for a bug that affected project and service management.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 947b751</samp>

*  Bypassed the authorization checks for listing code hosts in a project ([link](https://github.com/koderover/zadig/pull/3209/files?diff=unified&w=0#diff-f77f6ab05deb622fc8f6509b398b4481dd364f02791b8ddff320b275cf5b7e7fL109-R120)). This was done to fix a bug that prevented users from creating or updating services in the project. The authorization logic was marked as a TODO item and should be restored in the future.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
