### PR TITLE
add disable apollo config range filter feature

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -939,9 +939,10 @@ type SQLJobSpec struct {
 }
 
 type ApolloJobSpec struct {
-	ApolloID            string             `bson:"apolloID"            json:"apolloID"             yaml:"apolloID"`
-	NamespaceList       []*ApolloNamespace `bson:"namespaceList"       json:"namespaceList"        yaml:"namespaceList"`
-	NamespaceListOption []*ApolloNamespace `bson:"namespaceListOption" json:"namespaceListOption"  yaml:"namespaceListOption"`
+	ApolloID            string             `bson:"apolloID"                    json:"apolloID"                     yaml:"apolloID"`
+	DisableConfigRange  bool               `bson:"disable_config_range"        json:"disable_config_range"         yaml:"disable_config_range"`
+	NamespaceList       []*ApolloNamespace `bson:"namespaceList"               json:"namespaceList"                yaml:"namespaceList"`
+	NamespaceListOption []*ApolloNamespace `bson:"namespaceListOption"         json:"namespaceListOption"          yaml:"namespaceListOption"`
 }
 
 type ApolloNamespace struct {


### PR DESCRIPTION
### What this PR does / Why we need it:
add disable apollo config range filter feature

### What is changed and how it works?
add disable apollo config range filter feature

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
