### PR TITLE
clean share storage only when workflow task status is passed

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
@@ -192,8 +192,11 @@ func (c *workflowCtl) Run(ctx context.Context, concurrency int) {
 		c.workflowTask.EndTime = time.Now().Unix()
 		c.logger.Infof("finish workflow: %s,status: %s", c.workflowTask.WorkflowName, c.workflowTask.Status)
 		c.ack()
-		// clean share storage after workflow finished
-		go c.CleanShareStorage()
+
+		if c.workflowTask.Status == config.StatusPassed {
+			// clean share storage after workflow finished
+			go c.CleanShareStorage()
+		}
 	}()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()


### PR DESCRIPTION
### What this PR does / Why we need it:
clean share storage only when workflow task status is passed

### What is changed and how it works?
clean share storage only when workflow task status is passed

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
