### PR TITLE
change cluster status to always normal for kube config clusters

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/service.go
+++ b/pkg/microservice/aslan/core/common/service/kube/service.go
@@ -122,6 +122,10 @@ func (s *Service) CreateCluster(cluster *models.K8SCluster, id string, logger *z
 		cluster.Local = true
 		cluster.DindCfg = nil
 	}
+	if cluster.Type == setting.KubeConfigClusterType {
+		// kube config type is always connected
+		cluster.Status = setting.Normal
+	}
 	err = s.coll.Create(cluster, id)
 	if err != nil {
 		return nil, e.ErrCreateCluster.AddErr(err)


### PR DESCRIPTION
### What this PR does / Why we need it:


### What is changed and how it works?


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
