### PR TITLE
add registry login for chart pull

### DIFF
--- a/pkg/tool/helmclient/helmclient.go
+++ b/pkg/tool/helmclient/helmclient.go
@@ -681,6 +681,11 @@ func (hClient *HelmClient) downloadOCIChart(repoEntry *repo.Entry, chartRef stri
 	if err != nil {
 		return err
 	}
+	hostUrl := strings.TrimPrefix(repoEntry.URL, fmt.Sprintf("%s://", registry.OCIScheme))
+	err = pullConfig.RegistryClient.Login(hostUrl, registry.LoginOptBasicAuth(repoEntry.Username, repoEntry.Password))
+	if err != nil {
+		return err
+	}
 	pull := action.NewPullWithOpts(action.WithConfig(pullConfig))
 	pull.Password = repoEntry.Username
 	pull.Username = repoEntry.Password


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0d35093</samp>

Support private OCI repositories for helm charts. Add login step and trim OCIScheme prefix in `helmclient.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0d35093</samp>

*  Add login step to registry client for pulling OCI charts ([link](https://github.com/koderover/zadig/pull/3247/files?diff=unified&w=0#diff-43a9dce56755d1a350cdaddec8b11f9b7c4e7fa8fc7f7aa5204cbaddbb9c3869R684-R688))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
