### PR TITLE
update env list filter logic

### DIFF
--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -129,11 +129,6 @@ func ListProductionEnvs(c *gin.Context) {
 		return
 	}
 
-	excludeSharedNs := false
-	if c.Query("excludeSharedNS") == "true" {
-		excludeSharedNs = true
-	}
-
 	hasPermission := false
 	envFilter := make([]string, 0)
 
@@ -159,7 +154,7 @@ func ListProductionEnvs(c *gin.Context) {
 		return
 	}
 
-	ctx.Resp, ctx.Err = service.ListProductionEnvs(ctx.UserID, projectName, envFilter, excludeSharedNs, ctx.Logger)
+	ctx.Resp, ctx.Err = service.ListProductionEnvs(ctx.UserID, projectName, envFilter, ctx.Logger)
 }
 
 // @Summary Update Multi products

--- a/pkg/microservice/aslan/core/environment/service/environment_define.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_define.go
@@ -62,6 +62,7 @@ type EnvResp struct {
 	BaseName    string   `json:"base_name"`
 	IsExisted   bool     `json:"is_existed"`
 	IsFavorite  bool     `json:"is_favorite"`
+	SharedNS    bool     `json:"shared_ns"`
 
 	// New Since v1.11.0
 	ShareEnvEnable  bool   `json:"share_env_enable"`

--- a/pkg/microservice/aslan/core/environment/service/production_environment.go
+++ b/pkg/microservice/aslan/core/environment/service/production_environment.go
@@ -41,27 +41,21 @@ import (
 	"github.com/koderover/zadig/pkg/util"
 )
 
-func ListProductionEnvs(userId string, projectName string, envNames []string, excludeSharedNs bool, log *zap.SugaredLogger) ([]*EnvResp, error) {
+func ListProductionEnvs(userId string, projectName string, envNames []string, log *zap.SugaredLogger) ([]*EnvResp, error) {
 	envs, err := ListProducts(userId, projectName, envNames, true, log)
 	if err != nil {
 		return nil, err
 	}
-	ret := make([]*EnvResp, 0)
 	for _, env := range envs {
-		if !excludeSharedNs {
-			ret = append(ret, env)
-			continue
-		}
 		relatedEnvs, err := commonrepo.NewProductColl().ListEnvByNamespace(env.ClusterID, env.Namespace)
 		if err != nil {
-			return nil, err
-		}
-		if len(relatedEnvs) > 1 {
 			continue
 		}
-		ret = append(ret, env)
+		if len(relatedEnvs) > 1 {
+			env.SharedNS = true
+		}
 	}
-	return ret, nil
+	return envs, nil
 }
 
 func ListProductionGroups(serviceName, envName, productName string, perPage, page int, log *zap.SugaredLogger) ([]*commonservice.ServiceResp, int, error) {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c401d8b</samp>

Removed the `excludeSharedNS` parameter from the `ListProductionEnvs` API and added a new `SharedNS` field to the response type. Moved the shared namespace logic from the handler to the service layer.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c401d8b</samp>

*  Remove `excludeSharedNS` parameter from `ListProductionEnvs` API and move the logic of determining shared namespace status to the service layer ([link](https://github.com/koderover/zadig/pull/3230/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL132-L136), [link](https://github.com/koderover/zadig/pull/3230/files?diff=unified&w=0#diff-19928ccf42e13923ae0e21b9a98bdbfbb28ea7522b8c613188820ba03c99977eL162-R157), [link](https://github.com/koderover/zadig/pull/3230/files?diff=unified&w=0#diff-1e378fc30abf1668c8209f655b76cfe82dd9eadc9765a9ac63f83e2a63c68c4fL44-R58))
* Add `SharedNS` field to `EnvResp` type to indicate whether the environment shares the same namespace with other environments in the same cluster ([link](https://github.com/koderover/zadig/pull/3230/files?diff=unified&w=0#diff-d6af1605fb67bd928eeb0d1616c83ea70358f0a4195fd3fb18dd6c714c2a41d5R65))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
