### PR TITLE
cherry pick #3252 and #3255 to 2.1.0

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/share_env.go
+++ b/pkg/microservice/aslan/core/common/service/kube/share_env.go
@@ -28,6 +28,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/koderover/zadig/pkg/microservice/aslan/config"
@@ -532,4 +533,21 @@ func EnsureZadigServiceByManifest(ctx context.Context, productName, namespace, m
 	}
 
 	return nil
+}
+
+func CheckIstiodInstalled(ctx context.Context, clientset *kubernetes.Clientset) (bool, error) {
+	podList, err := clientset.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "istio",
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to list istio pods, err: %s", err)
+	}
+
+	for _, pod := range podList.Items {
+		if pod.Status.Phase != corev1.PodRunning {
+			return false, fmt.Errorf("istio pod %s is not running", pod.Name)
+		}
+	}
+
+	return true, nil
 }

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task.go
@@ -1825,7 +1825,7 @@ func CreateArtifactWorkflowTask(args *commonmodels.WorkflowTaskArgs, taskCreator
 			if env != nil {
 				// 生成部署的subtask
 				for _, deployEnv := range artifact.Deploy {
-					deployTask, err := deployEnvToSubTasks(deployEnv, env, productTempl.Timeout)
+					deployTask, err := deployEnvToSubTasks(deployEnv, env, productTempl.Timeout*60)
 					if err != nil {
 						log.Errorf("deploy env to subtask error: %v", err)
 						return nil, err


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0b6c439</samp>

This pull request enhances the istio gateway handling and fixes a timeout bug in the workflow package. It adds checks for istio installation and nil parameters in `environment.go` and `share_env.go`, and uses the istio networking package in `k8s.go`. It also corrects the timeout calculation for the deploy subtasks in `workflow_task.go`.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0b6c439</samp>

*  Add check for istio installation and running status before listing istio gateways to avoid errors ([link](https://github.com/koderover/zadig/pull/3256/files?diff=unified&w=0#diff-43b4a5df02ef75087654902b8d4afc32745599d35053d171a5b950a94d012960L838-R853), [link](https://github.com/koderover/zadig/pull/3256/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136L367-R384))
*  Add nil check for gateway list parameter to prevent nil pointer dereference ([link](https://github.com/koderover/zadig/pull/3256/files?diff=unified&w=0#diff-43b4a5df02ef75087654902b8d4afc32745599d35053d171a5b950a94d012960L924-R932))
*  Add `CheckIstiodInstalled` function in `kube` package to check istio pods status using kubernetes clientset ([link](https://github.com/koderover/zadig/pull/3256/files?diff=unified&w=0#diff-cc7fb5841e25af5acc225a53fd6c59207d13b470ca23d89feadd724c4e8a48bdR31), [link](https://github.com/koderover/zadig/pull/3256/files?diff=unified&w=0#diff-cc7fb5841e25af5acc225a53fd6c59207d13b470ca23d89feadd724c4e8a48bdR537-R553))
*  Fix bug in `CreateArtifactWorkflowTask` function in `workflow` package by multiplying timeout parameter by 60 to convert minutes to seconds ([link](https://github.com/koderover/zadig/pull/3256/files?diff=unified&w=0#diff-702d95f47c717dca690995fb95d143271e53dea771d151405fc50ae9f4b688e5L1828-R1828))
*  Import istio networking v1alpha3 package in `service` package to use istio gateway type ([link](https://github.com/koderover/zadig/pull/3256/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136R31))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
