### PR TITLE
support Lark approval cc_groups in release plans

### DIFF
--- a/pkg/microservice/aslan/core/common/util/lark.go
+++ b/pkg/microservice/aslan/core/common/util/lark.go
@@ -1,0 +1,51 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+	larkservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/lark"
+	"github.com/koderover/zadig/v2/pkg/setting"
+	"github.com/koderover/zadig/v2/pkg/tool/lark"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func ConvertLarkUserGroupToUser(larkApprovalID string, groups []*models.LarkApprovalGroup) ([]*lark.UserInfo, error) {
+	userSet := sets.NewString()
+	users := make([]*lark.UserInfo, 0)
+	for _, group := range groups {
+		userGroup, err := larkservice.GetLarkUserGroup(larkApprovalID, group.GroupID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get lark user group: %s", err)
+		}
+
+		if userGroup.MemberUserCount > 0 {
+			userInfos, err := larkservice.GetLarkUserGroupMembersInfo(larkApprovalID, group.GroupID, "user", setting.LarkUserOpenID, "")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get lark department user infos: %s", err)
+			}
+
+			for _, user := range userInfos {
+				if !userSet.Has(user.ID) {
+					users = append(users, user)
+					userSet.Insert(user.ID)
+				}
+			}
+		}
+
+		if userGroup.MemberDepartmentCount > 0 {
+			userInfos, err := larkservice.GetLarkUserGroupMembersInfo(larkApprovalID, group.GroupID, "department", setting.LarkDepartmentID, "")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get lark department user infos: %s", err)
+			}
+
+			for _, user := range userInfos {
+				if !userSet.Has(user.ID) {
+					users = append(users, user)
+					userSet.Insert(user.ID)
+				}
+			}
+		}
+	}
+	return users, nil
+}

