### PR TITLE
cherrypick #3209

### DIFF
--- a/pkg/microservice/aslan/core/project/handler/integration.go
+++ b/pkg/microservice/aslan/core/project/handler/integration.go
@@ -106,17 +106,18 @@ func ListProjectCodeHost(c *gin.Context) {
 		return
 	}
 
+	// TODO: Authorization leaks
 	// authorization checks
-	if !ctx.Resources.IsSystemAdmin {
-		if _, ok := ctx.Resources.ProjectAuthInfo[projectKey]; !ok {
-			ctx.UnAuthorized = true
-			return
-		}
-		if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin {
-			ctx.UnAuthorized = true
-			return
-		}
-	}
+	//if !ctx.Resources.IsSystemAdmin {
+	//	if _, ok := ctx.Resources.ProjectAuthInfo[projectKey]; !ok {
+	//		ctx.UnAuthorized = true
+	//		return
+	//	}
+	//	if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin {
+	//		ctx.UnAuthorized = true
+	//		return
+	//	}
+	//}
 
 	encryptedKey := c.Query("encryptedKey")
 	if len(encryptedKey) == 0 {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8ed8967</samp>

Temporarily removed authorization checks for listing project code hosts in `integration.go`. This was done to facilitate testing and debugging of the code host integration feature.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8ed8967</samp>

*  Temporarily disabled authorization checks for listing project code hosts ([link](https://github.com/koderover/zadig/pull/3210/files?diff=unified&w=0#diff-f77f6ab05deb622fc8f6509b398b4481dd364f02791b8ddff320b275cf5b7e7fL109-R120)). This was done to facilitate testing of the code host integration feature, which was part of the pull request's goal. The file `integration.go` contains the handler functions for the code host integration API endpoints.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
