### PR TITLE
fix deploy job panic when service contains init container

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/render.go
+++ b/pkg/microservice/aslan/core/common/service/kube/render.go
@@ -178,7 +178,7 @@ func ReplaceWorkloadImages(rawYaml string, images []*commonmodels.Container) (st
 			}
 
 			for i, c := range initContainers {
-				container := c.(map[interface{}]interface{})
+				container := c.(map[string]interface{})
 				containerName := container["name"].(string)
 				if image, ok := imageMap[containerName]; ok {
 					container["image"] = image.Image
@@ -198,7 +198,7 @@ func ReplaceWorkloadImages(rawYaml string, images []*commonmodels.Container) (st
 			}
 
 			for i, c := range containers {
-				container := c.(map[interface{}]interface{})
+				container := c.(map[string]interface{})
 				containerName := container["name"].(string)
 				if image, ok := imageMap[containerName]; ok {
 					container["image"] = image.Image
@@ -217,7 +217,7 @@ func ReplaceWorkloadImages(rawYaml string, images []*commonmodels.Container) (st
 			}
 
 			for i, c := range initContainers {
-				container := c.(map[interface{}]interface{})
+				container := c.(map[string]interface{})
 				containerName := container["name"].(string)
 				if image, ok := imageMap[containerName]; ok {
 					container["image"] = image.Image


### PR DESCRIPTION
### What this PR does / Why we need it:
fix deploy job panic when service contains init container

### What is changed and how it works?
fix deploy job panic when service contains init container

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
