### PR TITLE
feat: update docker secret handling to use .dockerconfigjson format.

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/actions.go
+++ b/pkg/microservice/aslan/core/common/service/kube/actions.go
@@ -142,13 +142,13 @@ func CreateOrUpdateRegistrySecret(namespace string, reg *commonmodels.RegistryNa
 	data := make(map[string][]byte)
 
 	dockerConfig := fmt.Sprintf(
-		`{"%s":{"username":"%s","password":"%s","email":"%s"}}`,
+		`{"auths":{"%s":{"username":"%s","password":"%s","email":"%s"}}}`,
 		reg.RegAddr,
 		reg.AccessKey,
 		reg.SecretKey,
 		"bot@koderover.com",
 	)
-	data[".dockercfg"] = []byte(dockerConfig)
+	data[".dockerconfigjson"] = []byte(dockerConfig)
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -156,7 +156,7 @@ func CreateOrUpdateRegistrySecret(namespace string, reg *commonmodels.RegistryNa
 			Name:      secretName,
 		},
 		Data: data,
-		Type: corev1.SecretTypeDockercfg,
+		Type: corev1.SecretTypeDockerConfigJson,
 	}
 	return updater.UpdateOrCreateSecret(secret, kubeClient)
 }

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
@@ -1239,13 +1239,13 @@ func createOrUpdateRegistrySecrets(namespace string, registries []*commonmodels.
 
 		data := make(map[string][]byte)
 		dockerConfig := fmt.Sprintf(
-			`{"%s":{"username":"%s","password":"%s","email":"%s"}}`,
+			`{"auths":{"%s":{"username":"%s","password":"%s","email":"%s"}}}`,
 			reg.RegAddr,
 			reg.AccessKey,
 			reg.SecretKey,
 			defaultSecretEmail,
 		)
-		data[".dockercfg"] = []byte(dockerConfig)
+		data[".dockerconfigjson"] = []byte(dockerConfig)
 
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1253,7 +1253,7 @@ func createOrUpdateRegistrySecrets(namespace string, registries []*commonmodels.
 				Name:      secretName,
 			},
 			Data: data,
-			Type: corev1.SecretTypeDockercfg,
+			Type: corev1.SecretTypeDockerConfigJson,
 		}
 		if err := updater.UpdateOrCreateSecret(secret, kubeClient); err != nil {
 			return err


### PR DESCRIPTION
### What this PR does / Why we need it:

- Changed the format of Docker configuration from .dockercfg to .dockerconfigjson in CreateOrUpdateRegistrySecret and createOrUpdateRegistrySecrets functions.
- Updated the secret type from corev1.SecretTypeDockercfg to corev1.SecretTypeDockerConfigJson.
- Enhanced UpdateOrCreateSecret function to handle immutable secret types by deleting and recreating the secret if the type changes.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4489)
<!-- Reviewable:end -->
