### PR TITLE
set status to executing in release plan callback's finish planning event

### DIFF
--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -1448,6 +1448,12 @@ func ReleasePlanHookCallback(c *handler.Context, callback *ReleasePlanCallBackBo
 		// target status process
 		if releasePlan.Status == config.ReleasePlanStatusFinishPlanning {
 			releasePlan.FinishPlanningTime = time.Now().Unix()
+			if releasePlan.Approval == nil || releasePlan.Approval.Enabled == false {
+				releasePlan.Status = config.ReleasePlanStatusExecuting
+				releasePlan.ExecutingTime = time.Now().Unix()
+				setReleaseJobsForExecuting(releasePlan)
+			}
+
 			// if releasePlan.Status == config.ReleasePlanStatusWaitForApprove {
 			// userInfo, err := user.New().GetUserByID(releasePlan.ApproverID)
 			// if err != nil {


### PR DESCRIPTION
### What this PR does / Why we need it:
set status to executing in release plan callback's finish planning event

### What is changed and how it works?
set status to executing in release plan callback's finish planning event

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue
