### PR TITLE
remove old test result data in workflow notification

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/custom_workflow_test_report.go
+++ b/pkg/microservice/aslan/core/common/repository/models/custom_workflow_test_report.go
@@ -24,6 +24,7 @@ type CustomWorkflowTestReport struct {
 	JobName          string             `bson:"job_name"`
 	JobTaskName      string             `bson:"job_task_name"`
 	TaskID           int64              `bson:"task_id"`
+	RetryNum         int                `bson:"retry_num"`
 	ServiceName      string             `bson:"service_name"`
 	ServiceModule    string             `bson:"service_module"`
 	ZadigTestName    string             `bson:"zadig_test_name"`

--- a/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
@@ -58,6 +58,7 @@ type WorkflowTask struct {
 	IsArchived          bool                          `bson:"is_archived"               json:"is_archived"`
 	Error               string                        `bson:"error,omitempty"           json:"error,omitempty"`
 	IsRestart           bool                          `bson:"is_restart"                json:"is_restart"`
+	RetryNum            int                           `bson:"retry_num"                 json:"retry_num"`
 	IsDebug             bool                          `bson:"is_debug"                  json:"is_debug"`
 	ShareStorages       []*ShareStorage               `bson:"share_storages"            json:"share_storages"`
 	Type                config.CustomWorkflowTaskType `bson:"type"                      json:"type"`
@@ -786,6 +787,7 @@ type WorkflowTaskCtx struct {
 	ProjectName                 string
 	TaskID                      int64
 	Remark                      string
+	RetryNum                    int
 	DockerHost                  string
 	Workspace                   string
 	DistDir                     string

--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -607,6 +607,7 @@ func (f *workloadFilter) UnmarshalJSON(data []byte) error {
 
 func (f *workloadFilter) Match(workload *Workload) bool {
 	if len(f.Name) > 0 {
+		log.Debugf("workload.Name: %s, f.Name: %s", workload.Name, f.Name)
 		if !strings.Contains(workload.Name, f.Name) {
 			return false
 		}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/stepcontroller/step.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/stepcontroller/step.go
@@ -92,7 +92,7 @@ func instantiateStepCtl(step *commonmodels.StepTask, workflowCtx *commonmodels.W
 	case config.StepDownloadArchive:
 		stepCtl, err = NewDownloadArchiveCtl(step, logger)
 	case config.StepJunitReport:
-		stepCtl, err = NewJunitReportCtl(step, logger)
+		stepCtl, err = NewJunitReportCtl(step, workflowCtx, logger)
 	case config.StepTarArchive:
 		stepCtl, err = NewTarArchiveCtl(step, logger)
 	case config.StepSonarCheck:

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/stepcontroller/step_junit_report.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/stepcontroller/step_junit_report.go
@@ -41,10 +41,11 @@ import (
 type junitReportCtl struct {
 	step            *commonmodels.StepTask
 	junitReportSpec *step.StepJunitReportSpec
+	workflowCtx     *commonmodels.WorkflowTaskCtx
 	log             *zap.SugaredLogger
 }
 
-func NewJunitReportCtl(stepTask *commonmodels.StepTask, log *zap.SugaredLogger) (*junitReportCtl, error) {
+func NewJunitReportCtl(stepTask *commonmodels.StepTask, workflowCtx *commonmodels.WorkflowTaskCtx, log *zap.SugaredLogger) (*junitReportCtl, error) {
 	yamlString, err := yaml.Marshal(stepTask.Spec)
 	if err != nil {
 		return nil, fmt.Errorf("marshal junit report spec error: %v", err)
@@ -54,7 +55,7 @@ func NewJunitReportCtl(stepTask *commonmodels.StepTask, log *zap.SugaredLogger) 
 		return nil, fmt.Errorf("unmarshal junit report spec error: %v", err)
 	}
 	stepTask.Spec = junitReportSpec
-	return &junitReportCtl{junitReportSpec: junitReportSpec, log: log, step: stepTask}, nil
+	return &junitReportCtl{junitReportSpec: junitReportSpec, log: log, step: stepTask, workflowCtx: workflowCtx}, nil
 }
 
 func (s *junitReportCtl) PreRun(ctx context.Context) error {
@@ -142,6 +143,7 @@ func (s *junitReportCtl) AfterRun(ctx context.Context) error {
 		ServiceModule:    s.junitReportSpec.ServiceModule,
 		ZadigTestName:    s.junitReportSpec.TestName,
 		ZadigTestProject: s.junitReportSpec.TestProject,
+		RetryNum:         s.workflowCtx.RetryNum,
 		TestName:         testReport.Name,
 		TestCaseNum:      testReport.Tests,
 		SuccessCaseNum:   testReport.Successes,

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
@@ -234,6 +234,7 @@ func (c *workflowCtl) Run(ctx context.Context, concurrency int) {
 		ProjectName:                 c.workflowTask.ProjectName,
 		Remark:                      c.workflowTask.Remark,
 		TaskID:                      c.workflowTask.TaskID,
+		RetryNum:                    c.workflowTask.RetryNum,
 		WorkflowTaskCreatorUsername: c.workflowTask.TaskCreator,
 		WorkflowTaskCreatorUserID:   c.workflowTask.TaskCreatorID,
 		WorkflowTaskCreatorMobile:   c.workflowTask.TaskCreatorPhone,

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -736,6 +736,8 @@ func RetryWorkflowTaskV4(workflowName string, taskID int64, logger *zap.SugaredL
 		return errors.New("工作流任务数据异常, 无法重试")
 	}
 
+	task.RetryNum++
+
 	globalKeyMap := make(map[string]string)
 	jobTaskMap := make(map[string]*commonmodels.JobTask)
 	for _, stage := range task.WorkflowArgs.Stages {


### PR DESCRIPTION
### What this PR does / Why we need it:
remove old test result data in workflow notification

### What is changed and how it works?
remove old test result data in workflow notification

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