--- a/pkg/microservice/aslan/core/release_plan/service/lint.go
+++ b/pkg/microservice/aslan/core/release_plan/service/lint.go
@@ -19,7 +19,10 @@ package service
 import (
 	"fmt"
 
+	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+	larkservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/lark"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
+	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/tool/lark"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
@@ -105,12 +108,42 @@ func lintApproval(approval *models.Approval) error {
 		if len(approval.LarkApproval.ApprovalNodes) == 0 {
 			return errors.New("num of approval-node is 0")
 		}
+
 		for i, node := range approval.LarkApproval.ApprovalNodes {
-			if node.Type == lark.ApproveTypeStart || node.Type == lark.ApproveTypeEnd {
-				continue
-			}
-			if len(node.ApproveUsers) == 0 {
-				return errors.Errorf("num of approval-node %d approver is 0", i)
+			if node.ApproveNodeType == lark.ApproveNodeTypeUser {
+				if node.Type == lark.ApproveTypeStart || node.Type == lark.ApproveTypeEnd {
+					continue
+				}
+				if len(node.ApproveUsers) == 0 {
+					return errors.Errorf("num of approval-node %d approver is 0", i)
+				}
+			} else if node.ApproveNodeType == lark.ApproveNodeTypeUserGroup {
+				if node.Type != lark.ApproveTypeStart && node.Type != lark.ApproveTypeEnd {
+					if len(node.ApproveGroups) == 0 {
+						return errors.Errorf("num of approval-node %d approver is 0", i)
+					}
+				}
+
+				users, err := convertLarkUserGroupToUser(approval.LarkApproval.ID, node.ApproveGroups)
+				if err != nil {
+					return errors.Errorf("failed to convert lark user group to user: %s", err)
+				}
+
+				approveUsers := make([]*commonmodels.LarkApprovalUser, 0)
+				for _, user := range users {
+					approveUsers = append(approveUsers, &commonmodels.LarkApprovalUser{
+						UserInfo: *user,
+					})
+				}
+				node.ApproveUsers = approveUsers
+
+				users, err = convertLarkUserGroupToUser(approval.LarkApproval.ID, node.CcGroups)
+				if err != nil {
+					return errors.Errorf("failed to convert lark user group to user: %s", err)
+				}
+				node.CcUsers = users
+
+				approval.LarkApproval.ApprovalNodes[i] = node
 			}
 			if !lo.Contains([]string{"AND", "OR"}, string(node.Type)) {
 				return errors.Errorf("approval-node %d type should be AND or OR", i)
@@ -149,4 +182,44 @@ func lintApproval(approval *models.Approval) error {
 	}
 
 	return nil
+}
+
+func convertLarkUserGroupToUser(larkApprovalID string, groups []*models.LarkApprovalGroup) ([]*lark.UserInfo, error) {
+	userSet := sets.NewString()
+	users := make([]*lark.UserInfo, 0)
+	for _, group := range groups {
+		userGroup, err := larkservice.GetLarkUserGroup(larkApprovalID, group.GroupID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get lark user group: %s", err)
+		}
+
+		if userGroup.MemberUserCount > 0 {
+			userInfos, err := larkservice.GetLarkUserGroupMembersInfo(larkApprovalID, group.GroupID, "user", setting.LarkUserOpenID, "")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get lark department user infos: %s", err)
+			}
+
+			for _, user := range userInfos {
+				if !userSet.Has(user.ID) {
+					users = append(users, user)
+					userSet.Insert(user.ID)
+				}
+			}
+		}
+
+		if userGroup.MemberDepartmentCount > 0 {
+			userInfos, err := larkservice.GetLarkUserGroupMembersInfo(larkApprovalID, group.GroupID, "department", setting.LarkDepartmentID, "")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get lark department user infos: %s", err)
+			}
+
+			for _, user := range userInfos {
+				if !userSet.Has(user.ID) {
+					users = append(users, user)
+					userSet.Insert(user.ID)
+				}
+			}
+		}
+	}
+	return users, nil
 }

--- a/pkg/microservice/aslan/core/release_plan/service/lint.go
+++ b/pkg/microservice/aslan/core/release_plan/service/lint.go
@@ -116,10 +116,18 @@ func lintApproval(approval *models.Approval) error {
 					return errors.Errorf("num of approval-node %d approver is 0", i)
 				}
 			} else if node.ApproveNodeType == lark.ApproveNodeTypeUserGroup {
-				if node.Type != lark.ApproveTypeStart && node.Type != lark.ApproveTypeEnd {
-					if len(node.ApproveGroups) == 0 {
-						return errors.Errorf("num of approval-node %d approver is 0", i)
+				if node.Type == lark.ApproveTypeStart || node.Type == lark.ApproveTypeEnd {
+					users, err := util.ConvertLarkUserGroupToUser(approval.LarkApproval.ID, node.CcGroups)
+					if err != nil {
+						return errors.Errorf("failed to convert lark user group to user: %s", err)
 					}
+					node.CcUsers = users
+					approval.LarkApproval.ApprovalNodes[i] = node
+					continue
+				}
+
+				if len(node.ApproveGroups) == 0 {
+					return errors.Errorf("num of approval-node %d approver is 0", i)
 				}
 
 				users, err := util.ConvertLarkUserGroupToUser(approval.LarkApproval.ID, node.ApproveGroups)
@@ -134,12 +142,6 @@ func lintApproval(approval *models.Approval) error {
 					})
 				}
 				node.ApproveUsers = approveUsers
-
-				users, err = util.ConvertLarkUserGroupToUser(approval.LarkApproval.ID, node.CcGroups)
-				if err != nil {
-					return errors.Errorf("failed to convert lark user group to user: %s", err)
-				}
-				node.CcUsers = users
 
 				approval.LarkApproval.ApprovalNodes[i] = node
 			}

--- a/pkg/microservice/aslan/core/release_plan/service/lint.go
+++ b/pkg/microservice/aslan/core/release_plan/service/lint.go
@@ -20,9 +20,7 @@ import (
 	"fmt"
 
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
-	larkservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/lark"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
-	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/tool/lark"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
@@ -124,7 +122,7 @@ func lintApproval(approval *models.Approval) error {
 					}
 				}
 
-				users, err := convertLarkUserGroupToUser(approval.LarkApproval.ID, node.ApproveGroups)
+				users, err := util.ConvertLarkUserGroupToUser(approval.LarkApproval.ID, node.ApproveGroups)
 				if err != nil {
 					return errors.Errorf("failed to convert lark user group to user: %s", err)
 				}
@@ -137,7 +135,7 @@ func lintApproval(approval *models.Approval) error {
 				}
 				node.ApproveUsers = approveUsers
 
-				users, err = convertLarkUserGroupToUser(approval.LarkApproval.ID, node.CcGroups)
+				users, err = util.ConvertLarkUserGroupToUser(approval.LarkApproval.ID, node.CcGroups)
 				if err != nil {
 					return errors.Errorf("failed to convert lark user group to user: %s", err)
 				}
@@ -182,44 +180,4 @@ func lintApproval(approval *models.Approval) error {
 	}
 
 	return nil
-}
-
-func convertLarkUserGroupToUser(larkApprovalID string, groups []*models.LarkApprovalGroup) ([]*lark.UserInfo, error) {
-	userSet := sets.NewString()
-	users := make([]*lark.UserInfo, 0)
-	for _, group := range groups {
-		userGroup, err := larkservice.GetLarkUserGroup(larkApprovalID, group.GroupID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get lark user group: %s", err)
-		}
-
-		if userGroup.MemberUserCount > 0 {
-			userInfos, err := larkservice.GetLarkUserGroupMembersInfo(larkApprovalID, group.GroupID, "user", setting.LarkUserOpenID, "")
-			if err != nil {
-				return nil, fmt.Errorf("failed to get lark department user infos: %s", err)
-			}
-
-			for _, user := range userInfos {
-				if !userSet.Has(user.ID) {
-					users = append(users, user)
-					userSet.Insert(user.ID)
-				}
-			}
-		}
-
-		if userGroup.MemberDepartmentCount > 0 {
-			userInfos, err := larkservice.GetLarkUserGroupMembersInfo(larkApprovalID, group.GroupID, "department", setting.LarkDepartmentID, "")
-			if err != nil {
-				return nil, fmt.Errorf("failed to get lark department user infos: %s", err)
-			}
-
-			for _, user := range userInfos {
-				if !userSet.Has(user.ID) {
-					users = append(users, user)
-					userSet.Insert(user.ID)
-				}
-			}
-		}
-	}
-	return users, nil
 }

