### PR TITLE
fix sync helm env vars sync lock expire time too short

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -1874,7 +1874,7 @@ func geneYamlData(args *commonservice.ValuesDataArgs) *templatemodels.CustomYaml
 }
 
 func SyncHelmProductEnvironment(productName, envName, requestID string, log *zap.SugaredLogger) error {
-	syncLock := cache.NewRedisLock(fmt.Sprintf("%s:%s:%s", SyncHelmEnvVariablesLockKey, productName, envName))
+	syncLock := cache.NewRedisLockWithExpiry(fmt.Sprintf("%s:%s:%s", SyncHelmEnvVariablesLockKey, productName, envName), time.Second*600)
 	err := syncLock.TryLock()
 	if err != nil {
 		log.Infof("sync helm env variables is processing, project: %s, env: %s", productName, envName)


### PR DESCRIPTION
### What this PR does / Why we need it:
fix sync helm env vars sync lock expire time too short

### What is changed and how it works?
fix sync helm env vars sync lock expire time too short

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
