### PR TITLE
fix cleanup helm stuck statefulset in other cluster

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/helm.go
+++ b/pkg/microservice/aslan/core/common/service/kube/helm.go
@@ -143,11 +143,15 @@ func InstallOrUpgradeHelmChartWithValues(param *ReleaseInstallParam, isRetry boo
 		}
 	}
 
-	clientSet, err := clientmanager.NewKubeClientManager().GetKubernetesClientSet(helmClient.ClusterID)
+	restCfg := helmClient.RestConfig
+	if restCfg == nil {
+		return fmt.Errorf("failed to get kubernetes client set, err: helm client rest config is nil")
+	}
+
+	clientSet, err := kubernetes.NewForConfig(restCfg)
 	if err != nil {
 		return fmt.Errorf("failed to get kubernetes client set, err: %v", err)
 	}
-
 	err = cleanupStuckWorkloads(clientSet, stuckDeployments, stuckStatefulSets, log.SugaredLogger())
 	if err != nil {
 		return fmt.Errorf("failed to cleanup stuck workloads, err: %v", err)


### PR DESCRIPTION
### What this PR does / Why we need it:
fix cleanup helm stuck statefulset in other cluster

### What is changed and how it works?
fix cleanup helm stuck statefulset in other cluster

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4645)
<!-- Reviewable:end -->
