### PR TITLE
fix env version displayed wrong system user after update env

### DIFF
--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -1234,7 +1234,7 @@ func updateMultiK8sEnv(c *gin.Context, request *service.UpdateEnvRequest, produc
 		return
 	}
 
-	ctx.Resp, ctx.Err = service.UpdateMultipleK8sEnv(args, envNames, request.ProjectName, ctx.RequestID, request.Force, production, ctx.Logger)
+	ctx.Resp, ctx.Err = service.UpdateMultipleK8sEnv(args, envNames, request.ProjectName, ctx.RequestID, request.Force, production, ctx.UserName, ctx.Logger)
 }
 
 func updateMultiHelmEnv(c *gin.Context, request *service.UpdateEnvRequest, production bool, ctx *internalhandler.Context) {

--- a/pkg/microservice/aslan/core/environment/handler/openapi.go
+++ b/pkg/microservice/aslan/core/environment/handler/openapi.go
@@ -175,7 +175,7 @@ func OpenAPIApplyYamlService(c *gin.Context) {
 		}
 	}
 
-	_, err = service.OpenAPIApplyYamlService(projectKey, req, false, ctx.RequestID, ctx.Logger)
+	_, err = service.OpenAPIApplyYamlService(projectKey, req, false, ctx.RequestID, ctx.UserName, ctx.Logger)
 
 	ctx.Err = err
 }
@@ -368,7 +368,7 @@ func OpenAPIApplyProductionYamlService(c *gin.Context) {
 		return
 	}
 
-	_, err = service.OpenAPIApplyYamlService(projectKey, req, true, ctx.RequestID, ctx.Logger)
+	_, err = service.OpenAPIApplyYamlService(projectKey, req, true, ctx.RequestID, ctx.UserName, ctx.Logger)
 	ctx.Err = err
 }
 

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -423,7 +423,7 @@ type UpdateEnv struct {
 	Services []*UpdateServiceArg `json:"services"`
 }
 
-func UpdateMultipleK8sEnv(args []*UpdateEnv, envNames []string, productName, requestID string, force, production bool, log *zap.SugaredLogger) ([]*EnvStatus, error) {
+func UpdateMultipleK8sEnv(args []*UpdateEnv, envNames []string, productName, requestID string, force, production bool, username string, log *zap.SugaredLogger) ([]*EnvStatus, error) {
 	mutexAutoUpdate := cache.NewRedisLock(fmt.Sprintf("update_multiple_product:%s", productName))
 	err := mutexAutoUpdate.Lock()
 	if err != nil {
@@ -497,7 +497,7 @@ func UpdateMultipleK8sEnv(args []*UpdateEnv, envNames []string, productName, req
 
 		// update env default variable, particular svcs from client are involved
 		// svc revision will not be updated
-		err = updateK8sProduct(exitedProd, setting.SystemUser, requestID, updateRevisionSvcs, filter, updateSvcs, strategyMap, force, exitedProd.GlobalVariables, log)
+		err = updateK8sProduct(exitedProd, username, requestID, updateRevisionSvcs, filter, updateSvcs, strategyMap, force, exitedProd.GlobalVariables, log)
 		if err != nil {
 			log.Errorf("UpdateMultipleK8sEnv UpdateProductV2 err:%v", err)
 			errList = multierror.Append(errList, err)
@@ -506,7 +506,7 @@ func UpdateMultipleK8sEnv(args []*UpdateEnv, envNames []string, productName, req
 
 	productResps := make([]*ProductResp, 0)
 	for _, envName := range envNames {
-		productResp, err := GetProduct(setting.SystemUser, envName, productName, log)
+		productResp, err := GetProduct(username, envName, productName, log)
 		if err == nil && productResp != nil {
 			productResps = append(productResps, productResp)
 		}
@@ -807,7 +807,7 @@ func UpdateMultiCVMProducts(envNames []string, productName, user, requestID stri
 
 	productResps := make([]*ProductResp, 0)
 	for _, envName := range envNames {
-		productResp, err := GetProduct(setting.SystemUser, envName, productName, log)
+		productResp, err := GetProduct(user, envName, productName, log)
 		if err == nil && productResp != nil {
 			productResps = append(productResps, productResp)
 		}

--- a/pkg/microservice/aslan/core/environment/service/openapi.go
+++ b/pkg/microservice/aslan/core/environment/service/openapi.go
@@ -210,11 +210,11 @@ func OpenAPIUpdateYamlService(req *OpenAPIServiceVariablesReq, userName, request
 	if len(args) == 0 {
 		return nil
 	}
-	_, err = UpdateMultipleK8sEnv(args, []string{envName}, projectName, requestID, true, production, logger)
+	_, err = UpdateMultipleK8sEnv(args, []string{envName}, projectName, requestID, true, production, userName, logger)
 	return err
 }
 
-func OpenAPIApplyYamlService(projectKey string, req *OpenAPIApplyYamlServiceReq, production bool, requestID string, logger *zap.SugaredLogger) ([]*EnvStatus, error) {
+func OpenAPIApplyYamlService(projectKey string, req *OpenAPIApplyYamlServiceReq, production bool, requestID, userName string, logger *zap.SugaredLogger) ([]*EnvStatus, error) {
 	env, err := commonrepo.NewProductColl().Find(&commonrepo.ProductFindOptions{Name: projectKey, EnvName: req.EnvName})
 	if err != nil {
 		logger.Errorf("failed to find env:%s from db, project:%s", req.EnvName, projectKey)
@@ -255,7 +255,7 @@ func OpenAPIApplyYamlService(projectKey string, req *OpenAPIApplyYamlServiceReq,
 		Services: svcList,
 	})
 
-	return UpdateMultipleK8sEnv(args, []string{req.EnvName}, projectKey, requestID, false, false, logger)
+	return UpdateMultipleK8sEnv(args, []string{req.EnvName}, projectKey, requestID, false, false, userName, logger)
 }
 
 func checkServiceInEnv(envServices [][]*commonmodels.ProductService, services []*YamlServiceWithKV) error {


### PR DESCRIPTION
### What this PR does / Why we need it:
fix env version displayed wrong system user after update env

### What is changed and how it works?
fix env version displayed wrong system user after update env

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
