### PR TITLE
support github/gitlab/gitee(no scanning) webhook auto cancel in testing/scanning

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/scanning.go
+++ b/pkg/microservice/aslan/core/common/repository/models/scanning.go
@@ -73,8 +73,8 @@ type ScanningAdvancedSetting struct {
 }
 
 type ScanningHookCtl struct {
-	Enabled bool            `bson:"enabled" json:"enabled"`
-	Items   []*ScanningHook `bson:"items"   json:"items"`
+	Enabled bool            `bson:"enabled"      json:"enabled"`
+	Items   []*ScanningHook `bson:"items"        json:"items"`
 }
 
 type ScanningHook struct {
@@ -87,6 +87,7 @@ type ScanningHook struct {
 	MatchFolders []string               `bson:"match_folders" json:"match_folders"`
 	IsRegular    bool                   `bson:"is_regular"    json:"is_regular"`
 	IsManual     bool                   `bson:"is_manual"     json:"is_manual"`
+	AutoCancel   bool                   `bson:"auto_cancel"   json:"auto_cancel"`
 }
 
 type SonarInfo struct {

--- a/pkg/microservice/aslan/core/common/repository/models/workflow.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow.go
@@ -228,16 +228,17 @@ type TestTaskArgs struct {
 	NotificationID  string `bson:"notification_id"         json:"notification_id"`
 	ReqID           string `bson:"req_id"                  json:"req_id"`
 	// webhook触发测试任务时，触发任务的repo、prID和commitID
-	MergeRequestID string `bson:"merge_request_id" json:"merge_request_id"`
-	CommitID       string `bson:"commit_id"        json:"commit_id"`
-	Source         string `bson:"source"           json:"source"`
-	CodehostID     int    `bson:"codehost_id"      json:"codehost_id"`
-	RepoOwner      string `bson:"repo_owner"       json:"repo_owner"`
-	RepoNamespace  string `bson:"repo_namespace"   json:"repo_namespace"`
-	RepoName       string `bson:"repo_name"        json:"repo_name"`
-	Ref            string `bson:"ref" json:"ref"`
-	Branch         string `bson:"branch" json:"branch"`
-	EventType      string `bson:"event_type" json:"event_type"`
+	MergeRequestID string       `bson:"merge_request_id" json:"merge_request_id"`
+	CommitID       string       `bson:"commit_id"        json:"commit_id"`
+	Source         string       `bson:"source"           json:"source"`
+	CodehostID     int          `bson:"codehost_id"      json:"codehost_id"`
+	RepoOwner      string       `bson:"repo_owner"       json:"repo_owner"`
+	RepoNamespace  string       `bson:"repo_namespace"   json:"repo_namespace"`
+	RepoName       string       `bson:"repo_name"        json:"repo_name"`
+	Ref            string       `bson:"ref" json:"ref"`
+	Branch         string       `bson:"branch" json:"branch"`
+	EventType      string       `bson:"event_type" json:"event_type"`
+	HookPayload    *HookPayload `bson:"hook_payload" json:"hook_payload"`
 }
 
 type Slack struct {

--- a/pkg/microservice/aslan/core/common/util/workflow.go
+++ b/pkg/microservice/aslan/core/common/util/workflow.go
@@ -17,7 +17,10 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
+
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/tool/log"
 )
 
@@ -34,4 +37,11 @@ func CalcWorkflowTaskRunningTime(task *commonmodels.WorkflowTask) int64 {
 		}
 	}
 	return runningTime
+}
+func GenScanningWorkflowName(scanningID string) string {
+	return fmt.Sprintf(setting.ScanWorkflowNamingConvention, scanningID)
+}
+
+func GenTestingWorkflowName(testingName string) string {
+	return fmt.Sprintf(setting.TestWorkflowNamingConvention, testingName)
 }

--- a/pkg/microservice/aslan/core/log/handler/sse.go
+++ b/pkg/microservice/aslan/core/log/handler/sse.go
@@ -23,14 +23,14 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
+	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller"
+	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	logservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/log/service"
 	jobctl "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/workflow/service/workflow/job"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/workflow/testing/service"
-	"github.com/koderover/zadig/v2/pkg/setting"
 	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
 	"github.com/koderover/zadig/v2/pkg/types"
