### PR TITLE
improve vm deploy job

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -291,6 +291,7 @@ type ServiceAndVMDeploy struct {
 	ServiceModule string              `bson:"service_module"      yaml:"service_module"   json:"service_module"`
 	ArtifactURL   string              `bson:"artifact_url"        yaml:"artifact_url"     json:"artifact_url"`
 	FileName      string              `bson:"file_name"           yaml:"file_name"        json:"file_name"`
+	Image         string              `bson:"image"               yaml:"image"            json:"image"`
 	TaskID        int                 `bson:"task_id"             yaml:"task_id"          json:"task_id"`
 	WorkflowType  config.PipelineType `bson:"workflow_type"       yaml:"workflow_type"    json:"workflow_type"`
 	WorkflowName  string              `bson:"workflow_name"       yaml:"workflow_name"    json:"workflow_name"`

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_vm_deploy.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_vm_deploy.go
@@ -473,6 +473,7 @@ func (j *VMDeployJob) getOriginReferedJobTargets(jobName string, taskID int) ([]
 						ServiceName:   build.ServiceName,
 						ServiceModule: build.ServiceModule,
 						FileName:      build.Package,
+						Image:         build.Image,
 						TaskID:        taskID,
 						WorkflowName:  j.workflow.Name,
 						WorkflowType:  config.WorkflowTypeV4,
@@ -623,6 +624,7 @@ func getVMDeployJobVariables(vmDeploy *commonmodels.ServiceAndVMDeploy, buildInf
 		}
 	}
 	ret = append(ret, &commonmodels.KeyVal{Key: "PKG_FILE", Value: vmDeploy.FileName, IsCredential: false})
+	ret = append(ret, &commonmodels.KeyVal{Key: "IMAGE", Value: vmDeploy.Image, IsCredential: false})
 	return ret
 }
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_vm_deploy.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_vm_deploy.go
@@ -373,18 +373,21 @@ func (j *VMDeployJob) ToJobs(taskID int64) ([]*commonmodels.JobTask, error) {
 		} else {
 			return resp, fmt.Errorf("unknown workflow type %s", vmDeployInfo.WorkflowType)
 		}
-		// init download artifact step
-		downloadArtifactStep := &commonmodels.StepTask{
-			Name:     vmDeployInfo.ServiceName + "-download-artifact",
-			JobName:  jobTask.Name,
-			StepType: config.StepDownloadArchive,
-			Spec: step.StepDownloadArchiveSpec{
-				FileName: vmDeployInfo.FileName,
-				DestDir:  "artifact",
-				S3:       modelS3toS3(s3Storage),
-			},
+
+		if buildInfo.PostBuild.FileArchive != nil {
+			// init download artifact step
+			downloadArtifactStep := &commonmodels.StepTask{
+				Name:     vmDeployInfo.ServiceName + "-download-artifact",
+				JobName:  jobTask.Name,
+				StepType: config.StepDownloadArchive,
+				Spec: step.StepDownloadArchiveSpec{
+					FileName: vmDeployInfo.FileName,
+					DestDir:  "artifact",
+					S3:       modelS3toS3(s3Storage),
+				},
+			}
+			jobTaskSpec.Steps = append(jobTaskSpec.Steps, downloadArtifactStep)
 		}
-		jobTaskSpec.Steps = append(jobTaskSpec.Steps, downloadArtifactStep)
 		// init debug before step
 		debugBeforeStep := &commonmodels.StepTask{
 			Name:     vmDeployInfo.ServiceName + "-debug_before",


### PR DESCRIPTION

### What this PR does / Why we need it:
1. skip download artifact step in vm deploy when build doesn't have file archive step
2. add IMAGE variable in vm deploy job

### What is changed and how it works?
1. skip download artifact step in vm deploy when build doesn't have file archive step
2. add IMAGE variable in vm deploy job

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
