### PR TITLE
add missing pprof api

### DIFF
--- a/pkg/microservice/aslan/server/server.go
+++ b/pkg/microservice/aslan/server/server.go
@@ -67,6 +67,7 @@ func Serve(ctx context.Context) error {
 	// pprof service, you can access it by {your_ip}:8888/debug/pprof
 	go func() {
 		mux := http.NewServeMux()
+		mux.HandleFunc("/api/debug/pprof/{cmd}", pprof.Index)
 		mux.HandleFunc("/api/debug/pprof", pprof.Index)
 		mux.HandleFunc("/api/debug/pprof/cmdline", pprof.Cmdline)
 		mux.HandleFunc("/api/debug/pprof/profile", pprof.Profile)

--- a/pkg/microservice/aslan/server/server.go
+++ b/pkg/microservice/aslan/server/server.go
@@ -23,6 +23,7 @@ import (
 	_ "net/http/pprof"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core"
 	"github.com/koderover/zadig/pkg/microservice/aslan/server/rest"
 	"github.com/koderover/zadig/pkg/tool/kube/client"
@@ -66,14 +67,14 @@ func Serve(ctx context.Context) error {
 
 	// pprof service, you can access it by {your_ip}:8888/debug/pprof
 	go func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/api/debug/pprof/{cmd}", pprof.Index)
-		mux.HandleFunc("/api/debug/pprof", pprof.Index)
-		mux.HandleFunc("/api/debug/pprof/cmdline", pprof.Cmdline)
-		mux.HandleFunc("/api/debug/pprof/profile", pprof.Profile)
-		mux.HandleFunc("/api/debug/pprof/symbol", pprof.Symbol)
-		mux.HandleFunc("/api/debug/pprof/trace", pprof.Trace)
-		err := http.ListenAndServe("0.0.0.0:8888", mux)
+		router := mux.NewRouter()
+		router.Handle("/api/debug/pprof", http.HandlerFunc(pprof.Index))
+		router.Handle("/api/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+		router.Handle("/api/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+		router.Handle("/api/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+		router.Handle("/api/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+		router.Handle("/api/debug/pprof/{cmd}", http.HandlerFunc(pprof.Index))
+		err := http.ListenAndServe("0.0.0.0:8888", router)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f0d78bb</samp>

Add support for pprof to the aslan server. This enables accessing the `/api/debug/pprof/{cmd}` endpoint to profile and debug the server performance and memory usage.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f0d78bb</samp>

* Add handler for `/api/debug/pprof/{cmd}` endpoint to access pprof tool ([link](https://github.com/koderover/zadig/pull/3242/files?diff=unified&w=0#diff-e2fbf4796a732f3f7a4f3610176e2b53b2777129d495566bc8bbe7af0d76e794R70))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
