### PR TITLE
support fixed zadig approval in create workflow task openapi

### DIFF
--- a/pkg/microservice/aslan/core/release_plan/handler/openapi.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/openapi.go
@@ -121,7 +121,7 @@ func OpenAPICreateReleasePlan(c *gin.Context) {
 
 // @summary Update Release Plan
 // @description Update Release Plan
-// @tags 	Openapi
+// @tags 	OpenAPI
 // @accept 	json
 // @produce json
 // @Param 	body 			body 		service.OpenAPIUpdateReleasePlanWithJobsArgs 				true 	"body"

--- a/pkg/microservice/aslan/core/workflow/service/workflow/openapi.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/openapi.go
@@ -370,6 +370,9 @@ func GetInputUpdater(job *commonmodels.Job, input interface{}) (CustomJobInput, 
 		updater := new(ZadigVMDeployJobInput)
 		err := commonmodels.IToi(input, updater)
 		return updater, err
+	case config.JobApproval:
+		updater := new(ApprovalJobInput)
+		return updater, nil
 	case config.JobSQL:
 		updater := new(SQLJobInput)
 		err := commonmodels.IToi(input, updater)

--- a/pkg/microservice/aslan/core/workflow/service/workflow/types.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/types.go
@@ -471,7 +471,7 @@ func (p *ZadigDeployJobInput) UpdateJobSpec(job *commonmodels.Job) (*commonmodel
 				}),
 			}
 			serviceMap[inputSvc.ServiceName] = &commonmodels.DeployServiceInfo{
-				DeployBasicInfo:    basicInfo,
+				DeployBasicInfo: basicInfo,
 				DeployVariableInfo: commonmodels.DeployVariableInfo{
 					ValueMergeStrategy: inputSvc.ValueMergeStrategy,
 				},
@@ -1175,4 +1175,11 @@ func (req *OpenAPICreateWorkflowViewReq) Validate() (bool, error) {
 		}
 	}
 	return true, nil
+}
+
+type ApprovalJobInput struct {
+}
+
+func (p *ApprovalJobInput) UpdateJobSpec(job *commonmodels.Job) (*commonmodels.Job, error) {
+	return job, nil
 }


### PR DESCRIPTION
### What this PR does / Why we need it:
support fixed zadig approval in create workflow task openapi

### What is changed and how it works?
support fixed zadig approval in create workflow task openapi

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
