### PR TITLE
fix can't continue to send notification when executor is empty and create workflow task by openapi

### DIFF
--- a/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
@@ -278,14 +278,14 @@ func (w *Service) SendWorkflowTaskApproveNotifications(workflowName string, task
 		}
 
 		if notify.WebHookType == setting.NotifyWebHookTypeFeishuPerson {
-			if task.TaskCreatorID != "" {
-				errMsg := fmt.Sprintf("executor id is empty, cannot send message")
-				log.Error(errMsg)
-				return errors.New(errMsg)
-			}
-
 			for _, target := range notify.LarkPersonNotificationConfig.TargetUsers {
 				if target.IsExecutor {
+					if task.TaskCreatorID == "" {
+						errMsg := fmt.Errorf("executor id is empty, cannot send message")
+						log.Error(errMsg)
+						continue
+					}
+
 					userInfo, err := userclient.New().GetUserByID(task.TaskCreatorID)
 					if err != nil {
 						log.Errorf("failed to find user %s, error: %s", task.TaskCreatorID, err)
@@ -390,9 +390,9 @@ func (w *Service) SendWorkflowTaskNotifications(task *models.WorkflowTask) error
 				for _, target := range notify.LarkPersonNotificationConfig.TargetUsers {
 					if target.IsExecutor {
 						if task.TaskCreatorID == "" {
-							errMsg := fmt.Sprintf("executor id is empty, cannot send message")
+							errMsg := fmt.Errorf("executor id is empty, cannot send message")
 							log.Error(errMsg)
-							return errors.New(errMsg)
+							continue
 						}
 
 						userInfo, err := userclient.New().GetUserByID(task.TaskCreatorID)


### PR DESCRIPTION

### What this PR does / Why we need it:
fix can't continue to send notification when executor is empty and create workflow task by openapi

### What is changed and how it works?
fix can't continue to send notification when executor is empty and create workflow task by openapi

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
