### PR TITLE
added apollo comparison api

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -589,12 +589,13 @@ type ApolloJobSpec struct {
 }
 
 type ApolloNamespace struct {
-	AppID      string      `bson:"appID"             json:"appID"             yaml:"appID"`
-	ClusterID  string      `bson:"clusterID"         json:"clusterID"         yaml:"clusterID"`
-	Env        string      `bson:"env"               json:"env"               yaml:"env"`
-	Namespace  string      `bson:"namespace"         json:"namespace"         yaml:"namespace"`
-	Type       string      `bson:"type"              json:"type"              yaml:"type"`
-	KeyValList []*ApolloKV `bson:"kv"                json:"kv"                yaml:"kv"`
+	AppID          string      `bson:"appID"             json:"appID"                       yaml:"appID"`
+	ClusterID      string      `bson:"clusterID"         json:"clusterID"                   yaml:"clusterID"`
+	Env            string      `bson:"env"               json:"env"                         yaml:"env"`
+	Namespace      string      `bson:"namespace"         json:"namespace"                   yaml:"namespace"`
+	Type           string      `bson:"type"              json:"type"                        yaml:"type"`
+	OriginalConfig []*ApolloKV `bson:"original_config"   json:"original_config,omitempty"   yaml:"original_config"`
+	KeyValList     []*ApolloKV `bson:"kv"                json:"kv"                          yaml:"kv"`
 }
 
 type MeegoTransitionJobSpec struct {

--- a/pkg/microservice/aslan/core/system/handler/configuration_management.go
+++ b/pkg/microservice/aslan/core/system/handler/configuration_management.go
@@ -202,11 +202,23 @@ func ListApolloNamespaces(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	if err != nil {
-
 		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
 		ctx.UnAuthorized = true
 		return
 	}
 
 	ctx.Resp, ctx.Err = service.ListApolloNamespaces(c.Param("id"), c.Param("app_id"), c.Param("env"), c.Param("cluster"), ctx.Logger)
+}
+
+func ListApolloConfig(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	ctx.Resp, ctx.Err = service.ListApolloConfig(c.Param("id"), c.Param("app_id"), c.Param("env"), c.Param("cluster"), c.Param("namespace"), ctx.Logger)
 }

--- a/pkg/microservice/aslan/core/system/handler/configuration_management.go
+++ b/pkg/microservice/aslan/core/system/handler/configuration_management.go
@@ -206,7 +206,7 @@ func ListApolloConfigByType(c *gin.Context) {
 		return
 	}
 
-	ctx.Resp, ctx.Err = service.ListApolloConfigByType(c.Param("id"), c.Param("app_id"), c.Query("content_type"), ctx.Logger)
+	ctx.Resp, ctx.Err = service.ListApolloConfigByType(c.Param("id"), c.Param("app_id"), c.Query("format"), ctx.Logger)
 }
 
 func ListApolloNamespaces(c *gin.Context) {

--- a/pkg/microservice/aslan/core/system/handler/configuration_management.go
+++ b/pkg/microservice/aslan/core/system/handler/configuration_management.go
@@ -188,13 +188,25 @@ func ListApolloEnvAndClusters(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	if err != nil {
-
 		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
 		ctx.UnAuthorized = true
 		return
 	}
 
 	ctx.Resp, ctx.Err = service.ListApolloEnvAndClusters(c.Param("id"), c.Param("app_id"), ctx.Logger)
+}
+
+func ListApolloConfigByType(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.Err = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	ctx.Resp, ctx.Err = service.ListApolloConfigByType(c.Param("id"), c.Param("app_id"), c.Query("content_type"), ctx.Logger)
 }
 
 func ListApolloNamespaces(c *gin.Context) {

--- a/pkg/microservice/aslan/core/system/handler/router.go
+++ b/pkg/microservice/aslan/core/system/handler/router.go
@@ -268,6 +268,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		configuration.GET("/apollo/:id/app", ListApolloApps)
 		configuration.GET("/apollo/:id/:app_id/env", ListApolloEnvAndClusters)
 		configuration.GET("/apollo/:id/:app_id/:env/:cluster/namespace", ListApolloNamespaces)
+		configuration.GET("/apollo/:id/:app_id/:env/:cluster/namespace/:namespace", ListApolloConfig)
 	}
 
 	imapp := router.Group("im_app")

--- a/pkg/microservice/aslan/core/system/handler/router.go
+++ b/pkg/microservice/aslan/core/system/handler/router.go
@@ -267,6 +267,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		configuration.POST("/validate", ValidateConfigurationManagement)
 		configuration.GET("/apollo/:id/app", ListApolloApps)
 		configuration.GET("/apollo/:id/:app_id/env", ListApolloEnvAndClusters)
+		configuration.GET("/apollo/:id/:app_id/config", ListApolloConfigByType)
 		configuration.GET("/apollo/:id/:app_id/:env/:cluster/namespace", ListApolloNamespaces)
 		configuration.GET("/apollo/:id/:app_id/:env/:cluster/namespace/:namespace", ListApolloConfig)
 	}

