### PR TITLE
fix parse sys key error

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/210.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/210.go
@@ -133,7 +133,7 @@ func addReleaseNameToHelmProductServices() error {
 func handleK8sProductService(product *models.Product) error {
 	for _, svc := range product.GetSvcList() {
 		if len(svc.Resources) > 0 {
-			return nil
+			continue
 		}
 
 		prodSvcTemplate, err := findSvcTemplate(product.ProductName, svc.ServiceName, svc.Revision, product.Production)
@@ -144,14 +144,14 @@ func handleK8sProductService(product *models.Product) error {
 
 		fullRenderedYaml, err := kube.RenderServiceYaml(prodSvcTemplate.Yaml, product.ProductName, svc.ServiceName, svc.GetServiceRender())
 		if err != nil {
-			log.Errorf("failed to render service yaml: %s/%s/%v, err: %s", product.ProductName, svc.ServiceName, svc.Revision, err.Error())
+			log.Errorf("failed to render service yaml: %s/%s/%s/%v, err: %s", product.ProductName, product.EnvName, svc.ServiceName, svc.Revision, err.Error())
 			continue
 		}
-		fullRenderedYaml = kube.ParseSysKeys(fullRenderedYaml, product.EnvName, product.ProductName, svc.ServiceName, fullRenderedYaml)
+		fullRenderedYaml = kube.ParseSysKeys(product.EnvName, product.EnvName, product.ProductName, svc.ServiceName, fullRenderedYaml)
 
 		svc.Resources, err = kube.ManifestToResource(fullRenderedYaml)
 		if err != nil {
-			log.Errorf("failed to convert service yaml to resource: %s/%s/%v, err: %s", product.ProductName, svc.ServiceName, svc.Revision, err.Error())
+			log.Errorf("failed to convert service yaml to resource: %s/%s/%s/%v, err: %s", product.ProductName, product.EnvName, svc.ServiceName, svc.Revision, err.Error())
 			continue
 		}
 		log.Infof("update service resource: %s/%s/%v", product.ProductName, product.EnvName, svc.ServiceName)


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 20e8790</samp>

Refactored and fixed a function for migrating Kubernetes services in `pkg/cli/upgradeassistant/cmd/migrate/210.go`. Improved logging and yaml output with environment name.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 20e8790</samp>

*  Refactor `handleK8sProductService` function to support multiple environments and clusters for Kubernetes services ([link](https://github.com/koderover/zadig/pull/3233/files?diff=unified&w=0#diff-1a4e6d99b8b7200b4b40003ffd4cb3d63de3bb4f166639b6d79e95fb3d199a3bL136-R136), [link](https://github.com/koderover/zadig/pull/3233/files?diff=unified&w=0#diff-1a4e6d99b8b7200b4b40003ffd4cb3d63de3bb4f166639b6d79e95fb3d199a3bL147-R154))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
