### PR TITLE
fix resource check logic

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/product.go
+++ b/pkg/microservice/aslan/core/common/repository/models/product.go
@@ -155,7 +155,7 @@ type ServiceResource struct {
 }
 
 func (r *ServiceResource) String() string {
-	return fmt.Sprintf("%s/%s", r.GroupVersionKind.String(), r.Name)
+	return fmt.Sprintf("%s/%s", r.GroupVersionKind.Kind, r.Name)
 }
 
 type ProductService struct {

--- a/pkg/microservice/aslan/core/common/repository/models/workload_stat.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workload_stat.go
@@ -17,6 +17,8 @@ limitations under the License.
 package models
 
 import (
+	"fmt"
+
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -36,4 +38,8 @@ type Workload struct {
 
 func (WorkloadStat) TableName() string {
 	return "workload_stat"
+}
+
+func (wl *Workload) String() string {
+	return fmt.Sprintf("%s/%s", wl.Type, wl.Name)
 }

--- a/pkg/microservice/aslan/core/common/service/kube/apply.go
+++ b/pkg/microservice/aslan/core/common/service/kube/apply.go
@@ -374,6 +374,17 @@ func CheckResourceAppliedByOtherEnv(serviceYaml string, productInfo *commonmodel
 	}
 
 	for _, env := range envs {
+		if env.Source == setting.SourceFromExternal {
+			workloadStat, _ := commonrepo.NewWorkLoadsStatColl().Find(productInfo.ClusterID, productInfo.Namespace)
+			for _, workload := range workloadStat.Workloads {
+				if resSet.Has(workload.String()) {
+					insertEnvData(workload.String(), env)
+					break
+				}
+			}
+			continue
+		}
+
 		for _, svc := range env.GetServiceMap() {
 			if env.ProductName == productInfo.ProductName && env.EnvName == productInfo.EnvName && svc.ServiceName == serviceName {
 				continue

--- a/pkg/microservice/aslan/core/common/service/kube/apply.go
+++ b/pkg/microservice/aslan/core/common/service/kube/apply.go
@@ -361,11 +361,10 @@ func CheckResourceAppliedByOtherEnv(serviceYaml string, productInfo *commonmodel
 	resSet := sets.NewString()
 	resources := UnstructuredToResources(unstructuredRes)
 
-	log.Infof("checkResourceAppliedByOtherEnv %s/%s, clusterID: %s, namespace: %s ", productInfo.ProductName, productInfo.EnvName, productInfo.ClusterID, productInfo.Namespace)
-
 	for _, res := range resources {
 		resSet.Insert(res.String())
 	}
+	log.Infof("checkResourceAppliedByOtherEnv %s/%s, clusterID: %s, namespace: %s, resource: %v ", productInfo.ProductName, productInfo.EnvName, productInfo.ClusterID, productInfo.Namespace, resSet.List())
 
 	envs, err := commonrepo.NewProductColl().ListEnvByNamespace(productInfo.ClusterID, productInfo.Namespace)
 	if err != nil {
@@ -374,9 +373,11 @@ func CheckResourceAppliedByOtherEnv(serviceYaml string, productInfo *commonmodel
 	}
 
 	for _, env := range envs {
+		log.Infof("handle single env: %s", env.ProductName, env.EnvName)
 		if env.Source == setting.SourceFromExternal {
 			workloadStat, _ := commonrepo.NewWorkLoadsStatColl().Find(productInfo.ClusterID, productInfo.Namespace)
 			for _, workload := range workloadStat.Workloads {
+				log.Infof("workload: %s", workload.String())
 				if resSet.Has(workload.String()) {
 					insertEnvData(workload.String(), env)
 					break

--- a/pkg/microservice/aslan/core/common/service/kube/apply.go
+++ b/pkg/microservice/aslan/core/common/service/kube/apply.go
@@ -373,11 +373,9 @@ func CheckResourceAppliedByOtherEnv(serviceYaml string, productInfo *commonmodel
 	}
 
 	for _, env := range envs {
-		log.Infof("handle single env: %s", env.ProductName, env.EnvName)
 		if env.Source == setting.SourceFromExternal {
 			workloadStat, _ := commonrepo.NewWorkLoadsStatColl().Find(productInfo.ClusterID, productInfo.Namespace)
 			for _, workload := range workloadStat.Workloads {
-				log.Infof("workload: %s", workload.String())
 				if resSet.Has(workload.String()) {
 					insertEnvData(workload.String(), env)
 					break


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0c2168c</samp>

Added support for external environment sources in Zadig by modifying the `CheckResourceAppliedByOtherEnv` function and adding a `String` method to the `Workload` struct. This allows Zadig to detect and display the environment data of resources that are managed by Helm or Kustomize.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0c2168c</samp>

*  Add `String` method to `Workload` struct to format workload type and name ([link](https://github.com/koderover/zadig/pull/3238/files?diff=unified&w=0#diff-61c72eb58bca7bc65d44af1a729d75a7fe388289356a792a48c949aa2cd5e60cR20-R21), [link](https://github.com/koderover/zadig/pull/3238/files?diff=unified&w=0#diff-61c72eb58bca7bc65d44af1a729d75a7fe388289356a792a48c949aa2cd5e60cR42-R45))
*  Modify `CheckResourceAppliedByOtherEnv` function to handle external environment sources ([link](https://github.com/koderover/zadig/pull/3238/files?diff=unified&w=0#diff-b7766b1ac130ecbefb6435761367e3203d8473340cd88204c1df1e057345b050R377-R387))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
