### PR TITLE
add transaction switch

### DIFF
--- a/pkg/microservice/aslan/config/config.go
+++ b/pkg/microservice/aslan/config/config.go
@@ -102,6 +102,10 @@ func KodespaceVersion() string {
 	return viper.GetString(setting.ENVKodespaceVersion)
 }
 
+func EnableTransaction() bool {
+	return viper.GetBool(setting.ENVEnableTransaction)
+}
+
 // CleanIgnoredList is a list which will be ignored during environment cleanup.
 func CleanSkippedList() []string {
 	return strings.Split(viper.GetString(setting.CleanSkippedList), ",")

--- a/pkg/microservice/aslan/config/config.go
+++ b/pkg/microservice/aslan/config/config.go
@@ -103,7 +103,7 @@ func KodespaceVersion() string {
 }
 
 func EnableTransaction() bool {
-	return viper.GetBool(setting.ENVEnableTransaction)
+	return viper.GetString(setting.ENVEnableTransaction) == "true"
 }
 
 // CleanIgnoredList is a list which will be ignored during environment cleanup.

--- a/pkg/microservice/aslan/core/common/service/kube/helm.go
+++ b/pkg/microservice/aslan/core/common/service/kube/helm.go
@@ -325,7 +325,7 @@ func UpgradeHelmRelease(product *commonmodels.Product, productSvc *commonmodels.
 	session := mongo.Session()
 	defer session.EndSession(context.TODO())
 
-	err = session.StartTransaction()
+	err = mongo.StartTransaction(session)
 	if err != nil {
 		return err
 	}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_env.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_env.go
@@ -124,7 +124,7 @@ func UpdateProductServiceDeployInfo(deployInfo *ProductServiceDeployInfo) error 
 	session := mongo.Session()
 	defer session.EndSession(context.TODO())
 
-	err = session.StartTransaction()
+	err = mongo.StartTransaction(session)
 	if err != nil {
 		return err
 	}

--- a/pkg/microservice/aslan/core/common/util/enviroment.go
+++ b/pkg/microservice/aslan/core/common/util/enviroment.go
@@ -15,6 +15,7 @@ import (
 	templaterepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb/template"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/repository"
 	"github.com/koderover/zadig/v2/pkg/tool/log"
+	"github.com/koderover/zadig/v2/pkg/tool/mongo"
 	mongotool "github.com/koderover/zadig/v2/pkg/tool/mongo"
 	"github.com/koderover/zadig/v2/pkg/util"
 	"github.com/koderover/zadig/v2/pkg/util/converter"
@@ -176,7 +177,7 @@ func UpdateProductImage(envName, productName, serviceName string, targets map[st
 	session := mongotool.Session()
 	defer session.EndSession(context.TODO())
 
-	err = session.StartTransaction()
+	err = mongo.StartTransaction(session)
 	if err != nil {
 		return err
 	}

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -380,7 +380,7 @@ func updateProductImpl(updateRevisionSvcs []string, deployStrategy map[string]st
 	session := mongotool.Session()
 	defer session.EndSession(context.TODO())
 
-	err = session.StartTransaction()
+	err = mongotool.StartTransaction(session)
 	if err != nil {
 		return e.ErrUpdateEnv.AddErr(err)
 	}
@@ -2813,7 +2813,7 @@ func proceedHelmRelease(productResp *commonmodels.Product, helmClient *helmtool.
 	session := mongotool.Session()
 	defer session.EndSession(context.TODO())
 
-	err := session.StartTransaction()
+	err := mongotool.StartTransaction(session)
 	if err != nil {
 		return err
 	}

--- a/pkg/microservice/aslan/core/environment/service/image.go
+++ b/pkg/microservice/aslan/core/environment/service/image.go
@@ -164,7 +164,7 @@ func UpdateContainerImage(requestID, username string, args *UpdateContainerImage
 		session := mongotool.Session()
 		defer session.EndSession(context.TODO())
 
-		err = session.StartTransaction()
+		err = mongotool.StartTransaction(session)
 		if err != nil {
 			return e.ErrUpdateConainterImage.AddErr(err)
 		}

--- a/pkg/microservice/aslan/core/environment/service/k8s.go
+++ b/pkg/microservice/aslan/core/environment/service/k8s.go
@@ -237,7 +237,7 @@ func (k *K8sService) updateService(args *SvcOptArgs) error {
 	session := mongotool.Session()
 	defer session.EndSession(context.Background())
 
-	err = session.StartTransaction()
+	err = mongotool.StartTransaction(session)
 	if err != nil {
 		return e.ErrUpdateProduct.AddErr(err)
 	}

--- a/pkg/microservice/aslan/core/environment/service/version.go
+++ b/pkg/microservice/aslan/core/environment/service/version.go
@@ -251,7 +251,7 @@ func RollbackEnvServiceVersion(ctx *internalhandler.Context, projectName, envNam
 		session := mongotool.Session()
 		defer session.EndSession(context.Background())
 
-		err = session.StartTransaction()
+		err = mongotool.StartTransaction(session)
 		if err != nil {
 			return e.ErrRollbackEnvServiceVersion.AddErr(err)
 		}

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -226,7 +226,7 @@ func CreateK8sWorkLoads(ctx context.Context, requestID, userName string, args *K
 	productCol := commonrepo.NewProductCollWithSession(session)
 	workloadStatCol := commonrepo.NewWorkLoadsStatCollWithSession(session)
 
-	mongo.StartTransaction(session)
+	mongotool.StartTransaction(session)
 
 	g := new(errgroup.Group)
 	for _, workload := range args.WorkLoads {
@@ -367,7 +367,7 @@ func UpdateWorkloads(ctx context.Context, requestID, username, productName, envN
 	serviceColl := commonrepo.NewServiceCollWithSession(session)
 	workloadStatCol := commonrepo.NewWorkLoadsStatCollWithSession(session)
 
-	mongo.StartTransaction(session)
+	mongotool.StartTransaction(session)
 
 	workloadStat, err := workloadStatCol.Find(args.ClusterID, args.Namespace)
 	if err != nil {

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -226,7 +226,7 @@ func CreateK8sWorkLoads(ctx context.Context, requestID, userName string, args *K
 	productCol := commonrepo.NewProductCollWithSession(session)
 	workloadStatCol := commonrepo.NewWorkLoadsStatCollWithSession(session)
 
-	session.StartTransaction()
+	mongo.StartTransaction(session)
 
 	g := new(errgroup.Group)
 	for _, workload := range args.WorkLoads {
@@ -367,7 +367,7 @@ func UpdateWorkloads(ctx context.Context, requestID, username, productName, envN
 	serviceColl := commonrepo.NewServiceCollWithSession(session)
 	workloadStatCol := commonrepo.NewWorkLoadsStatCollWithSession(session)
 
-	session.StartTransaction()
+	mongo.StartTransaction(session)
 
 	workloadStat, err := workloadStatCol.Find(args.ClusterID, args.Namespace)
 	if err != nil {

--- a/pkg/microservice/warpdrive/core/service/taskcontroller/task_controller.go
+++ b/pkg/microservice/warpdrive/core/service/taskcontroller/task_controller.go
@@ -190,4 +190,5 @@ func initMongoDB() {
 	if err := mongotool.Ping(ctx); err != nil {
 		panic(fmt.Errorf("failed to connect to mongo, error: %s", err))
 	}
+
 }

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -129,6 +129,8 @@ const (
 	// config
 	ENVMysqlDexDB = "MYSQL_DEX_DB"
 	FeatureFlag   = "feature-gates"
+
+	ENVEnableTransaction = "ENABLE_TRANSACTION"
 )
 
 // k8s concepts

--- a/pkg/tool/mongo/client.go
+++ b/pkg/tool/mongo/client.go
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"sync"
 
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -130,6 +132,10 @@ func InitWithOption(ctx context.Context, opt *options.ClientOptions) {
 
 func Close(ctx context.Context) error {
 	return client.Disconnect(ctx)
+}
+
+func Ping(ctx context.Context) error {
+	return client.Ping(ctx, readpref.Primary())
 }
 
 func connect(ctx context.Context, opt *options.ClientOptions) *mongo.Client {

--- a/pkg/tool/mongo/client.go
+++ b/pkg/tool/mongo/client.go
@@ -21,15 +21,13 @@ import (
 	"reflect"
 	"sync"
 
-	"go.mongodb.org/mongo-driver/mongo/readpref"
-
-	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
-
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
 	"go.mongodb.org/mongo-driver/bson/bsonoptions"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
 
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/v2/pkg/tool/log"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -63,10 +61,8 @@ func Session() mongo.Session {
 
 func StartTransaction(session mongo.Session) error {
 	if !config.EnableTransaction() {
-		log.Infof("------- EnableTransaction disabled")
 		return nil
 	}
-	log.Infof("++++++++++ EnableTransaction disabled")
 	return session.StartTransaction()
 }
 


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e9007a5</samp>

This pull request refactors the codebase to support MongoDB transactions for updating product images and helm releases. It adds a new flag `EnableTransaction` to the `config` package, which can be set by the environment variable `ENABLE_TRANSACTION`. It also updates the `util`, `environment`, `service`, `kube`, and `workflowcontroller` packages to use the `mongo` and `helm3` packages for transactional and helm operations. It removes some unused or redundant code from the `mongo` package. It does not change the `taskcontroller` package.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e9007a5</samp>

*  Add a new function `EnableTransaction` to the `config` package to control the mongo transaction logic based on the environment variable `ENABLE_TRANSACTION` ([link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-796020d74b0f724f6a4a8e260bf8a592fb3c3c04f1bec4d02429442d6ab995f9R105-R108), [link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-e9d22162901df783d481a21459bff59cd789639ec450de043099bb498963846cR132-R133))
*  Refactor the `mongo` package to check the `EnableTransaction` flag and log the status before starting, aborting, or committing transactions ([link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-06824b936aca55938cf7eed9b71c144ba502eae79d4a45fb5a8595efd4b8aeb1R24-R25), [link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-06824b936aca55938cf7eed9b71c144ba502eae79d4a45fb5a8595efd4b8aeb1L43-R46), [link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-06824b936aca55938cf7eed9b71c144ba502eae79d4a45fb5a8595efd4b8aeb1L61-R82))
*  Remove unused imports and functions from the `mongo` package ([link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-06824b936aca55938cf7eed9b71c144ba502eae79d4a45fb5a8595efd4b8aeb1L29-R33), [link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-06824b936aca55938cf7eed9b71c144ba502eae79d4a45fb5a8595efd4b8aeb1L121-L124))
*  Replace direct calls to `session.StartTransaction` with the wrapper function `mongo.StartTransaction` in various functions across the `aslan` microservice, such as `UpgradeHelmRelease`, `UpdateProductServiceDeployInfo`, `UpdateProductImage`, `updateProductImpl`, `proceedHelmRelease`, `UpdateContainerImage`, `updateService`, `RollbackEnvServiceVersion`, `CreateK8sWorkLoads`, and `UpdateWorkloads` ([link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-622e96cd3987393e3ae95185c4555f59f3b3ace6292ef497487eb0e7b383a722L328-R328), [link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-595392e64f1b99c3b9a86378055f808d9fcc8dac2db18369742bd4a8b31af07aL127-R127), [link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-f47c0a20e012ef2548ef6631ca90301c9eb29005eab5ff1269c4fe4df14997c1L179-R180), [link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L383-R383), [link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-41b831496d2a2407b51b755f672f95e3e0d592c080e0282adb872b9da7e02b24L2816-R2816), [link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-ec03ae2e652b194c605abd596fd18e1dc1696d9d51d0c3145137b483806f0436L167-R167), [link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-a2ef5c424ba640b6773acf5646ce1be0ad9b90c0fb9c1c5246a2b13198a14136L240-R240), [link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-c282f3a3ba6b7c450a15a42671e0eb40be4bdcb38d32311d3f3fc606d51e6ac2L254-R254), [link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-fcfbf6b1c510bcc0aac99a96af3adfab8a03337a991e91e0b1a7f79b0faac5f0L229-R229), [link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-fcfbf6b1c510bcc0aac99a96af3adfab8a03337a991e91e0b1a7f79b0faac5f0L370-R370))
*  Add the `mongo` package import to the `util` package in the `enviroment.go` file ([link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-f47c0a20e012ef2548ef6631ca90301c9eb29005eab5ff1269c4fe4df14997c1R18))
*  Leave an empty change in the `taskcontroller` package ([link](https://github.com/koderover/zadig/pull/3257/files?diff=unified&w=0#diff-fb8be334ba7b3ee3e60f72ceb8679db536a30e9834cddcdea820795e2d9770daR193))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
