### PR TITLE
feat: support manual execution stage notification in workflow notify controls

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -134,12 +134,14 @@ type WorkflowStage struct {
 }
 
 type ManualExec struct {
-	Enabled           bool    `bson:"enabled"                        yaml:"enabled"                       json:"enabled"`
-	ModifyParams      bool    `bson:"modify_params"                  yaml:"modify_params"                 json:"modify_params"`
-	Excuted           bool    `bson:"excuted,omitempty"              yaml:"excuted,omitempty"             json:"excuted,omitempty"`
-	ManualExecUsers   []*User `bson:"manual_exec_users"              yaml:"manual_exec_users"             json:"manual_exec_users"`
-	ManualExectorID   string  `bson:"manual_exector_id,omitempty"    yaml:"manual_exector_id,omitempty"   json:"manual_exector_id,omitempty"`
-	ManualExectorName string  `bson:"manual_exector_name,omitempty"  yaml:"manual_exector_name,omitempty" json:"manual_exector_name,omitempty"`
+	Enabled                      bool                          `bson:"enabled"                          yaml:"enabled"                          json:"enabled"`
+	ModifyParams                 bool                          `bson:"modify_params"                    yaml:"modify_params"                    json:"modify_params"`
+	Excuted                      bool                          `bson:"excuted,omitempty"                yaml:"excuted,omitempty"                json:"excuted,omitempty"`
+	ManualExecUsers              []*User                       `bson:"manual_exec_users"                yaml:"manual_exec_users"                json:"manual_exec_users"`
+	LarkPersonNotificationConfig *LarkPersonNotificationConfig `bson:"lark_person_notification_config,omitempty" yaml:"lark_person_notification_config,omitempty" json:"lark_person_notification_config,omitempty"`
+	NotificationSent             bool                          `bson:"notification_sent,omitempty"      yaml:"notification_sent,omitempty"      json:"notification_sent,omitempty"`
+	ManualExectorID              string                        `bson:"manual_exector_id,omitempty"      yaml:"manual_exector_id,omitempty"      json:"manual_exector_id,omitempty"`
+	ManualExectorName            string                        `bson:"manual_exector_name,omitempty"    yaml:"manual_exector_name,omitempty"    json:"manual_exector_name,omitempty"`
 }
 
 type Approval struct {

--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -134,14 +134,12 @@ type WorkflowStage struct {
 }
 
 type ManualExec struct {
-	Enabled                      bool                          `bson:"enabled"                          yaml:"enabled"                          json:"enabled"`
-	ModifyParams                 bool                          `bson:"modify_params"                    yaml:"modify_params"                    json:"modify_params"`
-	Excuted                      bool                          `bson:"excuted,omitempty"                yaml:"excuted,omitempty"                json:"excuted,omitempty"`
-	ManualExecUsers              []*User                       `bson:"manual_exec_users"                yaml:"manual_exec_users"                json:"manual_exec_users"`
-	LarkPersonNotificationConfig *LarkPersonNotificationConfig `bson:"lark_person_notification_config,omitempty" yaml:"lark_person_notification_config,omitempty" json:"lark_person_notification_config,omitempty"`
-	NotificationSent             bool                          `bson:"notification_sent,omitempty"      yaml:"notification_sent,omitempty"      json:"notification_sent,omitempty"`
-	ManualExectorID              string                        `bson:"manual_exector_id,omitempty"      yaml:"manual_exector_id,omitempty"      json:"manual_exector_id,omitempty"`
-	ManualExectorName            string                        `bson:"manual_exector_name,omitempty"    yaml:"manual_exector_name,omitempty"    json:"manual_exector_name,omitempty"`
+	Enabled           bool    `bson:"enabled"                       yaml:"enabled"                       json:"enabled"`
+	ModifyParams      bool    `bson:"modify_params"                 yaml:"modify_params"                 json:"modify_params"`
+	Excuted           bool    `bson:"excuted,omitempty"             yaml:"excuted,omitempty"             json:"excuted,omitempty"`
+	ManualExecUsers   []*User `bson:"manual_exec_users"             yaml:"manual_exec_users"             json:"manual_exec_users"`
+	ManualExectorID   string  `bson:"manual_exector_id,omitempty"   yaml:"manual_exector_id,omitempty"   json:"manual_exector_id,omitempty"`
+	ManualExectorName string  `bson:"manual_exector_name,omitempty" yaml:"manual_exector_name,omitempty" json:"manual_exector_name,omitempty"`
 }
 
 type Approval struct {

--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -134,12 +134,14 @@ type WorkflowStage struct {
 }
 
 type ManualExec struct {
-	Enabled           bool    `bson:"enabled"                       yaml:"enabled"                       json:"enabled"`
-	ModifyParams      bool    `bson:"modify_params"                 yaml:"modify_params"                 json:"modify_params"`
-	Excuted           bool    `bson:"excuted,omitempty"             yaml:"excuted,omitempty"             json:"excuted,omitempty"`
-	ManualExecUsers   []*User `bson:"manual_exec_users"             yaml:"manual_exec_users"             json:"manual_exec_users"`
-	ManualExectorID   string  `bson:"manual_exector_id,omitempty"   yaml:"manual_exector_id,omitempty"   json:"manual_exector_id,omitempty"`
-	ManualExectorName string  `bson:"manual_exector_name,omitempty" yaml:"manual_exector_name,omitempty" json:"manual_exector_name,omitempty"`
+	Enabled                      bool                          `bson:"enabled"                          yaml:"enabled"                          json:"enabled"`
+	ModifyParams                 bool                          `bson:"modify_params"                    yaml:"modify_params"                    json:"modify_params"`
+	Excuted                      bool                          `bson:"excuted,omitempty"                yaml:"excuted,omitempty"                json:"excuted,omitempty"`
+	ManualExecUsers              []*User                       `bson:"manual_exec_users"                yaml:"manual_exec_users"                json:"manual_exec_users"`
+	LarkPersonNotificationConfig *LarkPersonNotificationConfig `bson:"lark_person_notification_config,omitempty" yaml:"lark_person_notification_config,omitempty" json:"lark_person_notification_config,omitempty"`
+	NotificationSent             bool                          `bson:"notification_sent,omitempty"      yaml:"notification_sent,omitempty"      json:"notification_sent,omitempty"`
+	ManualExectorID              string                        `bson:"manual_exector_id,omitempty"      yaml:"manual_exector_id,omitempty"      json:"manual_exector_id,omitempty"`
+	ManualExectorName            string                        `bson:"manual_exector_name,omitempty"    yaml:"manual_exector_name,omitempty"    json:"manual_exector_name,omitempty"`
 }
 
 type Approval struct {

--- a/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
@@ -550,18 +550,10 @@ func formatManualExecStageJobs(stage *models.StageTask, language string) string 
 		return ""
 	}
 
-	const maxJobsShown = 5
-	lines := make([]string, 0, maxJobsShown+1)
-	for idx, job := range stage.Jobs {
+	lines := make([]string, 0, len(stage.Jobs))
+	for _, job := range stage.Jobs {
 		if job == nil {
 			continue
-		}
-		if len(lines) >= maxJobsShown {
-			remaining := len(stage.Jobs) - idx
-			if remaining > 0 {
-				lines = append(lines, fmt.Sprintf("... and %d more", remaining))
-			}
-			break
 		}
 
 		jobName := job.DisplayName
@@ -597,6 +589,8 @@ func formatManualExecJobType(jobType, language string) string {
 		return getText("jobTypeBuild", language)
 	case string(config.JobZadigDeploy):
 		return getText("jobTypeDeploy", language)
+	case string(config.JobCustomDeploy):
+		return getText("jobTypeCustomDeploy", language)
 	case string(config.JobZadigTesting):
 		return getText("jobTypeTest", language)
 	case string(config.JobZadigScanning):
@@ -611,6 +605,8 @@ func formatManualExecJobType(jobType, language string) string {
 		return getText("jobTypeApproval", language)
 	case string(config.JobZadigHelmDeploy):
 		return getText("jobTypeDeploy", language)
+	case string(config.JobZadigHelmChartDeploy):
+		return getText("jobTypeHelmChartDeploy", language)
 	default:
 		return jobType
 	}

--- a/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
@@ -120,6 +120,8 @@ var (
 		"notificationTextWaitingForApproval": "等待审批",
 		"notificationTextManualExecPending":  "等待手动执行",
 		"notificationTextExecutor":           "执行用户",
+		"notificationTextNotifiedUsers":      "被通知人",
+		"notificationTextJobs":               "任务信息",
 		"notificationTextProjectName":        "项目名称",
 		"notificationTextStageName":          "阶段名称",
 		"notificationTextStartTime":          "开始时间",
@@ -202,6 +204,8 @@ var (
 		"notificationTextWaitingForApproval": "waiting for approval",
 		"notificationTextManualExecPending":  "Waiting for Manual Execution",
 		"notificationTextExecutor":           "Executor",
+		"notificationTextNotifiedUsers":      "Notified Users",
+		"notificationTextJobs":               "Jobs",
 		"notificationTextProjectName":        "Project Name",
 		"notificationTextStageName":          "Stage Name",
 		"notificationTextStartTime":          "Start Time",
@@ -461,12 +465,14 @@ func (w *Service) SendManualExecStageNotifications(workflowCtx *models.WorkflowT
 		return fmt.Errorf("create feishu client error: %w", err)
 	}
 
-	messageContent, err := json.Marshal(w.getManualExecStageLarkCard(workflowCtx, stage, language))
+	manualExecUsers, userInfoMap := commonutil.GeneFlatUsersWithCaller(stage.ManualExec.ManualExecUsers, workflowCtx.WorkflowTaskCreatorUserID)
+	notifiedUsers := formatManualExecNotifiedUsers(manualExecUsers, userInfoMap)
+
+	messageContent, err := json.Marshal(w.getManualExecStageLarkCard(workflowCtx, stage, language, notifiedUsers))
 	if err != nil {
 		return fmt.Errorf("marshal manual exec stage notification card error: %w", err)
 	}
 
-	manualExecUsers, userInfoMap := commonutil.GeneFlatUsersWithCaller(stage.ManualExec.ManualExecUsers, workflowCtx.WorkflowTaskCreatorUserID)
 	respErr := new(multierror.Error)
 	sentTargets := sets.NewString()
 	for _, execUser := range manualExecUsers {
@@ -509,7 +515,108 @@ func (w *Service) SendManualExecStageNotifications(workflowCtx *models.WorkflowT
 	return respErr.ErrorOrNil()
 }
 
-func (w *Service) getManualExecStageLarkCard(workflowCtx *models.WorkflowTaskCtx, stage *models.StageTask, language string) *LarkCard {
+func formatManualExecNotifiedUsers(users []*models.User, userInfoMap map[string]*types.UserInfo) string {
+	if len(users) == 0 {
+		return ""
+	}
+
+	names := make([]string, 0, len(users))
+	nameSet := sets.NewString()
+	for _, user := range users {
+		if user == nil || user.UserID == "" {
+			continue
+		}
+
+		name := user.UserName
+		if info, ok := userInfoMap[user.UserID]; ok && info != nil && info.Name != "" {
+			name = info.Name
+		}
+		if name == "" {
+			name = user.UserID
+		}
+		if nameSet.Has(name) {
+			continue
+		}
+		nameSet.Insert(name)
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+func formatManualExecStageJobs(stage *models.StageTask, language string) string {
+	if stage == nil || len(stage.Jobs) == 0 {
+		return ""
+	}
+
+	const maxJobsShown = 5
+	lines := make([]string, 0, maxJobsShown+1)
+	for idx, job := range stage.Jobs {
+		if job == nil {
+			continue
+		}
+		if len(lines) >= maxJobsShown {
+			remaining := len(stage.Jobs) - idx
+			if remaining > 0 {
+				lines = append(lines, fmt.Sprintf("... and %d more", remaining))
+			}
+			break
+		}
+
+		jobName := job.DisplayName
+		if jobName == "" {
+			jobName = job.Name
+		}
+		jobLine := fmt.Sprintf("%s: %s", formatManualExecJobType(job.JobType, language), jobName)
+
+		switch job.JobType {
+		case string(config.JobZadigDeploy):
+			jobSpec := &models.JobTaskDeploySpec{}
+			models.IToi(job.Spec, jobSpec)
+			if jobSpec.Env != "" {
+				jobLine = fmt.Sprintf("%s (env: %s)", jobLine, jobSpec.Env)
+			}
+		case string(config.JobZadigHelmDeploy):
+			jobSpec := &models.JobTaskHelmDeploySpec{}
+			models.IToi(job.Spec, jobSpec)
+			if jobSpec.Env != "" {
+				jobLine = fmt.Sprintf("%s (env: %s)", jobLine, jobSpec.Env)
+			}
+		}
+
+		lines = append(lines, jobLine)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func formatManualExecJobType(jobType, language string) string {
+	switch jobType {
+	case string(config.JobZadigBuild):
+		return getText("jobTypeBuild", language)
+	case string(config.JobZadigDeploy):
+		return getText("jobTypeDeploy", language)
+	case string(config.JobZadigTesting):
+		return getText("jobTypeTest", language)
+	case string(config.JobZadigScanning):
+		return getText("jobTypeScan", language)
+	case string(config.JobFreestyle):
+		return getText("jobTypeFreestyle", language)
+	case string(config.JobPlugin):
+		return getText("jobTypePlugin", language)
+	case string(config.JobWorkflowTrigger):
+		return getText("jobTypeWorkflowTrigger", language)
+	case string(config.JobApproval):
+		return getText("jobTypeApproval", language)
+	case string(config.JobZadigHelmDeploy):
+		return getText("jobTypeDeploy", language)
+	default:
+		return jobType
+	}
+}
+
+func (w *Service) getManualExecStageLarkCard(workflowCtx *models.WorkflowTaskCtx, stage *models.StageTask, language, notifiedUsers string) *LarkCard {
 	title := fmt.Sprintf("%s %s #%d %s", getText("notificationTextWorkflow", language), workflowCtx.WorkflowDisplayName, workflowCtx.TaskID, getText("notificationTextManualExecPending", language))
 	detailURL := fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d?display_name=%s",
 		configbase.SystemAddress(),
@@ -525,6 +632,12 @@ func (w *Service) getManualExecStageLarkCard(workflowCtx *models.WorkflowTaskCtx
 	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextProjectName", language), workflowCtx.ProjectDisplayName), true)
 	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextStageName", language), stage.Name), true)
 	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextExecutor", language), workflowCtx.WorkflowTaskCreatorUsername), true)
+	if notifiedUsers != "" {
+		lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextNotifiedUsers", language), notifiedUsers), true)
+	}
+	if jobsSummary := formatManualExecStageJobs(stage, language); jobsSummary != "" {
+		lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextJobs", language), jobsSummary), true)
+	}
 	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextStartTime", language), workflowCtx.StartTime.Format(time.DateTime)), true)
 	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextRemark", language), workflowCtx.Remark), true)
 	lc.AddI18NElementsZhcnAction(getText("notificationTextClickForMore", language), detailURL)

--- a/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
@@ -39,6 +39,7 @@ import (
 	templaterepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb/template"
 	larkservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/lark"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/webhooknotify"
+	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	userclient "github.com/koderover/zadig/v2/pkg/shared/client/user"
 	"github.com/koderover/zadig/v2/pkg/tool/lark"
@@ -438,6 +439,96 @@ func (w *Service) SendWorkflowTaskNotifications(task *models.WorkflowTask) error
 		}
 	}
 	return nil
+}
+
+func (w *Service) SendManualExecStageNotifications(workflowCtx *models.WorkflowTaskCtx, stage *models.StageTask) error {
+	if workflowCtx == nil || stage == nil || stage.ManualExec == nil {
+		return nil
+	}
+	notifyCfg := stage.ManualExec.LarkPersonNotificationConfig
+	if notifyCfg == nil || notifyCfg.AppID == "" || len(stage.ManualExec.ManualExecUsers) == 0 {
+		return nil
+	}
+
+	systemSetting, err := commonrepo.NewSystemSettingColl().Get()
+	if err != nil {
+		return fmt.Errorf("get system language error: %w", err)
+	}
+	language := systemSetting.Language
+
+	client, err := larkservice.GetLarkClientByIMAppID(notifyCfg.AppID)
+	if err != nil {
+		return fmt.Errorf("create feishu client error: %w", err)
+	}
+
+	messageContent, err := json.Marshal(w.getManualExecStageLarkCard(workflowCtx, stage, language))
+	if err != nil {
+		return fmt.Errorf("marshal manual exec stage notification card error: %w", err)
+	}
+
+	manualExecUsers, userInfoMap := commonutil.GeneFlatUsersWithCaller(stage.ManualExec.ManualExecUsers, workflowCtx.WorkflowTaskCreatorUserID)
+	respErr := new(multierror.Error)
+	sentTargets := sets.NewString()
+	for _, execUser := range manualExecUsers {
+		if execUser == nil || execUser.UserID == "" {
+			continue
+		}
+		userInfo, ok := userInfoMap[execUser.UserID]
+		if !ok {
+			var getErr error
+			userInfo, getErr = userclient.New().GetUserByID(execUser.UserID)
+			if getErr != nil {
+				respErr = multierror.Append(respErr, fmt.Errorf("find manual executor %s error: %w", execUser.UserID, getErr))
+				continue
+			}
+		}
+		if userInfo.Phone == "" {
+			respErr = multierror.Append(respErr, fmt.Errorf("manual executor %s phone not configured", execUser.UserID))
+			continue
+		}
+
+		larkUser, err := client.GetUserIDByEmailOrMobile(lark.QueryTypeMobile, userInfo.Phone, setting.LarkUserID)
+		if err != nil {
+			respErr = multierror.Append(respErr, fmt.Errorf("find lark user with phone %s error: %w", userInfo.Phone, err))
+			continue
+		}
+		targetID := util.GetStringFromPointer(larkUser.UserId)
+		if targetID == "" {
+			continue
+		}
+		if sentTargets.Has(targetID) {
+			continue
+		}
+		sentTargets.Insert(targetID)
+
+		if err := w.sendFeishuMessageFromClient(client, setting.LarkUserID, targetID, LarkMessageTypeCard, string(messageContent)); err != nil {
+			respErr = multierror.Append(respErr, err)
+		}
+	}
+
+	return respErr.ErrorOrNil()
+}
+
+func (w *Service) getManualExecStageLarkCard(workflowCtx *models.WorkflowTaskCtx, stage *models.StageTask, language string) *LarkCard {
+	title := fmt.Sprintf("%s %s #%d %s", getText("notificationTextWorkflow", language), workflowCtx.WorkflowDisplayName, workflowCtx.TaskID, getText("notificationTextManualExecPending", language))
+	detailURL := fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d?display_name=%s",
+		configbase.SystemAddress(),
+		workflowCtx.ProjectName,
+		workflowCtx.WorkflowName,
+		workflowCtx.TaskID,
+		url.QueryEscape(workflowCtx.WorkflowDisplayName),
+	)
+
+	lc := NewLarkCard()
+	lc.SetConfig(true)
+	lc.SetHeader(feishuHeaderTemplateTurquoise, title, feiShuTagText)
+	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextProjectName", language), workflowCtx.ProjectDisplayName), true)
+	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextStageName", language), stage.Name), true)
+	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextExecutor", language), workflowCtx.WorkflowTaskCreatorUsername), true)
+	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextStartTime", language), workflowCtx.StartTime.Format(time.DateTime)), true)
+	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextRemark", language), workflowCtx.Remark), true)
+	lc.AddI18NElementsZhcnAction(getText("notificationTextClickForMore", language), detailURL)
+	return lc
 }
 
 func (w *Service) getApproveNotificationContent(notify *models.NotifyCtl, task *models.WorkflowTask) (string, string, *LarkCard, *webhooknotify.WorkflowNotify, error) {
@@ -1087,7 +1178,7 @@ func getWorkflowTaskTplExec(tplcontent string, args *workflowTaskNotification) (
 			} else if status == config.StatusManualApproval {
 				return getText("taskStatusManualApproval", language)
 			} else if status == config.StatusPause {
-				return getText("notificationTextManualExecPending", language)
+				return getText("taskStatusPause", language)
 			} else {
 				return getText("taskStatusFailed", language)
 			}
@@ -1147,7 +1238,7 @@ func getJobTaskTplExec(tplcontent string, args *jobTaskNotification, language st
 			} else if status == config.StatusManualApproval {
 				return getText("taskStatusManualApproval", language)
 			} else if status == config.StatusPause {
-				return getText("notificationTextManualExecPending", language)
+				return getText("taskStatusPause", language)
 			} else if status == "" {
 				return getText("jobStatusUnstarted", language)
 			}

--- a/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
@@ -300,7 +300,7 @@ func (w *Service) SendWorkflowTaskApproveNotifications(workflowName string, task
 						return fmt.Errorf("executor phone not configured")
 					}
 
-					client, err := larkservice.GetLarkClientByIMAppID(notify.LarkGroupNotificationConfig.AppID)
+					client, err := larkservice.GetLarkClientByIMAppID(notify.LarkPersonNotificationConfig.AppID)
 					if err != nil {
 						return fmt.Errorf("failed to get notify target info: create feishu client error: %s", err)
 					}
@@ -438,74 +438,6 @@ func (w *Service) SendWorkflowTaskNotifications(task *models.WorkflowTask) error
 		}
 	}
 	return nil
-}
-
-func (w *Service) SendManualExecStageNotifications(workflowCtx *models.WorkflowTaskCtx, stage *models.StageTask) error {
-	if workflowCtx == nil || stage == nil || stage.ManualExec == nil {
-		return nil
-	}
-	notifyCfg := stage.ManualExec.LarkPersonNotificationConfig
-	if notifyCfg == nil || notifyCfg.AppID == "" || len(notifyCfg.TargetUsers) == 0 {
-		return nil
-	}
-
-	systemSetting, err := commonrepo.NewSystemSettingColl().Get()
-	if err != nil {
-		return fmt.Errorf("get system language error: %w", err)
-	}
-	language := systemSetting.Language
-
-	client, err := larkservice.GetLarkClientByIMAppID(notifyCfg.AppID)
-	if err != nil {
-		return fmt.Errorf("create feishu client error: %w", err)
-	}
-
-	messageContent, err := json.Marshal(w.getManualExecStageLarkCard(workflowCtx, stage, language))
-	if err != nil {
-		return fmt.Errorf("marshal manual exec stage notification card error: %w", err)
-	}
-
-	respErr := new(multierror.Error)
-	sentTargets := sets.NewString()
-	for _, target := range notifyCfg.TargetUsers {
-		if target == nil || target.ID == "" || target.IDType == "" {
-			continue
-		}
-		targetKey := fmt.Sprintf("%s:%s", target.IDType, target.ID)
-		if sentTargets.Has(targetKey) {
-			continue
-		}
-		sentTargets.Insert(targetKey)
-
-		err = w.sendFeishuMessageFromClient(client, target.IDType, target.ID, LarkMessageTypeCard, string(messageContent))
-		if err != nil {
-			respErr = multierror.Append(respErr, err)
-		}
-	}
-
-	return respErr.ErrorOrNil()
-}
-
-func (w *Service) getManualExecStageLarkCard(workflowCtx *models.WorkflowTaskCtx, stage *models.StageTask, language string) *LarkCard {
-	title := fmt.Sprintf("%s %s #%d %s", getText("notificationTextWorkflow", language), workflowCtx.WorkflowDisplayName, workflowCtx.TaskID, getText("notificationTextManualExecPending", language))
-	detailURL := fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d?display_name=%s",
-		configbase.SystemAddress(),
-		workflowCtx.ProjectName,
-		workflowCtx.WorkflowName,
-		workflowCtx.TaskID,
-		url.QueryEscape(workflowCtx.WorkflowDisplayName),
-	)
-
-	lc := NewLarkCard()
-	lc.SetConfig(true)
-	lc.SetHeader(feishuHeaderTemplateTurquoise, title, feiShuTagText)
-	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextProjectName", language), workflowCtx.ProjectDisplayName), true)
-	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextStageName", language), stage.Name), true)
-	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextExecutor", language), workflowCtx.WorkflowTaskCreatorUsername), true)
-	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextStartTime", language), time.Now().Format(time.DateTime)), true)
-	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextRemark", language), workflowCtx.Remark), true)
-	lc.AddI18NElementsZhcnAction(getText("notificationTextClickForMore", language), detailURL)
-	return lc
 }
 
 func (w *Service) getApproveNotificationContent(notify *models.NotifyCtl, task *models.WorkflowTask) (string, string, *LarkCard, *webhooknotify.WorkflowNotify, error) {
@@ -1155,7 +1087,7 @@ func getWorkflowTaskTplExec(tplcontent string, args *workflowTaskNotification) (
 			} else if status == config.StatusManualApproval {
 				return getText("taskStatusManualApproval", language)
 			} else if status == config.StatusPause {
-				return getText("taskStatusPause", language)
+				return getText("notificationTextManualExecPending", language)
 			} else {
 				return getText("taskStatusFailed", language)
 			}
@@ -1215,7 +1147,7 @@ func getJobTaskTplExec(tplcontent string, args *jobTaskNotification, language st
 			} else if status == config.StatusManualApproval {
 				return getText("taskStatusManualApproval", language)
 			} else if status == config.StatusPause {
-				return getText("taskStatusPause", language)
+				return getText("notificationTextManualExecPending", language)
 			} else if status == "" {
 				return getText("jobStatusUnstarted", language)
 			}

--- a/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
@@ -40,13 +40,13 @@ import (
 	larkservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/lark"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/webhooknotify"
 	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
+	workflownotifyutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util/workflownotify"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	userclient "github.com/koderover/zadig/v2/pkg/shared/client/user"
 	"github.com/koderover/zadig/v2/pkg/tool/lark"
 	"github.com/koderover/zadig/v2/pkg/tool/log"
 	"github.com/koderover/zadig/v2/pkg/tool/sonar"
 	"github.com/koderover/zadig/v2/pkg/types"
-	jobspec "github.com/koderover/zadig/v2/pkg/types/job"
 	"github.com/koderover/zadig/v2/pkg/types/step"
 	"github.com/koderover/zadig/v2/pkg/util"
 )
@@ -468,7 +468,39 @@ func (w *Service) SendManualExecStageNotifications(workflowCtx *models.WorkflowT
 	manualExecUsers, userInfoMap := commonutil.GeneFlatUsersWithCaller(stage.ManualExec.ManualExecUsers, workflowCtx.WorkflowTaskCreatorUserID)
 	notifiedUsers := formatManualExecNotifiedUsers(manualExecUsers, userInfoMap)
 
-	messageContent, err := json.Marshal(w.getManualExecStageLarkCard(workflowCtx, stage, language, notifiedUsers))
+	jobContents := []string{}
+	taskForNotification := &models.WorkflowTask{
+		WorkflowName: workflowCtx.WorkflowName,
+		TaskID:       workflowCtx.TaskID,
+		Stages:       []*models.StageTask{stage},
+	}
+	stageForNotification := stage
+	if taskInColl, findErr := w.workflowTaskV4Coll.Find(workflowCtx.WorkflowName, workflowCtx.TaskID); findErr == nil && taskInColl != nil {
+		taskForNotification = taskInColl
+		if matchedStage := getStageTaskByName(taskInColl.Stages, stage.Name); matchedStage != nil {
+			stageForNotification = matchedStage
+		}
+	}
+
+	jobContents, _, err = workflownotifyutil.BuildWorkflowJobContents(&workflownotifyutil.BuildJobContentsArgs{
+		Task:        taskForNotification,
+		Stages:      []*models.StageTask{stageForNotification},
+		WebHookType: setting.NotifyWebHookTypeFeishuPerson,
+		RenderTemplate: func(tpl string, job *models.JobTask) (string, error) {
+			return getJobTaskTplExec(tpl, &jobTaskNotification{Job: job, WebHookType: setting.NotifyWebHookTypeFeishuPerson}, language)
+		},
+		GetTestResult: func(jobName string) (string, error) {
+			return genTestResultText(taskForNotification.WorkflowName, jobName, taskForNotification.TaskID, language)
+		},
+		GetSonarMetrics: func(jobSpec *models.JobTaskFreestyleSpec) (string, string, error) {
+			return genSonartMetricsText(jobSpec, language)
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("build manual exec stage notification jobs error: %w", err)
+	}
+
+	messageContent, err := json.Marshal(w.getManualExecStageLarkCard(workflowCtx, stageForNotification, language, notifiedUsers, jobContents))
 	if err != nil {
 		return fmt.Errorf("marshal manual exec stage notification card error: %w", err)
 	}
@@ -545,74 +577,16 @@ func formatManualExecNotifiedUsers(users []*models.User, userInfoMap map[string]
 	return strings.Join(names, ", ")
 }
 
-func formatManualExecStageJobs(stage *models.StageTask, language string) string {
-	if stage == nil || len(stage.Jobs) == 0 {
-		return ""
+func getStageTaskByName(stages []*models.StageTask, stageName string) *models.StageTask {
+	for _, stage := range stages {
+		if stage != nil && stage.Name == stageName {
+			return stage
+		}
 	}
-
-	lines := make([]string, 0, len(stage.Jobs))
-	for _, job := range stage.Jobs {
-		if job == nil {
-			continue
-		}
-
-		jobName := job.DisplayName
-		if jobName == "" {
-			jobName = job.Name
-		}
-		jobLine := fmt.Sprintf("%s: %s", formatManualExecJobType(job.JobType, language), jobName)
-
-		switch job.JobType {
-		case string(config.JobZadigDeploy):
-			jobSpec := &models.JobTaskDeploySpec{}
-			models.IToi(job.Spec, jobSpec)
-			if jobSpec.Env != "" {
-				jobLine = fmt.Sprintf("%s (env: %s)", jobLine, jobSpec.Env)
-			}
-		case string(config.JobZadigHelmDeploy):
-			jobSpec := &models.JobTaskHelmDeploySpec{}
-			models.IToi(job.Spec, jobSpec)
-			if jobSpec.Env != "" {
-				jobLine = fmt.Sprintf("%s (env: %s)", jobLine, jobSpec.Env)
-			}
-		}
-
-		lines = append(lines, jobLine)
-	}
-
-	return strings.Join(lines, "\n")
+	return nil
 }
 
-func formatManualExecJobType(jobType, language string) string {
-	switch jobType {
-	case string(config.JobZadigBuild):
-		return getText("jobTypeBuild", language)
-	case string(config.JobZadigDeploy):
-		return getText("jobTypeDeploy", language)
-	case string(config.JobCustomDeploy):
-		return getText("jobTypeCustomDeploy", language)
-	case string(config.JobZadigTesting):
-		return getText("jobTypeTest", language)
-	case string(config.JobZadigScanning):
-		return getText("jobTypeScan", language)
-	case string(config.JobFreestyle):
-		return getText("jobTypeFreestyle", language)
-	case string(config.JobPlugin):
-		return getText("jobTypePlugin", language)
-	case string(config.JobWorkflowTrigger):
-		return getText("jobTypeWorkflowTrigger", language)
-	case string(config.JobApproval):
-		return getText("jobTypeApproval", language)
-	case string(config.JobZadigHelmDeploy):
-		return getText("jobTypeDeploy", language)
-	case string(config.JobZadigHelmChartDeploy):
-		return getText("jobTypeHelmChartDeploy", language)
-	default:
-		return jobType
-	}
-}
-
-func (w *Service) getManualExecStageLarkCard(workflowCtx *models.WorkflowTaskCtx, stage *models.StageTask, language, notifiedUsers string) *LarkCard {
+func (w *Service) getManualExecStageLarkCard(workflowCtx *models.WorkflowTaskCtx, stage *models.StageTask, language, notifiedUsers string, jobContents []string) *LarkCard {
 	title := fmt.Sprintf("%s %s #%d %s", getText("notificationTextWorkflow", language), workflowCtx.WorkflowDisplayName, workflowCtx.TaskID, getText("notificationTextManualExecPending", language))
 	detailURL := fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d?display_name=%s",
 		configbase.SystemAddress(),
@@ -631,8 +605,15 @@ func (w *Service) getManualExecStageLarkCard(workflowCtx *models.WorkflowTaskCtx
 	if notifiedUsers != "" {
 		lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextNotifiedUsers", language), notifiedUsers), true)
 	}
-	if jobsSummary := formatManualExecStageJobs(stage, language); jobsSummary != "" {
-		lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextJobs", language), jobsSummary), true)
+	for idx, jobContent := range jobContents {
+		if jobContent == "" {
+			continue
+		}
+		if idx == 0 {
+			lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：\n%s", getText("notificationTextJobs", language), jobContent), true)
+			continue
+		}
+		lc.AddI18NElementsZhcnFeild(jobContent, true)
 	}
 	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextStartTime", language), workflowCtx.StartTime.Format(time.DateTime)), true)
 	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextRemark", language), workflowCtx.Remark), true)
@@ -883,247 +864,22 @@ func (w *Service) getNotificationContent(notify *models.NotifyCtl, task *models.
 		"{{getText \"notificationTextRemark\"}}：{{ .Task.Remark}} \n",
 	}
 
-	jobContents := []string{}
-	workflowNotifyStages := []*webhooknotify.WorkflowNotifyStage{}
-	for _, stage := range task.Stages {
-		workflowNotifyStage := &webhooknotify.WorkflowNotifyStage{
-			Name:      stage.Name,
-			Status:    stage.Status,
-			StartTime: stage.StartTime,
-			EndTime:   stage.EndTime,
-			Error:     stage.Error,
-		}
-
-		for _, job := range stage.Jobs {
-			workflowNotifyJob := &webhooknotify.WorkflowNotifyJobTask{
-				Name:        job.Name,
-				DisplayName: job.DisplayName,
-				JobType:     job.JobType,
-				Status:      job.Status,
-				StartTime:   job.StartTime,
-				EndTime:     job.EndTime,
-				Error:       job.Error,
-			}
-
-			jobTplcontent := "{{if and (ne .WebHookType \"feishu\") (ne .WebHookType \"feishu_app\") (ne .WebHookType \"feishu_person\")}}\n\n{{end}}{{if eq .WebHookType \"dingding\"}}---\n\n##### {{end}}**{{jobType .Job.JobType }}**: {{.Job.DisplayName}}    **{{getText \"notificationTextStatus\"}}**: {{taskStatus .Job.Status }}  \n"
-			mailJobTplcontent := "{{jobType .Job.JobType }}：{{.Job.DisplayName}}    {{getText \"notificationTextStatus\"}}：{{taskStatus .Job.Status }} \n"
-			switch job.JobType {
-			case string(config.JobZadigBuild):
-				fallthrough
-			case string(config.JobFreestyle):
-				jobSpec := &models.JobTaskFreestyleSpec{}
-				models.IToi(job.Spec, jobSpec)
-
-				workflowNotifyJobTaskSpec := &webhooknotify.WorkflowNotifyJobTaskBuildSpec{}
-
-				repos := []*types.Repository{}
-				for _, stepTask := range jobSpec.Steps {
-					if stepTask.StepType == config.StepGit {
-						stepSpec := &step.StepGitSpec{}
-						models.IToi(stepTask.Spec, stepSpec)
-						repos = stepSpec.Repos
-					}
-				}
-
-				branchTag, commitID, gitCommitURL := "", "", ""
-				commitMsgs := []string{}
-				var prInfoList []string
-				var prInfo string
-				for idx, buildRepo := range repos {
-					workflowNotifyRepository := &webhooknotify.WorkflowNotifyRepository{
-						Source:        buildRepo.Source,
-						RepoOwner:     buildRepo.RepoOwner,
-						RepoNamespace: buildRepo.RepoNamespace,
-						RepoName:      buildRepo.RepoName,
-						Branch:        buildRepo.Branch,
-						Tag:           buildRepo.Tag,
-						AuthorName:    buildRepo.AuthorName,
-						CommitID:      buildRepo.CommitID,
-						CommitMessage: buildRepo.CommitMessage,
-					}
-					if idx == 0 || buildRepo.IsPrimary {
-						branchTag = buildRepo.Branch
-						if buildRepo.Tag != "" {
-							branchTag = buildRepo.Tag
-						}
-						if len(buildRepo.CommitID) > 8 {
-							commitID = buildRepo.CommitID[0:8]
-						}
-						var prLinkBuilder func(baseURL, owner, repoName string, prID int) string
-						switch buildRepo.Source {
-						case types.ProviderGithub:
-							prLinkBuilder = func(baseURL, owner, repoName string, prID int) string {
-								return fmt.Sprintf("%s/%s/%s/pull/%d", baseURL, owner, repoName, prID)
-							}
-						case types.ProviderGitee:
-							prLinkBuilder = func(baseURL, owner, repoName string, prID int) string {
-								return fmt.Sprintf("%s/%s/%s/pulls/%d", baseURL, owner, repoName, prID)
-							}
-						case types.ProviderGitlab:
-							prLinkBuilder = func(baseURL, owner, repoName string, prID int) string {
-								return fmt.Sprintf("%s/%s/%s/merge_requests/%d", baseURL, owner, repoName, prID)
-							}
-						case types.ProviderGerrit:
-							prLinkBuilder = func(baseURL, owner, repoName string, prID int) string {
-								return fmt.Sprintf("%s/%d", baseURL, prID)
-							}
-						default:
-							prLinkBuilder = func(baseURL, owner, repoName string, prID int) string {
-								return ""
-							}
-						}
-						prInfoList = []string{}
-						sort.Ints(buildRepo.PRs)
-						for _, id := range buildRepo.PRs {
-							link := prLinkBuilder(buildRepo.Address, buildRepo.RepoOwner, buildRepo.RepoName, id)
-							if link != "" {
-								prInfoList = append(prInfoList, fmt.Sprintf("[#%d](%s)", id, link))
-							}
-						}
-						commitMsg := strings.Trim(buildRepo.CommitMessage, "\n")
-						commitMsgs = strings.Split(commitMsg, "\n")
-						gitCommitURL = fmt.Sprintf("%s/%s/%s/commit/%s", buildRepo.Address, buildRepo.RepoOwner, buildRepo.RepoName, commitID)
-						workflowNotifyRepository.CommitURL = gitCommitURL
-					}
-
-					workflowNotifyJobTaskSpec.Repositories = append(workflowNotifyJobTaskSpec.Repositories, workflowNotifyRepository)
-				}
-				if len(prInfoList) != 0 {
-					// need an extra space at the end
-					prInfo = strings.Join(prInfoList, " ") + " "
-				}
-				image := ""
-				imageContextKey := strings.Join(strings.Split(jobspec.GetJobOutputKey(job.Key, "IMAGE"), "."), "@?")
-				if task.GlobalContext != nil {
-					image = task.GlobalContext[imageContextKey]
-				}
-				if len(commitID) > 0 {
-					jobTplcontent += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextRepositoryInfo\"}}**：%s %s[%s](%s)  ", branchTag, prInfo, commitID, gitCommitURL)
-					jobTplcontent += "{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextCommitMessage\"}}**："
-					mailJobTplcontent += fmt.Sprintf("{{getText \"notificationTextRepositoryInfo\"}}：%s %s[%s]( %s )  ", branchTag, prInfo, commitID, gitCommitURL)
-					if len(commitMsgs) == 1 {
-						jobTplcontent += fmt.Sprintf("%s \n", commitMsgs[0])
-					} else {
-						jobTplcontent += "\n"
-						for _, commitMsg := range commitMsgs {
-							jobTplcontent += fmt.Sprintf("%s \n", commitMsg)
-						}
-					}
-				}
-				if job.Status == config.StatusPassed && image != "" && !strings.HasPrefix(image, "{{.") && !strings.Contains(image, "}}") {
-					jobTplcontent += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextImageInfo\"}}**：%s  \n", image)
-					mailJobTplcontent += fmt.Sprintf("{{getText \"notificationTextImageInfo\"}}：%s \n", image)
-					workflowNotifyJobTaskSpec.Image = image
-				}
-
-				workflowNotifyJob.Spec = workflowNotifyJobTaskSpec
-			case string(config.JobZadigDeploy):
-				jobSpec := &models.JobTaskDeploySpec{}
-				models.IToi(job.Spec, jobSpec)
-				jobTplcontent += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextEnvironment\"}}**：%s  \n", jobSpec.Env)
-				mailJobTplcontent += fmt.Sprintf("{{getText \"notificationTextEnvironment\"}}：%s \n", jobSpec.Env)
-
-				if job.Status == config.StatusPassed && len(jobSpec.ServiceAndImages) > 0 {
-					jobTplcontent += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextImageInfo\"}}**：  \n")
-					mailJobTplcontent += fmt.Sprintf("{{getText \"notificationTextImageInfo\"}}：  \n")
-				}
-
-				serviceModules := []*webhooknotify.WorkflowNotifyDeployServiceModule{}
-				for _, serviceAndImage := range jobSpec.ServiceAndImages {
-					if job.Status == config.StatusPassed && !strings.HasPrefix(serviceAndImage.Image, "{{.") && !strings.Contains(serviceAndImage.Image, "}}") {
-						jobTplcontent += fmt.Sprintf("%s  \n", serviceAndImage.Image)
-						mailJobTplcontent += fmt.Sprintf("%s  \n", serviceAndImage.Image)
-					}
-
-					serviceModule := &webhooknotify.WorkflowNotifyDeployServiceModule{
-						ServiceModule: serviceAndImage.ServiceModule,
-						Image:         serviceAndImage.Image,
-					}
-					serviceModules = append(serviceModules, serviceModule)
-				}
-
-				workflowNotifyJobTaskSpec := &webhooknotify.WorkflowNotifyJobTaskDeploySpec{
-					Env:            jobSpec.Env,
-					ServiceName:    jobSpec.ServiceName,
-					ServiceModules: serviceModules,
-				}
-				workflowNotifyJob.Spec = workflowNotifyJobTaskSpec
-			case string(config.JobZadigHelmDeploy):
-				jobSpec := &models.JobTaskHelmDeploySpec{}
-				models.IToi(job.Spec, jobSpec)
-				jobTplcontent += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextEnvironment\"}}**：%s  \n", jobSpec.Env)
-				mailJobTplcontent += fmt.Sprintf("{{getText \"notificationTextEnvironment\"}}：%s \n", jobSpec.Env)
-
-				if job.Status == config.StatusPassed && len(jobSpec.ImageAndModules) > 0 {
-					jobTplcontent += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextImageInfo\"}}**：  \n")
-					mailJobTplcontent += fmt.Sprintf("{{getText \"notificationTextImageInfo\"}}：  \n")
-				}
-
-				serviceModules := []*webhooknotify.WorkflowNotifyDeployServiceModule{}
-				for _, serviceAndImage := range jobSpec.ImageAndModules {
-					if !strings.HasPrefix(serviceAndImage.Image, "{{.") && !strings.Contains(serviceAndImage.Image, "}}") {
-						jobTplcontent += fmt.Sprintf("%s  \n", serviceAndImage.Image)
-						mailJobTplcontent += fmt.Sprintf("%s  \n", serviceAndImage.Image)
-					}
-
-					serviceModule := &webhooknotify.WorkflowNotifyDeployServiceModule{
-						ServiceModule: serviceAndImage.ServiceModule,
-						Image:         serviceAndImage.Image,
-					}
-					serviceModules = append(serviceModules, serviceModule)
-				}
-
-				workflowNotifyJobTaskSpec := &webhooknotify.WorkflowNotifyJobTaskDeploySpec{
-					Env:            jobSpec.Env,
-					ServiceName:    jobSpec.ServiceName,
-					ServiceModules: serviceModules,
-				}
-				workflowNotifyJob.Spec = workflowNotifyJobTaskSpec
-			case string(config.JobZadigTesting):
-				testResult, err := genTestResultText(task.WorkflowName, job.Name, task.TaskID, language)
-				if err != nil {
-					log.Errorf("genTestResultText err:%s", err)
-					return "", "", nil, nil, fmt.Errorf("genTestResultText err:%s", err)
-				}
-
-				jobTplcontent += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextTestResult\"}}**: %s  \n", testResult)
-				mailJobTplcontent += fmt.Sprintf("{{getText \"notificationTextTestResult\"}}: %s \n", testResult)
-			case string(config.JobZadigScanning):
-				jobSpec := &models.JobTaskFreestyleSpec{}
-				models.IToi(job.Spec, jobSpec)
-				sonarMetricsText, mailSonarMetricsText, err := genSonartMetricsText(jobSpec, language)
-				if err != nil {
-					log.Errorf("genTestResultText err:%s", err)
-					return "", "", nil, nil, fmt.Errorf("genTestResultText err:%s", err)
-				}
-
-				if sonarMetricsText != "" {
-					jobTplcontent += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextSonarMetrics\"}}**: %s  \n", sonarMetricsText)
-					mailJobTplcontent += fmt.Sprintf("{{getText \"notificationTextSonarMetrics\"}}: %s \n", mailSonarMetricsText)
-				}
-			}
-			jobNotifaication := &jobTaskNotification{
-				Job:         job,
-				WebHookType: notify.WebHookType,
-			}
-
-			if notify.WebHookType == setting.NotifyWebHookTypeMail {
-				jobContent, err := getJobTaskTplExec(mailJobTplcontent, jobNotifaication, language)
-				if err != nil {
-					return "", "", nil, nil, err
-				}
-				jobContents = append(jobContents, jobContent)
-			} else {
-				jobContent, err := getJobTaskTplExec(jobTplcontent, jobNotifaication, language)
-				if err != nil {
-					return "", "", nil, nil, err
-				}
-				jobContents = append(jobContents, jobContent)
-			}
-
-			workflowNotifyStage.Jobs = append(workflowNotifyStage.Jobs, workflowNotifyJob)
-		}
-		workflowNotifyStages = append(workflowNotifyStages, workflowNotifyStage)
+	jobContents, workflowNotifyStages, err := workflownotifyutil.BuildWorkflowJobContents(&workflownotifyutil.BuildJobContentsArgs{
+		Task:        task,
+		Stages:      task.Stages,
+		WebHookType: notify.WebHookType,
+		RenderTemplate: func(tpl string, job *models.JobTask) (string, error) {
+			return getJobTaskTplExec(tpl, &jobTaskNotification{Job: job, WebHookType: notify.WebHookType}, language)
+		},
+		GetTestResult: func(jobName string) (string, error) {
+			return genTestResultText(task.WorkflowName, jobName, task.TaskID, language)
+		},
+		GetSonarMetrics: func(jobSpec *models.JobTaskFreestyleSpec) (string, string, error) {
+			return genSonartMetricsText(jobSpec, language)
+		},
+	})
+	if err != nil {
+		return "", "", nil, nil, err
 	}
 	webhookNotify.Stages = workflowNotifyStages
 

--- a/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
@@ -117,8 +117,10 @@ var (
 
 		"notificationTextWorkflow":           "工作流",
 		"notificationTextWaitingForApproval": "等待审批",
+		"notificationTextManualExecPending":  "等待手动执行",
 		"notificationTextExecutor":           "执行用户",
 		"notificationTextProjectName":        "项目名称",
+		"notificationTextStageName":          "阶段名称",
 		"notificationTextStartTime":          "开始时间",
 		"notificationTextDuration":           "持续时间",
 		"notificationTextRemark":             "备注",
@@ -197,8 +199,10 @@ var (
 
 		"notificationTextWorkflow":           "Workflow",
 		"notificationTextWaitingForApproval": "waiting for approval",
+		"notificationTextManualExecPending":  "Waiting for Manual Execution",
 		"notificationTextExecutor":           "Executor",
 		"notificationTextProjectName":        "Project Name",
+		"notificationTextStageName":          "Stage Name",
 		"notificationTextStartTime":          "Start Time",
 		"notificationTextDuration":           "Duration",
 		"notificationTextRemark":             "Remark",
@@ -435,6 +439,75 @@ func (w *Service) SendWorkflowTaskNotifications(task *models.WorkflowTask) error
 	}
 	return nil
 }
+
+func (w *Service) SendManualExecStageNotifications(workflowCtx *models.WorkflowTaskCtx, stage *models.StageTask) error {
+	if workflowCtx == nil || stage == nil || stage.ManualExec == nil {
+		return nil
+	}
+	notifyCfg := stage.ManualExec.LarkPersonNotificationConfig
+	if notifyCfg == nil || notifyCfg.AppID == "" || len(notifyCfg.TargetUsers) == 0 {
+		return nil
+	}
+
+	systemSetting, err := commonrepo.NewSystemSettingColl().Get()
+	if err != nil {
+		return fmt.Errorf("get system language error: %w", err)
+	}
+	language := systemSetting.Language
+
+	client, err := larkservice.GetLarkClientByIMAppID(notifyCfg.AppID)
+	if err != nil {
+		return fmt.Errorf("create feishu client error: %w", err)
+	}
+
+	messageContent, err := json.Marshal(w.getManualExecStageLarkCard(workflowCtx, stage, language))
+	if err != nil {
+		return fmt.Errorf("marshal manual exec stage notification card error: %w", err)
+	}
+
+	respErr := new(multierror.Error)
+	sentTargets := sets.NewString()
+	for _, target := range notifyCfg.TargetUsers {
+		if target == nil || target.ID == "" || target.IDType == "" {
+			continue
+		}
+		targetKey := fmt.Sprintf("%s:%s", target.IDType, target.ID)
+		if sentTargets.Has(targetKey) {
+			continue
+		}
+		sentTargets.Insert(targetKey)
+
+		err = w.sendFeishuMessageFromClient(client, target.IDType, target.ID, LarkMessageTypeCard, string(messageContent))
+		if err != nil {
+			respErr = multierror.Append(respErr, err)
+		}
+	}
+
+	return respErr.ErrorOrNil()
+}
+
+func (w *Service) getManualExecStageLarkCard(workflowCtx *models.WorkflowTaskCtx, stage *models.StageTask, language string) *LarkCard {
+	title := fmt.Sprintf("%s %s #%d %s", getText("notificationTextWorkflow", language), workflowCtx.WorkflowDisplayName, workflowCtx.TaskID, getText("notificationTextManualExecPending", language))
+	detailURL := fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d?display_name=%s",
+		configbase.SystemAddress(),
+		workflowCtx.ProjectName,
+		workflowCtx.WorkflowName,
+		workflowCtx.TaskID,
+		url.QueryEscape(workflowCtx.WorkflowDisplayName),
+	)
+
+	lc := NewLarkCard()
+	lc.SetConfig(true)
+	lc.SetHeader(feishuHeaderTemplateTurquoise, title, feiShuTagText)
+	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextProjectName", language), workflowCtx.ProjectDisplayName), true)
+	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextStageName", language), stage.Name), true)
+	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextExecutor", language), workflowCtx.WorkflowTaskCreatorUsername), true)
+	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextStartTime", language), time.Now().Format(time.DateTime)), true)
+	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextRemark", language), workflowCtx.Remark), true)
+	lc.AddI18NElementsZhcnAction(getText("notificationTextClickForMore", language), detailURL)
+	return lc
+}
+
 func (w *Service) getApproveNotificationContent(notify *models.NotifyCtl, task *models.WorkflowTask) (string, string, *LarkCard, *webhooknotify.WorkflowNotify, error) {
 	project, err := templaterepo.NewProductColl().Find(task.ProjectName)
 	if err != nil {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/stage.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/stage.go
@@ -26,6 +26,7 @@ import (
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	approvalservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/approval"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/instantmessage"
 )
 
 type StageCtl interface {
@@ -94,6 +95,13 @@ func waitForManualExec(ctx context.Context, stage *commonmodels.StageTask, workf
 	}
 
 	stage.Status = config.StatusPause
+	if !stage.ManualExec.NotificationSent && stage.ManualExec.LarkPersonNotificationConfig != nil {
+		if err := instantmessage.NewWeChatClient().SendManualExecStageNotifications(workflowCtx, stage); err != nil {
+			logger.Errorf("failed to send manual execution stage notification for stage %s: %v", stage.Name, err)
+		} else {
+			stage.ManualExec.NotificationSent = true
+		}
+	}
 
 	return true, err
 }

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/stage.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/stage.go
@@ -26,7 +26,6 @@ import (
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	approvalservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/approval"
-	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/instantmessage"
 )
 
 type StageCtl interface {
@@ -95,13 +94,6 @@ func waitForManualExec(ctx context.Context, stage *commonmodels.StageTask, workf
 	}
 
 	stage.Status = config.StatusPause
-	if !stage.ManualExec.NotificationSent && stage.ManualExec.LarkPersonNotificationConfig != nil {
-		if err := instantmessage.NewWeChatClient().SendManualExecStageNotifications(workflowCtx, stage); err != nil {
-			logger.Errorf("failed to send manual execution stage notification for stage %s: %v", stage.Name, err)
-		} else {
-			stage.ManualExec.NotificationSent = true
-		}
-	}
 
 	return true, err
 }

--- a/pkg/microservice/aslan/core/common/util/workflownotify/job_content.go
+++ b/pkg/microservice/aslan/core/common/util/workflownotify/job_content.go
@@ -1,0 +1,300 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflownotify
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/webhooknotify"
+	"github.com/koderover/zadig/v2/pkg/setting"
+	"github.com/koderover/zadig/v2/pkg/types"
+	jobspec "github.com/koderover/zadig/v2/pkg/types/job"
+	"github.com/koderover/zadig/v2/pkg/types/step"
+)
+
+type RenderJobTemplate func(tpl string, job *models.JobTask) (string, error)
+type TestResultGetter func(jobName string) (string, error)
+type SonarMetricsGetter func(jobSpec *models.JobTaskFreestyleSpec) (string, string, error)
+
+type BuildJobContentsArgs struct {
+	Task            *models.WorkflowTask
+	Stages          []*models.StageTask
+	WebHookType     setting.NotifyWebHookType
+	RenderTemplate  RenderJobTemplate
+	GetTestResult   TestResultGetter
+	GetSonarMetrics SonarMetricsGetter
+}
+
+func BuildWorkflowJobContents(args *BuildJobContentsArgs) ([]string, []*webhooknotify.WorkflowNotifyStage, error) {
+	if args == nil || args.Task == nil || len(args.Stages) == 0 {
+		return nil, nil, nil
+	}
+	if args.RenderTemplate == nil {
+		return nil, nil, fmt.Errorf("render template callback is required")
+	}
+
+	jobContents := make([]string, 0)
+	workflowNotifyStages := make([]*webhooknotify.WorkflowNotifyStage, 0, len(args.Stages))
+
+	for _, stage := range args.Stages {
+		if stage == nil {
+			continue
+		}
+
+		workflowNotifyStage := &webhooknotify.WorkflowNotifyStage{
+			Name:      stage.Name,
+			Status:    stage.Status,
+			StartTime: stage.StartTime,
+			EndTime:   stage.EndTime,
+			Error:     stage.Error,
+		}
+
+		for _, job := range stage.Jobs {
+			if job == nil {
+				continue
+			}
+
+			workflowNotifyJob := &webhooknotify.WorkflowNotifyJobTask{
+				Name:        job.Name,
+				DisplayName: job.DisplayName,
+				JobType:     job.JobType,
+				Status:      job.Status,
+				StartTime:   job.StartTime,
+				EndTime:     job.EndTime,
+				Error:       job.Error,
+			}
+
+			jobTplcontent := "{{if and (ne .WebHookType \"feishu\") (ne .WebHookType \"feishu_app\") (ne .WebHookType \"feishu_person\")}}\n\n{{end}}{{if eq .WebHookType \"dingding\"}}---\n\n##### {{end}}**{{jobType .Job.JobType }}**: {{.Job.DisplayName}}    **{{getText \"notificationTextStatus\"}}**: {{taskStatus .Job.Status }}  \n"
+			mailJobTplcontent := "{{jobType .Job.JobType }}：{{.Job.DisplayName}}    {{getText \"notificationTextStatus\"}}：{{taskStatus .Job.Status }} \n"
+
+			switch job.JobType {
+			case string(config.JobZadigBuild), string(config.JobFreestyle):
+				jobSpec := &models.JobTaskFreestyleSpec{}
+				models.IToi(job.Spec, jobSpec)
+
+				workflowNotifyJobTaskSpec := &webhooknotify.WorkflowNotifyJobTaskBuildSpec{}
+
+				repos := []*types.Repository{}
+				for _, stepTask := range jobSpec.Steps {
+					if stepTask.StepType == config.StepGit {
+						stepSpec := &step.StepGitSpec{}
+						models.IToi(stepTask.Spec, stepSpec)
+						repos = stepSpec.Repos
+					}
+				}
+
+				branchTag, commitID, gitCommitURL := "", "", ""
+				commitMsgs := []string{}
+				var prInfoList []string
+				var prInfo string
+				for idx, buildRepo := range repos {
+					workflowNotifyRepository := &webhooknotify.WorkflowNotifyRepository{
+						Source:        buildRepo.Source,
+						RepoOwner:     buildRepo.RepoOwner,
+						RepoNamespace: buildRepo.RepoNamespace,
+						RepoName:      buildRepo.RepoName,
+						Branch:        buildRepo.Branch,
+						Tag:           buildRepo.Tag,
+						AuthorName:    buildRepo.AuthorName,
+						CommitID:      buildRepo.CommitID,
+						CommitMessage: buildRepo.CommitMessage,
+					}
+					if idx == 0 || buildRepo.IsPrimary {
+						branchTag = buildRepo.Branch
+						if buildRepo.Tag != "" {
+							branchTag = buildRepo.Tag
+						}
+						if len(buildRepo.CommitID) > 8 {
+							commitID = buildRepo.CommitID[0:8]
+						}
+						var prLinkBuilder func(baseURL, owner, repoName string, prID int) string
+						switch buildRepo.Source {
+						case types.ProviderGithub:
+							prLinkBuilder = func(baseURL, owner, repoName string, prID int) string {
+								return fmt.Sprintf("%s/%s/%s/pull/%d", baseURL, owner, repoName, prID)
+							}
+						case types.ProviderGitee:
+							prLinkBuilder = func(baseURL, owner, repoName string, prID int) string {
+								return fmt.Sprintf("%s/%s/%s/pulls/%d", baseURL, owner, repoName, prID)
+							}
+						case types.ProviderGitlab:
+							prLinkBuilder = func(baseURL, owner, repoName string, prID int) string {
+								return fmt.Sprintf("%s/%s/%s/merge_requests/%d", baseURL, owner, repoName, prID)
+							}
+						case types.ProviderGerrit:
+							prLinkBuilder = func(baseURL, owner, repoName string, prID int) string {
+								return fmt.Sprintf("%s/%d", baseURL, prID)
+							}
+						default:
+							prLinkBuilder = func(baseURL, owner, repoName string, prID int) string {
+								return ""
+							}
+						}
+						prInfoList = []string{}
+						sort.Ints(buildRepo.PRs)
+						for _, id := range buildRepo.PRs {
+							link := prLinkBuilder(buildRepo.Address, buildRepo.RepoOwner, buildRepo.RepoName, id)
+							if link != "" {
+								prInfoList = append(prInfoList, fmt.Sprintf("[#%d](%s)", id, link))
+							}
+						}
+						commitMsg := strings.Trim(buildRepo.CommitMessage, "\n")
+						commitMsgs = strings.Split(commitMsg, "\n")
+						gitCommitURL = fmt.Sprintf("%s/%s/%s/commit/%s", buildRepo.Address, buildRepo.RepoOwner, buildRepo.RepoName, commitID)
+						workflowNotifyRepository.CommitURL = gitCommitURL
+					}
+
+					workflowNotifyJobTaskSpec.Repositories = append(workflowNotifyJobTaskSpec.Repositories, workflowNotifyRepository)
+				}
+				if len(prInfoList) != 0 {
+					prInfo = strings.Join(prInfoList, " ") + " "
+				}
+
+				image := ""
+				imageContextKey := strings.Join(strings.Split(jobspec.GetJobOutputKey(job.Key, "IMAGE"), "."), "@?")
+				if args.Task.GlobalContext != nil {
+					image = args.Task.GlobalContext[imageContextKey]
+				}
+				if len(commitID) > 0 {
+					jobTplcontent += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextRepositoryInfo\"}}**：%s %s[%s](%s)  ", branchTag, prInfo, commitID, gitCommitURL)
+					jobTplcontent += "{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextCommitMessage\"}}**："
+					mailJobTplcontent += fmt.Sprintf("{{getText \"notificationTextRepositoryInfo\"}}：%s %s[%s]( %s )  ", branchTag, prInfo, commitID, gitCommitURL)
+					if len(commitMsgs) == 1 {
+						jobTplcontent += fmt.Sprintf("%s \n", commitMsgs[0])
+					} else {
+						jobTplcontent += "\n"
+						for _, commitMsg := range commitMsgs {
+							jobTplcontent += fmt.Sprintf("%s \n", commitMsg)
+						}
+					}
+				}
+				if job.Status == config.StatusPassed && image != "" && !strings.HasPrefix(image, "{{.") && !strings.Contains(image, "}}") {
+					jobTplcontent += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextImageInfo\"}}**：%s  \n", image)
+					mailJobTplcontent += fmt.Sprintf("{{getText \"notificationTextImageInfo\"}}：%s \n", image)
+					workflowNotifyJobTaskSpec.Image = image
+				}
+
+				workflowNotifyJob.Spec = workflowNotifyJobTaskSpec
+
+			case string(config.JobZadigDeploy):
+				jobSpec := &models.JobTaskDeploySpec{}
+				models.IToi(job.Spec, jobSpec)
+				jobTplcontent += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextEnvironment\"}}**：%s  \n", jobSpec.Env)
+				mailJobTplcontent += fmt.Sprintf("{{getText \"notificationTextEnvironment\"}}：%s \n", jobSpec.Env)
+
+				if job.Status == config.StatusPassed && len(jobSpec.ServiceAndImages) > 0 {
+					jobTplcontent += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextImageInfo\"}}**：  \n")
+					mailJobTplcontent += fmt.Sprintf("{{getText \"notificationTextImageInfo\"}}：  \n")
+				}
+
+				serviceModules := make([]*webhooknotify.WorkflowNotifyDeployServiceModule, 0, len(jobSpec.ServiceAndImages))
+				for _, serviceAndImage := range jobSpec.ServiceAndImages {
+					if job.Status == config.StatusPassed && !strings.HasPrefix(serviceAndImage.Image, "{{.") && !strings.Contains(serviceAndImage.Image, "}}") {
+						jobTplcontent += fmt.Sprintf("%s  \n", serviceAndImage.Image)
+						mailJobTplcontent += fmt.Sprintf("%s  \n", serviceAndImage.Image)
+					}
+
+					serviceModules = append(serviceModules, &webhooknotify.WorkflowNotifyDeployServiceModule{
+						ServiceModule: serviceAndImage.ServiceModule,
+						Image:         serviceAndImage.Image,
+					})
+				}
+
+				workflowNotifyJob.Spec = &webhooknotify.WorkflowNotifyJobTaskDeploySpec{
+					Env:            jobSpec.Env,
+					ServiceName:    jobSpec.ServiceName,
+					ServiceModules: serviceModules,
+				}
+
+			case string(config.JobZadigHelmDeploy):
+				jobSpec := &models.JobTaskHelmDeploySpec{}
+				models.IToi(job.Spec, jobSpec)
+				jobTplcontent += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextEnvironment\"}}**：%s  \n", jobSpec.Env)
+				mailJobTplcontent += fmt.Sprintf("{{getText \"notificationTextEnvironment\"}}：%s \n", jobSpec.Env)
+
+				if job.Status == config.StatusPassed && len(jobSpec.ImageAndModules) > 0 {
+					jobTplcontent += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextImageInfo\"}}**：  \n")
+					mailJobTplcontent += fmt.Sprintf("{{getText \"notificationTextImageInfo\"}}：  \n")
+				}
+
+				serviceModules := make([]*webhooknotify.WorkflowNotifyDeployServiceModule, 0, len(jobSpec.ImageAndModules))
+				for _, serviceAndImage := range jobSpec.ImageAndModules {
+					if !strings.HasPrefix(serviceAndImage.Image, "{{.") && !strings.Contains(serviceAndImage.Image, "}}") {
+						jobTplcontent += fmt.Sprintf("%s  \n", serviceAndImage.Image)
+						mailJobTplcontent += fmt.Sprintf("%s  \n", serviceAndImage.Image)
+					}
+
+					serviceModules = append(serviceModules, &webhooknotify.WorkflowNotifyDeployServiceModule{
+						ServiceModule: serviceAndImage.ServiceModule,
+						Image:         serviceAndImage.Image,
+					})
+				}
+
+				workflowNotifyJob.Spec = &webhooknotify.WorkflowNotifyJobTaskDeploySpec{
+					Env:            jobSpec.Env,
+					ServiceName:    jobSpec.ServiceName,
+					ServiceModules: serviceModules,
+				}
+
+			case string(config.JobZadigTesting):
+				if args.GetTestResult == nil {
+					return nil, nil, fmt.Errorf("test result callback is required")
+				}
+				testResult, err := args.GetTestResult(job.Name)
+				if err != nil {
+					return nil, nil, err
+				}
+				jobTplcontent += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextTestResult\"}}**: %s  \n", testResult)
+				mailJobTplcontent += fmt.Sprintf("{{getText \"notificationTextTestResult\"}}: %s \n", testResult)
+
+			case string(config.JobZadigScanning):
+				if args.GetSonarMetrics == nil {
+					return nil, nil, fmt.Errorf("sonar metrics callback is required")
+				}
+				jobSpec := &models.JobTaskFreestyleSpec{}
+				models.IToi(job.Spec, jobSpec)
+				sonarMetricsText, mailSonarMetricsText, err := args.GetSonarMetrics(jobSpec)
+				if err != nil {
+					return nil, nil, err
+				}
+				if sonarMetricsText != "" {
+					jobTplcontent += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextSonarMetrics\"}}**: %s  \n", sonarMetricsText)
+					mailJobTplcontent += fmt.Sprintf("{{getText \"notificationTextSonarMetrics\"}}: %s \n", mailSonarMetricsText)
+				}
+			}
+
+			tplToRender := jobTplcontent
+			if args.WebHookType == setting.NotifyWebHookTypeMail {
+				tplToRender = mailJobTplcontent
+			}
+			jobContent, err := args.RenderTemplate(tplToRender, job)
+			if err != nil {
+				return nil, nil, err
+			}
+			jobContents = append(jobContents, jobContent)
+			workflowNotifyStage.Jobs = append(workflowNotifyStage.Jobs, workflowNotifyJob)
+		}
+
+		workflowNotifyStages = append(workflowNotifyStages, workflowNotifyStage)
+	}
+
+	return jobContents, workflowNotifyStages, nil
+}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/workflow.go
@@ -450,6 +450,15 @@ func (w *Workflow) Validate(isExecution bool) error {
 				return e.ErrLicenseInvalid.AddDesc("基础版不支持工作流手动执行")
 			}
 		}
+		if stage.ManualExec != nil && stage.ManualExec.LarkPersonNotificationConfig != nil {
+			cfg := stage.ManualExec.LarkPersonNotificationConfig
+			if cfg.AppID == "" {
+				return e.ErrLintWorkflow.AddDesc(fmt.Sprintf("stage %s manual execute feishu notification app id is empty", stage.Name))
+			}
+			if len(cfg.TargetUsers) == 0 {
+				return e.ErrLintWorkflow.AddDesc(fmt.Sprintf("stage %s manual execute feishu notification users are empty", stage.Name))
+			}
+		}
 
 		if _, ok := stageNameMap[stage.Name]; !ok {
 			stageNameMap[stage.Name] = true

--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/workflow.go
@@ -450,16 +450,6 @@ func (w *Workflow) Validate(isExecution bool) error {
 				return e.ErrLicenseInvalid.AddDesc("基础版不支持工作流手动执行")
 			}
 		}
-		if stage.ManualExec != nil && stage.ManualExec.LarkPersonNotificationConfig != nil {
-			cfg := stage.ManualExec.LarkPersonNotificationConfig
-			if cfg.AppID == "" {
-				return e.ErrLintWorkflow.AddDesc(fmt.Sprintf("stage %s manual execute feishu notification app id is empty", stage.Name))
-			}
-			if len(cfg.TargetUsers) == 0 {
-				return e.ErrLintWorkflow.AddDesc(fmt.Sprintf("stage %s manual execute feishu notification users are empty", stage.Name))
-			}
-		}
-
 		if _, ok := stageNameMap[stage.Name]; !ok {
 			stageNameMap[stage.Name] = true
 		} else {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/workflow.go
@@ -450,6 +450,11 @@ func (w *Workflow) Validate(isExecution bool) error {
 				return e.ErrLicenseInvalid.AddDesc("基础版不支持工作流手动执行")
 			}
 		}
+		if stage.ManualExec != nil && stage.ManualExec.LarkPersonNotificationConfig != nil {
+			if stage.ManualExec.LarkPersonNotificationConfig.AppID == "" {
+				return e.ErrLintWorkflow.AddDesc(fmt.Sprintf("manual execution notification app id cannot be empty for stage %s", stage.Name))
+			}
+		}
 		if _, ok := stageNameMap[stage.Name]; !ok {
 			stageNameMap[stage.Name] = true
 		} else {


### PR DESCRIPTION
## Background
Manual execution stage notification should be handled by the existing workflow notification system instead of a separate notification flow under `manual_exec`.

The expected model is:
- `waiting for manual execution` is a workflow notification event
- `workflow executor` continues to be resolved through the existing receiver-role logic
- Feishu and mail notifications both follow existing notify control behavior

## Changes
- remove the manual-exec-specific notification fields added to `ManualExec`
- remove the direct notification trigger from `waitForManualExec`
- reuse the existing workflow notification pipeline for pause/manual-exec notifications
- render workflow pause status as `Waiting for Manual Execution` in workflow/job notification content
- fix one existing Feishu person notification bug by using `LarkPersonNotificationConfig.AppID` when resolving executor targets

## Notes
- this change keeps notification behavior in `NotifyCtl + NotifyTypes`
- Feishu executor resolution still reuses the existing Zadig user -> phone -> Lark user lookup logic
- mail notification still reuses the existing task-creator user resolution logic

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4641)
<!-- Reviewable:end -->
