### PR TITLE
fix scanning job get empty metrics in somecase

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/stepcontroller/step_sonar_get_metrics.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/stepcontroller/step_sonar_get_metrics.go
@@ -86,6 +86,12 @@ func (s *sonarGetMetricsCtl) AfterRun(ctx context.Context) error {
 	}
 
 	client := sonar.NewSonarClient(s.sonarGetMetricsSpec.SonarServer, s.sonarGetMetricsSpec.SonarToken)
+	analysisID, err := client.WaitForCETaskTobeDone(id, time.Minute*10)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
 	resp, err := client.GetComponentMeasures(s.sonarGetMetricsSpec.ProjectKey, s.sonarGetMetricsSpec.Branch)
 	if err != nil {
 		err = fmt.Errorf("get component measures error: %v", err)
@@ -111,11 +117,6 @@ func (s *sonarGetMetricsCtl) AfterRun(ctx context.Context) error {
 	}
 
 	if s.sonarGetMetricsSpec.CheckQualityGate {
-		analysisID, err := client.WaitForCETaskTobeDone(id, time.Minute*10)
-		if err != nil {
-			log.Error(err)
-			return err
-		}
 		gateInfo, err := client.GetQualityGateInfo(analysisID)
 		if err != nil {
 			log.Error(err)


### PR DESCRIPTION
### What this PR does / Why we need it:
fix scanning job get empty metrics in somecase

### What is changed and how it works?
fix scanning job get empty metrics in somecase

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
