### PR TITLE
add resource check for host workload creation

### DIFF
--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -1048,7 +1048,7 @@ func UpdateHelmProductDefaultValues(c *gin.Context) {
 		return
 	}
 
-	if arg.ValuesData.AutoSync {
+	if arg.ValuesData != nil && arg.ValuesData.AutoSync {
 		if !commonutil.ValidateZadigXLicenseStatus(licenseStatus) {
 			ctx.Err = e.ErrLicenseInvalid.AddDesc("")
 			return
@@ -2388,6 +2388,28 @@ func ListWorkloads(c *gin.Context) {
 			workloadM[serviceInExternalEnv.ServiceName] = commonmodels.Workload{
 				EnvName:     serviceInExternalEnv.EnvName,
 				ProductName: serviceInExternalEnv.ProductName,
+			}
+		}
+
+		// find workloads existed in other envs
+		sharedNSEnvs, err := mongodb.NewProductColl().ListEnvByNamespace(args.ClusterID, args.Namespace)
+		if err != nil {
+			log.Errorf("ListWorkloads ListEnvByNamespace err:%v", err)
+		}
+		for _, env := range sharedNSEnvs {
+			for _, svc := range env.GetSvcList() {
+				for _, res := range svc.Resources {
+					if res.Kind == setting.Deployment || res.Kind == setting.StatefulSet {
+						workloadM[res.Name] = commonmodels.Workload{
+							EnvName:     env.EnvName,
+							ProductName: env.ProductName,
+						}
+					}
+					workloadM[res.Name] = commonmodels.Workload{
+						EnvName:     env.EnvName,
+						ProductName: env.ProductName,
+					}
+				}
 			}
 		}
 

--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -2405,10 +2405,6 @@ func ListWorkloads(c *gin.Context) {
 							ProductName: env.ProductName,
 						}
 					}
-					workloadM[res.Name] = commonmodels.Workload{
-						EnvName:     env.EnvName,
-						ProductName: env.ProductName,
-					}
 				}
 			}
 		}


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 541f9c5</samp>

Fix a bug and add a feature in environment handler. This pull request resolves a nil pointer issue in `arg.ValuesData` and enables namespace isolation for different workloads in `environment.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 541f9c5</samp>

*  Add nil check for `arg.ValuesData` to avoid nil pointer dereference error ([link](https://github.com/koderover/zadig/pull/3228/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL1051-R1051))
*  Find workloads in other environments that share the same namespace as the current environment ([link](https://github.com/koderover/zadig/pull/3228/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eR2394-R2415))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
