### PR TITLE
change authn and pprof api for container

### DIFF
--- a/pkg/microservice/aslan/server/server.go
+++ b/pkg/microservice/aslan/server/server.go
@@ -68,12 +68,12 @@ func Serve(ctx context.Context) error {
 	// pprof service, you can access it by {your_ip}:8888/debug/pprof
 	go func() {
 		router := mux.NewRouter()
-		router.Handle("/api/debug/pprof", http.HandlerFunc(pprof.Index))
-		router.Handle("/api/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
-		router.Handle("/api/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
-		router.Handle("/api/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
-		router.Handle("/api/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
-		router.Handle("/api/debug/pprof/{cmd}", http.HandlerFunc(pprof.Index))
+		router.Handle("/debug/pprof", http.HandlerFunc(pprof.Index))
+		router.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+		router.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+		router.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+		router.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+		router.Handle("/debug/pprof/{cmd}", http.HandlerFunc(pprof.Index))
 		err := http.ListenAndServe("0.0.0.0:8888", router)
 		if err != nil {
 			log.Fatal(err)

--- a/pkg/microservice/user/core/service/permission/authn.go
+++ b/pkg/microservice/user/core/service/permission/authn.go
@@ -73,7 +73,7 @@ func IsPublicURL(reqPath, method string) bool {
 		return true
 	}
 
-	if strings.HasPrefix(realPath, "/api/debug/pprof") && method == http.MethodGet {
+	if strings.HasPrefix(realPath, "/debug/pprof") && method == http.MethodGet {
 		return true
 	}
 

--- a/pkg/microservice/user/core/service/permission/authn.go
+++ b/pkg/microservice/user/core/service/permission/authn.go
@@ -73,7 +73,7 @@ func IsPublicURL(reqPath, method string) bool {
 		return true
 	}
 
-	if strings.HasPrefix(realPath, "/debug/pprof") && method == http.MethodGet {
+	if strings.HasPrefix(realPath, "/debug") && method == http.MethodGet {
 		return true
 	}
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 26b5b2f</samp>

Moved pprof endpoints to `/debug/pprof` and updated authentication logic. This avoids conflicts with the API gateway and allows easier debugging of the Aslan service.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 26b5b2f</samp>

*  Move pprof endpoints to `/debug/pprof` to avoid conflicts and follow convention ([link](https://github.com/koderover/zadig/pull/3243/files?diff=unified&w=0#diff-e2fbf4796a732f3f7a4f3610176e2b53b2777129d495566bc8bbe7af0d76e794L71-R76))
*  Allow unauthenticated GET requests to pprof endpoints by updating `IsPublicURL` function ([link](https://github.com/koderover/zadig/pull/3243/files?diff=unified&w=0#diff-a183a10cb2bc26193bb8bfd0c8b78551dc357620da224f0b692c93c5cabe5c12L76-R76))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
