### PR TITLE
fix migrate 341 vm deploy's repos

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/341.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/341.go
@@ -330,6 +330,7 @@ func migrate341VMDeploy(ctx *internalhandler.Context, migrationInfo *internalmod
 								svc.ServiceModule = svc.ServiceName
 								svc.DeployName = build.Name
 								svc.DeployArtifactType = build.DeployArtifactType
+								svc.Repos = build.DeployRepos
 							}
 							newSpec.DefaultServiceAndVMDeploys = append(newSpec.DefaultServiceAndVMDeploys, svc)
 						}


### PR DESCRIPTION
### What this PR does / Why we need it:
fix migrate 341 vm deploy's repos

### What is changed and how it works?
fix migrate 341 vm deploy's repos

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
