### PR TITLE
[WIP]fix: preserve soft-delete flags in workflow task ACK writes.

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
@@ -556,6 +556,15 @@ func (c *workflowCtl) updateWorkflowTask() {
 
 	c.workflowTask.Remark = ""
 
+	// Preserve the soft-delete flags from the DB copy. The in-memory task was
+	// loaded before the workflow could have been deleted, so its IsDeleted /
+	// IsArchived fields may be stale (false). Blindly writing them back via
+	// $set would silently undo a soft-delete performed by DeleteWorkflowV4,
+	// making the task reappear in the UI as "running" even after the workflow
+	// has been removed.
+	c.workflowTask.IsDeleted = taskInColl.IsDeleted
+	c.workflowTask.IsArchived = taskInColl.IsArchived
+
 	c.workflowTaskMutex.Lock()
 	if err := commonrepo.NewworkflowTaskv4Coll().Update(c.workflowTask.ID.Hex(), c.workflowTask); err != nil {
 		c.workflowTaskMutex.Unlock()


### PR DESCRIPTION
### What this PR does / Why we need it:

The workflow controller loads a WorkflowTask document into memory at startup and holds a reference (c.workflowTask) for the entire lifetime of the run. When a workflow is deleted while a task is still executing, DeleteWorkflowV4 soft-deletes all associated task documents by setting is_deleted: true and is_archived: true in MongoDB.

However, updateWorkflowTask (the ACK callback invoked after every job/stage transition) writes the full in-memory task object back to MongoDB using $set. Because the in-memory object was loaded before the workflow was deleted, its IsDeleted and IsArchived fields are both false. Every ACK call therefore silently undoes the soft-delete, resetting is_deleted to false and making the task reappear in the UI as "running" — even after the workflow has been removed.

This also meant that a soft-deleted task could never be cleared by InitQueue on service restart (which queries InCompletedTasks filtered by is_deleted: false), nor by any automatic cleanup path, leaving a permanent "zombie" running indicator for users.

### What is changed and how it works?

Before writing the in-memory task back to MongoDB, sync IsDeleted and IsArchived from the freshly-read database copy (taskInColl) that is already fetched at the top of updateWorkflowTask. This ensures that a soft-delete performed concurrently (e.g., by DeleteWorkflowV4) is never overwritten by a stale ACK.



### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4620)
<!-- Reviewable:end -->
