### PR TITLE
remove unsupport service vars output in build job

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/job/job_build.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/job/job_build.go
@@ -942,9 +942,6 @@ func (j *BuildJob) GetOutPuts(log *zap.SugaredLogger) []string {
 		outputs = append(outputs, &commonmodels.Output{Name: outputKey})
 	}
 	resp = append(resp, getOutputKey(j.job.Name+".<SERVICE>.<MODULE>", outputs)...)
-	resp = append(resp, "{{.job."+j.job.Name+".<SERVICE>.<MODULE>."+GITURLKEY+"}}")
-	resp = append(resp, "{{.job."+j.job.Name+".<SERVICE>.<MODULE>."+BRANCHKEY+"}}")
-	resp = append(resp, "{{.job."+j.job.Name+".<SERVICE>.<MODULE>."+COMMITIDKEY+"}}")
 	return resp
 }
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -2147,6 +2147,7 @@ func getDefaultVars(workflow *commonmodels.WorkflowV4, currentJobName string) []
 				for _, s := range spec.ServiceAndBuilds {
 					vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, strings.Join([]string{"job", j.Name, s.ServiceName, s.ServiceModule, "COMMITID"}, ".")))
 					vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, strings.Join([]string{"job", j.Name, s.ServiceName, s.ServiceModule, "BRANCH"}, ".")))
+					vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, strings.Join([]string{"job", j.Name, s.ServiceName, s.ServiceModule, "GITURL"}, ".")))
 				}
 			case config.JobZadigDeploy:
 				vars = append(vars, fmt.Sprintf(setting.RenderValueTemplate, strings.Join([]string{"job", j.Name, "envName"}, ".")))


### PR DESCRIPTION
### What this PR does / Why we need it:
remove unsupport service vars output in build job

### What is changed and how it works?
remove unsupport service vars output in build job

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
