### PR TITLE
fix can't update service yaml when update from import to deploy

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/apply.go
+++ b/pkg/microservice/aslan/core/common/service/kube/apply.go
@@ -64,10 +64,10 @@ type ResourceApplyParam struct {
 	UpdateResourceYaml  string
 
 	// used for helm services
-	Images                []string // all images need to be updated, used for helm services
-	VariableYaml          string   // variables
-	Timeout               int      // timeout for helm services
-	UpdateServiceRevision bool
+	Images               []string // all images need to be updated, used for helm services
+	VariableYaml         string   // variables
+	Timeout              int      // timeout for helm services
+	IsFromImportToDeploy bool
 
 	Informer                 informers.SharedInformerFactory
 	KubeClient               client.Client
@@ -661,7 +661,7 @@ func CreateOrPatchResource(applyParam *ResourceApplyParam, log *zap.SugaredLogge
 		if !ok {
 			removeRes = append(removeRes, cr.unstructured)
 		} else {
-			if r.mainfest == cr.mainfest {
+			if r.mainfest == cr.mainfest && !applyParam.IsFromImportToDeploy {
 				unchangedResources = append(unchangedResources, cr.unstructured)
 				delete(updateResourceMap, GVKN)
 			}


### PR DESCRIPTION
### What this PR does / Why we need it:
fix can't update service yaml when update from import to deploy

### What is changed and how it works?
fix can't update service yaml when update from import to deploy

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
