### PR TITLE
fix the pagination issue of the codehost/:codehostId/tags interface

### DIFF
--- a/pkg/microservice/aslan/core/code/service/tag.go
+++ b/pkg/microservice/aslan/core/code/service/tag.go
@@ -44,7 +44,7 @@ func CodeHostListTags(codeHostID int, projectName string, namespace string, key 
 		ProjectName: projectName,
 		Key:         key,
 		Page:        page,
-		PerPage:     page,
+		PerPage:     perPage,
 	})
 	if err != nil {
 		log.Errorf("list tags err:%s", err)


### PR DESCRIPTION
### What this PR does / Why we need it:

Fixes the pagination issue in the `codehost/:codehostId/tags` interface, where the `perPage` parameter was incorrectly set to `page`, leading to incorrect pagination behavior.

### What is changed and how it works?

- In the `CodeHostListTags` function, the `client.ListOpt.PerPage` parameter was mistakenly set to `page`.
- This PR corrects it by setting the correct perPage value to the PerPage field, ensuring that pagination now works as expected when listing tags from the code host.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
