### PR TITLE
fix mysql execute error (#3197)

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_sql.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_sql.go
@@ -20,9 +20,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"net/url"
 
-	_ "github.com/go-sql-driver/mysql"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
@@ -85,7 +83,8 @@ func (c *SQLJobCtl) Run(ctx context.Context) {
 
 func (c *SQLJobCtl) ExecMySQLStatement() error {
 	info := c.dbInfo
-	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%s)/?charset=utf8&multiStatements=true", info.Username, url.QueryEscape(info.Password), info.Host, info.Port))
+
+	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%s)/?charset=utf8&multiStatements=true", info.Username, info.Password, info.Host, info.Port))
 	if err != nil {
 		return errors.Errorf("connect db error: %v", err)
 	}


### PR DESCRIPTION
* add mysql exec log



* add mysql exec log



* add mysql exec log



* remove useless code



---------

### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 936c87d</samp>

Fixed a bug and improved code quality in `workflowcontroller` service. Removed unused imports and corrected MySQL connection string in `job_sql.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 936c87d</samp>

* Remove unused imports of `net/url` and `_ "github.com/go-sql-driver/mysql"` from `jobcontroller` package ([link](https://github.com/koderover/zadig/pull/3222/files?diff=unified&w=0#diff-16e012cf93b7ed53523f060571242dcd8080cca99aa0b08a33c737e6e17a626fL23-R23))
* Fix bug in database connection string by removing `url.QueryEscape` function from password ([link](https://github.com/koderover/zadig/pull/3222/files?diff=unified&w=0#diff-16e012cf93b7ed53523f060571242dcd8080cca99aa0b08a33c737e6e17a626fL88-R87))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
