### PR TITLE
remove schedule workflow validate for vm integration

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/private_key.go
+++ b/pkg/microservice/aslan/core/common/repository/models/private_key.go
@@ -90,7 +90,7 @@ func (args *PrivateKey) Validate() error {
 	if !((licenseStatus.Type == plutusvendor.ZadigSystemTypeProfessional ||
 		licenseStatus.Type == plutusvendor.ZadigSystemTypeEnterprise) &&
 		licenseStatus.Status == plutusvendor.ZadigXLicenseStatusNormal) {
-		if args.Provider == config.VMProviderAmazon || args.ScheduleWorkflow {
+		if args.Provider == config.VMProviderAmazon {
 			return e.ErrLicenseInvalid.AddDesc("")
 		}
 	}


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f806e0d</samp>

Allow creating private keys for scheduled workflows. Remove the `ScheduleWorkflow` flag check from the `Validate` function in `private_key.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f806e0d</samp>

* Remove the license check for scheduled workflows when creating a private key ([link](https://github.com/koderover/zadig/pull/3236/files?diff=unified&w=0#diff-055853a775df04ee98804ce0d6c32a2c389c819f553ed2ea89dd9c1f44134644L93-R93))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
