### PR TITLE
add codehost-based yaml template support

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/yaml_template.go
+++ b/pkg/microservice/aslan/core/common/repository/models/yaml_template.go
@@ -29,6 +29,16 @@ type YamlTemplate struct {
 	VariableYaml       string                           `bson:"variable_yaml"        json:"variable_yaml"`
 	ServiceVariableKVs []*commontypes.ServiceVariableKV `bson:"service_variable_kvs" json:"service_variable_kvs"`
 	ServiceVars        []string                         `bson:"service_vars"         json:"service_vars"` // Deprecated since 1.18.0
+	Source             string                           `bson:"source,omitempty"     json:"source,omitempty"`
+	RepoOwner          string                           `bson:"repo_owner,omitempty" json:"repo_owner,omitempty"`
+	Namespace          string                           `bson:"namespace,omitempty"  json:"namespace,omitempty"`
+	RepoName           string                           `bson:"repo_name,omitempty"  json:"repo_name,omitempty"`
+	Path               string                           `bson:"path,omitempty"       json:"path,omitempty"`
+	BranchName         string                           `bson:"branch_name,omitempty" json:"branch_name,omitempty"`
+	RemoteName         string                           `bson:"remote_name,omitempty" json:"remote_name,omitempty"`
+	CodeHostID         int                              `bson:"codehost_id,omitempty" json:"codeHostID,omitempty"`
+	LoadFromDir        bool                             `bson:"load_from_dir,omitempty"     json:"load_from_dir,omitempty"`
+	Commit             *Commit                          `bson:"commit,omitempty"      json:"commit,omitempty"`
 }
 
 type Variable struct {

--- a/pkg/microservice/aslan/core/common/repository/mongodb/yaml_template.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/yaml_template.go
@@ -123,6 +123,24 @@ func (c *YamlTemplateColl) List(pageNum, pageSize int) ([]*models.YamlTemplate, 
 	return resp, int(count), nil
 }
 
+func (c *YamlTemplateColl) ListBySource(source string) ([]*models.YamlTemplate, error) {
+	resp := make([]*models.YamlTemplate, 0)
+	query := bson.M{}
+	if source != "" {
+		query["source"] = source
+	}
+
+	cursor, err := c.Collection.Find(context.TODO(), query)
+	if err != nil {
+		return nil, err
+	}
+	err = cursor.All(context.TODO(), &resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
 func (c *YamlTemplateColl) GetById(idstring string) (*models.YamlTemplate, error) {
 	resp := new(models.YamlTemplate)
 	id, err := primitive.ObjectIDFromHex(idstring)

--- a/pkg/microservice/aslan/core/common/service/template/types.go
+++ b/pkg/microservice/aslan/core/common/service/template/types.go
@@ -62,11 +62,32 @@ type YamlTemplate struct {
 	Content            string                           `json:"content"`
 	VariableYaml       string                           `json:"variable_yaml"`
 	ServiceVariableKVs []*commontypes.ServiceVariableKV `json:"service_variable_kvs"`
+
+	Source      string         `json:"source,omitempty"`
+	CodehostID  int            `json:"codehostID,omitempty"`
+	RepoOwner   string         `json:"repo_owner,omitempty"`
+	Namespace   string         `json:"namespace,omitempty"`
+	RepoName    string         `json:"repo,omitempty"`
+	Path        string         `json:"path,omitempty"`
+	BranchName  string         `json:"branch,omitempty"`
+	RemoteName  string         `json:"remote_name,omitempty"`
+	LoadFromDir bool           `json:"load_from_dir,omitempty"`
+	Commit      *models.Commit `json:"commit,omitempty"`
 }
 
 type YamlListObject struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID          string         `json:"id"`
+	Name        string         `json:"name"`
+	Source      string         `json:"source,omitempty"`
+	CodehostID  int            `json:"codehostID,omitempty"`
+	RepoOwner   string         `json:"repo_owner,omitempty"`
+	Namespace   string         `json:"namespace,omitempty"`
+	Repo        string         `json:"repo,omitempty"`
+	Path        string         `json:"path,omitempty"`
+	Branch      string         `json:"branch,omitempty"`
+	RemoteName  string         `json:"remote_name,omitempty"`
+	LoadFromDir bool           `json:"load_from_dir,omitempty"`
+	Commit      *models.Commit `json:"commit,omitempty"`
 }
 
 type YamlDetail struct {
@@ -75,6 +96,16 @@ type YamlDetail struct {
 	Content            string                           `json:"content"`
 	VariableYaml       string                           `json:"variable_yaml"`
 	ServiceVariableKVs []*commontypes.ServiceVariableKV `json:"service_variable_kvs"`
+	Source             string                           `json:"source,omitempty"`
+	CodehostID         int                              `json:"codehostID,omitempty"`
+	RepoOwner          string                           `json:"repo_owner,omitempty"`
+	Namespace          string                           `json:"namespace,omitempty"`
+	RepoName           string                           `json:"repo_name,omitempty"`
+	Path               string                           `json:"path,omitempty"`
+	BranchName         string                           `json:"branch_name,omitempty"`
+	RemoteName         string                           `json:"remote_name,omitempty"`
+	LoadFromDir        bool                             `json:"load_from_dir,omitempty"`
+	Commit             *models.Commit                   `json:"commit,omitempty"`
 }
 
 type ServiceReference struct {

--- a/pkg/microservice/aslan/core/common/service/template_store.go
+++ b/pkg/microservice/aslan/core/common/service/template_store.go
@@ -16,7 +16,18 @@ limitations under the License.
 
 package service
 
-import "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
+import (
+	"fmt"
+
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/webhook"
+	"github.com/koderover/zadig/v2/pkg/setting"
+	"github.com/koderover/zadig/v2/pkg/shared/client/systemconfig"
+	"github.com/koderover/zadig/v2/pkg/tool/gerrit"
+	"github.com/koderover/zadig/v2/pkg/tool/httpclient"
+	"go.uber.org/zap"
+)
 
 func GetDockerfileTemplateContent(id string) (string, error) {
 	dockerfileTemplate, err := mongodb.NewDockerfileTemplateColl().GetById(id)
@@ -24,4 +35,81 @@ func GetDockerfileTemplateContent(id string) (string, error) {
 		return "", err
 	}
 	return dockerfileTemplate.Content, nil
+}
+
+func ProcessYamlTemplateWebhook(updated, current *models.YamlTemplate, logger *zap.SugaredLogger) error {
+	var updatedHooks, currentHooks []*webhook.WebHook
+	if current != nil {
+		namespace := current.Namespace
+		if namespace == "" {
+			namespace = current.RepoOwner
+		}
+		switch current.Source {
+		case setting.SourceFromGithub, setting.SourceFromGitlab, setting.SourceFromGitee, setting.SourceFromGiteeEE:
+			currentHooks = append(currentHooks, &webhook.WebHook{
+				Owner:      current.RepoOwner,
+				Namespace:  namespace,
+				Repo:       current.RepoName,
+				Name:       "trigger",
+				CodeHostID: current.CodeHostID,
+			})
+		case setting.SourceFromGerrit:
+			detail, err := systemconfig.New().GetCodeHost(current.CodeHostID)
+			if err != nil {
+				return err
+			}
+
+			cl := gerrit.NewHTTPClient(detail.Address, detail.AccessToken)
+			if err := cl.DeleteWebhook(current.RepoName, webhook.YamlTemplatePrefix+current.Name); err != nil {
+				logger.Errorf("failed to delete gerrit webhook for yaml template %s, err: %s", current.Name, err)
+			}
+		}
+	}
+	if updated != nil {
+		namespace := updated.Namespace
+		if namespace == "" {
+			namespace = updated.RepoOwner
+		}
+		switch updated.Source {
+		case setting.SourceFromGithub, setting.SourceFromGitlab, setting.SourceFromGitee, setting.SourceFromGiteeEE:
+			updatedHooks = append(updatedHooks, &webhook.WebHook{
+				Owner:      updated.RepoOwner,
+				Namespace:  namespace,
+				Repo:       updated.RepoName,
+				Name:       "trigger",
+				CodeHostID: updated.CodeHostID,
+			})
+		case setting.SourceFromGerrit:
+			detail, err := systemconfig.New().GetCodeHost(updated.CodeHostID)
+			if err != nil {
+				return err
+			}
+
+			cl := gerrit.NewHTTPClient(detail.Address, detail.AccessToken)
+			webhookName := webhook.YamlTemplatePrefix + updated.Name
+			webhookURL := fmt.Sprintf("/%s/%s/%s/%s", "a/config/server/webhooks~projects", gerrit.Escape(updated.RepoName), "remotes", webhookName)
+			if _, err := cl.Get(webhookURL); err != nil {
+				gerritWebhook := &gerrit.Webhook{
+					URL:       fmt.Sprintf("%s?name=%s", WebHookURL(), webhookName),
+					MaxTries:  setting.MaxTries,
+					SslVerify: false,
+				}
+				if _, err = cl.Put(webhookURL, httpclient.SetBody(gerritWebhook)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	name := ""
+	if updated != nil {
+		name = webhook.YamlTemplatePrefix + updated.Name
+	} else if current != nil {
+		name = webhook.YamlTemplatePrefix + current.Name
+	}
+	if len(updatedHooks) == 0 && len(currentHooks) == 0 {
+		return nil
+	}
+
+	return ProcessWebhook(updatedHooks, currentHooks, name, logger)
 }

--- a/pkg/microservice/aslan/core/common/service/webhook/client.go
+++ b/pkg/microservice/aslan/core/common/service/webhook/client.go
@@ -22,13 +22,14 @@ import (
 )
 
 const (
-	WorkflowPrefix   = "workflow-"
-	WorkflowV4Prefix = "workflowv4-"
-	PipelinePrefix   = "pipeline-"
-	ColliePrefix     = "collie-"
-	ServicePrefix    = "service-"
-	TestingPrefix    = "testing-"
-	ScannerPrefix    = "scanning-"
+	WorkflowPrefix     = "workflow-"
+	WorkflowV4Prefix   = "workflowv4-"
+	PipelinePrefix     = "pipeline-"
+	ColliePrefix       = "collie-"
+	ServicePrefix      = "service-"
+	YamlTemplatePrefix = "yaml-template-"
+	TestingPrefix      = "testing-"
+	ScannerPrefix      = "scanning-"
 
 	taskTimeoutSecond = 10
 )

--- a/pkg/microservice/aslan/core/common/util/yaml.go
+++ b/pkg/microservice/aslan/core/common/util/yaml.go
@@ -1,0 +1,71 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/git"
+	githubservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/github"
+	gitlabservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/gitlab"
+	"github.com/koderover/zadig/v2/pkg/setting"
+	"github.com/koderover/zadig/v2/pkg/shared/client/systemconfig"
+	"github.com/koderover/zadig/v2/pkg/tool/log"
+)
+
+type YAMLLoader interface {
+	GetYAMLContents(owner, repo, path, branch string, isDir, split bool) ([]string, error)
+	GetLatestRepositoryCommit(owner, repo, path, branch string) (*git.RepositoryCommit, error)
+	GetTree(owner, repo, path, branch string) ([]*git.TreeNode, error)
+}
+
+func GetYAMLLoader(ch *systemconfig.CodeHost) (YAMLLoader, error) {
+	switch ch.Type {
+	case setting.SourceFromGithub:
+		return githubservice.NewClient(ch.AccessToken, config.ProxyHTTPSAddr(), ch.EnableProxy), nil
+	case setting.SourceFromGitlab:
+		return gitlabservice.NewClient(ch.ID, ch.Address, ch.AccessToken, config.ProxyHTTPSAddr(), ch.EnableProxy, ch.DisableSSL)
+	default:
+		// should not have happened here
+		log.DPanicf("invalid source: %s", ch.Type)
+		return nil, fmt.Errorf("invalid source: %s", ch.Type)
+	}
+}
+
+func GetFoldersAndYAMLFiles(treeNodes []*git.TreeNode) ([]*git.TreeNode, []*git.TreeNode) {
+	var folders, files []*git.TreeNode
+	for _, tn := range treeNodes {
+		if tn.IsDir {
+			folders = append(folders, tn)
+		} else if IsYaml(tn.Name) {
+			files = append(files, tn)
+		}
+	}
+
+	return folders, files
+}
+
+func IsYaml(filename string) bool {
+	filename = strings.ToLower(filename)
+	return strings.HasSuffix(filename, ".yaml") || strings.HasSuffix(filename, ".yml")
+}
+
+func HasYAMLFiles(treeNodes []*git.TreeNode) bool {
+	for _, tn := range treeNodes {
+		if !tn.IsDir && IsYaml(tn.Name) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func IsValidServiceDir(child []os.FileInfo) bool {
+	for _, file := range child {
+		if !file.IsDir() && IsYaml(file.Name()) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/microservice/aslan/core/service/service/loader.go
+++ b/pkg/microservice/aslan/core/service/service/loader.go
@@ -32,6 +32,7 @@ import (
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/command"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/repository"
+	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/shared/client/systemconfig"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
@@ -128,7 +129,7 @@ func preloadGerritService(detail *systemconfig.CodeHost, repoName, branchName, r
 		filePath := path.Join(base, loadPath.Path)
 
 		if !loadPath.IsDir {
-			if !isYaml(loadPath.Path) {
+			if !commonutil.IsYaml(loadPath.Path) {
 				log.Error("trying to preload a non-yaml file")
 				return nil, e.ErrPreloadServiceTemplate.AddDesc("Non-yaml service loading is not supported")
 			}
@@ -145,7 +146,7 @@ func preloadGerritService(detail *systemconfig.CodeHost, repoName, branchName, r
 				log.Error("Failed to read directory info of path: %s, the error is: %+v", filePath, err)
 				return nil, e.ErrPreloadServiceTemplate.AddDesc(err.Error())
 			}
-			if isValidServiceDir(fileInfos) {
+			if commonutil.IsValidServiceDir(fileInfos) {
 				svcName := loadPath.Path
 				if loadPath.Path == "" {
 					svcName = repoName
@@ -168,7 +169,7 @@ func preloadGerritService(detail *systemconfig.CodeHost, repoName, branchName, r
 						log.Errorf("Failed to get subdir content from gerrit with path: %s, the error is: %+v", subDirPath, err)
 						return nil, e.ErrPreloadServiceTemplate.AddDesc(err.Error())
 					}
-					if isValidServiceDir(subtree) {
+					if commonutil.IsValidServiceDir(subtree) {
 						ret = append(ret, LoadServicePath{
 							ServiceName: getFileName(file.Name()),
 							Path:        loadPath.Path,
@@ -210,7 +211,7 @@ func preloadGiteeService(detail *systemconfig.CodeHost, repoOwner, repoName, bra
 		filePath := path.Join(base, loadPath.Path)
 
 		if !loadPath.IsDir {
-			if !isYaml(loadPath.Path) {
+			if !commonutil.IsYaml(loadPath.Path) {
 				log.Error("trying to preload a non-yaml file")
 				return nil, e.ErrPreloadServiceTemplate.AddDesc("Non-yaml service loading is not supported")
 			}
@@ -228,7 +229,7 @@ func preloadGiteeService(detail *systemconfig.CodeHost, repoOwner, repoName, bra
 				os.RemoveAll(base)
 				return nil, e.ErrPreloadServiceTemplate.AddDesc(err.Error())
 			}
-			if isValidServiceDir(fileInfos) {
+			if commonutil.IsValidServiceDir(fileInfos) {
 				svcName := loadPath.Path
 				if loadPath.Path == "" {
 					svcName = repoName
@@ -251,7 +252,7 @@ func preloadGiteeService(detail *systemconfig.CodeHost, repoOwner, repoName, bra
 						log.Errorf("Failed to get subdir content from gitee with path: %s, the error is: %s", subDirPath, err)
 						return nil, e.ErrPreloadServiceTemplate.AddDesc(err.Error())
 					}
-					if isValidServiceDir(subtree) {
+					if commonutil.IsValidServiceDir(subtree) {
 						ret = append(ret, LoadServicePath{
 							ServiceName: getFileName(file.Name()),
 							Path:        loadPath.Path,
@@ -348,7 +349,7 @@ func loadGerritService(username string, ch *systemconfig.CodeHost, repoOwner, re
 				log.Errorf("Failed to read directory info of path: %s, the error is: %+v", filePath, err)
 				return e.ErrLoadServiceTemplate.AddDesc(err.Error())
 			}
-			if isValidServiceDir(fileInfos) {
+			if commonutil.IsValidServiceDir(fileInfos) {
 				return loadServiceFromGerrit(fileInfos, ch.ID, username, branchName, loadPath.Path, loadPath.ServiceName, filePath, repoOwner, remoteName, repoName, args.Type, args.ProductName, loadPath.IsDir, commitInfo, force, production, log)
 			} else {
 				return e.ErrLoadServiceTemplate.AddDesc(fmt.Sprintf("%s 路径下没有yaml文件，请重新选择", loadPath.Path))
@@ -361,7 +362,7 @@ func loadGerritService(username string, ch *systemconfig.CodeHost, repoOwner, re
 			// 		log.Errorf("Failed to read subdir info from gerrit package of path: %s, the error is: %+v", subtreePath, err)
 			// 		return e.ErrLoadServiceTemplate.AddDesc(err.Error())
 			// 	}
-			// 	if isValidServiceDir(subtreeInfo) {
+			// 	if commonutil.IsValidServiceDir(subtreeInfo) {
 			// 		if err := loadServiceFromGerrit(subtreeInfo, ch.ID, username, branchName, subtreeLoadPath, subtreePath, repoOwner, remoteName, repoName, args, commitInfo, force, production, log); err != nil {
 			// 			return err
 			// 		}
@@ -482,7 +483,7 @@ func loadGiteeService(username string, ch *systemconfig.CodeHost, repoOwner, rep
 				log.Errorf("Failed to read directory info of path: %s, the error is: %s", filePath, err)
 				return e.ErrLoadServiceTemplate.AddDesc(err.Error())
 			}
-			if isValidServiceDir(fileInfos) {
+			if commonutil.IsValidServiceDir(fileInfos) {
 				return loadServiceFromGitee(fileInfos, ch, username, branchName, loadPath.Path, loadPath.ServiceName, filePath, repoOwner, remoteName, repoName, args.Type, args.ProductName, loadPath.IsDir, commitInfo, force, production, log)
 			} else {
 				return e.ErrLoadServiceTemplate.AddDesc(fmt.Sprintf("%s 路径下没有yaml文件，请重新选择", loadPath.Path))
@@ -496,7 +497,7 @@ func loadGiteeService(username string, ch *systemconfig.CodeHost, repoOwner, rep
 			// 		log.Errorf("Failed to read subdir info from gitee package of path: %s, the error is: %s", subtreePath, err)
 			// 		return e.ErrLoadServiceTemplate.AddDesc(err.Error())
 			// 	}
-			// 	if isValidServiceDir(subtreeInfo) {
+			// 	if commonutil.IsValidServiceDir(subtreeInfo) {
 			// 		if err := loadServiceFromGitee(subtreeInfo, ch, username, branchName, subtreeLoadPath, subtreePath, repoOwner, remoteName, repoName, args, commitInfo, force, production, log); err != nil {
 			// 			return err
 			// 		}
@@ -552,7 +553,7 @@ func loadServiceFromGitee(tree []os.FileInfo, ch *systemconfig.CodeHost, usernam
 
 func isValidGithubServiceDir(child []*github.RepositoryContent) bool {
 	for _, entry := range child {
-		if entry.GetType() == "file" && isYaml(entry.GetName()) {
+		if entry.GetType() == "file" && commonutil.IsYaml(entry.GetName()) {
 			return true
 		}
 	}
@@ -561,16 +562,7 @@ func isValidGithubServiceDir(child []*github.RepositoryContent) bool {
 
 func isValidGitlabServiceDir(child []*gitlab.TreeNode) bool {
 	for _, entry := range child {
-		if entry.Type == "blob" && isYaml(entry.Name) {
-			return true
-		}
-	}
-	return false
-}
-
-func isValidServiceDir(child []os.FileInfo) bool {
-	for _, file := range child {
-		if !file.IsDir() && isYaml(file.Name()) {
+		if entry.Type == "blob" && commonutil.IsYaml(entry.Name) {
 			return true
 		}
 	}
@@ -580,7 +572,7 @@ func isValidServiceDir(child []os.FileInfo) bool {
 func extractYamls(basePath string, tree []os.FileInfo) ([]string, error) {
 	var ret []string
 	for _, entry := range tree {
-		if !entry.IsDir() && isYaml(entry.Name()) {
+		if !entry.IsDir() && commonutil.IsYaml(entry.Name()) {
 			tmpFilepath := fmt.Sprintf("%s/%s", basePath, entry.Name())
 			yamlByte, err := ioutil.ReadFile(tmpFilepath)
 			if err != nil {

--- a/pkg/microservice/aslan/core/service/service/new_loader.go
+++ b/pkg/microservice/aslan/core/service/service/new_loader.go
@@ -19,16 +19,11 @@ package service
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"go.uber.org/zap"
 
-	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
-	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/git"
-	githubservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/github"
-	gitlabservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/gitlab"
-	"github.com/koderover/zadig/v2/pkg/setting"
+	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/v2/pkg/shared/client/systemconfig"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
 	"github.com/koderover/zadig/v2/pkg/tool/log"
@@ -44,7 +39,7 @@ type LoadServicePath struct {
 func preloadService(ch *systemconfig.CodeHost, owner, repo, branch string, paths []PreLoadServicePath, logger *zap.SugaredLogger) ([]LoadServicePath, error) {
 	logger.Infof("Preloading service from %s with owner %s, repo %s, branch %s and path %s", ch.Type, owner, repo, branch, paths)
 
-	loader, err := getLoader(ch)
+	loader, err := commonutil.GetYAMLLoader(ch)
 	if err != nil {
 		logger.Errorf("Failed to create loader client, err: %s", err)
 		return nil, e.ErrLoadServiceTemplate.AddDesc(err.Error())
@@ -53,7 +48,7 @@ func preloadService(ch *systemconfig.CodeHost, owner, repo, branch string, paths
 	resp := make([]LoadServicePath, 0)
 	for _, path := range paths {
 		if !path.IsDir {
-			if !isYaml(path.Path) {
+			if !commonutil.IsYaml(path.Path) {
 				return nil, e.ErrPreloadServiceTemplate.AddDesc("File is not of type yaml or yml, select again")
 			}
 
@@ -69,7 +64,7 @@ func preloadService(ch *systemconfig.CodeHost, owner, repo, branch string, paths
 				return nil, e.ErrLoadServiceTemplate.AddDesc(err.Error())
 			}
 
-			folders, files := getFoldersAndYAMLFiles(treeNodes)
+			folders, files := commonutil.GetFoldersAndYAMLFiles(treeNodes)
 			// if load path is a directory, we will load services in following rules:
 			// 1. if there is any yaml files under this directory, collect them as a service and ignore other files and directories
 			// 2. if not, but there is some directories under this directory, load each of them as a service
@@ -87,7 +82,7 @@ func preloadService(ch *systemconfig.CodeHost, owner, repo, branch string, paths
 						return nil, e.ErrLoadServiceTemplate.AddDesc(err.Error())
 					}
 
-					if hasYAMLFiles(tns) {
+					if commonutil.HasYAMLFiles(tns) {
 						resp = append(resp, LoadServicePath{
 							ServiceName: getFileName(f.FullPath),
 							Path:        f.FullPath,
@@ -118,7 +113,7 @@ type serviceInfo struct {
 func loadService(username string, ch *systemconfig.CodeHost, owner, namespace, repo, branch string, args *LoadServiceReq, force, production bool, logger *zap.SugaredLogger) error {
 	logger.Infof("Loading service from %s with owner %s, namespace %s, repo %s, branch %s and path %v", ch.Type, owner, namespace, repo, branch, args.ServicePaths)
 
-	loader, err := getLoader(ch)
+	loader, err := commonutil.GetYAMLLoader(ch)
 	if err != nil {
 		logger.Errorf("Failed to create loader client, err: %s", err)
 		return e.ErrLoadServiceTemplate.AddDesc(err.Error())
@@ -141,7 +136,7 @@ func loadService(username string, ch *systemconfig.CodeHost, owner, namespace, r
 				return e.ErrLoadServiceTemplate.AddDesc(err.Error())
 			}
 
-			_, files := getFoldersAndYAMLFiles(treeNodes)
+			_, files := commonutil.GetFoldersAndYAMLFiles(treeNodes)
 			// if load path is a directory, we will load services in following rules:
 			// 1. if there is any yaml files under this directory, collect them as a service and ignore other files and directories
 			// 2. if not, but there is some directories under this directory, load each of them as a service
@@ -218,53 +213,6 @@ func loadService(username string, ch *systemconfig.CodeHost, owner, namespace, r
 	}
 
 	return nil
-}
-
-func getFoldersAndYAMLFiles(treeNodes []*git.TreeNode) ([]*git.TreeNode, []*git.TreeNode) {
-	var folders, files []*git.TreeNode
-	for _, tn := range treeNodes {
-		if tn.IsDir {
-			folders = append(folders, tn)
-		} else if isYaml(tn.Name) {
-			files = append(files, tn)
-		}
-	}
-
-	return folders, files
-}
-
-func hasYAMLFiles(treeNodes []*git.TreeNode) bool {
-	for _, tn := range treeNodes {
-		if !tn.IsDir && isYaml(tn.Name) {
-			return true
-		}
-	}
-
-	return false
-}
-
-type yamlLoader interface {
-	GetYAMLContents(owner, repo, path, branch string, isDir, split bool) ([]string, error)
-	GetLatestRepositoryCommit(owner, repo, path, branch string) (*git.RepositoryCommit, error)
-	GetTree(owner, repo, path, branch string) ([]*git.TreeNode, error)
-}
-
-func getLoader(ch *systemconfig.CodeHost) (yamlLoader, error) {
-	switch ch.Type {
-	case setting.SourceFromGithub:
-		return githubservice.NewClient(ch.AccessToken, config.ProxyHTTPSAddr(), ch.EnableProxy), nil
-	case setting.SourceFromGitlab:
-		return gitlabservice.NewClient(ch.ID, ch.Address, ch.AccessToken, config.ProxyHTTPSAddr(), ch.EnableProxy, ch.DisableSSL)
-	default:
-		// should not have happened here
-		log.DPanicf("invalid source: %s", ch.Type)
-		return nil, fmt.Errorf("invalid source: %s", ch.Type)
-	}
-}
-
-func isYaml(filename string) bool {
-	filename = strings.ToLower(filename)
-	return strings.HasSuffix(filename, ".yaml") || strings.HasSuffix(filename, ".yml")
 }
 
 func getFileName(fullName string) string {

--- a/pkg/microservice/aslan/core/templatestore/handler/router.go
+++ b/pkg/microservice/aslan/core/templatestore/handler/router.go
@@ -54,6 +54,9 @@ func (*Router) Inject(router *gin.RouterGroup) {
 	yaml := router.Group("yaml")
 	{
 		yaml.POST("", CreateYamlTemplate)
+		yaml.POST("/preload/:codehostId", PreloadYamlTemplateFromCodeHost)
+		yaml.POST("/load/:codehostId", LoadYamlTemplateFromCodeHost)
+		yaml.PUT("/load/:codehostId", SyncYamlTemplateFromCodeHost)
 		yaml.PUT("/:id", UpdateYamlTemplate)
 		yaml.PUT("/:id/variable", UpdateYamlTemplateVariable)
 		yaml.GET("", ListYamlTemplate)

--- a/pkg/microservice/aslan/core/templatestore/handler/yaml.go
+++ b/pkg/microservice/aslan/core/templatestore/handler/yaml.go
@@ -19,6 +19,8 @@ package handler
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/koderover/zadig/v2/pkg/types"
@@ -27,7 +29,18 @@ import (
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/template"
 	templateservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/templatestore/service"
 	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
+	e "github.com/koderover/zadig/v2/pkg/tool/errors"
 )
+
+type PreloadYamlTemplateFromCodeHostReq struct {
+	RepoOwner  string                                    `json:"repo_owner"`
+	RepoName   string                                    `json:"repo_name"`
+	NameSpace  string                                    `json:"namespace"`
+	RepoUUID   string                                    `json:"repo_uuid"`
+	BranchName string                                    `json:"branch_name"`
+	RemoteName string                                    `json:"remote_name"`
+	Paths      []templateservice.PreloadYamlTemplatePath `json:"paths"`
+}
 
 // @Summary Create yaml template
 // @Description Create yaml template
@@ -67,6 +80,189 @@ func CreateYamlTemplate(c *gin.Context) {
 	}
 
 	ctx.RespErr = templateservice.CreateYamlTemplate(req, ctx.Logger)
+}
+
+// @Summary Preload yaml template from codehost
+// @Description Preload yaml template from codehost
+// @Tags 	template
+// @Accept 	json
+// @Produce json
+// @Param 	codehostId 	path 		int 												true 	"codehostId"
+// @Param 	repoName 	query 		string 												false 	"repoName"
+// @Param 	branchName 	query 		string 												false 	"branchName"
+// @Param 	repoOwner 	query 		string 												false 	"repoOwner"
+// @Param 	namespace 	query 		string 												false 	"namespace"
+// @Param 	remoteName 	query 		string 												false 	"remoteName"
+// @Param 	body 		body 		PreloadYamlTemplateFromCodeHostReq					true	"body"
+// @Success 200 		{array} 	templateservice.LoadYamlTemplatePath
+// @Router /api/aslan/template/yaml/preload/{codehostId} [post]
+func PreloadYamlTemplateFromCodeHost(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	codehostIDStr := c.Param("codehostId")
+	codehostID, err := strconv.Atoi(codehostIDStr)
+	if err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("cannot convert codehost id to int")
+		return
+	}
+
+	var req PreloadYamlTemplateFromCodeHostReq
+	if err := c.BindJSON(&req); err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("invalid PreloadYamlTemplateFromCodeHostReq json args")
+		return
+	}
+
+	if req.RepoName == "" && req.RepoUUID == "" {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("repoName and repoUUID cannot be empty at the same time")
+		return
+	}
+
+	ctx.Resp, ctx.RespErr = templateservice.PreloadYamlTemplateFromCodeHost(codehostID, req.RepoOwner, req.RepoName, req.RepoUUID, req.BranchName, req.RemoteName, req.Paths, ctx.Logger)
+}
+
+// @Summary Load yaml template from codehost
+// @Description Load yaml template from codehost
+// @Tags 	template
+// @Accept 	json
+// @Produce json
+// @Param 	codehostId 	path 		int 											true 	"codehostId"
+// @Param 	repoName 	query 		string 											true 	"repoName"
+// @Param 	branchName 	query 		string 											true 	"branchName"
+// @Param 	repoOwner 	query 		string 											true 	"repoOwner"
+// @Param 	namespace 	query 		string 											false 	"namespace"
+// @Param 	remoteName 	query 		string 											false 	"remoteName"
+// @Param 	body 		body 		templateservice.LoadYamlTemplateFromCodeHostReq true	"body"
+// @Success 200
+// @Router /api/aslan/template/yaml/load/{codehostId} [post]
+func LoadYamlTemplateFromCodeHost(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	codehostIDStr := c.Param("codehostId")
+
+	codehostID, err := strconv.Atoi(codehostIDStr)
+	if err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("cannot convert codehost id to int")
+		return
+	}
+
+	repoName := c.Query("repoName")
+	repoUUID := c.Query("repoUUID")
+	if repoName == "" && repoUUID == "" {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("repoName and repoUUID cannot be empty at the same time")
+		return
+	}
+
+	branchName := c.Query("branchName")
+
+	args := new(templateservice.LoadYamlTemplateFromCodeHostReq)
+	if err := c.BindJSON(args); err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("invalid LoadYamlTemplateFromCodeHostReq json args")
+		return
+	}
+
+	remoteName := c.Query("remoteName")
+	repoOwner := c.Query("repoOwner")
+	namespace := c.Query("namespace")
+	if namespace == "" {
+		namespace = repoOwner
+	}
+
+	bs, _ := json.Marshal(args)
+	internalhandler.InsertOperationLog(c, ctx.UserName, "", "创建", "模板-YAML", "", "", string(bs), types.RequestBodyTypeJSON, ctx.Logger)
+
+	if !ctx.Resources.IsSystemAdmin {
+		if !ctx.Resources.SystemActions.Template.Create {
+			ctx.UnAuthorized = true
+			return
+		}
+	}
+
+	ctx.RespErr = templateservice.LoadYamlTemplateFromCodeHost(ctx.UserName, codehostID, repoOwner, namespace, repoName, repoUUID, branchName, remoteName, args, false, ctx.Logger)
+}
+
+// @Summary Sync yaml template from codehost
+// @Description Sync yaml template from codehost
+// @Tags 	template
+// @Accept 	json
+// @Produce json
+// @Param 	codehostId 	path 		int 										true 	"codehostId"
+// @Param 	repoName 	query 		string 									true 	"repoName"
+// @Param 	branchName 	query 		string 									true 	"branchName"
+// @Param 	repoOwner 	query 		string 									true 	"repoOwner"
+// @Param 	namespace 	query 		string 									false 	"namespace"
+// @Param 	remoteName 	query 		string 									false 	"remoteName"
+// @Param 	body 		body 		templateservice.LoadYamlTemplateFromCodeHostReq true "body"
+// @Success 200
+// @Router /api/aslan/template/yaml/load/{codehostId} [put]
+func SyncYamlTemplateFromCodeHost(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	codehostIDStr := c.Param("codehostId")
+
+	codehostID, err := strconv.Atoi(codehostIDStr)
+	if err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("cannot convert codehost id to string")
+		return
+	}
+
+	repoName := c.Query("repoName")
+	repoUUID := c.Query("repoUUID")
+	if repoName == "" && repoUUID == "" {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("repoName and repoUUID cannot be empty at the same time")
+		return
+	}
+
+	branchName := c.Query("branchName")
+
+	args := new(templateservice.LoadYamlTemplateFromCodeHostReq)
+	if err := c.BindJSON(args); err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("invalid LoadYamlTemplateFromCodeHostReq json args")
+		return
+	}
+
+	remoteName := c.Query("remoteName")
+	repoOwner := c.Query("repoOwner")
+	namespace := c.Query("namespace")
+	if namespace == "" {
+		namespace = repoOwner
+	}
+
+	if len(args.Paths) != 1 {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("paths must contain only one path")
+		return
+	}
+
+	bs, _ := json.Marshal(args)
+	templateNames := make([]string, 0, len(args.Paths))
+	for _, loadPath := range args.Paths {
+		templateNames = append(templateNames, loadPath.Name)
+	}
+	templateNameStr := strings.Join(templateNames, ",")
+	internalhandler.InsertOperationLog(c, ctx.UserName, "", "更新", "模板-YAML", templateNameStr, templateNameStr, string(bs), types.RequestBodyTypeJSON, ctx.Logger)
+
+	if !ctx.Resources.IsSystemAdmin {
+		if !ctx.Resources.SystemActions.Template.Edit {
+			ctx.UnAuthorized = true
+			return
+		}
+	}
+
+	ctx.RespErr = templateservice.LoadYamlTemplateFromCodeHost(ctx.UserName, codehostID, repoOwner, namespace, repoName, repoUUID, branchName, remoteName, args, true, ctx.Logger)
 }
 
 // @Summary Update yaml template

--- a/pkg/microservice/aslan/core/templatestore/service/yaml.go
+++ b/pkg/microservice/aslan/core/templatestore/service/yaml.go
@@ -19,17 +19,28 @@ package service
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
 
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/command"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/template"
 	commontypes "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/types"
 	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/service/service"
 	"github.com/koderover/zadig/v2/pkg/setting"
+	"github.com/koderover/zadig/v2/pkg/shared/client/systemconfig"
+	"github.com/koderover/zadig/v2/pkg/tool/gerrit"
+	"github.com/koderover/zadig/v2/pkg/tool/gitee"
+	"github.com/koderover/zadig/v2/pkg/util"
 	"github.com/koderover/zadig/v2/pkg/util/converter"
 	yamlutil "github.com/koderover/zadig/v2/pkg/util/yaml"
 )
@@ -37,6 +48,656 @@ import (
 var DefaultSystemVariable = map[string]string{
 	setting.TemplateVariableProduct: setting.TemplateVariableProductDescription,
 	setting.TemplateVariableService: setting.TemplateVariableServiceDescription,
+}
+
+type LoadYamlTemplateFromCodeHostReq struct {
+	Paths []LoadYamlTemplatePath `json:"paths"`
+}
+
+type LoadYamlTemplatePath struct {
+	Name  string `json:"name"`
+	Path  string `json:"path"`
+	IsDir bool   `json:"is_dir"`
+}
+
+type PreloadYamlTemplatePath struct {
+	Path  string `json:"path"`
+	IsDir bool   `json:"is_dir"`
+}
+
+type loadedYamlTemplateContent struct {
+	Path    LoadYamlTemplatePath
+	Content string
+	Commit  *models.Commit
+}
+
+func PreloadYamlTemplateFromCodeHost(codehostID int, repoOwner, repoName, repoUUID, branchName, remoteName string, loadPaths []PreloadYamlTemplatePath, logger *zap.SugaredLogger) ([]LoadYamlTemplatePath, error) {
+	var templates []LoadYamlTemplatePath
+
+	ch, err := systemconfig.New().GetCodeHost(codehostID)
+	if err != nil {
+		logger.Errorf("failed to get codehost %d for yaml template preload, err: %s", codehostID, err)
+		return nil, fmt.Errorf("failed to get codehost %d, err: %w", codehostID, err)
+	}
+
+	switch ch.Type {
+	case setting.SourceFromGithub, setting.SourceFromGitlab:
+		templates, err = preloadYamlTemplatesFromTreeGetter(ch, repoOwner, repoName, branchName, loadPaths, logger)
+	case setting.SourceFromGerrit:
+		templates, err = preloadYamlTemplatesFromGerrit(ch, repoOwner, repoName, branchName, remoteName, loadPaths, logger)
+	case setting.SourceFromGitee, setting.SourceFromGiteeEE:
+		templates, err = preloadYamlTemplatesFromGitee(ch, repoOwner, repoName, branchName, remoteName, loadPaths, logger)
+	default:
+		logger.Errorf("unsupported code source: %s", ch.Type)
+		return nil, fmt.Errorf("unsupported code source: %s", ch.Type)
+	}
+
+	return templates, err
+}
+
+func preloadYamlTemplatesFromTreeGetter(ch *systemconfig.CodeHost, repoOwner, repoName, branchName string, paths []PreloadYamlTemplatePath, logger *zap.SugaredLogger) ([]LoadYamlTemplatePath, error) {
+	logger.Infof("Preloading yaml template from codehost %d with namespace %s, repo %s, branch %s and path %v", ch.ID, repoOwner, repoName, branchName, paths)
+
+	loader, err := commonutil.GetYAMLLoader(ch)
+	if err != nil {
+		logger.Errorf("Failed to create loader client, err: %s", err)
+		return nil, err
+	}
+
+	resp := make([]LoadYamlTemplatePath, 0)
+	for _, loadPath := range paths {
+		if !loadPath.IsDir {
+			if !commonutil.IsYaml(loadPath.Path) {
+				return nil, fmt.Errorf("file is not of type yaml or yml, select again")
+			}
+
+			resp = append(resp, LoadYamlTemplatePath{
+				Name:  getFileName(loadPath.Path),
+				Path:  loadPath.Path,
+				IsDir: loadPath.IsDir,
+			})
+		} else {
+			treeNodes, err := loader.GetTree(repoOwner, repoName, loadPath.Path, branchName)
+			if err != nil {
+				logger.Errorf("failed to get tree under path %s, err: %s", loadPath.Path, err)
+				return nil, fmt.Errorf("failed to get tree under path %s, err: %s", loadPath.Path, err)
+			}
+
+			folders, files := commonutil.GetFoldersAndYAMLFiles(treeNodes)
+
+			if len(files) > 0 {
+				resp = append(resp, LoadYamlTemplatePath{
+					Name:  getFileName(loadPath.Path),
+					Path:  loadPath.Path,
+					IsDir: loadPath.IsDir,
+				})
+			} else if len(folders) > 0 {
+				for _, f := range folders {
+					tns, err := loader.GetTree(repoOwner, repoName, f.FullPath, branchName)
+					if err != nil {
+						logger.Errorf("Failed to get tree under path %s, err: %s", f.FullPath, err)
+						return nil, fmt.Errorf("Failed to get tree under path %s, err: %s", f.FullPath, err)
+					}
+
+					if commonutil.HasYAMLFiles(tns) {
+						resp = append(resp, LoadYamlTemplatePath{
+							Name:  getFileName(f.FullPath),
+							Path:  f.FullPath,
+							IsDir: f.IsDir,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	if len(resp) == 0 {
+		logger.Errorf("no valid yaml is found under paths %v", paths)
+		return nil, fmt.Errorf("no valid yaml is found under paths")
+	}
+
+	return resp, nil
+}
+
+func preloadYamlTemplatesFromGerrit(ch *systemconfig.CodeHost, repoOwner, repoName, branchName, remoteName string, paths []PreloadYamlTemplatePath, logger *zap.SugaredLogger) ([]LoadYamlTemplatePath, error) {
+	resp := make([]LoadYamlTemplatePath, 0)
+
+	if remoteName == "" {
+		remoteName = "origin"
+	}
+
+	base := path.Join(config.S3StoragePath(), strings.Replace(repoName, "/", "-", -1))
+
+	if _, err := os.Stat(base); os.IsNotExist(err) {
+		err = command.RunGitCmds(ch, setting.GerritDefaultOwner, setting.GerritDefaultOwner, repoName, branchName, remoteName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, loadPath := range paths {
+		filePath := path.Join(base, loadPath.Path)
+
+		if !loadPath.IsDir {
+			if !commonutil.IsYaml(loadPath.Path) {
+				logger.Errorf("file is not of type yaml or yml, select again")
+				return nil, fmt.Errorf("file is not of type yaml or yml, select again")
+			}
+
+			pathSegment := strings.Split(loadPath.Path, "/")
+			fileName := pathSegment[len(pathSegment)-1]
+
+			resp = append(resp, LoadYamlTemplatePath{
+				Name:  getFileName(fileName),
+				Path:  loadPath.Path,
+				IsDir: loadPath.IsDir,
+			})
+		} else {
+			fileInfos, err := ioutil.ReadDir(filePath)
+			if err != nil {
+				logger.Errorf("failed to read yaml directory %s, err: %s", loadPath.Path, err)
+				return nil, fmt.Errorf("failed to read yaml directory %s, err: %s", loadPath.Path, err)
+			}
+
+			if commonutil.IsValidServiceDir(fileInfos) {
+				name := loadPath.Path
+				if loadPath.Path == "" {
+					name = repoName
+				}
+
+				pathList := strings.Split(name, "/")
+				folderName := pathList[len(pathList)-1]
+				resp = append(resp, LoadYamlTemplatePath{
+					Name:  folderName,
+					Path:  loadPath.Path,
+					IsDir: loadPath.IsDir,
+				})
+				return resp, nil
+			}
+
+			isGrandParent := false
+			for _, file := range fileInfos {
+				if file.IsDir() {
+					subDirPath := fmt.Sprintf("%s/%s", filePath, file.Name())
+					subtree, err := ioutil.ReadDir(subDirPath)
+					if err != nil {
+						logger.Errorf("failed to get subtree fromwith path %s, err: %s", subDirPath, err)
+						return nil, fmt.Errorf("failed to get subtree fromwith path %s, err: %s", subDirPath, err)
+					}
+
+					if commonutil.IsValidServiceDir(subtree) {
+						resp = append(resp, LoadYamlTemplatePath{
+							Name:  getFileName(file.Name()),
+							Path:  loadPath.Path,
+							IsDir: loadPath.IsDir,
+						})
+						isGrandParent = true
+					}
+				}
+			}
+
+			if !isGrandParent {
+				logger.Errorf("no valid yaml is found under directory %s", filePath)
+				return nil, fmt.Errorf("no valid yaml is found under directory %s", filePath)
+			}
+		}
+	}
+
+	return resp, nil
+}
+
+func preloadYamlTemplatesFromGitee(ch *systemconfig.CodeHost, repoOwner, repoName, branchName, remoteName string, paths []PreloadYamlTemplatePath, logger *zap.SugaredLogger) ([]LoadYamlTemplatePath, error) {
+	resp := make([]LoadYamlTemplatePath, 0)
+
+	if remoteName == "" {
+		remoteName = "origin"
+	}
+
+	base := path.Join(config.S3StoragePath(), strings.Replace(repoName, "/", "-", -1))
+
+	if exist, err := util.PathExists(base); !exist {
+		logger.Warnf("path does not exist,err:%s", err)
+		err = command.RunGitCmds(ch, repoOwner, repoOwner, repoName, branchName, remoteName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to clone code, err: %s", err.Error())
+		}
+	}
+
+	for _, loadPath := range paths {
+		filePath := path.Join(base, loadPath.Path)
+
+		if !loadPath.IsDir {
+			if !commonutil.IsYaml(loadPath.Path) {
+				logger.Errorf("file is not of type yaml or yml, select again")
+				return nil, fmt.Errorf("file is not of type yaml or yml, select again")
+			}
+
+			pathSegment := strings.Split(loadPath.Path, "/")
+			fileName := pathSegment[len(pathSegment)-1]
+
+			resp = append(resp, LoadYamlTemplatePath{
+				Name:  getFileName(fileName),
+				Path:  loadPath.Path,
+				IsDir: loadPath.IsDir,
+			})
+		} else {
+			fileInfos, err := ioutil.ReadDir(filePath)
+			if err != nil {
+				logger.Errorf("failed to read yaml directory %s, err: %s", loadPath.Path, err)
+				os.RemoveAll(base)
+				return nil, fmt.Errorf("failed to read yaml directory %s, err: %s", loadPath.Path, err)
+			}
+
+			if commonutil.IsValidServiceDir(fileInfos) {
+				name := loadPath.Path
+				if loadPath.Path == "" {
+					name = repoName
+				}
+				pathList := strings.Split(name, "/")
+				folderName := pathList[len(pathList)-1]
+				resp = append(resp, LoadYamlTemplatePath{
+					Name:  folderName,
+					Path:  loadPath.Path,
+					IsDir: loadPath.IsDir,
+				})
+				return resp, nil
+			}
+
+			isGrandParent := false
+			for _, file := range fileInfos {
+				if file.IsDir() {
+					subDirPath := fmt.Sprintf("%s/%s", filePath, file.Name())
+					subtree, err := ioutil.ReadDir(subDirPath)
+					if err != nil {
+						logger.Errorf("failed to get subtree fromwith path %s, err: %s", subDirPath, err)
+						return nil, fmt.Errorf("failed to get subtree fromwith path %s, err: %s", subDirPath, err)
+					}
+					if commonutil.IsValidServiceDir(subtree) {
+						resp = append(resp, LoadYamlTemplatePath{
+							Name:  getFileName(file.Name()),
+							Path:  loadPath.Path,
+							IsDir: loadPath.IsDir,
+						})
+						isGrandParent = true
+					}
+				}
+			}
+			if !isGrandParent {
+				logger.Errorf("no valid yaml is found under directory %s", filePath)
+				return nil, fmt.Errorf("no valid yaml is found under directory %s", filePath)
+			}
+		}
+	}
+
+	return resp, nil
+}
+
+func getFileName(fullName string) string {
+	name := filepath.Base(fullName)
+	ext := filepath.Ext(name)
+	return name[0:(len(name) - len(ext))]
+}
+
+func LoadYamlTemplateFromCodeHost(username string, codehostID int, repoOwner, namespace, repoName, repoUUID, branchName, remoteName string, args *LoadYamlTemplateFromCodeHostReq, isSync bool, logger *zap.SugaredLogger) error {
+	ch, err := systemconfig.New().GetCodeHost(codehostID)
+	if err != nil {
+		logger.Errorf("failed to get codehost %d, err: %s", codehostID, err)
+		return fmt.Errorf("failed to get codehost %d, err: %s", codehostID, err)
+	}
+
+	if isSync {
+		yamlTemplate, err := commonrepo.NewYamlTemplateColl().GetByName(args.Paths[0].Name)
+		if err != nil {
+			logger.Errorf("failed to query yaml template, err: %s", err)
+			return fmt.Errorf("failed to query yaml template, err: %w", err)
+		}
+
+		if yamlTemplate.Name != args.Paths[0].Name {
+			return fmt.Errorf("yaml template name mismatch")
+		}
+	}
+
+	switch ch.Type {
+	case setting.SourceFromGithub, setting.SourceFromGitlab:
+		return loadYamlTemplateFromTreeGetter(ch, repoOwner, namespace, repoName, branchName, remoteName, args, isSync, logger)
+	case setting.SourceFromGerrit:
+		return loadYamlTemplateFromGerrit(ch, repoOwner, namespace, repoName, branchName, remoteName, args, isSync, logger)
+	case setting.SourceFromGitee, setting.SourceFromGiteeEE:
+		return loadYamlTemplateFromGitee(ch, repoOwner, namespace, repoName, branchName, remoteName, args, isSync, logger)
+	default:
+		logger.Errorf("unsupported code source: %s", ch.Type)
+		return fmt.Errorf("unsupported code source: %s", ch.Type)
+	}
+}
+
+func loadYamlTemplateFromTreeGetter(ch *systemconfig.CodeHost, repoOwner, namespace, repoName, branchName, remoteName string, args *LoadYamlTemplateFromCodeHostReq, isSync bool, logger *zap.SugaredLogger) error {
+	logger.Infof("Loading yaml template from codehost %d with owner %s, namespace %s, repo %s, branch %s and path %v", ch.ID, repoOwner, namespace, repoName, branchName, args.Paths)
+
+	loader, err := commonutil.GetYAMLLoader(ch)
+	if err != nil {
+		logger.Errorf("failed to get yaml loader for codehost %d, err: %s", ch.ID, err)
+		return err
+	}
+
+	contents := make([]*loadedYamlTemplateContent, 0, len(args.Paths))
+	for _, loadPath := range args.Paths {
+		if !loadPath.IsDir {
+			yamls, err := loader.GetYAMLContents(namespace, repoName, loadPath.Path, branchName, false, false)
+			if err != nil {
+				logger.Errorf("failed to get yaml content under path %s, err: %s", loadPath.Path, err)
+				return err
+			}
+			contents = append(contents, &loadedYamlTemplateContent{
+				Path:    loadPath,
+				Content: util.CombineManifests(yamls),
+			})
+		} else {
+			treeNodes, err := loader.GetTree(namespace, repoName, loadPath.Path, branchName)
+			if err != nil {
+				logger.Errorf("failed to get tree under path %s, err: %s", loadPath.Path, err)
+				return err
+			}
+
+			_, files := commonutil.GetFoldersAndYAMLFiles(treeNodes)
+
+			if len(files) > 0 {
+				yamls := make([]string, 0)
+				for _, file := range files {
+					res, err := loader.GetYAMLContents(namespace, repoName, file.FullPath, branchName, false, false)
+					if err != nil {
+						logger.Errorf("failed to get yaml content under path %s, err: %s", file.FullPath, err)
+						return err
+					}
+					yamls = append(yamls, res...)
+				}
+				contents = append(contents, &loadedYamlTemplateContent{
+					Path:    loadPath,
+					Content: util.CombineManifests(yamls),
+				})
+			} else {
+				logger.Errorf("no yaml file is found under directory %s", loadPath.Path)
+				return fmt.Errorf("no yaml file is found under directory %s", loadPath.Path)
+			}
+		}
+	}
+
+	for _, content := range contents {
+
+		if len(content.Content) == 0 {
+			continue
+		}
+
+		commit, err := loader.GetLatestRepositoryCommit(namespace, repoName, content.Path.Path, branchName)
+		if err != nil {
+			logger.Errorf("failed to get latest commit under path %s, err: %s", content.Path.Path, err)
+			return err
+		}
+		commitInfo := &models.Commit{SHA: commit.SHA, Message: commit.Message}
+
+		templateObj := &template.YamlTemplate{
+			Source:      ch.Type,
+			CodehostID:  ch.ID,
+			RepoOwner:   repoOwner,
+			Namespace:   namespace,
+			RepoName:    repoName,
+			BranchName:  branchName,
+			RemoteName:  remoteName,
+			Name:        content.Path.Name,
+			Content:     content.Content,
+			Path:        content.Path.Path,
+			LoadFromDir: content.Path.IsDir,
+			Commit:      commitInfo,
+		}
+
+		if isSync {
+			origin, err := commonrepo.NewYamlTemplateColl().GetByName(templateObj.Name)
+			if err != nil {
+				return fmt.Errorf("failed to find template by name: %s, err: %w", templateObj.Name, err)
+			}
+			if err := UpdateYamlTemplate(origin.ID.Hex(), templateObj, logger); err != nil {
+				return err
+			}
+			continue
+		} else {
+			if err := CreateYamlTemplate(templateObj, logger); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func loadYamlTemplateFromGerrit(ch *systemconfig.CodeHost, repoOwner, namespace, repoName, branchName, remoteName string, args *LoadYamlTemplateFromCodeHostReq, isSync bool, logger *zap.SugaredLogger) error {
+	if remoteName == "" {
+		remoteName = "origin"
+	}
+
+	base := path.Join(config.S3StoragePath(), strings.Replace(repoName, "/", "-", -1))
+	_ = os.RemoveAll(base)
+
+	if err := command.RunGitCmds(ch, repoOwner, repoOwner, repoName, branchName, remoteName); err != nil {
+		logger.Errorf("failed to clone gerrit repo %s branch %s, err: %s", repoName, branchName, err)
+		return err
+	}
+
+	gerritCli := gerrit.NewClient(ch.Address, ch.AccessToken, config.ProxyHTTPSAddr(), ch.EnableProxy)
+	commit, err := gerritCli.GetCommitByBranch(repoName, branchName)
+	if err != nil {
+		logger.Errorf("failed to get latest commit info from repo %s, err: %s", repoName, err)
+		return err
+	}
+	commitInfo := &models.Commit{
+		SHA:     commit.Commit,
+		Message: commit.Message,
+	}
+
+	for _, loadPath := range args.Paths {
+		if !loadPath.IsDir {
+
+			content, err := os.ReadFile(path.Join(base, loadPath.Path))
+			if err != nil {
+				logger.Errorf("failed to read yaml file %s, err: %s", loadPath.Path, err)
+				return err
+			}
+			templateObj := &template.YamlTemplate{
+				Source:      ch.Type,
+				CodehostID:  ch.ID,
+				RepoOwner:   repoOwner,
+				Namespace:   namespace,
+				RepoName:    repoName,
+				BranchName:  branchName,
+				RemoteName:  remoteName,
+				Name:        loadPath.Name,
+				Content:     string(content),
+				Path:        loadPath.Path,
+				LoadFromDir: loadPath.IsDir,
+				Commit:      commitInfo,
+			}
+
+			if isSync {
+				origin, err := commonrepo.NewYamlTemplateColl().GetByName(templateObj.Name)
+				if err != nil {
+					return fmt.Errorf("failed to find template by name: %s, err: %w", templateObj.Name, err)
+				}
+				if err := UpdateYamlTemplate(origin.ID.Hex(), templateObj, logger); err != nil {
+					return err
+				}
+			} else if err := CreateYamlTemplate(templateObj, logger); err != nil {
+				return err
+			}
+
+		} else {
+			filePath := path.Join(base, loadPath.Path)
+			fileInfos, err := ioutil.ReadDir(filePath)
+			if err != nil {
+				logger.Errorf("failed to read yaml directory %s, err: %s", loadPath.Path, err)
+				return err
+			}
+			if commonutil.IsValidServiceDir(fileInfos) {
+				yamls := make([]string, 0)
+				for _, fileInfo := range fileInfos {
+					if fileInfo.IsDir() || !commonutil.IsYaml(fileInfo.Name()) {
+						continue
+					}
+
+					content, err := os.ReadFile(path.Join(filePath, fileInfo.Name()))
+					if err != nil {
+						logger.Errorf("failed to read yaml file %s, err: %s", path.Join(loadPath.Path, fileInfo.Name()), err)
+						return err
+					}
+					yamls = append(yamls, string(content))
+				}
+
+				templateObj := &template.YamlTemplate{
+					Source:      ch.Type,
+					CodehostID:  ch.ID,
+					RepoOwner:   repoOwner,
+					Namespace:   namespace,
+					RepoName:    repoName,
+					BranchName:  branchName,
+					RemoteName:  remoteName,
+					Name:        loadPath.Name,
+					Content:     util.CombineManifests(yamls),
+					Path:        loadPath.Path,
+					LoadFromDir: loadPath.IsDir,
+					Commit:      commitInfo,
+				}
+
+				if isSync {
+					origin, err := commonrepo.NewYamlTemplateColl().GetByName(templateObj.Name)
+					if err != nil {
+						return fmt.Errorf("failed to find template by name: %s, err: %w", templateObj.Name, err)
+					}
+					if err := UpdateYamlTemplate(origin.ID.Hex(), templateObj, logger); err != nil {
+						return err
+					}
+				} else if err := CreateYamlTemplate(templateObj, logger); err != nil {
+					return err
+				}
+			} else {
+				logger.Errorf("no valid yaml is found under directory %s", loadPath.Path)
+				return fmt.Errorf("no valid yaml is found under directory %s", loadPath.Path)
+			}
+		}
+	}
+	return nil
+}
+
+func loadYamlTemplateFromGitee(ch *systemconfig.CodeHost, repoOwner, namespace, repoName, branchName, remoteName string, args *LoadYamlTemplateFromCodeHostReq, isSync bool, logger *zap.SugaredLogger) error {
+	if remoteName == "" {
+		remoteName = "origin"
+	}
+
+	base := path.Join(config.S3StoragePath(), repoName)
+	if _, err := os.Stat(base); os.IsNotExist(err) {
+		if err := command.RunGitCmds(ch, repoOwner, repoName, repoName, branchName, remoteName); err != nil {
+			logger.Errorf("failed to clone gitee repo %s/%s branch %s, err: %s", repoOwner, repoName, branchName, err)
+			return err
+		}
+	}
+
+	giteeCli := gitee.NewClient(ch.ID, ch.Address, ch.AccessToken, config.ProxyHTTPSAddr(), ch.EnableProxy)
+	branch, err := giteeCli.GetSingleBranch(ch.Address, ch.AccessToken, repoOwner, repoName, branchName)
+	if err != nil {
+		logger.Errorf("failed to get latest commit info from repo %s, err: %s", repoName, err)
+		return err
+	}
+	commitInfo := &models.Commit{
+		SHA:     branch.Commit.Sha,
+		Message: branch.Commit.Commit.Message,
+	}
+
+	for _, loadPath := range args.Paths {
+		if !loadPath.IsDir {
+			content, err := os.ReadFile(path.Join(base, loadPath.Path))
+			if err != nil {
+				logger.Errorf("failed to read yaml file %s, err: %s", loadPath.Path, err)
+				return err
+			}
+			templateObj := &template.YamlTemplate{
+				Source:      ch.Type,
+				CodehostID:  ch.ID,
+				RepoOwner:   repoOwner,
+				Namespace:   namespace,
+				RepoName:    repoName,
+				BranchName:  branchName,
+				RemoteName:  remoteName,
+				Name:        loadPath.Name,
+				Content:     string(content),
+				Path:        loadPath.Path,
+				LoadFromDir: loadPath.IsDir,
+				Commit:      commitInfo,
+			}
+
+			if isSync {
+				origin, err := commonrepo.NewYamlTemplateColl().GetByName(templateObj.Name)
+				if err != nil {
+					return fmt.Errorf("failed to find template by name: %s, err: %w", templateObj.Name, err)
+				}
+				if err := UpdateYamlTemplate(origin.ID.Hex(), templateObj, logger); err != nil {
+					return err
+				}
+			} else if err := CreateYamlTemplate(templateObj, logger); err != nil {
+				return err
+			}
+
+		} else {
+			filePath := path.Join(base, loadPath.Path)
+			fileInfos, err := ioutil.ReadDir(filePath)
+			if err != nil {
+				logger.Errorf("failed to read yaml directory %s, err: %s", loadPath.Path, err)
+				return err
+			}
+			if commonutil.IsValidServiceDir(fileInfos) {
+				yamls := make([]string, 0)
+				for _, fileInfo := range fileInfos {
+					if fileInfo.IsDir() || !commonutil.IsYaml(fileInfo.Name()) {
+						continue
+					}
+
+					content, err := os.ReadFile(path.Join(filePath, fileInfo.Name()))
+					if err != nil {
+						logger.Errorf("failed to read yaml file %s, err: %s", path.Join(loadPath.Path, fileInfo.Name()), err)
+						return err
+					}
+					yamls = append(yamls, string(content))
+				}
+
+				templateObj := &template.YamlTemplate{
+					Source:      ch.Type,
+					CodehostID:  ch.ID,
+					RepoOwner:   repoOwner,
+					Namespace:   namespace,
+					RepoName:    repoName,
+					BranchName:  branchName,
+					RemoteName:  remoteName,
+					Name:        loadPath.Name,
+					Content:     util.CombineManifests(yamls),
+					Path:        loadPath.Path,
+					LoadFromDir: loadPath.IsDir,
+					Commit:      commitInfo,
+				}
+
+				if isSync {
+					origin, err := commonrepo.NewYamlTemplateColl().GetByName(templateObj.Name)
+					if err != nil {
+						return fmt.Errorf("failed to find template by name: %s, err: %w", templateObj.Name, err)
+					}
+					if err := UpdateYamlTemplate(origin.ID.Hex(), templateObj, logger); err != nil {
+						return err
+					}
+				} else if err := CreateYamlTemplate(templateObj, logger); err != nil {
+					return err
+				}
+			} else {
+				logger.Errorf("no valid yaml is found under directory %s", loadPath.Path)
+				return fmt.Errorf("no valid yaml is found under directory %s", loadPath.Path)
+			}
+		}
+	}
+
+	return nil
 }
 
 func CreateYamlTemplate(template *template.YamlTemplate, logger *zap.SugaredLogger) error {
@@ -52,6 +713,16 @@ func CreateYamlTemplate(template *template.YamlTemplate, logger *zap.SugaredLogg
 	err = commonrepo.NewYamlTemplateColl().Create(&models.YamlTemplate{
 		Name:               template.Name,
 		Content:            template.Content,
+		Source:             template.Source,
+		RepoOwner:          template.RepoOwner,
+		Namespace:          template.Namespace,
+		RepoName:           template.RepoName,
+		Path:               template.Path,
+		BranchName:         template.BranchName,
+		RemoteName:         template.RemoteName,
+		CodeHostID:         template.CodehostID,
+		LoadFromDir:        template.LoadFromDir,
+		Commit:             template.Commit,
 		VariableYaml:       extractVariableYmal,
 		ServiceVariableKVs: extractServiceVariableKVs,
 	})
@@ -86,6 +757,16 @@ func UpdateYamlTemplate(id string, template *template.YamlTemplate, logger *zap.
 		&models.YamlTemplate{
 			Name:               template.Name,
 			Content:            template.Content,
+			Source:             template.Source,
+			CodeHostID:         template.CodehostID,
+			RepoOwner:          template.RepoOwner,
+			Namespace:          template.Namespace,
+			RepoName:           template.RepoName,
+			BranchName:         template.BranchName,
+			RemoteName:         template.RemoteName,
+			LoadFromDir:        template.LoadFromDir,
+			Path:               template.Path,
+			Commit:             template.Commit,
 			VariableYaml:       template.VariableYaml,
 			ServiceVariableKVs: template.ServiceVariableKVs,
 		},
@@ -123,8 +804,18 @@ func ListYamlTemplate(pageNum, pageSize int, logger *zap.SugaredLogger) ([]*temp
 	}
 	for _, obj := range templateList {
 		resp = append(resp, &template.YamlListObject{
-			ID:   obj.ID.Hex(),
-			Name: obj.Name,
+			ID:          obj.ID.Hex(),
+			Name:        obj.Name,
+			Source:      obj.Source,
+			CodehostID:  obj.CodeHostID,
+			RepoOwner:   obj.RepoOwner,
+			Namespace:   obj.Namespace,
+			Repo:        obj.RepoName,
+			Path:        obj.Path,
+			Branch:      obj.BranchName,
+			RemoteName:  obj.RemoteName,
+			LoadFromDir: obj.LoadFromDir,
+			Commit:      obj.Commit,
 		})
 	}
 	return resp, total, err
@@ -140,6 +831,16 @@ func GetYamlTemplateDetail(id string, logger *zap.SugaredLogger) (*template.Yaml
 	resp.ID = yamlTemplate.ID.Hex()
 	resp.Name = yamlTemplate.Name
 	resp.Content = yamlTemplate.Content
+	resp.Source = yamlTemplate.Source
+	resp.CodehostID = yamlTemplate.CodeHostID
+	resp.RepoOwner = yamlTemplate.RepoOwner
+	resp.Namespace = yamlTemplate.Namespace
+	resp.RepoName = yamlTemplate.RepoName
+	resp.Path = yamlTemplate.Path
+	resp.BranchName = yamlTemplate.BranchName
+	resp.RemoteName = yamlTemplate.RemoteName
+	resp.LoadFromDir = yamlTemplate.LoadFromDir
+	resp.Commit = yamlTemplate.Commit
 	resp.VariableYaml = yamlTemplate.VariableYaml
 	resp.ServiceVariableKVs = yamlTemplate.ServiceVariableKVs
 	return resp, err

--- a/pkg/microservice/aslan/core/templatestore/service/yaml.go
+++ b/pkg/microservice/aslan/core/templatestore/service/yaml.go
@@ -31,6 +31,7 @@ import (
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
+	commmonservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/command"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/template"
 	commontypes "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/types"
@@ -710,7 +711,7 @@ func CreateYamlTemplate(template *template.YamlTemplate, logger *zap.SugaredLogg
 		return fmt.Errorf("failed to convert variable yaml to service variable kv, err: %w", err)
 	}
 
-	err = commonrepo.NewYamlTemplateColl().Create(&models.YamlTemplate{
+	created := &models.YamlTemplate{
 		Name:               template.Name,
 		Content:            template.Content,
 		Source:             template.Source,
@@ -725,11 +726,18 @@ func CreateYamlTemplate(template *template.YamlTemplate, logger *zap.SugaredLogg
 		Commit:             template.Commit,
 		VariableYaml:       extractVariableYmal,
 		ServiceVariableKVs: extractServiceVariableKVs,
-	})
+	}
+
+	err = commonrepo.NewYamlTemplateColl().Create(created)
 	if err != nil {
 		logger.Errorf("create dockerfile template error: %s", err)
+		return err
 	}
-	return err
+
+	if err := commmonservice.ProcessYamlTemplateWebhook(created, nil, logger); err != nil {
+		logger.Errorf("failed to process yaml template webhook for create %s, err: %s", created.Name, err)
+	}
+	return nil
 }
 
 func UpdateYamlTemplate(id string, template *template.YamlTemplate, logger *zap.SugaredLogger) error {
@@ -752,29 +760,33 @@ func UpdateYamlTemplate(id string, template *template.YamlTemplate, logger *zap.
 		return fmt.Errorf("failed to merge service variables, err %w", err)
 	}
 
-	err = commonrepo.NewYamlTemplateColl().Update(
-		id,
-		&models.YamlTemplate{
-			Name:               template.Name,
-			Content:            template.Content,
-			Source:             template.Source,
-			CodeHostID:         template.CodehostID,
-			RepoOwner:          template.RepoOwner,
-			Namespace:          template.Namespace,
-			RepoName:           template.RepoName,
-			BranchName:         template.BranchName,
-			RemoteName:         template.RemoteName,
-			LoadFromDir:        template.LoadFromDir,
-			Path:               template.Path,
-			Commit:             template.Commit,
-			VariableYaml:       template.VariableYaml,
-			ServiceVariableKVs: template.ServiceVariableKVs,
-		},
-	)
+	updated := &models.YamlTemplate{
+		Name:               template.Name,
+		Content:            template.Content,
+		Source:             template.Source,
+		CodeHostID:         template.CodehostID,
+		RepoOwner:          template.RepoOwner,
+		Namespace:          template.Namespace,
+		RepoName:           template.RepoName,
+		BranchName:         template.BranchName,
+		RemoteName:         template.RemoteName,
+		LoadFromDir:        template.LoadFromDir,
+		Path:               template.Path,
+		Commit:             template.Commit,
+		VariableYaml:       template.VariableYaml,
+		ServiceVariableKVs: template.ServiceVariableKVs,
+	}
+
+	err = commonrepo.NewYamlTemplateColl().Update(id, updated)
 	if err != nil {
 		logger.Errorf("update yaml template error: %s", err)
+		return err
 	}
-	return err
+
+	if err := commmonservice.ProcessYamlTemplateWebhook(updated, origin, logger); err != nil {
+		logger.Errorf("failed to process yaml template webhook for update %s, err: %s", updated.Name, err)
+	}
+	return nil
 }
 
 func UpdateYamlTemplateVariable(id string, template *template.YamlTemplate, logger *zap.SugaredLogger) error {
@@ -864,11 +876,22 @@ func DeleteYamlTemplate(id string, logger *zap.SugaredLogger) error {
 		return errors.New("this template is in use")
 	}
 
+	origin, err := commonrepo.NewYamlTemplateColl().GetById(id)
+	if err != nil {
+		logger.Errorf("Failed to get yaml template of id: %s, the error is: %s", id, err)
+		return err
+	}
+
 	err = commonrepo.NewYamlTemplateColl().DeleteByID(id)
 	if err != nil {
-		logger.Errorf("Failed to delete dockerfile template of id: %s, the error is: %s", id, err)
+		logger.Errorf("Failed to delete yaml template of id: %s, the error is: %s", id, err)
+		return err
 	}
-	return err
+
+	if err := commmonservice.ProcessYamlTemplateWebhook(nil, origin, logger); err != nil {
+		logger.Errorf("failed to process yaml template webhook for delete %s, err: %s", origin.Name, err)
+	}
+	return nil
 }
 
 func SyncYamlTemplateReference(userName, id string, logger *zap.SugaredLogger) error {

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gerrit.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gerrit.go
@@ -40,9 +40,11 @@ import (
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/command"
 	gerritservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/gerrit"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/repository"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/template"
 	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	environmentservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/environment/service"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/service/service"
+	templateservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/templatestore/service"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/shared/client/systemconfig"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
@@ -75,6 +77,10 @@ func ProcessGerritHook(payload []byte, req *http.Request, requestID string, log 
 		err := updateServiceTemplateByGerritEvent(req.RequestURI, log)
 		if err != nil {
 			log.Errorf("updateServiceTemplateByGerritEvent err : %v", err)
+		}
+		err = updateYamlTemplateByGerritEvent(req.RequestURI, log)
+		if err != nil {
+			log.Errorf("updateYamlTemplateByGerritEvent err : %v", err)
 		}
 	}
 	var wg sync.WaitGroup
@@ -198,6 +204,128 @@ func updateServiceTemplateByGerritEvent(uri string, log *zap.SugaredLogger) erro
 	}
 
 	return errs.ErrorOrNil()
+}
+
+func updateYamlTemplateByGerritEvent(uri string, log *zap.SugaredLogger) error {
+	templates, err := commonrepo.NewYamlTemplateColl().ListBySource(setting.SourceFromGerrit)
+	if err != nil {
+		return err
+	}
+
+	errs := &multierror.Error{}
+	for _, tmpl := range templates {
+		if tmpl == nil || tmpl.Source != setting.SourceFromGerrit {
+			continue
+		}
+		if strings.Contains(uri, "?") && !strings.Contains(uri, tmpl.Name) {
+			continue
+		}
+
+		log.Infof("Started to sync yaml template %s from gerrit path %s", tmpl.Name, tmpl.Path)
+		if err := SyncYamlTemplateFromGerrit(tmpl, log); err != nil {
+			log.Errorf("failed to sync yaml template %s from gerrit, error: %v", tmpl.Name, err)
+			errs = multierror.Append(errs, err)
+		}
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func SyncYamlTemplateFromGerrit(tmpl *commonmodels.YamlTemplate, log *zap.SugaredLogger) error {
+	if tmpl.Source != setting.SourceFromGerrit {
+		return fmt.Errorf("yaml template is not from gerrit")
+	}
+
+	var before string
+	if tmpl.Commit != nil {
+		before = tmpl.Commit.SHA
+	}
+
+	ch, err := systemconfig.New().GetCodeHost(tmpl.CodeHostID)
+	if err != nil {
+		return err
+	}
+
+	remoteName := tmpl.RemoteName
+	if remoteName == "" {
+		remoteName = "origin"
+	}
+
+	gerritCli := gerrit.NewClient(ch.Address, ch.AccessToken, config.ProxyHTTPSAddr(), ch.EnableProxy)
+	commit, err := gerritCli.GetCommitByBranch(tmpl.RepoName, tmpl.BranchName)
+	if err != nil {
+		return err
+	}
+
+	tmpl.Commit = &commonmodels.Commit{
+		SHA:     commit.Commit,
+		Message: commit.Message,
+	}
+
+	if before == tmpl.Commit.SHA {
+		log.Infof("Before and after SHA: %s remains the same, no need to sync, source:%s", before, tmpl.Source)
+		return nil
+	}
+
+	if err := command.RunGitCmds(ch, setting.GerritDefaultOwner, setting.GerritDefaultOwner, tmpl.RepoName, tmpl.BranchName, remoteName); err != nil {
+		return err
+	}
+
+	base, err := GetGerritWorkspaceBasePath(tmpl.RepoName)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	fullPath := path.Join(base, tmpl.Path)
+	content := ""
+	if tmpl.LoadFromDir {
+		fileInfos, err := ioutil.ReadDir(fullPath)
+		if err != nil {
+			return err
+		}
+
+		files := make([]string, 0)
+		for _, fileInfo := range fileInfos {
+			if fileInfo.IsDir() || !commonutil.IsYaml(fileInfo.Name()) {
+				continue
+			}
+			file, err := os.ReadFile(path.Join(fullPath, fileInfo.Name()))
+			if err != nil {
+				return err
+			}
+			files = append(files, string(file))
+		}
+		if len(files) == 0 {
+			return fmt.Errorf("no yaml file is found under directory %s", tmpl.Path)
+		}
+		content = util.CombineManifests(files)
+	} else {
+		file, err := os.ReadFile(fullPath)
+		if err != nil {
+			return err
+		}
+		content = string(file)
+	}
+
+	if err := templateservice.UpdateYamlTemplate(tmpl.ID.Hex(), &template.YamlTemplate{
+		Name:        tmpl.Name,
+		Content:     content,
+		Source:      tmpl.Source,
+		CodehostID:  tmpl.CodeHostID,
+		RepoOwner:   tmpl.RepoOwner,
+		Namespace:   tmpl.Namespace,
+		RepoName:    tmpl.RepoName,
+		Path:        tmpl.Path,
+		BranchName:  tmpl.BranchName,
+		RemoteName:  tmpl.RemoteName,
+		LoadFromDir: tmpl.LoadFromDir,
+		Commit:      tmpl.Commit,
+	}, log); err != nil {
+		return err
+	}
+
+	log.Infof("End of sync yaml template %s from gerrit path %s", tmpl.Name, tmpl.Path)
+	return nil
 }
 
 func GetGerritWorkspaceBasePath(repoName string) (string, error) {

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitee.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitee.go
@@ -32,14 +32,18 @@ import (
 	"github.com/otiai10/copy"
 	"go.uber.org/zap"
 
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	microserviceConfig "github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	commonservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/command"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/repository"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/template"
+	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	environmentservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/environment/service"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/service/service"
+	templateservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/templatestore/service"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/shared/client/systemconfig"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
@@ -85,6 +89,9 @@ func ProcessGiteeHook(payload []byte, req *http.Request, requestID string, log *
 
 		// FIXME: this func maybe panic if any errors occurred, just like gitee token expired
 		if err := updateServiceTemplateByGiteeEvent(req.RequestURI, log); err != nil {
+			errorList = multierror.Append(errorList, err)
+		}
+		if err := updateYamlTemplateByGiteePush(event, log); err != nil {
 			errorList = multierror.Append(errorList, err)
 		}
 		// build webhook
@@ -294,6 +301,153 @@ func updateServiceTemplateByGiteeEvent(uri string, log *zap.SugaredLogger) error
 	}
 
 	return errs.ErrorOrNil()
+}
+
+func updateYamlTemplateByGiteePush(pushEvent *gitee.PushEvent, log *zap.SugaredLogger) error {
+	changeFiles := make([]string, 0)
+	for _, commit := range pushEvent.Commits {
+		changeFiles = append(changeFiles, commit.Added...)
+		changeFiles = append(changeFiles, commit.Removed...)
+		changeFiles = append(changeFiles, commit.Modified...)
+	}
+
+	templates, _, err := commonrepo.NewYamlTemplateColl().List(0, 0)
+	if err != nil {
+		return err
+	}
+
+	errs := &multierror.Error{}
+	for _, tmpl := range templates {
+		if tmpl == nil || (tmpl.Source != setting.SourceFromGitee && tmpl.Source != setting.SourceFromGiteeEE) {
+			continue
+		}
+		namespace := tmpl.Namespace
+		if namespace == "" {
+			namespace = tmpl.RepoOwner
+		}
+		if namespace+"/"+tmpl.RepoName != pushEvent.Repository.PathWithNamespace {
+			continue
+		}
+		if strings.TrimPrefix(pushEvent.Ref, "refs/heads/") != tmpl.BranchName {
+			continue
+		}
+
+		affected := len(changeFiles) == 0
+		for _, changeFile := range changeFiles {
+			if subElem(tmpl.Path, changeFile) {
+				affected = true
+				break
+			}
+		}
+		if affected {
+			log.Infof("Started to sync yaml template %s from gitee path %s", tmpl.Name, tmpl.Path)
+			if err := SyncYamlTemplateFromGitee(tmpl, log); err != nil {
+				log.Errorf("failed to sync yaml template %s from gitee, error: %v", tmpl.Name, err)
+				errs = multierror.Append(errs, err)
+			}
+		} else {
+			log.Infof("Yaml template %s from gitee %s is not affected, no sync", tmpl.Name, tmpl.Path)
+		}
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func SyncYamlTemplateFromGitee(tmpl *commonmodels.YamlTemplate, log *zap.SugaredLogger) error {
+	if tmpl.Source != setting.SourceFromGitee && tmpl.Source != setting.SourceFromGiteeEE {
+		return fmt.Errorf("yaml template is not from gitee")
+	}
+
+	var before string
+	if tmpl.Commit != nil {
+		before = tmpl.Commit.SHA
+	}
+
+	ch, err := systemconfig.New().GetCodeHost(tmpl.CodeHostID)
+	if err != nil {
+		return err
+	}
+
+	namespace := tmpl.Namespace
+	if namespace == "" {
+		namespace = tmpl.RepoOwner
+	}
+
+	giteeCli := gitee.NewClient(ch.ID, ch.Address, ch.AccessToken, config.ProxyHTTPSAddr(), ch.EnableProxy)
+	branch, err := giteeCli.GetSingleBranch(ch.Address, ch.AccessToken, tmpl.RepoOwner, tmpl.RepoName, tmpl.BranchName)
+	if err != nil {
+		return err
+	}
+
+	tmpl.Commit = &commonmodels.Commit{
+		SHA:     branch.Commit.Sha,
+		Message: branch.Commit.Commit.Message,
+	}
+
+	if before == tmpl.Commit.SHA {
+		log.Infof("Before and after SHA: %s remains the same, no need to sync, source:%s", before, tmpl.Source)
+		return nil
+	}
+
+	if err := command.RunGitCmds(ch, tmpl.RepoOwner, namespace, tmpl.RepoName, tmpl.BranchName, "origin"); err != nil {
+		return err
+	}
+
+	base, err := GetWorkspaceBasePath(tmpl.RepoName)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	fullPath := path.Join(base, tmpl.Path)
+	content := ""
+	if tmpl.LoadFromDir {
+		fileInfos, err := ioutil.ReadDir(fullPath)
+		if err != nil {
+			return err
+		}
+
+		files := make([]string, 0)
+		for _, fileInfo := range fileInfos {
+			if fileInfo.IsDir() || !commonutil.IsYaml(fileInfo.Name()) {
+				continue
+			}
+			file, err := os.ReadFile(path.Join(fullPath, fileInfo.Name()))
+			if err != nil {
+				return err
+			}
+			files = append(files, string(file))
+		}
+		if len(files) == 0 {
+			return fmt.Errorf("no yaml file is found under directory %s", tmpl.Path)
+		}
+		content = util.CombineManifests(files)
+	} else {
+		file, err := os.ReadFile(fullPath)
+		if err != nil {
+			return err
+		}
+		content = string(file)
+	}
+
+	if err := templateservice.UpdateYamlTemplate(tmpl.ID.Hex(), &template.YamlTemplate{
+		Name:        tmpl.Name,
+		Content:     content,
+		Source:      tmpl.Source,
+		CodehostID:  tmpl.CodeHostID,
+		RepoOwner:   tmpl.RepoOwner,
+		Namespace:   tmpl.Namespace,
+		RepoName:    tmpl.RepoName,
+		Path:        tmpl.Path,
+		BranchName:  tmpl.BranchName,
+		RemoteName:  tmpl.RemoteName,
+		LoadFromDir: tmpl.LoadFromDir,
+		Commit:      tmpl.Commit,
+	}, log); err != nil {
+		return err
+	}
+
+	log.Infof("End of sync yaml template %s from gitee path %s", tmpl.Name, tmpl.Path)
+	return nil
 }
 
 // GetGiteeTestingServiceTemplates Get all service templates maintained in gitee

--- a/pkg/microservice/aslan/core/workflow/service/webhook/github.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github.go
@@ -32,6 +32,8 @@ import (
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/template"
+	templateservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/templatestore/service"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/shared/client/systemconfig"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
@@ -308,6 +310,11 @@ func ProcessGithubWebHook(payload []byte, req *http.Request, requestID string, l
 		// sync service template
 		if err = updateServiceTemplateByGithubPush(et, log); err != nil {
 			log.Errorf("updateServiceTemplateByGithubPush failed, error:%v", err)
+		}
+
+		// sync yaml template
+		if err = updateYamlTemplateByGithubPush(et, log); err != nil {
+			log.Errorf("updateYamlTemplateByGithubPush failed, error:%v", err)
 		}
 
 		// sync service template helm values
@@ -755,5 +762,156 @@ func SyncServiceTemplateHelmValuesFromGithub(service *commonmodels.Service, late
 	}
 
 	log.Infof("End of sync service template %s's helm values from github path %s", service.ServiceName, sourceFrom.LoadPath)
+	return nil
+}
+
+func updateYamlTemplateByGithubPush(pushEvent *github.PushEvent, log *zap.SugaredLogger) error {
+
+	changeFiles := make([]string, 0)
+	for _, commit := range pushEvent.Commits {
+		changeFiles = append(changeFiles, commit.Added...)
+		changeFiles = append(changeFiles, commit.Removed...)
+		changeFiles = append(changeFiles, commit.Modified...)
+	}
+
+	latestCommitID := *pushEvent.After
+	latestCommitMessage := ""
+	for _, commit := range pushEvent.Commits {
+		if *commit.ID == latestCommitID {
+			latestCommitMessage = *commit.Message
+			break
+		}
+	}
+
+	templates, err := commonrepo.NewYamlTemplateColl().ListBySource(setting.SourceFromGithub)
+	if err != nil {
+		log.Errorf("Failed to get github yaml templates, error: %v", err)
+		return fmt.Errorf("failed to get github yaml templates: %w", err)
+	}
+
+	errs := &multierror.Error{}
+	for _, tmpl := range templates {
+
+		namespace := tmpl.Namespace
+		if namespace == "" {
+			namespace = tmpl.RepoOwner
+		}
+
+		// 判断 PushEvent 的 Repo 和 Branch 是否匹配该 yaml 模板
+		if namespace+"/"+tmpl.RepoName != pushEvent.GetRepo().GetFullName() {
+			continue
+		}
+		if strings.TrimPrefix(pushEvent.GetRef(), "refs/heads/") != tmpl.BranchName {
+			continue
+		}
+
+		affected := false
+		for _, changeFile := range changeFiles {
+			if subElem(tmpl.Path, changeFile) {
+				affected = true
+				break
+			}
+		}
+		if affected {
+			log.Infof("Started to sync yaml template %s from github %s", tmpl.Name, tmpl.Path)
+			if err := SyncYamlTemplateFromGithub(tmpl, latestCommitID, latestCommitMessage, log); err != nil {
+				log.Errorf("SyncYamlTemplateFromGithub failed, error: %v", err)
+				errs = multierror.Append(errs, err)
+			}
+		} else {
+			log.Infof("Yaml template %s from github %s is not affected, no sync", tmpl.Name, tmpl.Path)
+		}
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func SyncYamlTemplateFromGithub(tmpl *commonmodels.YamlTemplate, latestCommitID, latestCommitMessage string, log *zap.SugaredLogger) error {
+	if tmpl.Source != setting.SourceFromGithub {
+		log.Error("YAML template is not from github")
+		return errors.New("yaml template is not from github")
+	}
+
+	var before string
+	if tmpl.Commit != nil {
+		before = tmpl.Commit.SHA
+	}
+
+	tmpl.Commit = &commonmodels.Commit{
+		SHA:     latestCommitID,
+		Message: latestCommitMessage,
+	}
+
+	if before == latestCommitID {
+		log.Infof("Before and after SHA: %s remains the same, no need to sync, source:%s", before, tmpl.Source)
+		return nil
+	}
+
+	ch, err := systemconfig.New().GetCodeHost(tmpl.CodeHostID)
+	if err != nil {
+		log.Errorf("failed to get codehost %d, err: %s", tmpl.CodeHostID, err)
+		return err
+	}
+
+	namespace := tmpl.Namespace
+	if namespace == "" {
+		namespace = tmpl.RepoOwner
+	}
+
+	gc := githubtool.NewClient(&githubtool.Config{AccessToken: ch.AccessToken, Proxy: config.ProxyHTTPSAddr()})
+	fileContent, directoryContent, err := gc.GetContents(context.TODO(), namespace, tmpl.RepoName, tmpl.Path, &github.RepositoryContentGetOptions{Ref: tmpl.BranchName})
+	if err != nil {
+		return err
+	}
+
+	content := ""
+	if fileContent != nil {
+		content, err = fileContent.GetContent()
+		if err != nil {
+			return err
+		}
+	} else {
+		files := make([]string, 0)
+		for _, f := range directoryContent {
+			if f.GetType() != "file" {
+				continue
+			}
+			fileName := strings.ToLower(f.GetPath())
+			if !strings.HasSuffix(fileName, ".yaml") && !strings.HasSuffix(fileName, ".yml") {
+				continue
+			}
+
+			file, err := syncSingleFileFromGithub(namespace, tmpl.RepoName, tmpl.BranchName, f.GetPath(), ch.AccessToken)
+			if err != nil {
+				log.Errorf("syncSingleFileFromGithub failed, path: %s, err: %v", f.GetPath(), err)
+				continue
+			}
+			files = append(files, file)
+		}
+		if len(files) == 0 {
+			return fmt.Errorf("no yaml file is found under directory %s", tmpl.Path)
+		}
+		content = util.JoinYamls(files)
+	}
+
+	if err := templateservice.UpdateYamlTemplate(tmpl.ID.Hex(), &template.YamlTemplate{
+		Name:        tmpl.Name,
+		Content:     content,
+		Source:      tmpl.Source,
+		CodehostID:  tmpl.CodeHostID,
+		RepoOwner:   tmpl.RepoOwner,
+		Namespace:   tmpl.Namespace,
+		RepoName:    tmpl.RepoName,
+		Path:        tmpl.Path,
+		BranchName:  tmpl.BranchName,
+		RemoteName:  tmpl.RemoteName,
+		LoadFromDir: tmpl.LoadFromDir,
+		Commit:      tmpl.Commit,
+	}, log); err != nil {
+		log.Errorf("update yaml template error: %s", err)
+		return err
+	}
+
+	log.Infof("End of sync yaml template %s from github path %s", tmpl.Name, tmpl.Path)
 	return nil
 }

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -30,6 +31,8 @@ import (
 	"github.com/koderover/zadig/v2/pkg/config"
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/template"
+	templateservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/templatestore/service"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
 	"github.com/koderover/zadig/v2/pkg/tool/log"
@@ -92,6 +95,9 @@ func ProcessGitlabHook(payload []byte, req *http.Request, requestID string, log 
 		pathWithNamespace := pushEvent.Project.PathWithNamespace
 		// trigger service template to re-sync from remote repo
 		if err = updateServiceTemplateByPushEvent(pushEvent.Ref, changeFiles, pathWithNamespace, log); err != nil {
+			errorList = multierror.Append(errorList, err)
+		}
+		if err = updateYamlTemplateByGitlabPush(pushEvent.Ref, changeFiles, pathWithNamespace, log); err != nil {
 			errorList = multierror.Append(errorList, err)
 		}
 		if err = updateServiceTemplateValuesByPushEvent(pushEvent.Ref, changeFiles, pathWithNamespace, log); err != nil {
@@ -325,6 +331,122 @@ func updateServiceTemplateByPushEvent(ref string, diffs []string, pathWithNamesp
 	}
 
 	return errs.ErrorOrNil()
+}
+
+func updateYamlTemplateByGitlabPush(ref string, diffs []string, pathWithNamespace string, log *zap.SugaredLogger) error {
+	templates, err := commonrepo.NewYamlTemplateColl().ListBySource(setting.SourceFromGitlab)
+	if err != nil {
+		return err
+	}
+
+	errs := &multierror.Error{}
+	for _, tmpl := range templates {
+		if tmpl == nil || tmpl.Source != setting.SourceFromGitlab {
+			continue
+		}
+		namespace := tmpl.Namespace
+		if namespace == "" {
+			namespace = tmpl.RepoOwner
+		}
+		if namespace+"/"+tmpl.RepoName != pathWithNamespace {
+			continue
+		}
+		if strings.TrimPrefix(ref, "refs/heads/") != tmpl.BranchName {
+			continue
+		}
+
+		affected := len(diffs) == 0
+		for _, diff := range diffs {
+			if subElem(tmpl.Path, diff) {
+				affected = true
+				break
+			}
+		}
+		if affected {
+			log.Infof("Started to sync yaml template %s from gitlab path %s", tmpl.Name, tmpl.Path)
+			if err := SyncYamlTemplateFromGitlab(tmpl, log); err != nil {
+				log.Errorf("failed to sync yaml template %s from gitlab, error: %v", tmpl.Name, err)
+				errs = multierror.Append(errs, err)
+			}
+		} else {
+			log.Infof("Yaml template %s from gitlab %s is not affected, no sync", tmpl.Name, tmpl.Path)
+		}
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func SyncYamlTemplateFromGitlab(tmpl *commonmodels.YamlTemplate, log *zap.SugaredLogger) error {
+	if tmpl.Source != setting.SourceFromGitlab {
+		return fmt.Errorf("yaml template is not from gitlab")
+	}
+
+	var before string
+	if tmpl.Commit != nil {
+		before = tmpl.Commit.SHA
+	}
+
+	client, err := getGitlabClientByCodehostId(tmpl.CodeHostID)
+	if err != nil {
+		return err
+	}
+
+	namespace := tmpl.Namespace
+	if namespace == "" {
+		namespace = tmpl.RepoOwner
+	}
+
+	commit, err := GitlabGetLatestCommit(client, namespace, tmpl.RepoName, tmpl.BranchName, tmpl.Path)
+	if err != nil {
+		return err
+	}
+
+	tmpl.Commit = &commonmodels.Commit{
+		SHA:     commit.ID,
+		Message: commit.Message,
+	}
+
+	if before == tmpl.Commit.SHA {
+		log.Infof("Before and after SHA: %s remains the same, no need to sync", before)
+		return nil
+	}
+
+	pathType := "blob"
+	if tmpl.LoadFromDir {
+		pathType = "tree"
+	}
+	files, err := GitlabGetRawFiles(client, namespace, tmpl.RepoName, tmpl.BranchName, tmpl.Path, pathType)
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("no yaml file is found under directory %s", tmpl.Path)
+	}
+
+	content := util.JoinYamls(files)
+	if pathType == "blob" {
+		content = files[0]
+	}
+
+	if err := templateservice.UpdateYamlTemplate(tmpl.ID.Hex(), &template.YamlTemplate{
+		Name:        tmpl.Name,
+		Content:     content,
+		Source:      tmpl.Source,
+		CodehostID:  tmpl.CodeHostID,
+		RepoOwner:   tmpl.RepoOwner,
+		Namespace:   tmpl.Namespace,
+		RepoName:    tmpl.RepoName,
+		Path:        tmpl.Path,
+		BranchName:  tmpl.BranchName,
+		RemoteName:  tmpl.RemoteName,
+		LoadFromDir: tmpl.LoadFromDir,
+		Commit:      tmpl.Commit,
+	}, log); err != nil {
+		return err
+	}
+
+	log.Infof("End of sync yaml template %s from gitlab path %s", tmpl.Name, tmpl.Path)
+	return nil
 }
 
 func GetGitlabTestingServiceTemplates() ([]*commonmodels.Service, error) {

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab.go
@@ -50,6 +50,7 @@ type EventPush struct {
 }
 
 func ProcessGitlabHook(payload []byte, req *http.Request, requestID string, log *zap.SugaredLogger) error {
+	start := time.Now()
 	token := req.Header.Get("X-Gitlab-Token")
 	secret := util.GetGitHookSecret()
 
@@ -58,10 +59,12 @@ func ProcessGitlabHook(payload []byte, req *http.Request, requestID string, log 
 	}
 
 	eventType := gitlab.HookEventType(req)
+	parseStart := time.Now()
 	event, err := gitlab.ParseHook(eventType, payload)
 	if err != nil {
 		return err
 	}
+	log.Infof("gitlab webhook parsed event type %s in %s", eventType, time.Since(parseStart))
 
 	baseURI := config.SystemAddress()
 	var pushEvent *gitlab.PushEvent
@@ -71,12 +74,14 @@ func ProcessGitlabHook(payload []byte, req *http.Request, requestID string, log 
 
 	switch event.(type) {
 	case *gitlab.PushSystemEvent:
+		parsePushSystemEventStart := time.Now()
 		if ev, err := gitlab.ParseWebhook(gitlab.EventTypePush, payload); err != nil {
 			errorList = multierror.Append(errorList, err)
 		} else {
 			event = ev
 			eventType = gitlab.EventTypePush
 		}
+		log.Infof("gitlab webhook parsed push system event in %s", time.Since(parsePushSystemEventStart))
 	case *gitlab.MergeEvent:
 		if eventType == gitlab.EventTypeSystemHook {
 			eventType = gitlab.EventTypeMergeRequest
@@ -86,23 +91,31 @@ func ProcessGitlabHook(payload []byte, req *http.Request, requestID string, log 
 	switch event := event.(type) {
 	case *gitlab.PushEvent:
 		pushEvent = event
+		pushEventStart := time.Now()
 		changeFiles := make([]string, 0)
 		for _, commit := range pushEvent.Commits {
 			changeFiles = append(changeFiles, commit.Added...)
 			changeFiles = append(changeFiles, commit.Removed...)
 			changeFiles = append(changeFiles, commit.Modified...)
 		}
+		log.Infof("gitlab webhook collected %d changed files in %s", len(changeFiles), time.Since(pushEventStart))
 		pathWithNamespace := pushEvent.Project.PathWithNamespace
 		// trigger service template to re-sync from remote repo
+		serviceSyncStart := time.Now()
 		if err = updateServiceTemplateByPushEvent(pushEvent.Ref, changeFiles, pathWithNamespace, log); err != nil {
 			errorList = multierror.Append(errorList, err)
 		}
-		if err = updateYamlTemplateByGitlabPush(pushEvent.Ref, changeFiles, pathWithNamespace, log); err != nil {
-			errorList = multierror.Append(errorList, err)
-		}
+		log.Infof("gitlab webhook updateServiceTemplateByPushEvent cost %s", time.Since(serviceSyncStart))
+		valuesSyncStart := time.Now()
 		if err = updateServiceTemplateValuesByPushEvent(pushEvent.Ref, changeFiles, pathWithNamespace, log); err != nil {
 			errorList = multierror.Append(errorList, err)
 		}
+		log.Infof("gitlab webhook updateServiceTemplateValuesByPushEvent cost %s", time.Since(valuesSyncStart))
+		yamlSyncStart := time.Now()
+		if err = updateYamlTemplateByGitlabPush(pushEvent.Ref, changeFiles, pathWithNamespace, log); err != nil {
+			errorList = multierror.Append(errorList, err)
+		}
+		log.Infof("gitlab webhook updateYamlTemplateByGitlabPush cost %s", time.Since(yamlSyncStart))
 	case *gitlab.MergeEvent:
 		mergeEvent = event
 	case *gitlab.TagEvent:
@@ -129,25 +142,31 @@ func ProcessGitlabHook(payload []byte, req *http.Request, requestID string, log 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			triggerTestStart := time.Now()
 			if err = TriggerTestByGitlabEvent(pushEvent, baseURI, requestID, log); err != nil {
 				errorList = multierror.Append(errorList, err)
 			}
+			log.Infof("gitlab webhook TriggerTestByGitlabEvent push cost %s", time.Since(triggerTestStart))
 		}()
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			triggerScanningStart := time.Now()
 			if err = TriggerScanningByGitlabEvent(pushEvent, baseURI, requestID, log); err != nil {
 				errorList = multierror.Append(errorList, err)
 			}
+			log.Infof("gitlab webhook TriggerScanningByGitlabEvent push cost %s", time.Since(triggerScanningStart))
 		}()
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			triggerWorkflowV4Start := time.Now()
 			if err = TriggerWorkflowV4ByGitlabEvent(pushEvent, baseURI, requestID, log); err != nil {
 				errorList = multierror.Append(errorList, err)
 			}
+			log.Infof("gitlab webhook TriggerWorkflowV4ByGitlabEvent push cost %s", time.Since(triggerWorkflowV4Start))
 		}()
 	}
 
@@ -156,25 +175,31 @@ func ProcessGitlabHook(payload []byte, req *http.Request, requestID string, log 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			triggerTestStart := time.Now()
 			if err = TriggerTestByGitlabEvent(mergeEvent, baseURI, requestID, log); err != nil {
 				errorList = multierror.Append(errorList, err)
 			}
+			log.Infof("gitlab webhook TriggerTestByGitlabEvent merge cost %s", time.Since(triggerTestStart))
 		}()
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			triggerScanningStart := time.Now()
 			if err = TriggerScanningByGitlabEvent(mergeEvent, baseURI, requestID, log); err != nil {
 				errorList = multierror.Append(errorList, err)
 			}
+			log.Infof("gitlab webhook TriggerScanningByGitlabEvent merge cost %s", time.Since(triggerScanningStart))
 		}()
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			triggerWorkflowV4Start := time.Now()
 			if err = TriggerWorkflowV4ByGitlabEvent(mergeEvent, baseURI, requestID, log); err != nil {
 				errorList = multierror.Append(errorList, err)
 			}
+			log.Infof("gitlab webhook TriggerWorkflowV4ByGitlabEvent merge cost %s", time.Since(triggerWorkflowV4Start))
 		}()
 	}
 
@@ -183,29 +208,38 @@ func ProcessGitlabHook(payload []byte, req *http.Request, requestID string, log 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			triggerTestStart := time.Now()
 			if err = TriggerTestByGitlabEvent(tagEvent, baseURI, requestID, log); err != nil {
 				errorList = multierror.Append(errorList, err)
 			}
+			log.Infof("gitlab webhook TriggerTestByGitlabEvent tag cost %s", time.Since(triggerTestStart))
 		}()
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			triggerScanningStart := time.Now()
 			if err = TriggerScanningByGitlabEvent(tagEvent, baseURI, requestID, log); err != nil {
 				errorList = multierror.Append(errorList, err)
 			}
+			log.Infof("gitlab webhook TriggerScanningByGitlabEvent tag cost %s", time.Since(triggerScanningStart))
 		}()
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			triggerWorkflowV4Start := time.Now()
 			if err = TriggerWorkflowV4ByGitlabEvent(tagEvent, baseURI, requestID, log); err != nil {
 				errorList = multierror.Append(errorList, err)
 			}
+			log.Infof("gitlab webhook TriggerWorkflowV4ByGitlabEvent tag cost %s", time.Since(triggerWorkflowV4Start))
 		}()
 	}
 
+	waitStart := time.Now()
 	wg.Wait()
+	log.Infof("gitlab webhook wait async tasks cost %s", time.Since(waitStart))
+	log.Infof("gitlab webhook total cost %s", time.Since(start))
 
 	return errorList.ErrorOrNil()
 }
@@ -334,6 +368,7 @@ func updateServiceTemplateByPushEvent(ref string, diffs []string, pathWithNamesp
 }
 
 func updateYamlTemplateByGitlabPush(ref string, diffs []string, pathWithNamespace string, log *zap.SugaredLogger) error {
+	start := time.Now()
 	templates, err := commonrepo.NewYamlTemplateColl().ListBySource(setting.SourceFromGitlab)
 	if err != nil {
 		return err
@@ -373,10 +408,12 @@ func updateYamlTemplateByGitlabPush(ref string, diffs []string, pathWithNamespac
 		}
 	}
 
+	log.Infof("gitlab webhook updateYamlTemplateByGitlabPush scanned %d templates in %s", len(templates), time.Since(start))
 	return errs.ErrorOrNil()
 }
 
 func SyncYamlTemplateFromGitlab(tmpl *commonmodels.YamlTemplate, log *zap.SugaredLogger) error {
+	start := time.Now()
 	if tmpl.Source != setting.SourceFromGitlab {
 		return fmt.Errorf("yaml template is not from gitlab")
 	}
@@ -396,10 +433,12 @@ func SyncYamlTemplateFromGitlab(tmpl *commonmodels.YamlTemplate, log *zap.Sugare
 		namespace = tmpl.RepoOwner
 	}
 
+	latestCommitStart := time.Now()
 	commit, err := GitlabGetLatestCommit(client, namespace, tmpl.RepoName, tmpl.BranchName, tmpl.Path)
 	if err != nil {
 		return err
 	}
+	log.Infof("gitlab webhook sync yaml template %s get latest commit cost %s", tmpl.Name, time.Since(latestCommitStart))
 
 	tmpl.Commit = &commonmodels.Commit{
 		SHA:     commit.ID,
@@ -415,10 +454,12 @@ func SyncYamlTemplateFromGitlab(tmpl *commonmodels.YamlTemplate, log *zap.Sugare
 	if tmpl.LoadFromDir {
 		pathType = "tree"
 	}
+	rawFilesStart := time.Now()
 	files, err := GitlabGetRawFiles(client, namespace, tmpl.RepoName, tmpl.BranchName, tmpl.Path, pathType)
 	if err != nil {
 		return err
 	}
+	log.Infof("gitlab webhook sync yaml template %s get raw files cost %s", tmpl.Name, time.Since(rawFilesStart))
 	if len(files) == 0 {
 		return fmt.Errorf("no yaml file is found under directory %s", tmpl.Path)
 	}
@@ -428,6 +469,7 @@ func SyncYamlTemplateFromGitlab(tmpl *commonmodels.YamlTemplate, log *zap.Sugare
 		content = files[0]
 	}
 
+	updateTemplateStart := time.Now()
 	if err := templateservice.UpdateYamlTemplate(tmpl.ID.Hex(), &template.YamlTemplate{
 		Name:        tmpl.Name,
 		Content:     content,
@@ -444,8 +486,9 @@ func SyncYamlTemplateFromGitlab(tmpl *commonmodels.YamlTemplate, log *zap.Sugare
 	}, log); err != nil {
 		return err
 	}
+	log.Infof("gitlab webhook sync yaml template %s update template cost %s", tmpl.Name, time.Since(updateTemplateStart))
 
-	log.Infof("End of sync yaml template %s from gitlab path %s", tmpl.Name, tmpl.Path)
+	log.Infof("End of sync yaml template %s from gitlab path %s, total cost %s", tmpl.Name, tmpl.Path, time.Since(start))
 	return nil
 }
 

--- a/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
@@ -20,9 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"sync"
 
@@ -672,17 +670,28 @@ func checkRepoNamespaceMatch(hookRepo *commonmodels.MainHookRepo, pathWithNamesp
 	return (hookRepo.GetRepoNamespace() + "/" + hookRepo.RepoName) == pathWithNamespace
 }
 
+func normalizeRepoRelativePath(p string) string {
+	p = strings.TrimSpace(strings.ReplaceAll(p, "\\", "/"))
+	if p == "" {
+		return ""
+	}
+	cleaned := path.Clean("/" + strings.TrimLeft(p, "/"))
+	if cleaned == "/" || cleaned == "." {
+		return ""
+	}
+	return strings.TrimPrefix(cleaned, "/")
+}
+
 // check if sub path is a part of parent path
 // eg: parent: k1/k2   sub: k1/k2/k3  return true
 // parent k1/k2-2  sub: k1/k2/k3 return false
 func subElem(parent, sub string) bool {
-	up := ".." + string(os.PathSeparator)
-	rel, err := filepath.Rel(parent, sub)
-	if err != nil {
-		log.Errorf("failed to check path is relative, parent: %s, sub: %s", parent, sub)
-		return false
+	parent = normalizeRepoRelativePath(parent)
+	sub = normalizeRepoRelativePath(sub)
+	if parent == "" {
+		return true
 	}
-	if !strings.HasPrefix(rel, up) && rel != ".." {
+	if sub == parent || strings.HasPrefix(sub, parent+"/") {
 		return true
 	}
 	return false


### PR DESCRIPTION
### What this PR does / Why we need it:

This PR adds codehost-based preload, load, and sync support for YAML templates in template store, and aligns the YAML template loading flow with the existing service loader implementation.

### What is changed and how it works?

This PR adds preload, load, and sync support for YAML templates from codehosts, with implementations for GitHub, GitLab, Gerrit, and Gitee.
Preload is used to scan the target repository path and return available YAML template candidates without creating anything. Load fetches YAML content from the selected codehost path and creates a new YAML template . 
Sync reloads the latest content from the original codehost path and updates the existing YAML template while preserving existing variable values through merge logic.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4637)
<!-- Reviewable:end -->
