### PR TITLE
fix dynmaic variable when job is after a manual exec job

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -931,12 +931,12 @@ func ManualExecWorkflowTaskV4(workflowName string, taskID int64, stageName strin
 		}
 	}
 
-	if err := jobctl.RemoveFixedValueMarks(task.OriginWorkflowArgs); err != nil {
+	if err := jobctl.RemoveFixedValueMarks(task.WorkflowArgs); err != nil {
 		log.Errorf("RemoveFixedValueMarks error: %v", err)
 		return e.ErrCreateTask.AddDesc(err.Error())
 	}
 
-	if err := jobctl.RenderWorkflowParams(task.OriginWorkflowArgs, task.TaskID, task.TaskCreator, task.TaskCreatorAccount, task.TaskCreatorID); err != nil {
+	if err := jobctl.RenderWorkflowParams(task.WorkflowArgs, task.TaskID, task.TaskCreator, task.TaskCreatorAccount, task.TaskCreatorID); err != nil {
 		log.Errorf("RenderGlobalVariables error: %v", err)
 		return e.ErrCreateTask.AddDesc(err.Error())
 	}


### PR DESCRIPTION
### What this PR does / Why we need it:
fix dynmaic variable when job is after a manual exec job

### What is changed and how it works?
fix dynmaic variable when job is after a manual exec job

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
