### PR TITLE
added namespace info for nacos configuration

### DIFF
--- a/pkg/microservice/aslan/core/common/service/nacos.go
+++ b/pkg/microservice/aslan/core/common/service/nacos.go
@@ -50,11 +50,30 @@ func ListNacosConfig(nacosID, namespaceID string, log *zap.SugaredLogger) ([]*ty
 		log.Error(err)
 		return []*types.NacosConfig{}, err
 	}
+	namespaces, err := client.ListNamespaces()
+	if err != nil {
+		err = errors.Wrap(err, "fail to list nacos namespaces")
+		log.Error(err)
+		return nil, err
+	}
+
+	namespaceName := ""
+	for _, namespace := range namespaces {
+		if namespace.NamespaceID == namespaceID {
+			namespaceName = namespace.NamespacedName
+			break
+		}
+	}
+
 	resp, err := client.ListConfigs(namespaceID)
 	if err != nil {
 		err = errors.Wrap(err, "fail to list nacos config")
 		log.Error(err)
 		return []*types.NacosConfig{}, err
+	}
+	for _, item := range resp {
+		item.NamespaceID = namespaceID
+		item.NamespaceName = namespaceName
 	}
 	return resp, nil
 }

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_nacos.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_nacos.go
@@ -214,7 +214,6 @@ func (j *NacosJob) LintJob() error {
 func transNacosDatas(confs []*types.NacosConfig) []*commonmodels.NacosData {
 	resp := []*commonmodels.NacosData{}
 	for _, conf := range confs {
-		fmt.Printf("original data: %s\n", conf.OriginalContent)
 		resp = append(resp, &commonmodels.NacosData{
 			NacosConfig: *conf,
 		})

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_nacos.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_nacos.go
@@ -214,6 +214,7 @@ func (j *NacosJob) LintJob() error {
 func transNacosDatas(confs []*types.NacosConfig) []*commonmodels.NacosData {
 	resp := []*commonmodels.NacosData{}
 	for _, conf := range confs {
+		fmt.Printf("original data: %s\n", conf.OriginalContent)
 		resp = append(resp, &commonmodels.NacosData{
 			NacosConfig: *conf,
 		})

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_nacos.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_nacos.go
@@ -64,8 +64,24 @@ func (j *NacosJob) SetPreset() error {
 		return fmt.Errorf("fail to list nacos config: %w", err)
 	}
 
+	namespaces, err := commonservice.ListNacosNamespace(j.spec.NacosID, log.SugaredLogger())
+	if err != nil {
+		return fmt.Errorf("failed to list nacos namespace")
+	}
+
+	namespaceName := ""
+	for _, namespace := range namespaces {
+		if namespace.NamespaceID == originNamespaceID {
+			namespaceName = namespace.NamespacedName
+			break
+		}
+	}
+
 	nacosConfigsMap := map[string]*types.NacosConfig{}
 	for _, config := range nacosConfigs {
+		config.NamespaceID = originNamespaceID
+		config.NamespaceName = namespaceName
+
 		nacosConfigsMap[getNacosConfigKey(config.Group, config.DataID)] = config
 	}
 

--- a/pkg/types/nacos.go
+++ b/pkg/types/nacos.go
@@ -28,6 +28,8 @@ type NacosConfig struct {
 	Format          string `bson:"format,omitempty"        json:"format,omitempty"        yaml:"format,omitempty"`
 	Content         string `bson:"content,omitempty"       json:"content,omitempty"       yaml:"content,omitempty"`
 	OriginalContent string `bson:"original_content,omitempty" json:"original_content,omitempty" yaml:"original_content,omitempty"`
+	NamespaceID     string `bson:"namespace_id"               json:"namespace_id"               yaml:"namespace_id"`
+	NamespaceName   string `bson:"namespace_name"             json:"namespace_name"             yaml:"namespace_name"`
 
 	// for frontend
 	Diff        interface{} `bson:"diff,omitempty" json:"diff,omitempty" yaml:"diff,omitempty"`


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c0de4ee</samp>

This pull request adds the namespace name to the nacos config items, both in the UI and in the preset. This is done by querying the nacos API for the list of namespaces and matching them with the config items, and by updating the `NacosConfig` type and the related functions.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c0de4ee</samp>

*  Add namespace ID and name to nacos config items ([link](https://github.com/koderover/zadig/pull/3223/files?diff=unified&w=0#diff-2334706c18c9b860968c28c101bce600125069b72853e4688a0c3bfd86bb08e3R53-R67), [link](https://github.com/koderover/zadig/pull/3223/files?diff=unified&w=0#diff-2334706c18c9b860968c28c101bce600125069b72853e4688a0c3bfd86bb08e3R74-R77), [link](https://github.com/koderover/zadig/pull/3223/files?diff=unified&w=0#diff-0c434543f5413935eb7cb57adc29368e21f2c9dd50801d6f84c20a9de6d0ed8dL67-R84), [link](https://github.com/koderover/zadig/pull/3223/files?diff=unified&w=0#diff-ba4f7729ce909195cb9660331bbebb52409b1b1f2108ba7f98a97e2997faba2aR31-R32))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
