### PR TITLE
fix variable missing error

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_env.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_env.go
@@ -141,16 +141,9 @@ func UpdateProductServiceDeployInfo(deployInfo *ProductServiceDeployInfo) error 
 			}
 			productInfo.Services[0] = append(productInfo.Services[0], productSvc)
 			sevOnline = true
-		}
-		productSvc.UpdateTime = time.Now().Unix()
-
-		if svcRender == nil {
-			svcRender = &template.ServiceRender{
-				ServiceName:  deployInfo.ServiceName,
-				OverrideYaml: &template.CustomYaml{},
-			}
 			productSvc.Render = svcRender
 		}
+		productSvc.UpdateTime = time.Now().Unix()
 
 		// merge render variables and deploy variables
 		mergedVariableYaml := deployInfo.VariableYaml


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7dcf281</samp>

Store rendered service template data in product service struct. This change modifies `job_env.go` to assign the `svcRender` variable to the `Render` field of the `productSvc` struct, so that the rendered data can be used for deployment or rollback.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7dcf281</samp>

*  Assign rendered service template data to product service information ([link](https://github.com/koderover/zadig/pull/3225/files?diff=unified&w=0#diff-595392e64f1b99c3b9a86378055f808d9fcc8dac2db18369742bd4a8b31af07aR152)). This allows the data to be used later for deployment or rollback. The file `job_env.go` contains the function `UpdateProductServiceDeployInfo` that updates the database after a workflow task is completed.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
