### PR TITLE
fix: add timeout to cache sync in KubeClientManager to prevent timeout.

### DIFF
--- a/pkg/tool/clientmanager/kube.go
+++ b/pkg/tool/clientmanager/kube.go
@@ -373,7 +373,7 @@ func (cm *KubeClientManager) GetInformer(clusterID, namespace string) (informers
 	// wait for the cache to be synced for the first time, with a timeout to
 	// prevent blocking indefinitely when the cluster is unreachable or RBAC
 	// prevents list/watch operations.
-	syncCtx, syncCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	syncCtx, syncCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer syncCancel()
 	informerFactory.WaitForCacheSync(syncCtx.Done())
 

--- a/pkg/tool/clientmanager/kube.go
+++ b/pkg/tool/clientmanager/kube.go
@@ -370,8 +370,12 @@ func (cm *KubeClientManager) GetInformer(clusterID, namespace string) (informers
 
 	stopchan := make(chan struct{})
 	informerFactory.Start(stopchan)
-	// wait for the cache to be synced for the first time
-	informerFactory.WaitForCacheSync(make(chan struct{}))
+	// wait for the cache to be synced for the first time, with a timeout to
+	// prevent blocking indefinitely when the cluster is unreachable or RBAC
+	// prevents list/watch operations.
+	syncCtx, syncCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer syncCancel()
+	informerFactory.WaitForCacheSync(syncCtx.Done())
 
 	oldStopChan, ok := cm.informerStopChanMap.Load(key)
 	if ok {


### PR DESCRIPTION
fix: add timeout to cache sync in KubeClientManager to prevent timeout.


### What is changed and how it works?

add timeout to cache sync in KubeClientManager to prevent informer timeout.


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4584)
<!-- Reviewable:end -->
