### PR TITLE
added enterprise version

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/private_key.go
+++ b/pkg/microservice/aslan/core/common/repository/models/private_key.go
@@ -87,7 +87,9 @@ func (args *PrivateKey) Validate() error {
 	if err != nil {
 		return fmt.Errorf("failed to validate zadig license status, error: %s", err)
 	}
-	if !(licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional && licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
+	if !((licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional ||
+		licenseStatus.Type == plutusvendor.ZadigSystemTypeEnterprise) &&
+		licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
 		if args.Provider == config.VMProviderAmazon || args.ScheduleWorkflow {
 			return e.ErrLicenseInvalid.AddDesc("")
 		}

--- a/pkg/microservice/aslan/core/common/repository/models/registry_namespace.go
+++ b/pkg/microservice/aslan/core/common/repository/models/registry_namespace.go
@@ -83,7 +83,9 @@ func (args *RegistryNamespace) LicenseValidate() error {
 		args.RegProvider == config.RegistryProviderTCREnterprise ||
 		args.RegProvider == config.RegistryProviderECR ||
 		args.RegProvider == config.RegistryProviderJFrog {
-		if !(licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional && licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
+		if !((licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional ||
+			licenseStatus.Type == plutusvendor.ZadigSystemTypeEnterprise) &&
+			licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
 			return e.ErrLicenseInvalid.AddDesc("")
 		}
 	}

--- a/pkg/microservice/aslan/core/common/util/validate.go
+++ b/pkg/microservice/aslan/core/common/util/validate.go
@@ -68,7 +68,9 @@ func CheckZadigXLicenseStatus() error {
 }
 
 func ValidateZadigXLicenseStatus(licenseStatus *plutusvendor.ZadigXLicenseStatus) bool {
-	if !(licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional && licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
+	if !((licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional ||
+		licenseStatus.Type == plutusvendor.ZadigSystemTypeEnterprise) &&
+		licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
 		return false
 	}
 	return true

--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -1583,7 +1583,9 @@ func updateMultiK8sEnv(c *gin.Context, request *service.UpdateEnvRequest, produc
 	for _, arg := range args {
 		for _, service := range arg.Services {
 			if service.DeployStrategy == setting.ServiceDeployStrategyImport {
-				if !(licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional && licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
+				if !((licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional ||
+					licenseStatus.Type == plutusvendor.ZadigSystemTypeEnterprise) &&
+					licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
 					ctx.Err = e.ErrLicenseInvalid.AddDesc("")
 					return
 				}

--- a/pkg/microservice/aslan/core/multicluster/service/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/service/clusters.go
@@ -106,7 +106,9 @@ func (args *K8SCluster) Validate() error {
 	if err != nil {
 		return fmt.Errorf("failed to validate zadig license status, error: %s", err)
 	}
-	if !(licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional && licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
+	if !((licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional ||
+		licenseStatus.Type == plutusvendor.ZadigSystemTypeEnterprise) &&
+		licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
 		if args.Provider == config.ClusterProviderTKEServerless || args.Provider == config.ClusterProviderAmazonEKS || args.Production {
 			return e.ErrLicenseInvalid.AddDesc("")
 		}

--- a/pkg/microservice/aslan/core/system/handler/project_management.go
+++ b/pkg/microservice/aslan/core/system/handler/project_management.go
@@ -111,7 +111,9 @@ func CreateProjectManagement(c *gin.Context) {
 		return
 	}
 	if req.MeegoHost != "" {
-		if !(licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional && licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
+		if !((licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional ||
+			licenseStatus.Type == plutusvendor.ZadigSystemTypeEnterprise) &&
+			licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
 			ctx.Err = e.ErrLicenseInvalid.AddDesc("")
 			return
 		}
@@ -148,7 +150,9 @@ func UpdateProjectManagement(c *gin.Context) {
 		return
 	}
 	if req.MeegoHost != "" {
-		if !(licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional && licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
+		if !((licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional ||
+			licenseStatus.Type == plutusvendor.ZadigSystemTypeEnterprise) &&
+			licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
 			ctx.Err = e.ErrLicenseInvalid.AddDesc("")
 			return
 		}

--- a/pkg/microservice/aslan/core/system/handler/registry.go
+++ b/pkg/microservice/aslan/core/system/handler/registry.go
@@ -91,7 +91,9 @@ func GetDefaultRegistryNamespace(c *gin.Context) {
 	if reg.RegType == config.RegistryProviderACREnterprise ||
 		reg.RegType == config.RegistryProviderTCREnterprise ||
 		reg.RegType == config.RegistryProviderJFrog {
-		if !(licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional && licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
+		if !((licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional ||
+			licenseStatus.Type == plutusvendor.ZadigSystemTypeEnterprise) &&
+			licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
 			ctx.Err = e.ErrLicenseInvalid.AddDesc("")
 			return
 		}

--- a/pkg/microservice/aslan/core/system/handler/s3.go
+++ b/pkg/microservice/aslan/core/system/handler/s3.go
@@ -134,7 +134,9 @@ func CreateS3Storage(c *gin.Context) {
 		return
 	}
 	if args.Provider == config.S3StorageProviderAmazonS3 {
-		if !(licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional && licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
+		if !((licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional ||
+			licenseStatus.Type == plutusvendor.ZadigSystemTypeEnterprise) &&
+			licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
 			ctx.Err = e.ErrLicenseInvalid.AddDesc("")
 			return
 		}
@@ -213,7 +215,9 @@ func UpdateS3Storage(c *gin.Context) {
 		return
 	}
 	if args.Provider == config.S3StorageProviderAmazonS3 {
-		if !(licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional && licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
+		if !((licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional ||
+			licenseStatus.Type == plutusvendor.ZadigSystemTypeEnterprise) &&
+			licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
 			ctx.Err = e.ErrLicenseInvalid.AddDesc("")
 			return
 		}

--- a/pkg/microservice/user/core/handler/permission/role.go
+++ b/pkg/microservice/user/core/handler/permission/role.go
@@ -86,7 +86,9 @@ func CreateRole(c *gin.Context) {
 		ctx.Err = fmt.Errorf("failed to validate zadig license status, error: %s", err)
 		return
 	}
-	if !(licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional && licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
+	if !((licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional ||
+		licenseStatus.Type == plutusvendor.ZadigSystemTypeEnterprise) &&
+		licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
 		actionSet := sets.NewString(args.Actions...)
 		if actionSet.Has(permission.VerbCreateReleasePlan) || actionSet.Has(permission.VerbDeleteReleasePlan) ||
 			actionSet.Has(permission.VerbEditReleasePlan) || actionSet.Has(permission.VerbGetReleasePlan) ||
@@ -160,7 +162,9 @@ func UpdateRole(c *gin.Context) {
 		ctx.Err = fmt.Errorf("failed to validate zadig license status, error: %s", err)
 		return
 	}
-	if !(licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional && licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
+	if !((licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional ||
+		licenseStatus.Type == plutusvendor.ZadigSystemTypeEnterprise) &&
+		licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
 		actionSet := sets.NewString(args.Actions...)
 		if actionSet.Has(permission.VerbCreateReleasePlan) || actionSet.Has(permission.VerbDeleteReleasePlan) ||
 			actionSet.Has(permission.VerbEditReleasePlan) || actionSet.Has(permission.VerbGetReleasePlan) ||

--- a/pkg/shared/client/plutusvendor/plutusvendor.go
+++ b/pkg/shared/client/plutusvendor/plutusvendor.go
@@ -36,6 +36,7 @@ func (c *Client) CheckSignature(userNum int64) (*CheckSignatrueResp, error) {
 const (
 	ZadigSystemTypeBasic        = "basic"
 	ZadigSystemTypeProfessional = "professional"
+	ZadigSystemTypeEnterprise   = "enterprise"
 	ZadigXLicenseStatusNormal   = "normal"
 )
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2a404da</samp>

This pull request adds support for enterprise zadig license holders to use various features and providers that were previously restricted to professional license holders. It updates several functions and constants in `project_management.go`, `s3.go`, `role.go`, `private_key.go`, `registry_namespace.go`, `validate.go`, `environment.go`, `clusters.go`, `registry.go` and `plutusvendor.go` to check for both license types.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2a404da</samp>

*  Allow enterprise type of zadig license to use various features and providers that were previously restricted to professional type ([link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-055853a775df04ee98804ce0d6c32a2c389c819f553ed2ea89dd9c1f44134644L90-R92), [link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-9ee605e9895a57840e3ea89dd40dc587a32f42cfcdd7c4d8883bfe6a940721a7L86-R88), [link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-6c869f952a442cd16ebaa1d7262cd635161ecc5e0c55d73fc069a0cebeed3ce5L71-R73), [link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL1586-R1588), [link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-4e85c1af9762124c9c31e475d7a54712ffc81a99054ebef0ea2d97cd73ca6a8cL109-R111), [link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-62f3e43235e6e49dd81ebf025750ce0966db6d6b08d18608366f890861542fd4L114-R116), [link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-62f3e43235e6e49dd81ebf025750ce0966db6d6b08d18608366f890861542fd4L151-R155), [link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-19b41d62129e62f812f57327c25629c825112f2a06085d1ee9f795c12bfbae9fL94-R96), [link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-f4d07910703a42260fa7b7e9d2df09b8a2afc6f3f911111ac72777b74f6b1540L137-R139), [link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-f4d07910703a42260fa7b7e9d2df09b8a2afc6f3f911111ac72777b74f6b1540L216-R220), [link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-8407064698a6762926d24e3698c78eb36c7e0cf9c5a997386f9eeb0e586d9388L89-R91), [link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-8407064698a6762926d24e3698c78eb36c7e0cf9c5a997386f9eeb0e586d9388L163-R167))
  * Modify the `Validate` function in `private_key.go` to enable VM provider Amazon and schedule workflow feature for enterprise license ([link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-055853a775df04ee98804ce0d6c32a2c389c819f553ed2ea89dd9c1f44134644L90-R92))
  * Modify the `LicenseValidate` function in `registry_namespace.go` to enable registry providers ECR and JFrog for enterprise license ([link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-9ee605e9895a57840e3ea89dd40dc587a32f42cfcdd7c4d8883bfe6a940721a7L86-R88))
  * Modify the `ValidateZadigXLicenseStatus` function in `validate.go` to accept enterprise license with normal status ([link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-6c869f952a442cd16ebaa1d7262cd635161ecc5e0c55d73fc069a0cebeed3ce5L71-R73))
  * Modify the `updateMultiK8sEnv` function in `environment.go` to enable service deploy strategy import for enterprise license ([link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL1586-R1588))
  * Modify the `Validate` function in `clusters.go` to enable cluster providers TKEServerless, AmazonEKS and the production flag for enterprise license ([link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-4e85c1af9762124c9c31e475d7a54712ffc81a99054ebef0ea2d97cd73ca6a8cL109-R111))
  * Modify the `CreateProjectManagement` and `UpdateProjectManagement` functions in `project_management.go` to enable meego host feature for enterprise license ([link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-62f3e43235e6e49dd81ebf025750ce0966db6d6b08d18608366f890861542fd4L114-R116), [link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-62f3e43235e6e49dd81ebf025750ce0966db6d6b08d18608366f890861542fd4L151-R155))
  * Modify the `GetDefaultRegistryNamespace` function in `registry.go` to enable registry types TCREnterprise and JFrog for enterprise license ([link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-19b41d62129e62f812f57327c25629c825112f2a06085d1ee9f795c12bfbae9fL94-R96))
  * Modify the `CreateS3Storage` and `UpdateS3Storage` functions in `s3.go` to enable s3 storage provider AmazonS3 for enterprise license ([link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-f4d07910703a42260fa7b7e9d2df09b8a2afc6f3f911111ac72777b74f6b1540L137-R139), [link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-f4d07910703a42260fa7b7e9d2df09b8a2afc6f3f911111ac72777b74f6b1540L216-R220))
  * Modify the `CreateRole` and `UpdateRole` functions in `role.go` to enable permission actions create release plan and delete release plan for enterprise license ([link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-8407064698a6762926d24e3698c78eb36c7e0cf9c5a997386f9eeb0e586d9388L89-R91), [link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-8407064698a6762926d24e3698c78eb36c7e0cf9c5a997386f9eeb0e586d9388L163-R167))
* Add a constant `ZadigSystemTypeEnterprise` to the `plutusvendor` package in `plutusvendor.go` to represent the enterprise type of zadig license ([link](https://github.com/koderover/zadig/pull/3211/files?diff=unified&w=0#diff-dc647553163be176b091e99b6f71a7c1093cabdc6cdfc55c3dbdace59a5113c8R39))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
