### PR TITLE
fix lark approval timeout not cancel approval instance

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
@@ -324,6 +324,7 @@ func waitForLarkApprove(ctx context.Context, spec *commonmodels.JobTaskApprovalS
 			cancelApproval()
 			return config.StatusCancelled, fmt.Errorf("workflow was canceled")
 		case <-timeoutChan:
+			cancelApproval()
 			return config.StatusTimeout, fmt.Errorf("workflow timeout")
 		default:
 			done, isApprove, err := approvalUpdate(approval)


### PR DESCRIPTION
### What this PR does / Why we need it:
fix lark approval timeout not cancel approval instance

### What is changed and how it works?
fix lark approval timeout not cancel approval instance

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
