### PR TITLE
remove resource deletion for cluster deletion

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/service.go
+++ b/pkg/microservice/aslan/core/common/service/kube/service.go
@@ -197,10 +197,10 @@ func (s *Service) UpdateCluster(id string, cluster *models.K8SCluster, logger *z
 }
 
 func (s *Service) DeleteCluster(user string, id string, logger *zap.SugaredLogger) error {
-	clusterInfo, err := s.coll.Get(id)
-	if err != nil {
-		return e.ErrDeleteCluster.AddErr(e.ErrClusterNotFound.AddDesc(id))
-	}
+	//clusterInfo, err := s.coll.Get(id)
+	//if err != nil {
+	//	return e.ErrDeleteCluster.AddErr(e.ErrClusterNotFound.AddDesc(id))
+	//}
 
 	// Now we only clear the cluster resources when the cluster is using a kubeconfig
 	// This logic is required if the cluster need to be re-applied to Zadig.
@@ -212,7 +212,7 @@ func (s *Service) DeleteCluster(user string, id string, logger *zap.SugaredLogge
 	//	}
 	//}
 
-	err = s.coll.Delete(id)
+	err := s.coll.Delete(id)
 	if err != nil {
 		logger.Errorf("failed to delete cluster by id %s %v", id, err)
 		return e.ErrDeleteCluster.AddErr(err)

--- a/pkg/microservice/aslan/core/common/service/kube/service.go
+++ b/pkg/microservice/aslan/core/common/service/kube/service.go
@@ -204,12 +204,13 @@ func (s *Service) DeleteCluster(user string, id string, logger *zap.SugaredLogge
 
 	// Now we only clear the cluster resources when the cluster is using a kubeconfig
 	// This logic is required if the cluster need to be re-applied to Zadig.
-	if clusterInfo.Type == setting.KubeConfigClusterType {
-		err = RemoveClusterResources(config.HubServerAddress(), id)
-		if err != nil {
-			return e.ErrDeleteCluster.AddDesc(err.Error())
-		}
-	}
+	// 2023-12-06 this logic is removed. Cluster resource under koderover-agent ns is no longer maintained
+	//if clusterInfo.Type == setting.KubeConfigClusterType {
+	//	err = RemoveClusterResources(config.HubServerAddress(), id)
+	//	if err != nil {
+	//		return e.ErrDeleteCluster.AddDesc(err.Error())
+	//	}
+	//}
 
 	err = s.coll.Delete(id)
 	if err != nil {


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5a6a68a</samp>

Comment out code that deletes `koderover-agent` namespace resources in `service.go`. This preserves the cluster state managed by the `koderover-agent` controller, which was added in a previous pull request.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5a6a68a</samp>

*  Comment out the code that deletes the cluster resources under the `koderover-agent` namespace to avoid conflicts with the `koderover-agent` controller ([link](https://github.com/koderover/zadig/pull/3234/files?diff=unified&w=0#diff-fd1b679b0eba7f1a705b787b0efa3963a000d823cbc4a458e9a352d9eb97895dL207-R213))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