--- a/pkg/microservice/aslan/core/system/service/configuration_management.go
+++ b/pkg/microservice/aslan/core/system/service/configuration_management.go
@@ -229,7 +229,7 @@ func ListApolloEnvAndClusters(id string, appID string, log *zap.SugaredLogger) (
 	return envs, nil
 }
 
-func ListApolloConfigByType(id, appID, configType string, log *zap.SugaredLogger) ([]*apollo.BriefNamespace, error) {
+func ListApolloConfigByType(id, appID, format string, log *zap.SugaredLogger) ([]*apollo.BriefNamespace, error) {
 	resp := make([]*apollo.BriefNamespace, 0)
 	info, err := mongodb.NewConfigurationManagementColl().GetApolloByID(context.Background(), id)
 	if err != nil {
@@ -250,7 +250,7 @@ func ListApolloConfigByType(id, appID, configType string, log *zap.SugaredLogger
 				return nil, e.ErrGetApolloInfo.AddErr(err)
 			}
 			for _, namespace := range namesapceList {
-				if configType != "" && namespace.Format != configType {
+				if format != "" && namespace.Format != format {
 					continue
 				}
 				resp = append(resp, &apollo.BriefNamespace{

--- a/pkg/microservice/aslan/core/system/service/types.go
+++ b/pkg/microservice/aslan/core/system/service/types.go
@@ -226,3 +226,8 @@ type SecurityAndPrivacySettings struct {
 	TokenExpirationTime int64 `json:"token_expiration_time"`
 	ImprovementPlan     bool  `json:"improvement_plan"`
 }
+
+type ApolloConfig struct {
+	ConfigType string                   `json:"type"`
+	Config     []*commonmodels.ApolloKV `json:"kv"`
+}

--- a/pkg/tool/apollo/apollo.go
+++ b/pkg/tool/apollo/apollo.go
@@ -16,6 +16,14 @@
 
 package apollo
 
+type BriefNamespace struct {
+	AppID         string `json:"appId"`
+	Env           string `json:"env"`
+	ClusterName   string `json:"clusterName"`
+	NamespaceName string `json:"namespaceName"`
+	Format        string `json:"format"`
+}
+
 type Namespace struct {
 	AppID                      string   `json:"appId"`
 	ClusterName                string   `json:"clusterName"`


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e1803f5</samp>

Added a new API endpoint to list the apollo configuration for a given app, environment, cluster and namespace. Modified the `ApolloNamespace` struct to store the original configuration and added a new `ApolloConfig` struct to return the configuration as a JSON response.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e1803f5</samp>

*  Added a new field `OriginalConfig` to the `ApolloNamespace` struct to store the original key-value pairs of the apollo namespace ([link](https://github.com/koderover/zadig/pull/3216/files?diff=unified&w=0#diff-95d655186557675089c4ca26d31aa74884ccdfc8855d24c9092f4e4082389a4cL592-R598))
*  Removed the unused `ListApolloConfig` handler function from the `configuration_management.go` file ([link](https://github.com/koderover/zadig/pull/3216/files?diff=unified&w=0#diff-bcb21cda1603ff220e29e5e496f78ee87338927f7b63e348f0d87f1071725f33L205))
*  Added a new `ListApolloConfig` handler function to the `configuration_management.go` file to get the key-value pairs of the apollo namespace from the apollo server and return them as a JSON response ([link](https://github.com/koderover/zadig/pull/3216/files?diff=unified&w=0#diff-bcb21cda1603ff220e29e5e496f78ee87338927f7b63e348f0d87f1071725f33R212-R224))
*  Registered the `ListApolloConfig` handler function to the `configuration` router group with the GET method and the URL pattern `/apollo/:id/:app_id/:env/:cluster/namespace/:namespace` ([link](https://github.com/koderover/zadig/pull/3216/files?diff=unified&w=0#diff-a788b6154d88f1681af6dd9bb4b9504e74a014ea5e30ba254f38beb73d7bf5d7R271))
*  Added a new `ListApolloConfig` service function to the `configuration_management.go` file to get the apollo information from the database and create a new apollo client to get the namespace information from the apollo server ([link](https://github.com/koderover/zadig/pull/3216/files?diff=unified&w=0#diff-6a5138cab08e710f681da75d7449bade5ac40763bf8fdbd656cd4fccead5422eR248-R275))
*  Added a new `ApolloConfig` struct to the `types.go` file to store the format and the key-value pairs of the apollo namespace ([link](https://github.com/koderover/zadig/pull/3216/files?diff=unified&w=0#diff-d710876fb6c2d08ef6a5170dc9b5f6aee848a54e52e8e7e268b07c46f2816b3fR229-R233))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
