### PR TITLE
fix env creation missing resource error

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2399,7 +2399,6 @@ func preCreateProduct(envName string, args *commonmodels.Product, kubeClient cli
 	)
 
 	var productTmpl *templatemodels.Product
-	// 查询产品模板
 	productTmpl, err = templaterepo.NewProductColl().Find(productTemplateName)
 	if err != nil {
 		log.Errorf("[%s][P:%s] get product template error: %v", envName, productTemplateName, err)

--- a/pkg/microservice/aslan/core/environment/service/environment_creation.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_creation.go
@@ -275,6 +275,14 @@ func prepareK8sProductCreation(templateProduct *templatemodels.Product, productO
 		for _, svc := range svcGroup {
 			sg = append(sg, svc.ProductService)
 			serviceDeployStrategy[svc.ServiceName] = svc.DeployStrategy
+			parsedYaml, err := kube.RenderEnvService(productObj, svc.ProductService.GetServiceRender(), svc.ProductService)
+			if err != nil {
+				return fmt.Errorf("failed to render yaml for env creation, serviceName: %s, err: %w", svc.ServiceName, err)
+			}
+			svc.Resources, err = kube.ManifestToResource(parsedYaml)
+			if err != nil {
+				return fmt.Errorf("failed to parse yaml for env creation, serviceName: %s, err: %w", svc.ServiceName, err)
+			}
 		}
 		productObj.Services = append(productObj.Services, sg)
 	}


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6aed920</samp>

This pull request enhances the environment creation feature by rendering and parsing the service YAML manifests before creating the Kubernetes environment. It also removes a redundant comment in `environment.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6aed920</samp>

*  Render and parse YAML manifest for each service before creating Kubernetes environment ([link](https://github.com/koderover/zadig/pull/3231/files?diff=unified&w=0#diff-308a1d44b6f32df5de86aa202b44f768b669a86f0798c5bdb1688e17f95df44dR278-R285))
* Remove redundant comment in Chinese from `environment.go` file ([link](https://github.com/koderover/zadig/pull/3231/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L2402))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
