### PR TITLE
fix workflow job is skipped when update release plan by openapi

### DIFF
--- a/pkg/microservice/aslan/core/release_plan/service/openapi.go
+++ b/pkg/microservice/aslan/core/release_plan/service/openapi.go
@@ -332,6 +332,7 @@ func OpenAPICreateReleasePlanWithJobs(c *handler.Context, id string, rawArgs *Op
 							log.Errorf("Failed to update jobspec for job: %s, error: %s", job.Name, err)
 							return fmt.Errorf("failed to update jobspec for job: %s, err: %w", job.Name, err)
 						}
+						job.Skipped = false
 						jobList = append(jobList, newJob)
 					} else {
 						job.Skipped = true


### PR DESCRIPTION
### What this PR does / Why we need it:
fix workflow job is skipped when update release plan by openapi

### What is changed and how it works?
fix workflow job is skipped when update release plan by openapi

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
