### PR TITLE
fix artifact deploy timeout issue

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -1825,7 +1825,7 @@ func CreateArtifactWorkflowTask(args *commonmodels.WorkflowTaskArgs, taskCreator
 			if env != nil {
 				// 生成部署的subtask
 				for _, deployEnv := range artifact.Deploy {
-					deployTask, err := deployEnvToSubTasks(deployEnv, env, productTempl.Timeout)
+					deployTask, err := deployEnvToSubTasks(deployEnv, env, productTempl.Timeout*60)
 					if err != nil {
 						log.Errorf("deploy env to subtask error: %v", err)
 						return nil, err


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5c19494</samp>

Improved logging for the `taskplugin` package and the artifact deploy task. This allows users to track the progress and status of their deployment tasks and troubleshoot any issues.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5c19494</samp>

* Import `log` package to enable logging in `taskplugin` package ([link](https://github.com/koderover/zadig/pull/3252/files?diff=unified&w=0#diff-98eeafb103c9b66a212554c07c7d005f4361725054ad60ca8cf3dcd408ca5590R41))
* Add debug log statement to print task timeout value in `TaskTimeout` function ([link](https://github.com/koderover/zadig/pull/3252/files?diff=unified&w=0#diff-98eeafb103c9b66a212554c07c7d005f4361725054ad60ca8cf3dcd408ca5590L104-R106))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
