### PR TITLE
update spring-cloud-piggymetrics example

### DIFF
--- a/examples/spring-cloud-piggymetrics/account-service/8-account-service.yaml
+++ b/examples/spring-cloud-piggymetrics/account-service/8-account-service.yaml
@@ -57,7 +57,7 @@ spec:
         - name: SW_AGENT_NAME
           value: "account-service"
         - name: SW_AGENT_COLLECTOR_BACKEND_SERVICES
-          value: "skywalking-oap.skywalking.svc.cluster.local:11800"
+          value: "{{.oap_svc}}.skywalking.svc.cluster.local:11800"
         - name: ACCOUNT_SERVICE_PASSWORD
           valueFrom: 
             secretKeyRef:

--- a/examples/spring-cloud-piggymetrics/auth-service/6-auth-service.yaml
+++ b/examples/spring-cloud-piggymetrics/auth-service/6-auth-service.yaml
@@ -57,7 +57,7 @@ spec:
         - name: SW_AGENT_NAME
           value: "auth-service"
         - name: SW_AGENT_COLLECTOR_BACKEND_SERVICES
-          value: "skywalking-oap.skywalking.svc.cluster.local:11800"
+          value: "{{.oap_svc}}.skywalking.svc.cluster.local:11800"
         - name: ACCOUNT_SERVICE_PASSWORD
           valueFrom: 
             secretKeyRef:

--- a/examples/spring-cloud-piggymetrics/config-service/2-config-service.yaml
+++ b/examples/spring-cloud-piggymetrics/config-service/2-config-service.yaml
@@ -57,7 +57,7 @@ spec:
         - name: SW_AGENT_NAME
           value: "config"
         - name: SW_AGENT_COLLECTOR_BACKEND_SERVICES
-          value: "skywalking-oap.skywalking.svc.cluster.local:11800"
+          value: "{{.oap_svc}}.skywalking.svc.cluster.local:11800"
         - name: CONFIG_SERVICE_PASSWORD
           valueFrom: 
             secretKeyRef:

--- a/examples/spring-cloud-piggymetrics/gateway-service/4-gateway-service.yaml
+++ b/examples/spring-cloud-piggymetrics/gateway-service/4-gateway-service.yaml
@@ -66,7 +66,7 @@ spec:
         - name: SW_AGENT_NAME
           value: "gateway"
         - name: SW_AGENT_COLLECTOR_BACKEND_SERVICES
-          value: "skywalking-oap.skywalking.svc.cluster.local:11800"
+          value: "{{.oap_svc}}.skywalking.svc.cluster.local:11800"
         - name: CONFIG_SERVICE_PASSWORD
           valueFrom: 
             secretKeyRef:

--- a/examples/spring-cloud-piggymetrics/monitoring-service/13-monitoring-service.yaml
+++ b/examples/spring-cloud-piggymetrics/monitoring-service/13-monitoring-service.yaml
@@ -59,7 +59,7 @@ spec:
         - name: SW_AGENT_NAME
           value: "monitoring"
         - name: SW_AGENT_COLLECTOR_BACKEND_SERVICES
-          value: "skywalking-oap.skywalking.svc.cluster.local:11800"
+          value: "{{.oap_svc}}.skywalking.svc.cluster.local:11800"
         - name: CONFIG_SERVICE_PASSWORD
           valueFrom: 
             secretKeyRef:

--- a/examples/spring-cloud-piggymetrics/notification-service/12-notification-service.yaml
+++ b/examples/spring-cloud-piggymetrics/notification-service/12-notification-service.yaml
@@ -57,7 +57,7 @@ spec:
         - name: SW_AGENT_NAME
           value: "notification-service"
         - name: SW_AGENT_COLLECTOR_BACKEND_SERVICES
-          value: "skywalking-oap.skywalking.svc.cluster.local:11800"
+          value: "{{.oap_svc}}.skywalking.svc.cluster.local:11800"
         - name: CONFIG_SERVICE_PASSWORD
           valueFrom: 
             secretKeyRef:

--- a/examples/spring-cloud-piggymetrics/registry-service/3-registry-service.yaml
+++ b/examples/spring-cloud-piggymetrics/registry-service/3-registry-service.yaml
@@ -57,7 +57,7 @@ spec:
         - name: SW_AGENT_NAME
           value: "registry"
         - name: SW_AGENT_COLLECTOR_BACKEND_SERVICES
-          value: "skywalking-oap.skywalking.svc.cluster.local:11800"
+          value: "{{.oap_svc}}.skywalking.svc.cluster.local:11800"
         - name: CONFIG_SERVICE_PASSWORD
           valueFrom: 
             secretKeyRef:

--- a/examples/spring-cloud-piggymetrics/statistics-services/10-statistics-service.yaml
+++ b/examples/spring-cloud-piggymetrics/statistics-services/10-statistics-service.yaml
@@ -57,7 +57,7 @@ spec:
         - name: SW_AGENT_NAME
           value: "statistics-service"
         - name: SW_AGENT_COLLECTOR_BACKEND_SERVICES
-          value: "skywalking-oap.skywalking.svc.cluster.local:11800"
+          value: "{{.oap_svc}}.skywalking.svc.cluster.local:11800"
         - name: CONFIG_SERVICE_PASSWORD
           valueFrom: 
             secretKeyRef:

--- a/examples/spring-cloud-piggymetrics/turbine-stream-service/14-turbine-stream-service.yaml
+++ b/examples/spring-cloud-piggymetrics/turbine-stream-service/14-turbine-stream-service.yaml
@@ -60,7 +60,7 @@ spec:
         - name: SW_AGENT_NAME
           value: "turbine-stream-service"
         - name: SW_AGENT_COLLECTOR_BACKEND_SERVICES
-          value: "skywalking-oap.skywalking.svc.cluster.local:11800"
+          value: "{{.oap_svc}}.skywalking.svc.cluster.local:11800"
         - name: CONFIG_SERVICE_PASSWORD
           valueFrom: 
             secretKeyRef:


### PR DESCRIPTION
### What this PR does / Why we need it:


### What is changed and how it works?


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but an incorrect `oap_svc` template value could break SkyWalking agent connectivity across the example services.
> 
> **Overview**
> Updates the spring-cloud-piggymetrics Kubernetes example manifests to **parameterize the SkyWalking OAP endpoint**. All services now set `SW_AGENT_COLLECTOR_BACKEND_SERVICES` to `{{.oap_svc}}.skywalking.svc.cluster.local:11800` instead of hard-coding `skywalking-oap`, allowing the OAP service name to be injected at deploy time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b4407cad6f528598bc5b67afa1a116c2f4cb71e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4628)
<!-- Reviewable:end -->
