### PR TITLE
fix get all user group's userinfos in sprint

### DIFF
--- a/pkg/microservice/user/core/repository/models/user_group.go
+++ b/pkg/microservice/user/core/repository/models/user_group.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package models
 
+import (
+	"github.com/koderover/zadig/v2/pkg/setting"
+)
+
 type UserGroup struct {
 	Model
 	GroupID     string `gorm:"column:group_id"    json:"group_id"`
@@ -31,4 +35,11 @@ type UserGroup struct {
 // TableName sets the insert table name for this struct type
 func (UserGroup) TableName() string {
 	return "user_group"
+}
+
+func (ug *UserGroup) IsAllUserGroup() bool {
+	if ug.GroupName == "所有用户" && ug.Type == int64(setting.RoleTypeSystem) {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
### What this PR does / Why we need it:
fix get all user group's userinfos in sprint

### What is changed and how it works?
fix get all user group's userinfos in sprint

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
