### PR TITLE
remove openapi deploy job updater's service limit

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/1180_vars.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/1180_vars.go
@@ -665,15 +665,15 @@ func turnFlatKVToRenderKV(originKVs []*commonmodels.ServiceKeyVal) ([]*types.Ren
 	return types.ServiceToRenderVariableKVs(renderKVs), nil
 }
 
-func workflowOriginKValsToVariableConfig(kvs []*commonmodels.ServiceKeyVal) []*commonmodels.DeplopyVariableConfig {
-	ret := make([]*commonmodels.DeplopyVariableConfig, 0)
+func workflowOriginKValsToVariableConfig(kvs []*commonmodels.ServiceKeyVal) []*commonmodels.DeployVariableConfig {
+	ret := make([]*commonmodels.DeployVariableConfig, 0)
 	kvSet := sets.NewString()
 	for _, kv := range kvs {
 		if kvSet.Has(ExtractRootKeyFromFlat(kv.Key)) {
 			continue
 		}
 		kvSet.Insert(ExtractRootKeyFromFlat(kv.Key))
-		ret = append(ret, &commonmodels.DeplopyVariableConfig{
+		ret = append(ret, &commonmodels.DeployVariableConfig{
 			VariableKey:       ExtractRootKeyFromFlat(kv.Key),
 			UseGlobalVariable: false,
 		})
@@ -777,9 +777,9 @@ func migrateWorkflows() error {
 							}
 							updateKVConfig = true
 
-							jobSpec.VariableConfigs = make([]*commonmodels.DeplopyVariableConfig, 0)
+							jobSpec.VariableConfigs = make([]*commonmodels.DeployVariableConfig, 0)
 							for _, kv := range jobSpec.VariableKVs {
-								jobSpec.VariableConfigs = append(jobSpec.VariableConfigs, &commonmodels.DeplopyVariableConfig{
+								jobSpec.VariableConfigs = append(jobSpec.VariableConfigs, &commonmodels.DeployVariableConfig{
 									VariableKey:       kv.Key,
 									UseGlobalVariable: false,
 								})

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_build.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_build.go
@@ -102,7 +102,6 @@ func (j *BuildJob) SetPreset() error {
 		}
 		for _, target := range buildInfo.Targets {
 			if target.ServiceName == build.ServiceName && target.ServiceModule == build.ServiceModule {
-				fmt.Println("building stuff for service:", target.ServiceName, ", module:", target.ServiceModule)
 				build.Repos = mergeRepos(buildInfo.Repos, build.Repos)
 				build.KeyVals = renderKeyVals(build.KeyVals, buildInfo.PreBuild.Envs)
 				break

--- a/pkg/microservice/aslan/core/workflow/service/workflow/types.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/types.go
@@ -278,14 +278,23 @@ func (p *ZadigDeployJobInput) UpdateJobSpec(job *commonmodels.Job) (*commonmodel
 	}
 
 	newSpec.Env = p.EnvName
-
-	for _, svc := range newSpec.Services {
-		for _, module := range svc.Modules {
-			for _, inputSvc := range p.ServiceList {
-				if inputSvc.ServiceName == svc.ServiceName && inputSvc.ServiceModule == module.ServiceModule {
-					module.Image = inputSvc.ImageName
-				}
+	newSpec.Services = make([]*commonmodels.DeployServiceInfo, 0)
+	serviceMap := map[string]*commonmodels.DeployServiceInfo{}
+	for _, inputSvc := range p.ServiceList {
+		if serivce, ok := serviceMap[inputSvc.ServiceName]; ok {
+			serivce.Modules = append(serivce.Modules, &commonmodels.DeployModuleInfo{
+				Image:         inputSvc.ImageName,
+				ServiceModule: inputSvc.ServiceModule,
+			})
+		} else {
+			serviceMap[inputSvc.ServiceName] = &commonmodels.DeployServiceInfo{
+				ServiceName: inputSvc.ServiceName,
+				Modules: append([]*commonmodels.DeployModuleInfo{}, &commonmodels.DeployModuleInfo{
+					Image:         inputSvc.ImageName,
+					ServiceModule: inputSvc.ServiceModule,
+				}),
 			}
+			newSpec.Services = append(newSpec.Services, serviceMap[inputSvc.ServiceName])
 		}
 	}
 


### PR DESCRIPTION
### What this PR does / Why we need it:
remove openapi deploy job updater's service limit

### What is changed and how it works?
remove openapi deploy job updater's service limit

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
