### PR TITLE
fix SyncEnvResource panic when source is gerrit

### DIFF
--- a/pkg/microservice/aslan/core/common/service/fs/git.go
+++ b/pkg/microservice/aslan/core/common/service/fs/git.go
@@ -128,8 +128,7 @@ func GetTreeGetter(codeHostID int) (TreeGetter, error) {
 	case setting.SourceFromGitlab:
 		return gitlabservice.NewClient(ch.ID, ch.Address, ch.AccessToken, config.ProxyHTTPSAddr(), ch.EnableProxy)
 	default:
-		// should not have happened here
-		log.DPanicf("invalid source: %s", ch.Type)
+		log.Errorf("GetTreeGetter invalid source: %s", ch.Type)
 		return nil, fmt.Errorf("invalid source: %s", ch.Type)
 	}
 }


### PR DESCRIPTION
### What this PR does / Why we need it:
fix SyncEnvResource panic when source is gerrit

### What is changed and how it works?
fix SyncEnvResource panic when source is gerrit

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
