### PR TITLE
pprof support in 1.5.1

### DIFF
--- a/pkg/microservice/aslan/server/server.go
+++ b/pkg/microservice/aslan/server/server.go
@@ -68,12 +68,12 @@ func Serve(ctx context.Context) error {
 	// pprof service, you can access it by {your_ip}:8888/debug/pprof
 	go func() {
 		router := mux.NewRouter()
-		router.Handle("/api/debug/pprof", http.HandlerFunc(pprof.Index))
-		router.Handle("/api/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
-		router.Handle("/api/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
-		router.Handle("/api/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
-		router.Handle("/api/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
-		router.Handle("/api/debug/pprof/{cmd}", http.HandlerFunc(pprof.Index))
+		router.Handle("/debug/pprof", http.HandlerFunc(pprof.Index))
+		router.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+		router.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+		router.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+		router.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+		router.Handle("/debug/pprof/{cmd}", http.HandlerFunc(pprof.Index))
 		err := http.ListenAndServe("0.0.0.0:8888", router)
 		if err != nil {
 			log.Fatal(err)

--- a/pkg/microservice/aslan/server/server.go
+++ b/pkg/microservice/aslan/server/server.go
@@ -67,6 +67,7 @@ func Serve(ctx context.Context) error {
 	// pprof service, you can access it by {your_ip}:8888/debug/pprof
 	go func() {
 		mux := http.NewServeMux()
+		mux.HandleFunc("/api/debug/pprof/{cmd}", pprof.Index)
 		mux.HandleFunc("/api/debug/pprof", pprof.Index)
 		mux.HandleFunc("/api/debug/pprof/cmdline", pprof.Cmdline)
 		mux.HandleFunc("/api/debug/pprof/profile", pprof.Profile)

--- a/pkg/microservice/aslan/server/server.go
+++ b/pkg/microservice/aslan/server/server.go
@@ -23,6 +23,7 @@ import (
 	_ "net/http/pprof"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/koderover/zadig/pkg/microservice/aslan/core"
 	"github.com/koderover/zadig/pkg/microservice/aslan/server/rest"
 	"github.com/koderover/zadig/pkg/tool/kube/client"
@@ -66,14 +67,14 @@ func Serve(ctx context.Context) error {
 
 	// pprof service, you can access it by {your_ip}:8888/debug/pprof
 	go func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/api/debug/pprof/{cmd}", pprof.Index)
-		mux.HandleFunc("/api/debug/pprof", pprof.Index)
-		mux.HandleFunc("/api/debug/pprof/cmdline", pprof.Cmdline)
-		mux.HandleFunc("/api/debug/pprof/profile", pprof.Profile)
-		mux.HandleFunc("/api/debug/pprof/symbol", pprof.Symbol)
-		mux.HandleFunc("/api/debug/pprof/trace", pprof.Trace)
-		err := http.ListenAndServe("0.0.0.0:8888", mux)
+		router := mux.NewRouter()
+		router.Handle("/api/debug/pprof", http.HandlerFunc(pprof.Index))
+		router.Handle("/api/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+		router.Handle("/api/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+		router.Handle("/api/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+		router.Handle("/api/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+		router.Handle("/api/debug/pprof/{cmd}", http.HandlerFunc(pprof.Index))
+		err := http.ListenAndServe("0.0.0.0:8888", router)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/microservice/policy/core/yamlconfig/urls.yaml
+++ b/pkg/microservice/policy/core/yamlconfig/urls.yaml
@@ -1,7 +1,7 @@
 description: "public urls: url not need to authentication ; system_admin urls: urls that only system admin has permission ; project_admin: urls that project admin has permission"
 exemption_urls:
   public:
-    - endpoint: /debug/**
+    - endpoint: /api/debug/**
       methods:
         - GET
     - endpoint: /api/plutus/license

--- a/pkg/microservice/policy/core/yamlconfig/urls.yaml
+++ b/pkg/microservice/policy/core/yamlconfig/urls.yaml
@@ -1,10 +1,7 @@
 description: "public urls: url not need to authentication ; system_admin urls: urls that only system admin has permission ; project_admin: urls that project admin has permission"
 exemption_urls:
   public:
-    - endpoint: /api/debug/pprof/**
-      methods:
-        - GET
-    - endpoint: /api/debug/pprof
+    - endpoint: /debug/**
       methods:
         - GET
     - endpoint: /api/plutus/license


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f5eb9e4</samp>

This pull request improves the pprof service by using `mux` to handle its routes and updates the `urls.yaml` file to exempt the new routes from policy enforcement.

### What is changed and how it works?
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f5eb9e4</samp>

*  Import `github.com/gorilla/mux` package to use a powerful HTTP router and URL matcher for Go ([link](https://github.com/koderover/zadig/pull/3258/files?diff=unified&w=0#diff-e2fbf4796a732f3f7a4f3610176e2b53b2777129d495566bc8bbe7af0d76e794R26))
* Replace `http.NewServeMux` with `mux.NewRouter` to create a router for the pprof service and match the `/debug/pprof` and `/debug/pprof/{cmd}` patterns with the `pprof` handlers ([link](https://github.com/koderover/zadig/pull/3258/files?diff=unified&w=0#diff-e2fbf4796a732f3f7a4f3610176e2b53b2777129d495566bc8bbe7af0d76e794L69-R77))
* Update `exemption_urls` in `urls.yaml` to reflect the new pprof service routes under `/debug` instead of `/api/debug/pprof` and allow access without authentication or authorization ([link](https://github.com/koderover/zadig/pull/3258/files?diff=unified&w=0#diff-59606179c6b3374faeafb8e52b46af35a5b633af38bdd085ba3dcf90830d2d3bL4-R6))

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
