### PR TITLE
fix archive step add delivery data even it has failed

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
@@ -590,7 +590,7 @@ func (e *Events) Error(message string) {
 type StepTask struct {
 	Name      string          `bson:"name"           json:"name"         yaml:"name"`
 	JobName   string          `bson:"job_name"       json:"job_name"     yaml:"job_name"`
-	Error     string          `bson:"error"          json:"error"        yaml:"error"`
+	Error     error           `bson:"error"          json:"error"        yaml:"error"`
 	StepType  config.StepType `bson:"type"           json:"type"         yaml:"type"`
 	Onfailure bool            `bson:"on_failure"     json:"on_failure"   yaml:"on_failure"`
 	// step input params,differ form steps


### PR DESCRIPTION
### What this PR does / Why we need it:
fix archive step add delivery data even it has failed

### What is changed and how it works?
fix archive step add delivery data even it has failed

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
