### PR TITLE
fix get docker host panic when dind replica is 0

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_freestyle.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_freestyle.go
@@ -150,8 +150,10 @@ func (c *FreestyleJobCtl) run(ctx context.Context) error {
 
 	// decide which docker host to use.
 	// TODO: do not use code in warpdrive moudule, should move to a public place
-	dockerhosts := dockerhost.NewDockerHosts(hubServerAddr, c.logger)
-	c.jobTaskSpec.Properties.DockerHost = dockerhosts.GetBestHost(dockerhost.ClusterID(c.jobTaskSpec.Properties.ClusterID), fmt.Sprintf("%v", c.workflowCtx.TaskID))
+	if !c.jobTaskSpec.Properties.UseHostDockerDaemon {
+		dockerhosts := dockerhost.NewDockerHosts(hubServerAddr, c.logger)
+		c.jobTaskSpec.Properties.DockerHost = dockerhosts.GetBestHost(dockerhost.ClusterID(c.jobTaskSpec.Properties.ClusterID), fmt.Sprintf("%v", c.workflowCtx.TaskID))
+	}
 
 	// not local cluster
 	var (


### PR DESCRIPTION
### What this PR does / Why we need it:
fix get docker host panic when dind replica is 0

### What is changed and how it works?
fix get docker host panic when dind replica is 0

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
