### PR TITLE
fix get scanning err when delete 1st sonar integration

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/scanning.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/scanning.go
@@ -152,6 +152,9 @@ func (c *ScanningColl) Find(projectName, name string) (*models.Scanning, error) 
 	return resp, err
 }
 
+// (CAUTION) This function is used to get the scanning by id,
+// but it will not fill the scanning template info.
+// If you need to get the scanning template info at once, please use the service layer to get it.
 func (c *ScanningColl) GetByID(idstring string) (*models.Scanning, error) {
 	resp := new(models.Scanning)
 	id, err := primitive.ObjectIDFromHex(idstring)


### PR DESCRIPTION
### What this PR does / Why we need it:
fix get scanning err when delete 1st sonar integration

### What is changed and how it works?
fix get scanning err when delete 1st sonar integration

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
