### PR TITLE
fix release image bug

### DIFF
--- a/pkg/microservice/warpdrive/core/service/taskplugin/release_image.go
+++ b/pkg/microservice/warpdrive/core/service/taskplugin/release_image.go
@@ -709,6 +709,7 @@ DistributeLoop:
 				continue DistributeLoop
 			}
 			p.Log.Infof("final minimum merged values.yaml: \n%s", mergedValuesYaml)
+			replacedMergedValuesYaml = mergedValuesYaml
 
 			helmClient, err = helmtool.NewClientFromNamespace(distribute.DeployClusterID, distribute.DeployNamespace)
 			if err != nil {

--- a/pkg/tool/helmclient/helmclient.go
+++ b/pkg/tool/helmclient/helmclient.go
@@ -198,7 +198,6 @@ func MergeOverrideValues(valuesYaml, defaultValues, overrideYaml, overrideValues
 		}
 	}
 
-	log.Debugf("imageRelatedValues: %s", string(imageRelatedValues))
 	valuesMap, err := yamlutil.MergeAndUnmarshal([][]byte{imageRelatedValues, []byte(valuesYaml), []byte(defaultValues), []byte(overrideYaml)})
 	if err != nil {
 		return "", err
@@ -235,7 +234,6 @@ func MergeOverrideValues(valuesYaml, defaultValues, overrideYaml, overrideValues
 	if err != nil {
 		return "", err
 	}
-	log.Debugf("final values: %s", string(bs))
 	return string(bs), nil
 }
 

--- a/pkg/tool/helmclient/helmclient.go
+++ b/pkg/tool/helmclient/helmclient.go
@@ -193,8 +193,12 @@ func MergeOverrideValues(valuesYaml, defaultValues, overrideYaml, overrideValues
 			return "", err
 		}
 		imageRelatedValues, err = yaml.Marshal(imageValuesMap)
+		if err != nil {
+			return "", err
+		}
 	}
 
+	log.Debugf("imageRelatedValues: %s", string(imageRelatedValues))
 	valuesMap, err := yamlutil.MergeAndUnmarshal([][]byte{imageRelatedValues, []byte(valuesYaml), []byte(defaultValues), []byte(overrideYaml)})
 	if err != nil {
 		return "", err
@@ -231,6 +235,7 @@ func MergeOverrideValues(valuesYaml, defaultValues, overrideYaml, overrideValues
 	if err != nil {
 		return "", err
 	}
+	log.Debugf("final values: %s", string(bs))
 	return string(bs), nil
 }
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 640d053</samp>

Fix image value override bug and add debug logs in `helmclient`. Improve the reliability and observability of `helmclient` when deploying applications with Zadig.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 640d053</samp>

*  Add error handling and debug logs for image values merging ([link](https://github.com/koderover/zadig/pull/3240/files?diff=unified&w=0#diff-43a9dce56755d1a350cdaddec8b11f9b7c4e7fa8fc7f7aa5204cbaddbb9c3869L196-R201), [link](https://github.com/koderover/zadig/pull/3240/files?diff=unified&w=0#diff-43a9dce56755d1a350cdaddec8b11f9b7c4e7fa8fc7f7aa5204cbaddbb9c3869R238))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
