### PR TITLE
fix get workflow error when scanning dont have project name

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -758,7 +758,11 @@ func ensureWorkflowV4Resp(encryptedKey string, workflow *commonmodels.WorkflowV4
 				}
 
 				for _, scanning := range spec.Scannings {
-					scanningInfo, err := commonrepo.NewScanningColl().Find(scanning.ProjectName, scanning.Name)
+					projectName := scanning.ProjectName
+					if projectName == "" {
+						projectName = workflow.Project
+					}
+					scanningInfo, err := commonrepo.NewScanningColl().Find(projectName, scanning.Name)
 					if err != nil {
 						logger.Errorf(err.Error())
 						return e.ErrFindWorkflow.AddErr(err)

--- a/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
@@ -19,7 +19,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"github.com/koderover/zadig/v2/pkg/tool/sonar"
 	"os"
 	"sort"
 	"strings"
@@ -41,6 +40,7 @@ import (
 	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/shared/client/systemconfig"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
+	"github.com/koderover/zadig/v2/pkg/tool/sonar"
 	"github.com/koderover/zadig/v2/pkg/types"
 )
 


### PR DESCRIPTION
### What this PR does / Why we need it:
fix get workflow error when scanning dont have project name

### What is changed and how it works?
fix get workflow error when scanning dont have project name

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
