### PR TITLE
fix vm deploy job don't have COMMIT_ID variable

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_vm_deploy.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_vm_deploy.go
@@ -474,6 +474,12 @@ func (j VMDeployJobController) SetRepo(repo *types.Repository) error {
 }
 
 func (j VMDeployJobController) SetRepoCommitInfo() error {
+	for _, vmDeploy := range j.jobSpec.ServiceAndVMDeploys {
+		if err := setRepoInfo(vmDeploy.Repos); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -700,7 +706,7 @@ func getVMDeployJobVariables(vmDeploy *commonmodels.ServiceAndVMDeploy, buildInf
 	}
 
 	// repo envs
-	ret = append(ret, getReposVariables(buildInfo.DeployRepos)...)
+	ret = append(ret, getReposVariables(vmDeploy.Repos)...)
 
 	// vm deploy specific envs
 	ret = append(ret, &commonmodels.KeyVal{Key: "ENV_NAME", Value: envName, IsCredential: false})


### PR DESCRIPTION
### What this PR does / Why we need it:
fix vm deploy job don't have COMMIT_ID variable

### What is changed and how it works?
fix vm deploy job don't have COMMIT_ID variable

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
