### PR TITLE
fix helm chart deploy suffix '\n' in preview

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -2341,6 +2341,7 @@ func CompareHelmServiceYamlInEnv(serviceName, variableYaml, envName, projectName
 				return nil, fmt.Errorf("failed to merge override values, err: %s", err)
 			}
 		}
+		currentYaml = strings.TrimSuffix(currentYaml, "\n")
 		return &GetHelmValuesDifferenceResp{
 			Current: currentYaml,
 			Latest:  variableYaml,


### PR DESCRIPTION
### What this PR does / Why we need it:
fix helm chart deploy suffix '\n' in preview

### What is changed and how it works?
fix helm chart deploy suffix '\n' in preview

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
