### PR TITLE
fix workflow scanning job container name illegal in some case

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
@@ -154,8 +154,10 @@ func GetJobContainerName(name string) string {
 
 	resp := strings.Join(pinyins, "")
 	if len(resp) > 63 {
-		return resp[:63]
+		resp = strings.TrimSuffix(resp[:63], "-")
+		return resp
 	}
+	resp = strings.TrimSuffix(resp, "-")
 	return resp
 }
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_approval.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_approval.go
@@ -61,6 +61,10 @@ func (j *ApprovalJob) ClearSelectionField() error {
 	return nil
 }
 
+func (j *ApprovalJob) ClearOptions() error {
+	return nil
+}
+
 func (j *ApprovalJob) UpdateWithLatestSetting() error {
 	j.spec = &commonmodels.ApprovalJobSpec{}
 	if err := commonmodels.IToi(j.job.Spec, j.spec); err != nil {


### PR DESCRIPTION
### What this PR does / Why we need it:
fix workflow scanning job container name illegal in some case

### What is changed and how it works?
fix workflow scanning job container name illegal in some case
### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
