### PR TITLE
fix: normalize ding-talk approval result mapping

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/koderover/zadig/v2/pkg/util"
@@ -384,6 +385,9 @@ func waitForDingTalkApprove(ctx context.Context, spec *commonmodels.JobTaskAppro
 		"refuse":   config.ApprovalStatusReject,
 		"redirect": config.ApprovalStatusRedirect,
 	}
+	getApprovalStatus := func(result string) config.ApprovalStatus {
+		return resultMap[strings.ToLower(result)]
+	}
 
 	checkNodeStatus := func(node *commonmodels.DingTalkApprovalNode) (config.ApprovalStatus, error) {
 		users := node.ApproveUsers
@@ -454,13 +458,14 @@ func waitForDingTalkApprove(ctx context.Context, spec *commonmodels.JobTaskAppro
 				isRedirected := false
 				for _, user := range node.ApproveUsers {
 					if result := userApprovalResult[user.ID]; result != nil {
-						if user.RejectOrApprove == resultMap[result.Result] &&
+						approvalStatus := getApprovalStatus(result.Result)
+						if user.RejectOrApprove == approvalStatus &&
 							user.Comment == result.Remark &&
 							user.OperationTime == result.OperationTime {
 							continue
 						}
 
-						user.RejectOrApprove = resultMap[result.Result]
+						user.RejectOrApprove = approvalStatus
 						user.Comment = result.Remark
 						user.OperationTime = result.OperationTime
 						userUpdated = true
@@ -527,7 +532,7 @@ func waitForDingTalkApprove(ctx context.Context, spec *commonmodels.JobTaskAppro
 							redirectedUser := &commonmodels.DingTalkApprovalUser{
 								ID:              task.UserID,
 								Name:            userInfo.Name,
-								RejectOrApprove: resultMap[task.Result],
+								RejectOrApprove: getApprovalStatus(task.Result),
 								Comment:         record.Remark,
 								OperationTime:   operationTime,
 							}
@@ -565,7 +570,7 @@ func waitForDingTalkApprove(ctx context.Context, spec *commonmodels.JobTaskAppro
 					log.Errorf("get instance final info failed: %v", err)
 					return config.StatusFailed, fmt.Errorf("get instance final info error: %s", err)
 				}
-				if instanceInfo.Status == "COMPLETED" && instanceInfo.Result == "agree" {
+				if instanceInfo.Status == "COMPLETED" && getApprovalStatus(instanceInfo.Result) == config.ApprovalStatusApprove {
 					return config.StatusPassed, nil
 				} else {
 					err = fmt.Errorf("Unexpect instance final status is %s, result is %s", instanceInfo.Status, instanceInfo.Result)

--- a/pkg/microservice/aslan/core/release_plan/service/approval.go
+++ b/pkg/microservice/aslan/core/release_plan/service/approval.go
@@ -246,6 +246,9 @@ func updateDingTalkApproval(ctx context.Context, approvalInfo *models.Approval) 
 		"agree":  config.ApprovalStatusApprove,
 		"refuse": config.ApprovalStatusReject,
 	}
+	getApprovalStatus := func(result string) config.ApprovalStatus {
+		return resultMap[strings.ToLower(result)]
+	}
 
 	checkNodeStatus := func(node *models.DingTalkApprovalNode) (config.ApprovalStatus, error) {
 		users := node.ApproveUsers
@@ -278,19 +281,45 @@ func updateDingTalkApproval(ctx context.Context, approvalInfo *models.Approval) 
 	if err != nil {
 		return errors.Wrap(err, "get approval instance")
 	}
+	log.Infof("updateDingTalkApproval: instanceID=%s status=%s result=%s operationRecords=%d tasks=%d",
+		instanceID, instanceInfo.Status, instanceInfo.Result, len(instanceInfo.OperationRecords), len(instanceInfo.Tasks))
 
 	operationRecordMap := make(map[string]*dingtalk.OperationRecord)
 	for _, record := range instanceInfo.OperationRecords {
 		operationRecordMap[record.UserID] = record
+		log.Infof("updateDingTalkApproval: instanceID=%s operationRecord userID=%s result=%s date=%s remark=%s",
+			instanceID, record.UserID, record.Result, record.Date, record.Remark)
+	}
+	taskMap := make(map[string]*dingtalk.ApprovalInstanceTask)
+	for _, task := range instanceInfo.Tasks {
+		taskMap[task.UserID] = task
+		log.Infof("updateDingTalkApproval: instanceID=%s task userID=%s result=%s activityID=%s",
+			instanceID, task.UserID, task.Result, task.ActivityID)
 	}
 
-	for _, node := range approval.ApprovalNodes {
+	for nodeIndex, node := range approval.ApprovalNodes {
 		if node.RejectOrApprove != "" {
+			log.Infof("updateDingTalkApproval: instanceID=%s skip node index=%d type=%s status=%s",
+				instanceID, nodeIndex, node.Type, node.RejectOrApprove)
 			continue
 		}
 		for _, user := range node.ApproveUsers {
 			if record := operationRecordMap[user.ID]; record != nil && user.RejectOrApprove == "" {
-				user.RejectOrApprove = resultMap[record.Result]
+				user.RejectOrApprove = getApprovalStatus(record.Result)
+				if user.RejectOrApprove == "" {
+					if task := taskMap[user.ID]; task != nil {
+						user.RejectOrApprove = getApprovalStatus(task.Result)
+						log.Infof("updateDingTalkApproval: instanceID=%s userID=%s operation result=%s mapped empty, fallback task result=%s mapped=%s",
+							instanceID, user.ID, record.Result, task.Result, user.RejectOrApprove)
+					}
+				}
+				if user.RejectOrApprove == "" {
+					log.Warnf("updateDingTalkApproval: instanceID=%s userID=%s result not mapped, operation result=%s",
+						instanceID, user.ID, record.Result)
+				} else {
+					log.Infof("updateDingTalkApproval: instanceID=%s userID=%s mapped approval result=%s from operation result=%s",
+						instanceID, user.ID, user.RejectOrApprove, record.Result)
+				}
 				user.Comment = record.Remark
 				if record.Date != "" {
 					operationTime, err := time.Parse("2006-01-02T15:04Z", record.Date)
@@ -299,16 +328,22 @@ func updateDingTalkApproval(ctx context.Context, approvalInfo *models.Approval) 
 					}
 					user.OperationTime = operationTime.Unix()
 				}
+			} else if user.RejectOrApprove == "" {
+				log.Infof("updateDingTalkApproval: instanceID=%s node index=%d userID=%s has no operation record",
+					instanceID, nodeIndex, user.ID)
 			}
 		}
 		node.RejectOrApprove, err = checkNodeStatus(node)
 		if err != nil {
 			return errors.Wrap(err, "check node")
 		}
+		log.Infof("updateDingTalkApproval: instanceID=%s node index=%d type=%s checked status=%s",
+			instanceID, nodeIndex, node.Type, node.RejectOrApprove)
 		switch node.RejectOrApprove {
 		case config.ApprovalStatusApprove:
 		case config.ApprovalStatusReject:
 			approvalInfo.Status = config.StatusReject
+			log.Infof("updateDingTalkApproval: instanceID=%s approval rejected at node index=%d", instanceID, nodeIndex)
 			return nil
 		}
 		break
@@ -316,11 +351,15 @@ func updateDingTalkApproval(ctx context.Context, approvalInfo *models.Approval) 
 	if approval.ApprovalNodes[len(approval.ApprovalNodes)-1].RejectOrApprove == config.ApprovalStatusApprove {
 		if instanceInfo.Status == "COMPLETED" && instanceInfo.Result == "agree" {
 			approvalInfo.Status = config.StatusPassed
+			log.Infof("updateDingTalkApproval: instanceID=%s approval passed", instanceID)
 			return nil
 		} else {
+			log.Warnf("updateDingTalkApproval: instanceID=%s final node approved but instance status=%s result=%s",
+				instanceID, instanceInfo.Status, instanceInfo.Result)
 			return errors.Errorf("unexpected instance final status is %s, result is %s", instanceInfo.Status, instanceInfo.Result)
 		}
 	}
+	log.Infof("updateDingTalkApproval: instanceID=%s approval still pending", instanceID)
 
 	return nil
 }

--- a/pkg/microservice/aslan/core/release_plan/service/approval.go
+++ b/pkg/microservice/aslan/core/release_plan/service/approval.go
@@ -40,6 +40,7 @@ import (
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	approvalservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/approval"
+	dingservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/dingtalk"
 	"github.com/koderover/zadig/v2/pkg/shared/client/systemconfig"
 	"github.com/koderover/zadig/v2/pkg/shared/client/user"
 	"github.com/koderover/zadig/v2/pkg/tool/dingtalk"
@@ -249,20 +250,6 @@ func updateDingTalkApproval(ctx context.Context, approvalInfo *models.Approval) 
 	getApprovalStatus := func(result string) config.ApprovalStatus {
 		return resultMap[strings.ToLower(result)]
 	}
-	parseDingTalkOperationTime := func(date string) (int64, error) {
-		if date == "" {
-			return 0, nil
-		}
-		location, err := time.LoadLocation("Asia/Shanghai")
-		if err != nil {
-			return 0, err
-		}
-		t, err := time.ParseInLocation("2006-01-02T15:04Z", date, location)
-		if err != nil {
-			return 0, err
-		}
-		return t.Unix(), nil
-	}
 
 	checkNodeStatus := func(node *models.DingTalkApprovalNode) (config.ApprovalStatus, error) {
 		users := node.ApproveUsers
@@ -290,42 +277,16 @@ func updateDingTalkApproval(ctx context.Context, approvalInfo *models.Approval) 
 		}
 	}
 
-	// Directly poll from DingTalk API instead of relying on webhook-populated cache.
-	instanceInfo, err := client.GetApprovalInstance(instanceID)
-	if err != nil {
-		return errors.Wrap(err, "get approval instance")
-	}
-
-	operationRecordMap := make(map[string]*dingtalk.OperationRecord)
-	for _, record := range instanceInfo.OperationRecords {
-		operationRecordMap[record.UserID] = record
-	}
-	taskMap := make(map[string]*dingtalk.ApprovalInstanceTask)
-	for _, task := range instanceInfo.Tasks {
-		taskMap[task.UserID] = task
-	}
-
+	userApprovalResult := dingservice.GetAllUserApprovalResults(instanceID)
 	for _, node := range approval.ApprovalNodes {
 		if node.RejectOrApprove != "" {
 			continue
 		}
 		for _, user := range node.ApproveUsers {
-			if record := operationRecordMap[user.ID]; record != nil && user.RejectOrApprove == "" {
-				user.RejectOrApprove = getApprovalStatus(record.Result)
-				if user.RejectOrApprove == "" {
-					if task := taskMap[user.ID]; task != nil {
-						user.RejectOrApprove = getApprovalStatus(task.Result)
-					}
-				}
-				if user.RejectOrApprove == "" {
-					log.Warnf("updateDingTalkApproval: instanceID=%s userID=%s result not mapped, operation result=%s",
-						instanceID, user.ID, record.Result)
-				}
-				user.Comment = record.Remark
-				user.OperationTime, err = parseDingTalkOperationTime(record.Date)
-				if err != nil {
-					return errors.Wrapf(err, "parse operation time for user %s", user.ID)
-				}
+			if result := userApprovalResult[user.ID]; result != nil && user.RejectOrApprove == "" {
+				user.RejectOrApprove = getApprovalStatus(result.Result)
+				user.Comment = result.Remark
+				user.OperationTime = result.OperationTime
 			}
 		}
 		node.RejectOrApprove, err = checkNodeStatus(node)
@@ -342,6 +303,10 @@ func updateDingTalkApproval(ctx context.Context, approvalInfo *models.Approval) 
 		break
 	}
 	if approval.ApprovalNodes[len(approval.ApprovalNodes)-1].RejectOrApprove == config.ApprovalStatusApprove {
+		instanceInfo, err := client.GetApprovalInstance(instanceID)
+		if err != nil {
+			return errors.Wrap(err, "get instance final info")
+		}
 		if instanceInfo.Status == "COMPLETED" && getApprovalStatus(instanceInfo.Result) == config.ApprovalStatusApprove {
 			approvalInfo.Status = config.StatusPassed
 			log.Infof("updateDingTalkApproval: instanceID=%s approval passed", instanceID)

--- a/pkg/microservice/aslan/core/release_plan/service/approval.go
+++ b/pkg/microservice/aslan/core/release_plan/service/approval.go
@@ -40,7 +40,6 @@ import (
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	approvalservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/approval"
-	dingservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/dingtalk"
 	"github.com/koderover/zadig/v2/pkg/shared/client/systemconfig"
 	"github.com/koderover/zadig/v2/pkg/shared/client/user"
 	"github.com/koderover/zadig/v2/pkg/tool/dingtalk"
@@ -237,7 +236,7 @@ func updateDingTalkApproval(ctx context.Context, approvalInfo *models.Approval) 
 		return errors.New("updateDingTalkApproval: instance id not found")
 	}
 
-	data, err := mongodb.NewIMAppColl().GetByID(context.Background(), approval.ID)
+	data, err := mongodb.NewIMAppColl().GetByID(ctx, approval.ID)
 	if err != nil {
 		return errors.Wrap(err, "get dingtalk im data")
 	}
@@ -274,16 +273,32 @@ func updateDingTalkApproval(ctx context.Context, approvalInfo *models.Approval) 
 		}
 	}
 
-	userApprovalResult := dingservice.GetAllUserApprovalResults(instanceID)
+	// Directly poll from DingTalk API instead of relying on webhook-populated cache.
+	instanceInfo, err := client.GetApprovalInstance(instanceID)
+	if err != nil {
+		return errors.Wrap(err, "get approval instance")
+	}
+
+	operationRecordMap := make(map[string]*dingtalk.OperationRecord)
+	for _, record := range instanceInfo.OperationRecords {
+		operationRecordMap[record.UserID] = record
+	}
+
 	for _, node := range approval.ApprovalNodes {
 		if node.RejectOrApprove != "" {
 			continue
 		}
 		for _, user := range node.ApproveUsers {
-			if result := userApprovalResult[user.ID]; result != nil && user.RejectOrApprove == "" {
-				user.RejectOrApprove = resultMap[result.Result]
-				user.Comment = result.Remark
-				user.OperationTime = result.OperationTime
+			if record := operationRecordMap[user.ID]; record != nil && user.RejectOrApprove == "" {
+				user.RejectOrApprove = resultMap[record.Result]
+				user.Comment = record.Remark
+				if record.Date != "" {
+					operationTime, err := time.Parse("2006-01-02T15:04Z", record.Date)
+					if err != nil {
+						return errors.Wrapf(err, "parse operation time for user %s", user.ID)
+					}
+					user.OperationTime = operationTime.Unix()
+				}
 			}
 		}
 		node.RejectOrApprove, err = checkNodeStatus(node)
@@ -299,18 +314,14 @@ func updateDingTalkApproval(ctx context.Context, approvalInfo *models.Approval) 
 		break
 	}
 	if approval.ApprovalNodes[len(approval.ApprovalNodes)-1].RejectOrApprove == config.ApprovalStatusApprove {
-		instanceInfo, err := client.GetApprovalInstance(instanceID)
-		if err != nil {
-			return errors.Wrap(err, "get instance final info")
-		}
 		if instanceInfo.Status == "COMPLETED" && instanceInfo.Result == "agree" {
 			approvalInfo.Status = config.StatusPassed
 			return nil
 		} else {
-			log.Errorf("Unexpect instance final status is %s, result is %s", instanceInfo.Status, instanceInfo.Result)
-			return errors.Wrap(err, "get unexpected instance final info")
+			return errors.Errorf("unexpected instance final status is %s, result is %s", instanceInfo.Status, instanceInfo.Result)
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/microservice/aslan/core/release_plan/service/approval.go
+++ b/pkg/microservice/aslan/core/release_plan/service/approval.go
@@ -249,6 +249,20 @@ func updateDingTalkApproval(ctx context.Context, approvalInfo *models.Approval) 
 	getApprovalStatus := func(result string) config.ApprovalStatus {
 		return resultMap[strings.ToLower(result)]
 	}
+	parseDingTalkOperationTime := func(date string) (int64, error) {
+		if date == "" {
+			return 0, nil
+		}
+		location, err := time.LoadLocation("Asia/Shanghai")
+		if err != nil {
+			return 0, err
+		}
+		t, err := time.ParseInLocation("2006-01-02T15:04Z", date, location)
+		if err != nil {
+			return 0, err
+		}
+		return t.Unix(), nil
+	}
 
 	checkNodeStatus := func(node *models.DingTalkApprovalNode) (config.ApprovalStatus, error) {
 		users := node.ApproveUsers
@@ -281,26 +295,18 @@ func updateDingTalkApproval(ctx context.Context, approvalInfo *models.Approval) 
 	if err != nil {
 		return errors.Wrap(err, "get approval instance")
 	}
-	log.Infof("updateDingTalkApproval: instanceID=%s status=%s result=%s operationRecords=%d tasks=%d",
-		instanceID, instanceInfo.Status, instanceInfo.Result, len(instanceInfo.OperationRecords), len(instanceInfo.Tasks))
 
 	operationRecordMap := make(map[string]*dingtalk.OperationRecord)
 	for _, record := range instanceInfo.OperationRecords {
 		operationRecordMap[record.UserID] = record
-		log.Infof("updateDingTalkApproval: instanceID=%s operationRecord userID=%s result=%s date=%s remark=%s",
-			instanceID, record.UserID, record.Result, record.Date, record.Remark)
 	}
 	taskMap := make(map[string]*dingtalk.ApprovalInstanceTask)
 	for _, task := range instanceInfo.Tasks {
 		taskMap[task.UserID] = task
-		log.Infof("updateDingTalkApproval: instanceID=%s task userID=%s result=%s activityID=%s",
-			instanceID, task.UserID, task.Result, task.ActivityID)
 	}
 
-	for nodeIndex, node := range approval.ApprovalNodes {
+	for _, node := range approval.ApprovalNodes {
 		if node.RejectOrApprove != "" {
-			log.Infof("updateDingTalkApproval: instanceID=%s skip node index=%d type=%s status=%s",
-				instanceID, nodeIndex, node.Type, node.RejectOrApprove)
 			continue
 		}
 		for _, user := range node.ApproveUsers {
@@ -309,47 +315,34 @@ func updateDingTalkApproval(ctx context.Context, approvalInfo *models.Approval) 
 				if user.RejectOrApprove == "" {
 					if task := taskMap[user.ID]; task != nil {
 						user.RejectOrApprove = getApprovalStatus(task.Result)
-						log.Infof("updateDingTalkApproval: instanceID=%s userID=%s operation result=%s mapped empty, fallback task result=%s mapped=%s",
-							instanceID, user.ID, record.Result, task.Result, user.RejectOrApprove)
 					}
 				}
 				if user.RejectOrApprove == "" {
 					log.Warnf("updateDingTalkApproval: instanceID=%s userID=%s result not mapped, operation result=%s",
 						instanceID, user.ID, record.Result)
-				} else {
-					log.Infof("updateDingTalkApproval: instanceID=%s userID=%s mapped approval result=%s from operation result=%s",
-						instanceID, user.ID, user.RejectOrApprove, record.Result)
 				}
 				user.Comment = record.Remark
-				if record.Date != "" {
-					operationTime, err := time.Parse("2006-01-02T15:04Z", record.Date)
-					if err != nil {
-						return errors.Wrapf(err, "parse operation time for user %s", user.ID)
-					}
-					user.OperationTime = operationTime.Unix()
+				user.OperationTime, err = parseDingTalkOperationTime(record.Date)
+				if err != nil {
+					return errors.Wrapf(err, "parse operation time for user %s", user.ID)
 				}
-			} else if user.RejectOrApprove == "" {
-				log.Infof("updateDingTalkApproval: instanceID=%s node index=%d userID=%s has no operation record",
-					instanceID, nodeIndex, user.ID)
 			}
 		}
 		node.RejectOrApprove, err = checkNodeStatus(node)
 		if err != nil {
 			return errors.Wrap(err, "check node")
 		}
-		log.Infof("updateDingTalkApproval: instanceID=%s node index=%d type=%s checked status=%s",
-			instanceID, nodeIndex, node.Type, node.RejectOrApprove)
 		switch node.RejectOrApprove {
 		case config.ApprovalStatusApprove:
 		case config.ApprovalStatusReject:
 			approvalInfo.Status = config.StatusReject
-			log.Infof("updateDingTalkApproval: instanceID=%s approval rejected at node index=%d", instanceID, nodeIndex)
+			log.Infof("updateDingTalkApproval: instanceID=%s approval rejected", instanceID)
 			return nil
 		}
 		break
 	}
 	if approval.ApprovalNodes[len(approval.ApprovalNodes)-1].RejectOrApprove == config.ApprovalStatusApprove {
-		if instanceInfo.Status == "COMPLETED" && instanceInfo.Result == "agree" {
+		if instanceInfo.Status == "COMPLETED" && getApprovalStatus(instanceInfo.Result) == config.ApprovalStatusApprove {
 			approvalInfo.Status = config.StatusPassed
 			log.Infof("updateDingTalkApproval: instanceID=%s approval passed", instanceID)
 			return nil
@@ -359,7 +352,6 @@ func updateDingTalkApproval(ctx context.Context, approvalInfo *models.Approval) 
 			return errors.Errorf("unexpected instance final status is %s, result is %s", instanceInfo.Status, instanceInfo.Result)
 		}
 	}
-	log.Infof("updateDingTalkApproval: instanceID=%s approval still pending", instanceID)
 
 	return nil
 }


### PR DESCRIPTION
### What this PR does / Why we need it:

This PR fixes DingTalk approval status updates when DingTalk returns approval result values with different letter casing.Both release plan approval and workflow approval map DingTalk result values such as agree, refuse, and redirect to internal approval statuses. In some cases, DingTalk may return these values with different casing through approval-related data, causing the mapping to fail and leaving approval status empty or not updated correctly.

### What is changed and how it works?

Normalize DingTalk approval result values with strings.ToLower before mapping them to internal statuses.
Apply the same normalization in release plan DingTalk approval handling.
Apply the same normalization in workflow DingTalk approval handling.
Keep the existing approval flow unchanged.Final DingTalk instance result checks also use the normalized result mapping.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4649)
<!-- Reviewable:end -->