@@ -185,7 +185,7 @@ func GetScanningContainerLogsSSE(c *gin.Context) {
 		clusterId = resp.AdvancedSetting.ClusterID
 	}
 
-	workflowName := fmt.Sprintf(setting.ScanWorkflowNamingConvention, id)
+	workflowName := commonutil.GenScanningWorkflowName(id)
 	workflowTask, err := commonrepo.NewworkflowTaskv4Coll().Find(workflowName, taskID)
 	if err != nil {
 		ctx.Logger.Errorf("failed to find workflow task for scanning: %s, err: %s", workflowName, err)
@@ -212,7 +212,7 @@ func GetScanningContainerLogsSSE(c *gin.Context) {
 			ctx1, streamChan,
 			&logservice.GetContainerOptions{
 				Namespace:    namespace,
-				PipelineName: fmt.Sprintf(setting.ScanWorkflowNamingConvention, id),
+				PipelineName: commonutil.GenScanningWorkflowName(id),
 				SubTask:      jobcontroller.GetJobContainerName(jobName),
 				TaskID:       taskID,
 				TailLines:    tails,
@@ -247,7 +247,8 @@ func GetTestingContainerLogsSSE(c *gin.Context) {
 	if err != nil {
 		tails = int64(9999999)
 	}
-	workflowName := fmt.Sprintf(setting.TestWorkflowNamingConvention, testName)
+
+	workflowName := commonutil.GenTestingWorkflowName(testName)
 	workflowTask, err := commonrepo.NewworkflowTaskv4Coll().Find(workflowName, taskID)
 	if err != nil {
 		ctx.Logger.Errorf("failed to find workflow task for testing: %s, err: %s", testName, err)
@@ -275,7 +276,7 @@ func GetTestingContainerLogsSSE(c *gin.Context) {
 			ctx1, streamChan,
 			&logservice.GetContainerOptions{
 				Namespace:    config.Namespace(),
-				PipelineName: fmt.Sprintf(setting.TestWorkflowNamingConvention, testName),
+				PipelineName: commonutil.GenTestingWorkflowName(testName),
 				SubTask:      jobcontroller.GetJobContainerName(jobName),
 				TaskID:       taskID,
 				TailLines:    tails,

--- a/pkg/microservice/aslan/core/log/service/log.go
+++ b/pkg/microservice/aslan/core/log/service/log.go
@@ -31,7 +31,7 @@ import (
 	s3service "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/s3"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller"
 	jobctl "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/workflow/service/workflow/job"
-	"github.com/koderover/zadig/v2/pkg/setting"
+	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/v2/pkg/tool/kube/containerlog"
 	s3tool "github.com/koderover/zadig/v2/pkg/tool/s3"
 	"github.com/koderover/zadig/v2/pkg/util"
@@ -111,7 +111,7 @@ func GetCurrentContainerLogs(podName, containerName, envName, productName string
 }
 
 func GetScanningContainerLogs(scanID string, taskID int64, log *zap.SugaredLogger) (string, error) {
-	workflowName := fmt.Sprintf(setting.ScanWorkflowNamingConvention, scanID)
+	workflowName := commonutil.GenScanningWorkflowName(scanID)
 	workflowTask, err := commonrepo.NewworkflowTaskv4Coll().Find(workflowName, taskID)
 	if err != nil {
 		return "", fmt.Errorf("failed to find workflow task for scanning: %s, err: %s", workflowName, err)
@@ -159,7 +159,7 @@ func GetScanningContainerLogs(scanID string, taskID int64, log *zap.SugaredLogge
 }
 
 func GetTestingContainerLogs(testName string, taskID int64, log *zap.SugaredLogger) (string, error) {
-	workflowName := fmt.Sprintf(setting.TestWorkflowNamingConvention, testName)
+	workflowName := commonutil.GenTestingWorkflowName(testName)
 
 	workflowTask, err := commonrepo.NewworkflowTaskv4Coll().Find(workflowName, taskID)
 	if err != nil {

--- a/pkg/microservice/aslan/core/system/service/capacity.go
+++ b/pkg/microservice/aslan/core/system/service/capacity.go
@@ -27,6 +27,7 @@ import (
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/s3"
+	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/tool/log"
 	s3tool "github.com/koderover/zadig/v2/pkg/tool/s3"
@@ -209,7 +210,7 @@ func handleWorkflowTaskRetentionCenter(strategy *commonmodels.CapacityStrategy, 
 			return err
 		}
 		for _, testing := range testings {
-			workflowName := fmt.Sprintf(setting.TestWorkflowNamingConvention, testing.Name)
+			workflowName := commonutil.GenTestingWorkflowName(testing.Name)
 			err = archiveWorkflowTaskV4(workflowName, retention.MaxItems, retention.MaxDays)
 			if err != nil {
 				log.Errorf("archiveWorkflowTaskV4 %s failed, err: %v", workflowName, err)
@@ -224,7 +225,7 @@ func handleWorkflowTaskRetentionCenter(strategy *commonmodels.CapacityStrategy, 
 			return err
 		}
 		for _, scanning := range scannings {
-			workflowName := fmt.Sprintf(setting.ScanWorkflowNamingConvention, scanning.ID.Hex())
+			workflowName := commonutil.GenScanningWorkflowName(scanning.ID.Hex())
 			err = archiveWorkflowTaskV4(workflowName, retention.MaxItems, retention.MaxDays)
 			if err != nil {
 				log.Errorf("archiveWorkflowTaskV4 %s failed, err: %v", workflowName, err)
@@ -290,7 +291,7 @@ func handleWorkflowTaskRetentionCenter(strategy *commonmodels.CapacityStrategy, 
 			return err
 		}
 		for _, testing := range testings {
-			workflowName := fmt.Sprintf(setting.TestWorkflowNamingConvention, testing.Name)
+			workflowName := commonutil.GenTestingWorkflowName(testing.Name)
 			v4Option := &commonrepo.ListWorkflowTaskV4Option{
 				WorkflowName: workflowName,
 				Skip:         retention.MaxItems,
@@ -317,7 +318,7 @@ func handleWorkflowTaskRetentionCenter(strategy *commonmodels.CapacityStrategy, 
 			return err
 		}
 		for _, scanning := range scannings {
-			workflowName := fmt.Sprintf(setting.ScanWorkflowNamingConvention, scanning.ID.Hex())
+			workflowName := commonutil.GenScanningWorkflowName(scanning.ID.Hex())
 			v4Option := &commonrepo.ListWorkflowTaskV4Option{
 				WorkflowName: workflowName,
 				Skip:         retention.MaxItems,

--- a/pkg/microservice/aslan/core/workflow/service/webhook/auto_cancel_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/auto_cancel_task.go
@@ -189,10 +189,10 @@ func AutoCancelWorkflowV4Task(autoCancelOpt *AutoCancelOpt, log *zap.SugaredLogg
 		if task.WorkflowArgs.HookPayload.CommitID == autoCancelOpt.CommitID {
 			continue
 		}
+
 		if err = workflowcontroller.CancelWorkflowTask(task.TaskCreator, task.WorkflowName, task.TaskID, log); err != nil {
 			log.Errorf(" failed,task.TaskCreator:%s, task.WorkflowName:%s, task.TaskID:%d, error: %v", task.TaskCreator, task.WorkflowName, task.TaskID, err)
 		}
-		break
 	}
 	return nil
 }

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitee_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitee_workflowv4_task.go
@@ -308,6 +308,9 @@ func TriggerWorkflowV4ByGiteeEvent(event interface{}, baseURI, requestID string,
 				}
 			case *gitee.TagPushEvent:
 				eventType = EventTypeTag
+				hookPayload = &commonmodels.HookPayload{
+					EventType: eventType,
+				}
 			}
 			if autoCancelOpt.Type != "" {
 				err := AutoCancelWorkflowV4Task(autoCancelOpt, log)

--- a/pkg/microservice/aslan/core/workflow/testing/handler/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/handler/scanning.go
@@ -33,7 +33,6 @@ import (
 	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	workflowservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/workflow/service/workflow"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/workflow/testing/service"
-	"github.com/koderover/zadig/v2/pkg/setting"
 	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
 	"github.com/koderover/zadig/v2/pkg/tool/log"
@@ -494,7 +493,7 @@ func CancelScanningTask(c *gin.Context) {
 		}
 	}
 
-	workflowName := fmt.Sprintf(setting.ScanWorkflowNamingConvention, scanningID)
+	workflowName := commonutil.GenScanningWorkflowName(scanningID)
 
 	ctx.RespErr = workflowservice.CancelWorkflowTaskV4(ctx.UserName, workflowName, taskID, ctx.Logger)
 }
@@ -559,7 +558,7 @@ func GetScanningTaskArtifact(c *gin.Context) {
 		ctx.RespErr = fmt.Errorf("failed to get scanning from mongodb, the error is: %s", err)
 		return
 	}
-	workflowName := fmt.Sprintf(setting.ScanWorkflowNamingConvention, scanningInfo.ID.Hex())
+	workflowName := commonutil.GenScanningWorkflowName(scanningInfo.ID.Hex())
 
 	resp, err := workflowservice.GetWorkflowV4ArtifactFileContent(workflowName, jobName, taskID, ctx.Logger)
 	if err != nil {

--- a/pkg/microservice/aslan/core/workflow/testing/handler/test_task.go
+++ b/pkg/microservice/aslan/core/workflow/testing/handler/test_task.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gin-gonic/gin/binding"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/notify"
@@ -182,7 +183,7 @@ func CancelTestTaskV3(c *gin.Context) {
 		return
 	}
 
-	workflowName := fmt.Sprintf(setting.TestWorkflowNamingConvention, testName)
+	workflowName := commonutil.GenTestingWorkflowName(testName)
 
 	ctx.RespErr = workflowservice.CancelWorkflowTaskV4(ctx.UserName, workflowName, taskID, ctx.Logger)
 }
@@ -341,7 +342,7 @@ func RestartTestTaskV2(c *gin.Context) {
 		return
 	}
 
-	workflowName := fmt.Sprintf(setting.TestWorkflowNamingConvention, testName)
+	workflowName := commonutil.GenTestingWorkflowName(testName)
 
 	ctx.RespErr = workflowservice.RetryWorkflowTaskV4(workflowName, taskID, ctx.Logger)
 }
@@ -381,7 +382,7 @@ func GetTestingTaskArtifact(c *gin.Context) {
 		return
 	}
 
-	workflowName := fmt.Sprintf(setting.TestWorkflowNamingConvention, testName)
+	workflowName := commonutil.GenTestingWorkflowName(testName)
 
 	resp, err := workflowservice.GetWorkflowV4ArtifactFileContent(workflowName, jobName, taskID, ctx.Logger)
 	if err != nil {

--- a/pkg/microservice/aslan/core/workflow/testing/handler/workspace.go
+++ b/pkg/microservice/aslan/core/workflow/testing/handler/workspace.go
@@ -17,13 +17,12 @@ limitations under the License.
 package handler
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
 
+	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/workflow/testing/service"
-	"github.com/koderover/zadig/v2/pkg/setting"
 	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
 )
@@ -53,7 +52,7 @@ func GetTestArtifactInfoV2(c *gin.Context) {
 		return
 	}
 
-	workflowName := fmt.Sprintf(setting.TestWorkflowNamingConvention, c.Param("testName"))
+	workflowName := commonutil.GenTestingWorkflowName(c.Param("testName"))
 
 	ctx.Resp, ctx.RespErr = service.GetWorkflowV4ArtifactInfo(workflowName, c.Query("jobName"), taskID, ctx.Logger)
 }

--- a/pkg/microservice/aslan/core/workflow/testing/service/it_report.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/it_report.go
@@ -17,19 +17,17 @@ limitations under the License.
 package service
 
 import (
-	"fmt"
-	"github.com/koderover/zadig/v2/pkg/setting"
-
 	"go.uber.org/zap"
 
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
+	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 )
 
 func GetTestLocalTestSuite(testName string, log *zap.SugaredLogger) (*commonmodels.TestSuite, error) {
 	resp := new(commonmodels.TestSuite)
 
-	testCustomWorkflowName := fmt.Sprintf(setting.TestWorkflowNamingConvention, testName)
+	testCustomWorkflowName := commonutil.GenTestingWorkflowName(testName)
 	testTasks, err := commonrepo.NewJobInfoColl().GetTestJobsByWorkflow(testCustomWorkflowName)
 	if err != nil {
 		log.Errorf("failed to get test task from mongodb, error: %s", err)

--- a/pkg/microservice/aslan/core/workflow/testing/service/openapi.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/openapi.go
@@ -27,7 +27,7 @@ import (
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
-	"github.com/koderover/zadig/v2/pkg/setting"
+	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	openapitool "github.com/koderover/zadig/v2/pkg/tool/openapi"
 	"github.com/koderover/zadig/v2/pkg/types"
 )
@@ -149,7 +149,7 @@ func OpenAPICreateTestTask(userName, account, userID string, args *OpenAPICreate
 }
 
 func OpenAPIGetTestTaskResult(taskID int64, productName, testName string, logger *zap.SugaredLogger) (*OpenAPITestTaskDetail, error) {
-	workflowName := fmt.Sprintf(setting.TestWorkflowNamingConvention, testName)
+	workflowName := commonutil.GenTestingWorkflowName(testName)
 	workflowTask, err := commonrepo.NewworkflowTaskv4Coll().Find(workflowName, taskID)
 	if err != nil {
 		logger.Errorf("failed to find workflow task %d for test: %s, error: %s", taskID, testName, err)

--- a/pkg/microservice/aslan/core/workflow/testing/service/testing.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/testing.go
@@ -227,7 +227,7 @@ func ListTestingOpt(productNames []string, testType string, log *zap.SugaredLogg
 }
 
 func GetTestTask(testName string) (*commonmodels.TestTaskStat, error) {
-	testCustomWorkflowName := fmt.Sprintf(setting.TestWorkflowNamingConvention, testName)
+	testCustomWorkflowName := commonutil.GenTestingWorkflowName(testName)
 	testTasks, err := commonrepo.NewJobInfoColl().GetTestJobsByWorkflow(testCustomWorkflowName)
 	if err != nil {
 		log.Errorf("failed to get test task from mongodb, error: %s", err)
@@ -465,7 +465,7 @@ func GetWorkflowV4HTMLTestReport(workflowName, jobName string, taskID int64, log
 }
 
 func GetTestTaskHTMLTestReport(testName string, taskID int64, log *zap.SugaredLogger) (string, error) {
-	workflowName := fmt.Sprintf(setting.TestWorkflowNamingConvention, testName)
+	workflowName := commonutil.GenTestingWorkflowName(testName)
 	workflowTask, err := mongodb.NewworkflowTaskv4Coll().Find(workflowName, taskID)
 	if err != nil {
 		return "", fmt.Errorf("cannot find workflow task, workflow name: %s, task id: %d", workflowName, taskID)

--- a/pkg/microservice/aslan/core/workflow/testing/service/types.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/types.go
@@ -128,8 +128,9 @@ type ListScanningRespItem struct {
 }
 
 type CreateScanningTaskReq struct {
-	KeyVals []*commonmodels.KeyVal `json:"key_vals"`
-	Repos   []*ScanningRepoInfo    `json:"repos"`
+	KeyVals     []*commonmodels.KeyVal    `json:"key_vals"`
+	Repos       []*ScanningRepoInfo       `json:"repos"`
+	HookPayload *commonmodels.HookPayload `json:"hook_payload"`
 }
 
 type ScanningRepoInfo struct {

--- a/pkg/microservice/aslan/core/workflow/testing/service/workspace.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/workspace.go
@@ -33,6 +33,7 @@ import (
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/s3"
+	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	s3tool "github.com/koderover/zadig/v2/pkg/tool/s3"
 	"github.com/koderover/zadig/v2/pkg/types/step"
@@ -257,8 +258,8 @@ func GetWorkflowV4ScanningArtifactInfo(scanningID, jobName string, taskID int64,
 	if err != nil {
 		return nil, fmt.Errorf("failed to get scanning from mongodb, the error is: %s", err)
 	}
-	workflowName := fmt.Sprintf(setting.ScanWorkflowNamingConvention, scanningInfo.ID.Hex())
 
+	workflowName := commonutil.GenScanningWorkflowName(scanningInfo.ID.Hex())
 	workflowTask, err := mongodb.NewworkflowTaskv4Coll().Find(workflowName, taskID)
 	if err != nil {
 		return resp, fmt.Errorf("cannot find workflow task, workflow name: %s, task id: %d", workflowName, taskID)


### PR DESCRIPTION
### What this PR does / Why we need it:
support github/gitlab/gitee(no scanning) webhook auto cancel in testing/scanning

### What is changed and how it works?
support github/gitlab/gitee(no scanning) webhook auto cancel in testing/scanning

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