--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_approval.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_approval.go
@@ -287,10 +287,19 @@ func (j ApprovalJobController) ToTask(taskID int64) ([]*commonmodels.JobTask, er
 					return nil, fmt.Errorf("num of approval-node %d approver is 0", i)
 				}
 			} else if node.ApproveNodeType == lark.ApproveNodeTypeUserGroup {
-				if node.Type != lark.ApproveTypeStart && node.Type != lark.ApproveTypeEnd {
-					if len(node.ApproveGroups) == 0 {
-						return nil, fmt.Errorf("num of approval-node %d approver is 0", i)
+
+				if node.Type == lark.ApproveTypeStart || node.Type == lark.ApproveTypeEnd {
+					users, err := util.ConvertLarkUserGroupToUser(j.jobSpec.LarkApproval.ID, node.CcGroups)
+					if err != nil {
+						return nil, fmt.Errorf("failed to convert lark user group to user: %s", err)
 					}
+					node.CcUsers = users
+					jobSpec.LarkApproval.ApprovalNodes[i] = node
+					continue
+				}
+
+				if len(node.ApproveGroups) == 0 {
+					return nil, fmt.Errorf("num of approval-node %d approver is 0", i)
 				}
 
 				users, err := util.ConvertLarkUserGroupToUser(j.jobSpec.LarkApproval.ID, node.ApproveGroups)
@@ -305,12 +314,6 @@ func (j ApprovalJobController) ToTask(taskID int64) ([]*commonmodels.JobTask, er
 					})
 				}
 				node.ApproveUsers = approveUsers
-
-				users, err = util.ConvertLarkUserGroupToUser(j.jobSpec.LarkApproval.ID, node.CcGroups)
-				if err != nil {
-					return nil, fmt.Errorf("failed to convert lark user group to user: %s", err)
-				}
-				node.CcUsers = users
 
 				jobSpec.LarkApproval.ApprovalNodes[i] = node
 			}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_approval.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_approval.go
@@ -25,9 +25,7 @@ import (
 
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
-	larkservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/lark"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
-	"github.com/koderover/zadig/v2/pkg/setting"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
 	"github.com/koderover/zadig/v2/pkg/tool/lark"
 	"github.com/koderover/zadig/v2/pkg/types"
@@ -295,7 +293,7 @@ func (j ApprovalJobController) ToTask(taskID int64) ([]*commonmodels.JobTask, er
 					}
 				}
 
-				users, err := convertLarkUserGroupToUser(j.jobSpec.LarkApproval.ID, node.ApproveGroups)
+				users, err := util.ConvertLarkUserGroupToUser(j.jobSpec.LarkApproval.ID, node.ApproveGroups)
 				if err != nil {
 					return nil, fmt.Errorf("failed to convert lark user group to user: %s", err)
 				}
@@ -308,7 +306,7 @@ func (j ApprovalJobController) ToTask(taskID int64) ([]*commonmodels.JobTask, er
 				}
 				node.ApproveUsers = approveUsers
 
-				users, err = convertLarkUserGroupToUser(j.jobSpec.LarkApproval.ID, node.CcGroups)
+				users, err = util.ConvertLarkUserGroupToUser(j.jobSpec.LarkApproval.ID, node.CcGroups)
 				if err != nil {
 					return nil, fmt.Errorf("failed to convert lark user group to user: %s", err)
 				}
@@ -335,46 +333,6 @@ func (j ApprovalJobController) ToTask(taskID int64) ([]*commonmodels.JobTask, er
 	resp = append(resp, jobTask)
 
 	return resp, nil
-}
-
-func convertLarkUserGroupToUser(larkApprovalID string, groups []*commonmodels.LarkApprovalGroup) ([]*lark.UserInfo, error) {
-	userSet := sets.NewString()
-	users := make([]*lark.UserInfo, 0)
-	for _, group := range groups {
-		userGroup, err := larkservice.GetLarkUserGroup(larkApprovalID, group.GroupID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get lark user group: %s", err)
-		}
-
-		if userGroup.MemberUserCount > 0 {
-			userInfos, err := larkservice.GetLarkUserGroupMembersInfo(larkApprovalID, group.GroupID, "user", setting.LarkUserOpenID, "")
-			if err != nil {
-				return nil, fmt.Errorf("failed to get lark department user infos: %s", err)
-			}
-
-			for _, user := range userInfos {
-				if !userSet.Has(user.ID) {
-					users = append(users, user)
-					userSet.Insert(user.ID)
-				}
-			}
-		}
-
-		if userGroup.MemberDepartmentCount > 0 {
-			userInfos, err := larkservice.GetLarkUserGroupMembersInfo(larkApprovalID, group.GroupID, "department", setting.LarkDepartmentID, "")
-			if err != nil {
-				return nil, fmt.Errorf("failed to get lark department user infos: %s", err)
-			}
-
-			for _, user := range userInfos {
-				if !userSet.Has(user.ID) {
-					users = append(users, user)
-					userSet.Insert(user.ID)
-				}
-			}
-		}
-	}
-	return users, nil
 }
 
 func (j ApprovalJobController) SetRepo(repo *types.Repository) error {


### PR DESCRIPTION
### What this PR does / Why we need it:

This PR improves Lark approval handling in release plans by supporting cc group nodes. It aligns the release plan approval flow with the existing workflow approval behavior.Users can configure cc recipients on START/END approval nodes and have them correctly included when creating Lark approval instances.

### What is changed and how it works?

START/END cc nodes can use cc groups, which are expanded into cc users,the expanded cc users will be converted into CcerIDList when creating the Lark approval instance.

The existing Lark approval definition and instance creation flow remains unchanged.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4627)
<!-- Reviewable:end -->
