### PR TITLE
feat: add sorting option to project list API

### DIFF
--- a/pkg/microservice/aslan/core/project/handler/project.go
+++ b/pkg/microservice/aslan/core/project/handler/project.go
@@ -37,6 +37,7 @@ type projectListArgs struct {
 	PageNum          int64    `json:"page_num"         form:"page_num,default=1"`
 	Filter           string   `json:"filter"           form:"filter"`
 	GroupName        string   `json:"group_name"       form:"group_name"`
+	SortByUpdatedAt  string   `json:"sort_by_updated_at" form:"sort_by_updated_at"`
 }
 
 type projectResp struct {
@@ -98,6 +99,7 @@ func ListProjects(c *gin.Context) {
 			Filter:           args.Filter,
 			GroupName:        args.GroupName,
 			Ungrouped:        ungrouped,
+			SortByUpdatedAt:  args.SortByUpdatedAt,
 		},
 		ctx.Logger,
 	)

--- a/pkg/microservice/aslan/core/project/service/project.go
+++ b/pkg/microservice/aslan/core/project/service/project.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"fmt"
+	"sort"
 
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.uber.org/zap"
@@ -45,6 +46,7 @@ type ProjectListOptions struct {
 	Filter           string
 	GroupName        string
 	Ungrouped        bool
+	SortByUpdatedAt  string // 新增字段，支持 "asc" 或 "desc"
 }
 type ProjectDetailedResponse struct {
 	ProjectDetailedRepresentation []*ProjectDetailedRepresentation `json:"projects"`
@@ -330,6 +332,17 @@ func getProjects(opts *ProjectListOptions) ([]string, sets.String, map[string]*t
 		nameSet.Insert(r.Name)
 		nameMap[r.Name] = r
 		nameOrder = append(nameOrder, r.Name)
+	}
+
+	// 根据 SortByUpdatedAt 字段进行排序
+	if opts.SortByUpdatedAt == "asc" {
+		sort.Slice(nameOrder, func(i, j int) bool {
+			return nameMap[nameOrder[i]].UpdatedAt < nameMap[nameOrder[j]].UpdatedAt
+		})
+	} else if opts.SortByUpdatedAt == "desc" {
+		sort.Slice(nameOrder, func(i, j int) bool {
+			return nameMap[nameOrder[i]].UpdatedAt > nameMap[nameOrder[j]].UpdatedAt
+		})
 	}
 
 	return nameOrder, nameSet, nameMap, total, nil


### PR DESCRIPTION
### What this PR does / Why we need it:
This PR adds a new parameter SortByUpdatedAt to control whether the project list should be sorted by the UpdatedAt field, supporting both ascending and descending order. 
### What is changed and how it works?

1. Added the SortByUpdatedAt field to the ProjectListOptions struct.
2. Modified the getProjects function to sort the project list based on the SortByUpdatedAt field:
    - If SortByUpdatedAt is "asc", the list is sorted in ascending order by UpdatedAt.
    - If SortByUpdatedAt is "desc", the list is sorted in descending order by UpdatedAt.
### Does this PR introduce a user-facing change?

- [x] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
