### PR TITLE
fix:implement workflow task cancellation before deletion in DeleteWorkflowV4 function.

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -58,6 +58,7 @@ import (
 	commonservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/collaboration"
 	helmservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/helm"
+	runtimeWorkflowController "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/workflowcontroller"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/kube"
 	larkservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/lark"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/s3"
@@ -305,6 +306,20 @@ func FindWorkflowV4Raw(name string, logger *zap.SugaredLogger) (*commonmodels.Wo
 }
 
 func DeleteWorkflowV4(name string, logger *zap.SugaredLogger) error {
+	// Cancel any queued or running tasks before deleting the workflow.
+	taskQueue, err := commonrepo.NewWorkflowQueueColl().List(&commonrepo.ListWorfklowQueueOption{
+		WorkflowName: name,
+	})
+	if err != nil {
+		logger.Errorf("Failed to list queued tasks for workflow %s, the error is: %v", name, err)
+		return e.ErrDeleteWorkflow.AddErr(err)
+	}
+	for _, task := range taskQueue {
+		if err := runtimeWorkflowController.CancelWorkflowTask("system", task.WorkflowName, task.TaskID, logger); err != nil {
+			logger.Warnf("Failed to cancel task %d for workflow %s before deletion, the error is: %v", task.TaskID, name, err)
+		}
+	}
+
 	workflow, err := commonrepo.NewWorkflowV4Coll().Find(name)
 	if err != nil {
 		logger.Errorf("Failed to delete WorkflowV4: %s, the error is: %v", name, err)


### PR DESCRIPTION
### What this PR does / Why we need it:
When a user deletes a workflow that has queued or running tasks, the system soft-deletes all associated tasks (setting is_deleted: true, is_archived: true) without sending a cancellation signal to the execution controller. This results in:

Tasks disappear from the UI immediately (all list queries filter by is_deleted: false)
The workflow controller keeps executing the task in memory — it is unaware of the is_deleted flag
Users have no way to find or cancel the "zombie" task from any UI surface
On service restart, InitQueue also skips these tasks (InCompletedTasks filters is_deleted: false), so they are never cleaned up automatically

### What is changed and how it works?

Before soft-deleting workflow tasks in DeleteWorkflowV4, query WorkflowQueueColl by workflow name to retrieve all enqueued tasks, then call CancelWorkflowTask for each one. This triggers a DB status update to Cancelled and publishes a Redis cancel signal, allowing the controller to exit gracefully. Cancellation failures are logged as warnings and do not block the deletion.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4617)
<!-- Reviewable:end -->
