### PR TITLE
fix can't ssh clone codeup repo

### DIFF
--- a/pkg/microservice/jobexecutor/core/service/step/step_git.go
+++ b/pkg/microservice/jobexecutor/core/service/step/step_git.go
@@ -369,7 +369,10 @@ func writeSSHConfigFile(hostNames sets.String, proxy *step.Proxy) error {
 // return github.com
 func getHost(address string) string {
 	address = strings.TrimPrefix(address, "ssh://")
-	address = strings.TrimPrefix(address, "git@")
+	addressArr := strings.Split(address, "@")
+	if len(addressArr) == 2 {
+		address = addressArr[1]
+	}
 	hostArr := strings.Split(address, ":")
 	return hostArr[0]
 }


### PR DESCRIPTION
### What this PR does / Why we need it:
fix can't ssh clone codeup repo

### What is changed and how it works?
fix can't ssh clone codeup repo

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
