### PR TITLE
do not patch k8s resources if the yaml not change 

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -526,8 +526,10 @@ func (c *DeployJobCtl) getResourcesPodOwnerUIDImpl(strict bool) ([]commonmodels.
 
 func (c *DeployJobCtl) getResourcesPodOwnerUID() ([]commonmodels.Resource, error) {
 	timeout := time.After(time.Second * 20)
+
 	var newResources []commonmodels.Resource
 	var err error
+
 	for {
 		if len(newResources) > 0 || err != nil {
 			break

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2241,7 +2241,7 @@ func deleteK8sProductServices(productInfo *commonmodels.Product, serviceNames []
 			continue
 		}
 
-		unstructuredList, err := kube.ManifestToUnstructured(serviceRelatedYaml[name])
+		unstructuredList, _, err := kube.ManifestToUnstructured(serviceRelatedYaml[name])
 		if err != nil {
 			// Only record and do not block subsequent traversals.
 			log.Errorf("failed to convert k8s manifest to unstructured list when deleting service: %s, err: %s", name, err)

--- a/pkg/microservice/aslan/core/environment/service/share_env.go
+++ b/pkg/microservice/aslan/core/environment/service/share_env.go
@@ -1023,7 +1023,7 @@ func parseK8SProjectServices(ctx context.Context, env *commonmodels.Product, ser
 	if err != nil {
 		return nil, fmt.Errorf("failed to render env service, err: %w", err)
 	}
-	resources, err := kube.ManifestToUnstructured(yaml)
+	resources, _, err := kube.ManifestToUnstructured(yaml)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert yaml to Unstructured, manifest is\n%s\n, error: %v", yaml, err)
 	}


### PR DESCRIPTION
### What this PR does / Why we need it:
do not patch k8s resources if the yaml not change
### What is changed and how it works?
do not patch k8s resources if the yaml not change
### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
