### PR TITLE
fix job is skipped when create workflow task by openapi

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/openapi.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/openapi.go
@@ -117,6 +117,8 @@ func CreateCustomWorkflowTask(username string, args *OpenAPICreateCustomWorkflow
 					log.Errorf("Failed to update jobspec for job: %s, error: %s", job.Name, err)
 					return nil, fmt.Errorf("failed to update jobspec for job: %s, err: %w", job.Name, err)
 				}
+
+				job.Skipped = false
 				jobList = append(jobList, newJob)
 			} else {
 				job.Skipped = true


### PR DESCRIPTION
### What this PR does / Why we need it:
fix job is skipped when create workflow task by openapi

### What is changed and how it works?
fix job is skipped when create workflow task by openapi

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
