### PR TITLE
improve codehost error handling for better frontend experience

### DIFF
--- a/pkg/microservice/aslan/core/code/handler/codehost.go
+++ b/pkg/microservice/aslan/core/code/handler/codehost.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/code/service"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/shared/client/systemconfig"
 	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
@@ -60,7 +61,12 @@ func CodeHostGetNamespaceList(c *gin.Context) {
 		return
 	}
 	chID, _ := strconv.Atoi(codehostID)
-	ctx.Resp, ctx.RespErr = service.CodeHostListNamespaces(chID, keyword, ctx.Logger)
+	namespaces, err := service.CodeHostListNamespaces(chID, keyword, ctx.Logger)
+	if err != nil {
+		ctx.RespErr = e.NewWithDesc(e.ErrCodehostListNamespaces, util.FormatCodeHostErrorWithDefault("Failed to connect to the code host or the configuration is invalid. Please check your code host settings", err))
+		return
+	}
+	ctx.Resp = namespaces
 }
 
 type CodeHostListProjectsArgs struct {
@@ -110,7 +116,7 @@ func CodeHostGetProjectsList(c *gin.Context) {
 		args.Key,
 		ctx.Logger)
 	if err != nil {
-		ctx.RespErr = err
+		ctx.RespErr = e.NewWithDesc(e.ErrCodehostListProjects, util.FormatCodeHostErrorWithDefault("Failed to fetch repositories. Please verify the code host connection and namespace permissions", err))
 		return
 	}
 
@@ -168,7 +174,7 @@ func CodeHostGetBranchList(c *gin.Context) {
 	}
 
 	chID, _ := strconv.Atoi(codehostID)
-	ctx.Resp, ctx.RespErr = service.CodeHostListBranches(
+	branches, err := service.CodeHostListBranches(
 		chID,
 		repoName,
 		strings.Replace(repoOwner, "%2F", "/", -1),
@@ -176,6 +182,11 @@ func CodeHostGetBranchList(c *gin.Context) {
 		args.Page,
 		args.PerPage,
 		ctx.Logger)
+	if err != nil {
+		ctx.RespErr = e.NewWithDesc(e.ErrCodehostListBranches, util.FormatCodeHostErrorWithDefault("Failed to fetch branches. Please check if the repository exists and you have access permissions", err))
+		return
+	}
+	ctx.Resp = branches
 }
 
 // @Summary 获取代码仓库标签列表
@@ -217,7 +228,12 @@ func CodeHostGetTagList(c *gin.Context) {
 	}
 
 	chID, _ := strconv.Atoi(codehostID)
-	ctx.Resp, ctx.RespErr = service.CodeHostListTags(chID, repoName, strings.Replace(repoOwner, "%2F", "/", -1), args.Key, args.Page, args.PerPage, ctx.Logger)
+	tags, err := service.CodeHostListTags(chID, repoName, strings.Replace(repoOwner, "%2F", "/", -1), args.Key, args.Page, args.PerPage, ctx.Logger)
+	if err != nil {
+		ctx.RespErr = e.NewWithDesc(e.ErrCodehostListTags, util.FormatCodeHostErrorWithDefault("Failed to fetch tags. Please check if the repository exists and you have access permissions", err))
+		return
+	}
+	ctx.Resp = tags
 }
 
 func CodeHostGetPRList(c *gin.Context) {
@@ -250,7 +266,12 @@ func CodeHostGetPRList(c *gin.Context) {
 	targetBr := c.Query("targetBranch")
 
 	chID, _ := strconv.Atoi(codehostID)
-	ctx.Resp, ctx.RespErr = service.CodeHostListPRs(chID, repoName, strings.Replace(repoOwner, "%2F", "/", -1), targetBr, args.Key, args.Page, args.PerPage, ctx.Logger)
+	prs, err := service.CodeHostListPRs(chID, repoName, strings.Replace(repoOwner, "%2F", "/", -1), targetBr, args.Key, args.Page, args.PerPage, ctx.Logger)
+	if err != nil {
+		ctx.RespErr = e.NewWithDesc(e.ErrCodehostListPrs, util.FormatCodeHostErrorWithDefault("Failed to fetch pull requests. Please verify repository access and permissions", err))
+		return
+	}
+	ctx.Resp = prs
 }
 
 func CodeHostGetCommits(c *gin.Context) {
@@ -283,7 +304,12 @@ func CodeHostGetCommits(c *gin.Context) {
 	targetBr := c.Query("branchName")
 
 	chID, _ := strconv.Atoi(codehostID)
-	ctx.Resp, ctx.RespErr = service.CodeHostListCommits(chID, repoName, strings.Replace(repoNamespace, "%2F", "/", -1), targetBr, args.Page, args.PerPage, ctx.Logger)
+	commits, err := service.CodeHostListCommits(chID, repoName, strings.Replace(repoNamespace, "%2F", "/", -1), targetBr, args.Page, args.PerPage, ctx.Logger)
+	if err != nil {
+		ctx.RespErr = e.NewWithDesc(e.ErrCodehostListCommits, util.FormatCodeHostErrorWithDefault("Failed to fetch commits. Please check if the branch exists and you have access permissions", err))
+		return
+	}
+	ctx.Resp = commits
 }
 
 func ListRepoInfos(c *gin.Context) {
@@ -306,7 +332,12 @@ func ListRepoInfos(c *gin.Context) {
 		return
 	}
 
-	ctx.Resp, ctx.RespErr = service.ListRepoInfos(args.Infos, page, perPage, ctx.Logger)
+	repoInfos, err := service.ListRepoInfos(args.Infos, page, perPage, ctx.Logger)
+	if err != nil {
+		ctx.RespErr = e.NewWithDesc(e.ErrCodehostListProjects, util.FormatCodeHostErrorWithDefault("Failed to fetch repository information. Please verify the repository configuration and permissions", err))
+		return
+	}
+	ctx.Resp = repoInfos
 }
 
 type MatchBranchesListRequest struct {
@@ -343,7 +374,7 @@ func MatchRegularList(c *gin.Context) {
 	}
 
 	chID, _ := strconv.Atoi(codehostID)
-	ctx.Resp, ctx.RespErr = service.MatchRegularList(
+	branches, err := service.MatchRegularList(
 		chID,
 		req.RepoName,
 		strings.Replace(req.RepoOwner, "%2F", "/", -1),
@@ -352,4 +383,9 @@ func MatchRegularList(c *gin.Context) {
 		perPage,
 		req.Regular,
 		ctx.Logger)
+	if err != nil {
+		ctx.RespErr = e.NewWithDesc(e.ErrCodehostListBranches, util.FormatCodeHostErrorWithDefault("Failed to match branches. Please check if the repository exists and you have access permissions", err))
+		return
+	}
+	ctx.Resp = branches
 }

--- a/pkg/microservice/aslan/core/code/service/repo.go
+++ b/pkg/microservice/aslan/core/code/service/repo.go
@@ -21,12 +21,12 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/koderover/zadig/v2/pkg/types"
 	"go.uber.org/zap"
 
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/code/client"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/code/client/open"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/v2/pkg/shared/client/systemconfig"
 )
 
@@ -63,20 +63,37 @@ func (repo *GitRepoInfo) GetNamespace() string {
 // ListRepoInfos ...
 func ListRepoInfos(infos []*GitRepoInfo, page, perPage int, log *zap.SugaredLogger) ([]*GitRepoInfo, error) {
 	var wg sync.WaitGroup
-	var errList *multierror.Error
 
 	for _, info := range infos {
 		ch, err := systemconfig.New().GetCodeHost(info.CodehostID)
 		if err != nil {
 			log.Errorf("get code host info err:%s", err)
-			return nil, err
+			info.ErrorMsg = util.FormatRepoInfoError(err)
+			info.Branches = []*client.Branch{}
+			info.Tags = []*client.Tag{}
+			info.PRs = []*client.PullRequest{}
+			continue
 		}
 		if ch.Type == types.ProviderPerforce {
 			continue
 		}
 		codehostClient, err := open.OpenClient(ch, log)
 		if err != nil {
-			return nil, err
+			log.Errorf("open client err:%s", err)
+			info.ErrorMsg = util.FormatRepoInfoError(err)
+			info.Branches = []*client.Branch{}
+			info.Tags = []*client.Tag{}
+			info.PRs = []*client.PullRequest{}
+			continue
+		}
+		var setErrorOnce sync.Once
+		setRepoInfoError := func(err error) {
+			if err == nil {
+				return
+			}
+			setErrorOnce.Do(func() {
+				info.ErrorMsg = util.FormatRepoInfoError(err)
+			})
 		}
 		wg.Add(1)
 		go func(info *GitRepoInfo) {
@@ -88,18 +105,19 @@ func ListRepoInfos(infos []*GitRepoInfo, page, perPage int, log *zap.SugaredLogg
 				return
 			}
 
-			info.PRs, err = codehostClient.ListPrs(client.ListOpt{
+			prs, err := codehostClient.ListPrs(client.ListOpt{
 				Namespace:   strings.Replace(info.GetNamespace(), "%2F", "/", -1),
 				ProjectName: info.Repo,
 				Page:        page,
 				PerPage:     perPage,
 			})
 			if err != nil {
-				errList = multierror.Append(errList, err)
-				info.ErrorMsg = err.Error()
+				log.Errorf("list pr err:%s", err)
+				setRepoInfoError(err)
 				info.PRs = []*client.PullRequest{}
 				return
 			}
+			info.PRs = prs
 		}(info)
 
 		wg.Add(1)
@@ -108,7 +126,7 @@ func ListRepoInfos(infos []*GitRepoInfo, page, perPage int, log *zap.SugaredLogg
 				wg.Done()
 			}()
 			projectName := info.Repo
-			info.Branches, err = codehostClient.ListBranches(client.ListOpt{
+			branches, err := codehostClient.ListBranches(client.ListOpt{
 				Namespace:     strings.Replace(info.GetNamespace(), "%2F", "/", -1),
 				ProjectName:   projectName,
 				Key:           info.Key,
@@ -117,11 +135,12 @@ func ListRepoInfos(infos []*GitRepoInfo, page, perPage int, log *zap.SugaredLogg
 				MatchBranches: true,
 			})
 			if err != nil {
-				errList = multierror.Append(errList, err)
-				info.ErrorMsg = err.Error()
+				log.Errorf("list branch err:%s", err)
+				setRepoInfoError(err)
 				info.Branches = []*client.Branch{}
 				return
 			}
+			info.Branches = branches
 
 			if info.DefaultBranch != "" {
 				foundDefaultBranch := false
@@ -139,8 +158,8 @@ func ListRepoInfos(infos []*GitRepoInfo, page, perPage int, log *zap.SugaredLogg
 						Key:         info.DefaultBranch,
 					})
 					if err != nil {
-						errList = multierror.Append(errList, err)
-						info.ErrorMsg = err.Error()
+						log.Errorf("list default branch err:%s", err)
+						setRepoInfoError(err)
 						info.Branches = []*client.Branch{}
 						return
 					}
@@ -162,7 +181,7 @@ func ListRepoInfos(infos []*GitRepoInfo, page, perPage int, log *zap.SugaredLogg
 			}()
 			projectName := info.Repo
 
-			info.Tags, err = codehostClient.ListTags(client.ListOpt{
+			tags, err := codehostClient.ListTags(client.ListOpt{
 				Namespace:   strings.Replace(info.GetNamespace(), "%2F", "/", -1),
 				ProjectName: projectName,
 				Key:         info.Key,
@@ -170,11 +189,12 @@ func ListRepoInfos(infos []*GitRepoInfo, page, perPage int, log *zap.SugaredLogg
 				PerPage:     perPage,
 			})
 			if err != nil {
-				errList = multierror.Append(errList, err)
-				info.ErrorMsg = err.Error()
+				log.Errorf("list tag err:%s", err)
+				setRepoInfoError(err)
 				info.Tags = []*client.Tag{}
 				return
 			}
+			info.Tags = tags
 		}(info)
 	}
 
@@ -215,10 +235,6 @@ func ListRepoInfos(infos []*GitRepoInfo, page, perPage int, log *zap.SugaredLogg
 				info.DefaultBranch = ""
 			}
 		}
-	}
-	if err := errList.ErrorOrNil(); err != nil {
-		log.Errorf("list repo info error: %v", err)
-		return nil, err
 	}
 	return infos, nil
 }

--- a/pkg/microservice/aslan/core/common/util/error_formatter.go
+++ b/pkg/microservice/aslan/core/common/util/error_formatter.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.mongodb.org/mongo-driver/mongo"
+
+	e "github.com/koderover/zadig/v2/pkg/tool/errors"
+)
+
+// FormatCodeHostError formats code host errors into generic user-friendly messages.
+// It identifies common error types (401, 403, 404, 429, timeout, etc.) and
+// returns appropriate descriptions for frontend display.
+func FormatCodeHostError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return "Code host is not configured or does not exist"
+	}
+
+	var httpErr *e.HTTPError
+	if errors.As(err, &httpErr) && httpErr.Desc() != "" {
+		raw := strings.ToLower(httpErr.Desc())
+		if msg := matchErrorPattern(raw, "Resource not found"); msg != "" {
+			return msg
+		}
+	}
+
+	raw := strings.ToLower(err.Error())
+	if msg := matchErrorPattern(raw, "Resource not found"); msg != "" {
+		return msg
+	}
+
+	return ""
+}
+
+// FormatRepoInfoError formats repo info lookup errors into repo-specific user-facing messages.
+func FormatRepoInfoError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return "Code host is not configured or does not exist"
+	}
+
+	var httpErr *e.HTTPError
+	if errors.As(err, &httpErr) && httpErr.Desc() != "" {
+		raw := strings.ToLower(httpErr.Desc())
+		if msg := matchErrorPattern(raw, "Repository not found or access denied"); msg != "" {
+			return msg
+		}
+	}
+
+	raw := strings.ToLower(err.Error())
+	if msg := matchErrorPattern(raw, "Repository not found or access denied"); msg != "" {
+		return msg
+	}
+
+	return "Failed to fetch repository metadata"
+}
+
+// FormatCodeHostErrorWithDefault formats code host errors with a default description.
+// It appends the specific error detail to the default description.
+func FormatCodeHostErrorWithDefault(defaultDesc string, err error) string {
+	if err == nil {
+		return defaultDesc
+	}
+
+	detail := FormatCodeHostError(err)
+	if detail == "" {
+		return defaultDesc
+	}
+
+	base := strings.TrimSpace(strings.TrimRight(defaultDesc, "."))
+	return fmt.Sprintf("%s. %s", base, detail)
+}
+
+// matchErrorPattern matches common error patterns and returns user-friendly messages.
+func matchErrorPattern(raw, notFoundMsg string) string {
+	switch {
+	case strings.Contains(raw, "401"), strings.Contains(raw, "unauthorized"):
+		return "Authentication failed, please check the access credentials"
+	case strings.Contains(raw, "403"), strings.Contains(raw, "forbidden"):
+		return "Permission denied"
+	case strings.Contains(raw, "404"), strings.Contains(raw, "not found"):
+		return notFoundMsg
+	case strings.Contains(raw, "429"), strings.Contains(raw, "rate limit"):
+		return "Rate limit exceeded"
+	case strings.Contains(raw, "deadline exceeded"), strings.Contains(raw, "timeout"):
+		return "Connection timeout"
+	case strings.Contains(raw, "no documents"), strings.Contains(raw, "not exist"):
+		return "Code host is not configured or does not exist"
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
## Summary

Improve codehost-related error handling to make frontend behavior clearer and avoid noisy duplicated error output.

## Changes

- improve user-facing error descriptions for codehost operations in `codehost.go`
- normalize handler error responses with `NewWithDesc` instead of mutating shared error objects in place
- detect common codehost failure cases such as authentication failure, permission denied, not found, timeout, rate limit, and missing configuration
- avoid aggregated multierror responses in repo info lookup
- keep repo info lookup failures scoped to each repo item by filling `ErrorMsg` and empty result lists instead of failing the whole request
- reduce repeated frontend error noise caused by a single repo lookup triggering multiple sub-request failures
- clean up concurrent error handling in `repo.go` by avoiding shared outer-scope error mutation inside goroutines

## Expected Result

- frontend should no longer receive aggregated errors like `3 errors occurred: * [404 NotFound] * [404 NotFound] * [404 NotFound]` from repo info lookup
- codehost-related API failures should return clearer and more stable descriptions
- partial repo metadata lookup failures should stay localized to the affected repo entry

## Verification

Verified in UAT with mixed repo inputs:

- one valid repo returns normal branch data
- one invalid repo returns `error_msg: "Repository not found or access denied"`
- the whole API still returns `200`
- aggregated multierror output is no longer returned to frontend

## Frontend Impact

Frontend can now handle repo info results per repo item instead of treating a single repo failure as a full request failure. Successful repos continue to render normally, while failed repos expose localized `error_msg` for targeted display.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4630)
<!-- Reviewable:end -->
