### PR TITLE
fix GetUserPermissionByProject not check group role namespace

### DIFF
--- a/pkg/microservice/user/core/service/permission/permission.go
+++ b/pkg/microservice/user/core/service/permission/permission.go
@@ -94,6 +94,7 @@ func GetUserPermissionByProject(uid, projectName string, log *zap.SugaredLogger)
 		if role.Name == ProjectAdminRole {
 			return &GetUserRulesByProjectResp{
 				IsProjectAdmin: true,
+				ProjectVerbs:   projectVerbSet.List(),
 			}, nil
 		}
 		actions, err := ListActionByRole(role.ID)
@@ -127,10 +128,15 @@ func GetUserPermissionByProject(uid, projectName string, log *zap.SugaredLogger)
 	}
 
 	for _, role := range groupRoleMap {
+		if role.Namespace != projectName {
+			continue
+		}
+
 		// if the user's group has project admin role,
 		if role.Name == ProjectAdminRole {
 			return &GetUserRulesByProjectResp{
 				IsProjectAdmin: true,
+				ProjectVerbs:   projectVerbSet.List(),
 			}, nil
 		}
 		// if the role has been seen previously, it has already been processed


### PR DESCRIPTION
### What this PR does / Why we need it:
fix GetUserPermissionByProject not check group role namespace

### What is changed and how it works?
fix GetUserPermissionByProject not check group role namespace

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
