### PR TITLE
delete relate deploy when delete vm service

### DIFF
--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -1005,6 +1005,22 @@ func DeleteServiceTemplate(serviceName, serviceType, productName string, product
 		if production {
 			return e.ErrDeleteTemplate.AddDesc("PM service type only support testing service")
 		}
+
+		// 删除与该PM服务关联的部署
+		deploy, err := commonrepo.NewDeployColl().Find(&commonrepo.DeployFindOption{
+			ProjectName: productName,
+			ServiceName: serviceName,
+		})
+		if err != nil && err != mongo.ErrNoDocuments {
+			log.Errorf("DeleteServiceTemplate: failed to find deploy for pm service %s/%s, err: %v", productName, serviceName, err)
+			return e.ErrDeleteTemplate.AddDesc(err.Error())
+		}
+		if deploy != nil {
+			if err := commonrepo.NewDeployColl().Delete(deploy.ProjectName, deploy.Name); err != nil {
+				log.Errorf("DeleteServiceTemplate: failed to delete deploy %s/%s for pm service %s, err: %v", deploy.ProjectName, deploy.Name, serviceName, err)
+				return e.ErrDeleteTemplate.AddDesc(err.Error())
+			}
+		}
 	}
 
 	err := repository.UpdateStatus(serviceName, productName, setting.ProductStatusDeleting, production)


### PR DESCRIPTION
### What this PR does / Why we need it:
delete relate deploy when delete vm service

### What is changed and how it works?
delete relate deploy when delete vm service

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4639)
<!-- Reviewable:end -->
