### PR TITLE
fix get test report in workflow task when status is unstable or wait for manual error handling

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -1869,7 +1869,8 @@ func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, 
 				}
 
 			}
-			if job.Status == config.StatusPassed || job.Status == config.StatusFailed {
+			if job.Status == config.StatusPassed || job.Status == config.StatusFailed ||
+				job.Status == config.StatusUnstable || job.Status == config.StatusManualApproval {
 				for _, step := range taskJobSpec.Steps {
 					if step.Name == config.TestJobArchiveResultStepName {
 						spec.Archive = true


### PR DESCRIPTION
### What this PR does / Why we need it:
fix get test report in workflow task when status is unstable or wait for manual error handling

### What is changed and how it works?
fix get test report in workflow task when status is unstable or wait for manual error handling

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
