### PR TITLE
fix ssh type vm's label not correct in building

### DIFF
--- a/pkg/microservice/aslan/core/system/service/private_key.go
+++ b/pkg/microservice/aslan/core/system/service/private_key.go
@@ -25,11 +25,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
-	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	commonservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/pm"
+	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/tool/crypto"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
@@ -113,8 +113,9 @@ func CreatePrivateKey(args *commonmodels.PrivateKey, log *zap.SugaredLogger) (*C
 
 	if args.Agent == nil {
 		args.Agent = &commonmodels.VMAgent{}
+	} else {
+		args.Type = setting.NewVMType
 	}
-	args.Type = setting.NewVMType
 	args.Status = setting.VMCreated
 
 	if args.IP != "" && !util.IsValidIPv4(args.IP) {

--- a/pkg/microservice/aslan/core/vm/service/vm.go
+++ b/pkg/microservice/aslan/core/vm/service/vm.go
@@ -363,7 +363,7 @@ func ListVMLabels(projectKey string, logger *zap.SugaredLogger) ([]string, error
 			continue
 		}
 
-		if vm.Agent != nil && vm.Type == setting.NewVMType && vm.Status == setting.VMNormal {
+		if vm.ScheduleWorkflow && vm.Agent != nil && vm.Type == setting.NewVMType && vm.Status == setting.VMNormal {
 			if vm.Label != "" && !labelSet.Has(vm.Label) {
 				labelSet.Insert(vm.Label)
 			}


### PR DESCRIPTION
### What this PR does / Why we need it:
fix ssh type vm's label not correct in building

### What is changed and how it works?
fix ssh type vm's label not correct in building

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
