### PR TITLE
cherry pick #3592 to release 3.0.0-0607

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/jinzhu/now v1.1.5
 	github.com/juju/ratelimit v1.0.2
-	github.com/koderover/gojenkins v1.5.2
+	github.com/koderover/gojenkins v1.5.3
 	github.com/larksuite/oapi-sdk-go/v3 v3.0.10
 	github.com/magiconair/properties v1.8.5
 	github.com/mholt/archiver v3.1.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -649,8 +649,8 @@ github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgo
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
-github.com/koderover/gojenkins v1.5.2 h1:P8xVAd/g+FR2bLAZSr+tTyDqGNUltA8yCWYA77PV9U0=
-github.com/koderover/gojenkins v1.5.2/go.mod h1:XTLwVFTEB6tNV2cK+TQBKkY2Z6TVbueQIMaVii8T3CE=
+github.com/koderover/gojenkins v1.5.3 h1:n99ZnepNNRA+m1S8Nbi2KGAWjrl56DGpxdd12IT7arI=
+github.com/koderover/gojenkins v1.5.3/go.mod h1:XTLwVFTEB6tNV2cK+TQBKkY2Z6TVbueQIMaVii8T3CE=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kortschak/utter v1.0.1/go.mod h1:vSmSjbyrlKjjsL71193LmzBOKgwePk9DH6uFaWHIInc=


### PR DESCRIPTION
### What this PR does / Why we need it:
cherry pick #3592 to release 3.0.0-0607

### What is changed and how it works?
cherry pick #3592 to release 3.0.0-0607

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
