### PR TITLE
feat: support stage executor notifications for manual execution pause

### DIFF
--- a/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
@@ -481,6 +481,9 @@ func (w *Service) SendManualExecStageNotifications(workflowCtx *models.WorkflowT
 			stageForNotification = matchedStage
 		}
 	}
+	if !shouldSendManualExecStageNotification(taskForNotification) {
+		return nil
+	}
 
 	jobContents, _, err = workflownotifyutil.BuildWorkflowJobContents(&workflownotifyutil.BuildJobContentsArgs{
 		Task:        taskForNotification,
@@ -545,6 +548,35 @@ func (w *Service) SendManualExecStageNotifications(workflowCtx *models.WorkflowT
 	}
 
 	return respErr.ErrorOrNil()
+}
+
+func shouldSendManualExecStageNotification(task *models.WorkflowTask) bool {
+	if task == nil {
+		return false
+	}
+
+	notifyCtls := []*models.NotifyCtl{}
+	switch {
+	case task.OriginWorkflowArgs != nil:
+		notifyCtls = task.OriginWorkflowArgs.NotifyCtls
+	case task.WorkflowArgs != nil:
+		notifyCtls = task.WorkflowArgs.NotifyCtls
+	}
+
+	for _, notify := range notifyCtls {
+		if notify == nil || !notify.Enabled || notify.WebHookType != setting.NotifyWebHookTypeFeishuPerson {
+			continue
+		}
+		if err := notify.GenerateNewNotifyConfigWithOldData(); err != nil {
+			log.Errorf("failed to parse feishu person notification config for workflow %s task %d: %v", task.WorkflowName, task.TaskID, err)
+			continue
+		}
+		if sets.NewString(notify.NotifyTypes...).Has(string(config.StatusPause)) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func formatManualExecNotifiedUsers(users []*models.User, userInfoMap map[string]*types.UserInfo) string {

--- a/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
@@ -449,24 +449,12 @@ func (w *Service) SendManualExecStageNotifications(workflowCtx *models.WorkflowT
 	if workflowCtx == nil || stage == nil || stage.ManualExec == nil {
 		return nil
 	}
-	notifyCfg := stage.ManualExec.LarkPersonNotificationConfig
-	if notifyCfg == nil || notifyCfg.AppID == "" || len(stage.ManualExec.ManualExecUsers) == 0 {
-		return nil
-	}
 
 	systemSetting, err := commonrepo.NewSystemSettingColl().Get()
 	if err != nil {
 		return fmt.Errorf("get system language error: %w", err)
 	}
 	language := systemSetting.Language
-
-	client, err := larkservice.GetLarkClientByIMAppID(notifyCfg.AppID)
-	if err != nil {
-		return fmt.Errorf("create feishu client error: %w", err)
-	}
-
-	manualExecUsers, userInfoMap := commonutil.GeneFlatUsersWithCaller(stage.ManualExec.ManualExecUsers, workflowCtx.WorkflowTaskCreatorUserID)
-	notifiedUsers := formatManualExecNotifiedUsers(manualExecUsers, userInfoMap)
 
 	jobContents := []string{}
 	taskForNotification := &models.WorkflowTask{
@@ -481,81 +469,74 @@ func (w *Service) SendManualExecStageNotifications(workflowCtx *models.WorkflowT
 			stageForNotification = matchedStage
 		}
 	}
-	if !shouldSendManualExecStageNotification(taskForNotification) {
+	notifyCtls := getManualExecStageNotifyCtls(taskForNotification)
+	if len(notifyCtls) == 0 {
 		return nil
 	}
 
-	jobContents, _, err = workflownotifyutil.BuildWorkflowJobContents(&workflownotifyutil.BuildJobContentsArgs{
-		Task:        taskForNotification,
-		Stages:      []*models.StageTask{stageForNotification},
-		WebHookType: setting.NotifyWebHookTypeFeishuPerson,
-		RenderTemplate: func(tpl string, job *models.JobTask) (string, error) {
-			return getJobTaskTplExec(tpl, &jobTaskNotification{Job: job, WebHookType: setting.NotifyWebHookTypeFeishuPerson}, language)
-		},
-		GetTestResult: func(jobName string) (string, error) {
-			return genTestResultText(taskForNotification.WorkflowName, jobName, taskForNotification.TaskID, language)
-		},
-		GetSonarMetrics: func(jobSpec *models.JobTaskFreestyleSpec) (string, string, error) {
-			return genSonartMetricsText(jobSpec, language)
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("build manual exec stage notification jobs error: %w", err)
-	}
-
-	messageContent, err := json.Marshal(w.getManualExecStageLarkCard(workflowCtx, stageForNotification, language, notifiedUsers, jobContents))
-	if err != nil {
-		return fmt.Errorf("marshal manual exec stage notification card error: %w", err)
-	}
-
 	respErr := new(multierror.Error)
-	sentTargets := sets.NewString()
-	for _, execUser := range manualExecUsers {
-		if execUser == nil || execUser.UserID == "" {
+	for _, notify := range notifyCtls {
+		jobContents, err = w.buildManualExecStageJobContents(taskForNotification, stageForNotification, notify.WebHookType, language)
+		if err != nil {
+			respErr = multierror.Append(respErr, fmt.Errorf("build manual exec stage notification jobs error: %w", err))
 			continue
 		}
-		userInfo, ok := userInfoMap[execUser.UserID]
-		if !ok {
-			var getErr error
-			userInfo, getErr = userclient.New().GetUserByID(execUser.UserID)
-			if getErr != nil {
-				respErr = multierror.Append(respErr, fmt.Errorf("find manual executor %s error: %w", execUser.UserID, getErr))
+
+		switch notify.WebHookType {
+		case setting.NotifyWebHookTypeFeishuPerson:
+			resolvedTargets, notifiedUsers, err := w.resolveManualExecStageLarkTargets(taskForNotification, stageForNotification, notify)
+			if err != nil {
+				respErr = multierror.Append(respErr, err)
 				continue
 			}
-		}
-		if userInfo.Phone == "" {
-			respErr = multierror.Append(respErr, fmt.Errorf("manual executor %s phone not configured", execUser.UserID))
-			continue
-		}
+			if len(resolvedTargets) == 0 {
+				continue
+			}
 
-		larkUser, err := client.GetUserIDByEmailOrMobile(lark.QueryTypeMobile, userInfo.Phone, setting.LarkUserID)
-		if err != nil {
-			respErr = multierror.Append(respErr, fmt.Errorf("find lark user with phone %s error: %w", userInfo.Phone, err))
-			continue
-		}
-		targetID := util.GetStringFromPointer(larkUser.UserId)
-		if targetID == "" {
-			continue
-		}
-		if sentTargets.Has(targetID) {
-			continue
-		}
-		sentTargets.Insert(targetID)
+			notifyToSend := *notify
+			notifyToSend.LarkPersonNotificationConfig = &models.LarkPersonNotificationConfig{
+				AppID:       notify.LarkPersonNotificationConfig.AppID,
+				TargetUsers: resolvedTargets,
+			}
 
-		if err := w.sendFeishuMessageFromClient(client, setting.LarkUserID, targetID, LarkMessageTypeCard, string(messageContent)); err != nil {
-			respErr = multierror.Append(respErr, err)
+			card := w.getManualExecStageLarkCard(workflowCtx, stageForNotification, language, notifiedUsers, jobContents)
+			if err := w.sendNotification("", "", &notifyToSend, card, nil, config.StatusPause); err != nil {
+				respErr = multierror.Append(respErr, err)
+			}
+
+		case setting.NotifyWebHookTypeMail:
+			resolvedUsers, notifiedUsers, err := w.resolveManualExecStageMailUsers(taskForNotification, stageForNotification, notify)
+			if err != nil {
+				respErr = multierror.Append(respErr, err)
+				continue
+			}
+			if len(resolvedUsers) == 0 {
+				continue
+			}
+
+			title, content, err := w.getManualExecStageMailContent(workflowCtx, stageForNotification, language, notifiedUsers, jobContents)
+			if err != nil {
+				respErr = multierror.Append(respErr, err)
+				continue
+			}
+
+			notifyToSend := *notify
+			notifyToSend.MailNotificationConfig = &models.MailNotificationConfig{TargetUsers: resolvedUsers}
+			if err := w.sendNotification(title, content, &notifyToSend, nil, nil, config.StatusPause); err != nil {
+				respErr = multierror.Append(respErr, err)
+			}
 		}
 	}
 
 	return respErr.ErrorOrNil()
 }
 
-func shouldSendManualExecStageNotification(task *models.WorkflowTask) bool {
+func getManualExecStageNotifyCtls(task *models.WorkflowTask) []*models.NotifyCtl {
 	if task == nil {
-		return false
+		return nil
 	}
 
-	notifyCtls := []*models.NotifyCtl{}
+	var notifyCtls []*models.NotifyCtl
 	switch {
 	case task.OriginWorkflowArgs != nil:
 		notifyCtls = task.OriginWorkflowArgs.NotifyCtls
@@ -563,20 +544,228 @@ func shouldSendManualExecStageNotification(task *models.WorkflowTask) bool {
 		notifyCtls = task.WorkflowArgs.NotifyCtls
 	}
 
+	ret := make([]*models.NotifyCtl, 0, len(notifyCtls))
 	for _, notify := range notifyCtls {
-		if notify == nil || !notify.Enabled || notify.WebHookType != setting.NotifyWebHookTypeFeishuPerson {
+		if notify == nil || !notify.Enabled {
 			continue
 		}
 		if err := notify.GenerateNewNotifyConfigWithOldData(); err != nil {
-			log.Errorf("failed to parse feishu person notification config for workflow %s task %d: %v", task.WorkflowName, task.TaskID, err)
+			log.Errorf("failed to parse notification config for workflow %s task %d: %v", task.WorkflowName, task.TaskID, err)
 			continue
 		}
-		if sets.NewString(notify.NotifyTypes...).Has(string(config.StatusPause)) {
-			return true
+		if !sets.NewString(notify.NotifyTypes...).Has(string(config.StatusPause)) {
+			continue
 		}
+		if notify.WebHookType != setting.NotifyWebHookTypeFeishuPerson && notify.WebHookType != setting.NotifyWebHookTypeMail {
+			continue
+		}
+		ret = append(ret, notify)
 	}
 
-	return false
+	return ret
+}
+
+func (w *Service) buildManualExecStageJobContents(task *models.WorkflowTask, stage *models.StageTask, webHookType setting.NotifyWebHookType, language string) ([]string, error) {
+	jobContents, _, err := workflownotifyutil.BuildWorkflowJobContents(&workflownotifyutil.BuildJobContentsArgs{
+		Task:        task,
+		Stages:      []*models.StageTask{stage},
+		WebHookType: webHookType,
+		RenderTemplate: func(tpl string, job *models.JobTask) (string, error) {
+			return getJobTaskTplExec(tpl, &jobTaskNotification{Job: job, WebHookType: webHookType}, language)
+		},
+		GetTestResult: func(jobName string) (string, error) {
+			return genTestResultText(task.WorkflowName, jobName, task.TaskID, language)
+		},
+		GetSonarMetrics: func(jobSpec *models.JobTaskFreestyleSpec) (string, string, error) {
+			return genSonartMetricsText(jobSpec, language)
+		},
+	})
+	return jobContents, err
+}
+
+func (w *Service) resolveManualExecStageLarkTargets(task *models.WorkflowTask, stage *models.StageTask, notify *models.NotifyCtl) ([]*lark.UserInfo, string, error) {
+	if notify == nil || notify.LarkPersonNotificationConfig == nil || notify.LarkPersonNotificationConfig.AppID == "" {
+		return nil, "", nil
+	}
+
+	client, err := larkservice.GetLarkClientByIMAppID(notify.LarkPersonNotificationConfig.AppID)
+	if err != nil {
+		return nil, "", fmt.Errorf("create feishu client error: %w", err)
+	}
+
+	respErr := new(multierror.Error)
+	targets := make([]*lark.UserInfo, 0, len(notify.LarkPersonNotificationConfig.TargetUsers))
+	targetSet := sets.NewString()
+	nameSet := sets.NewString()
+	notifiedUsers := make([]string, 0, len(notify.LarkPersonNotificationConfig.TargetUsers))
+	stageUsers, stageUserInfoMap := resolveManualExecStageUsers(stage, task.TaskCreatorID)
+
+	for _, target := range notify.LarkPersonNotificationConfig.TargetUsers {
+		if target == nil {
+			continue
+		}
+
+		if target.IsExecutor {
+			if task.TaskCreatorID == "" {
+				respErr = multierror.Append(respErr, fmt.Errorf("executor id is empty, cannot send message"))
+				continue
+			}
+			userInfo, err := userclient.New().GetUserByID(task.TaskCreatorID)
+			if err != nil {
+				respErr = multierror.Append(respErr, fmt.Errorf("failed to find user %s, error: %w", task.TaskCreatorID, err))
+				continue
+			}
+			resolvedTarget, displayName, resolveErr := w.resolveManualExecStageLarkTargetFromUser(client, userInfo.Uid, userInfo.Name)
+			if resolveErr != nil {
+				respErr = multierror.Append(respErr, resolveErr)
+				continue
+			}
+			targets, notifiedUsers = appendManualExecStageLarkTarget(targets, targetSet, notifiedUsers, nameSet, resolvedTarget, displayName)
+			continue
+		}
+
+		if target.IsStageExecutor {
+			for _, stageUser := range stageUsers {
+				if stageUser == nil || stageUser.UserID == "" {
+					continue
+				}
+				displayName := stageUser.UserName
+				if info, ok := stageUserInfoMap[stageUser.UserID]; ok && info != nil && info.Name != "" {
+					displayName = info.Name
+				}
+				resolvedTarget, resolvedDisplayName, resolveErr := w.resolveManualExecStageLarkTargetFromUser(client, stageUser.UserID, displayName)
+				if resolveErr != nil {
+					respErr = multierror.Append(respErr, fmt.Errorf("stage executor %s: %w", stageUser.UserID, resolveErr))
+					continue
+				}
+				targets, notifiedUsers = appendManualExecStageLarkTarget(targets, targetSet, notifiedUsers, nameSet, resolvedTarget, resolvedDisplayName)
+			}
+			continue
+		}
+
+		resolvedTarget := &lark.UserInfo{
+			ID:              target.ID,
+			IDType:          target.IDType,
+			Name:            target.Name,
+			Avatar:          target.Avatar,
+			IsExecutor:      target.IsExecutor,
+			IsStageExecutor: target.IsStageExecutor,
+		}
+		displayName := target.Name
+
+		if resolvedTarget.ID == "" {
+			continue
+		}
+		if resolvedTarget.IDType == "" {
+			resolvedTarget.IDType = setting.LarkUserID
+		}
+		targets, notifiedUsers = appendManualExecStageLarkTarget(targets, targetSet, notifiedUsers, nameSet, resolvedTarget, displayName)
+	}
+
+	return targets, strings.Join(notifiedUsers, ", "), respErr.ErrorOrNil()
+}
+
+func (w *Service) resolveManualExecStageMailUsers(task *models.WorkflowTask, stage *models.StageTask, notify *models.NotifyCtl) ([]*models.User, string, error) {
+	if notify == nil || notify.MailNotificationConfig == nil {
+		return nil, "", nil
+	}
+
+	usersToExpand := make([]*models.User, 0, len(notify.MailNotificationConfig.TargetUsers))
+	for _, user := range notify.MailNotificationConfig.TargetUsers {
+		if user == nil {
+			continue
+		}
+		if user.Type == setting.UserTypeStageExecutor {
+			if stage == nil || stage.ManualExec == nil {
+				continue
+			}
+			usersToExpand = append(usersToExpand, stage.ManualExec.ManualExecUsers...)
+			continue
+		}
+		usersToExpand = append(usersToExpand, user)
+	}
+
+	var users []*models.User
+	var userInfoMap map[string]*types.UserInfo
+	if task.TaskCreatorID != "" {
+		users, userInfoMap = commonutil.GeneFlatUsersWithCaller(usersToExpand, task.TaskCreatorID)
+	} else {
+		users, userInfoMap = commonutil.GeneFlatUsers(usersToExpand)
+	}
+
+	return users, formatManualExecNotifiedUsers(users, userInfoMap), nil
+}
+
+func resolveManualExecStageUsers(stage *models.StageTask, taskCreatorID string) ([]*models.User, map[string]*types.UserInfo) {
+	if stage == nil || stage.ManualExec == nil || len(stage.ManualExec.ManualExecUsers) == 0 {
+		return nil, map[string]*types.UserInfo{}
+	}
+
+	if taskCreatorID != "" {
+		return commonutil.GeneFlatUsersWithCaller(stage.ManualExec.ManualExecUsers, taskCreatorID)
+	}
+
+	return commonutil.GeneFlatUsers(stage.ManualExec.ManualExecUsers)
+}
+
+func (w *Service) resolveManualExecStageLarkTargetFromUser(client *lark.Client, userID, userName string) (*lark.UserInfo, string, error) {
+	userInfo, err := userclient.New().GetUserByID(userID)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to find user %s, error: %w", userID, err)
+	}
+	if len(userInfo.Phone) == 0 {
+		return nil, "", fmt.Errorf("phone not configured")
+	}
+
+	larkUser, err := client.GetUserIDByEmailOrMobile(lark.QueryTypeMobile, userInfo.Phone, setting.LarkUserID)
+	if err != nil {
+		return nil, "", fmt.Errorf("find lark user with phone %s error: %w", userInfo.Phone, err)
+	}
+
+	userDetailedInfo, err := client.GetUserInfoByID(util.GetStringFromPointer(larkUser.UserId), setting.LarkUserID)
+	if err != nil {
+		return nil, "", fmt.Errorf("find lark user info for userID %s error: %w", util.GetStringFromPointer(larkUser.UserId), err)
+	}
+
+	displayName := userDetailedInfo.Name
+	if displayName == "" {
+		displayName = userName
+	}
+
+	return &lark.UserInfo{
+		ID:     util.GetStringFromPointer(larkUser.UserId),
+		IDType: setting.LarkUserID,
+		Name:   userDetailedInfo.Name,
+		Avatar: userDetailedInfo.Avatar,
+	}, displayName, nil
+}
+
+func appendManualExecStageLarkTarget(targets []*lark.UserInfo, targetSet sets.String, notifiedUsers []string, nameSet sets.String, target *lark.UserInfo, displayName string) ([]*lark.UserInfo, []string) {
+	if target == nil || target.ID == "" {
+		return targets, notifiedUsers
+	}
+	if target.IDType == "" {
+		target.IDType = setting.LarkUserID
+	}
+
+	targetKey := fmt.Sprintf("%s:%s", target.IDType, target.ID)
+	if !targetSet.Has(targetKey) {
+		targetSet.Insert(targetKey)
+		targets = append(targets, target)
+	}
+
+	if displayName == "" {
+		displayName = target.Name
+	}
+	if displayName == "" {
+		displayName = target.ID
+	}
+	if !nameSet.Has(displayName) {
+		nameSet.Insert(displayName)
+		notifiedUsers = append(notifiedUsers, displayName)
+	}
+
+	return targets, notifiedUsers
 }
 
 func formatManualExecNotifiedUsers(users []*models.User, userInfoMap map[string]*types.UserInfo) string {
@@ -651,6 +840,58 @@ func (w *Service) getManualExecStageLarkCard(workflowCtx *models.WorkflowTaskCtx
 	lc.AddI18NElementsZhcnFeild(fmt.Sprintf("**%s**：%s", getText("notificationTextRemark", language), workflowCtx.Remark), true)
 	lc.AddI18NElementsZhcnAction(getText("notificationTextClickForMore", language), detailURL)
 	return lc
+}
+
+func (w *Service) getManualExecStageMailContent(workflowCtx *models.WorkflowTaskCtx, stage *models.StageTask, language, notifiedUsers string, jobContents []string) (string, string, error) {
+	title := fmt.Sprintf("%s %s #%d %s", getText("notificationTextWorkflow", language), workflowCtx.WorkflowDisplayName, workflowCtx.TaskID, getText("notificationTextManualExecPending", language))
+	detailURL := fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d?display_name=%s",
+		configbase.SystemAddress(),
+		workflowCtx.ProjectName,
+		workflowCtx.WorkflowName,
+		workflowCtx.TaskID,
+		url.QueryEscape(workflowCtx.WorkflowDisplayName),
+	)
+
+	lines := []string{
+		fmt.Sprintf("%s：%s \n", getText("notificationTextProjectName", language), workflowCtx.ProjectDisplayName),
+		fmt.Sprintf("%s：%s \n", getText("notificationTextStageName", language), stage.Name),
+		fmt.Sprintf("%s：%s \n", getText("notificationTextExecutor", language), workflowCtx.WorkflowTaskCreatorUsername),
+	}
+	if notifiedUsers != "" {
+		lines = append(lines, fmt.Sprintf("%s：%s \n", getText("notificationTextNotifiedUsers", language), notifiedUsers))
+	}
+	if len(jobContents) > 0 {
+		lines = append(lines, fmt.Sprintf("%s：\n", getText("notificationTextJobs", language)))
+		lines = append(lines, strings.Join(jobContents, ""))
+	}
+	lines = append(lines,
+		fmt.Sprintf("%s：%s \n", getText("notificationTextStartTime", language), workflowCtx.StartTime.Format(time.DateTime)),
+		fmt.Sprintf("%s：%s \n", getText("notificationTextRemark", language), workflowCtx.Remark),
+	)
+
+	content := strings.TrimSpace(strings.Join(lines, ""))
+	t, err := template.New("workflow_notification").Parse(getMailTemplate(language))
+	if err != nil {
+		return "", "", fmt.Errorf("workflow notification template parse error, error msg:%s", err)
+	}
+
+	var buf bytes.Buffer
+	err = t.Execute(&buf, struct {
+		WorkflowName   string
+		WorkflowTaskID int64
+		Content        string
+		Url            string
+	}{
+		WorkflowName:   workflowCtx.WorkflowDisplayName,
+		WorkflowTaskID: workflowCtx.TaskID,
+		Content:        content,
+		Url:            detailURL,
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("workflow notification template execute error, error msg:%s", err)
+	}
+
+	return title, buf.String(), nil
 }
 
 func (w *Service) getApproveNotificationContent(notify *models.NotifyCtl, task *models.WorkflowTask) (string, string, *LarkCard, *webhooknotify.WorkflowNotify, error) {
@@ -1389,6 +1630,9 @@ func (w *Service) sendNotification(title, content string, notify *models.NotifyC
 
 		respErr := new(multierror.Error)
 		for _, target := range notify.LarkPersonNotificationConfig.TargetUsers {
+			if target == nil || target.ID == "" {
+				continue
+			}
 			err = w.sendFeishuMessageFromClient(client, target.IDType, target.ID, LarkMessageTypeCard, string(messageContent))
 			if err != nil {
 				respErr = multierror.Append(respErr, err)

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/stage.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/stage.go
@@ -95,7 +95,7 @@ func waitForManualExec(ctx context.Context, stage *commonmodels.StageTask, workf
 	}
 
 	stage.Status = config.StatusPause
-	if !stage.ManualExec.NotificationSent && stage.ManualExec.LarkPersonNotificationConfig != nil {
+	if !stage.ManualExec.NotificationSent {
 		if err := instantmessage.NewWeChatClient().SendManualExecStageNotifications(workflowCtx, stage); err != nil {
 			logger.Errorf("failed to send manual execution stage notification for stage %s: %v", stage.Name, err)
 		} else {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/types.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/types.go
@@ -160,6 +160,10 @@ type CreateCustomTaskLarkUserInfo struct {
 	ID string `json:"id"`
 	// 支持 open_id、user_id
 	IDType string `json:"id_type"`
+	// 标记该成员是否为工作流执行人
+	IsExecutor bool `json:"is_executor,omitempty"`
+	// 标记该成员是否为当前阶段执行人
+	IsStageExecutor bool `json:"is_stage_executor,omitempty"`
 }
 
 type CreateCustomTaskLarkGroupNotificationConfig struct {
@@ -191,7 +195,8 @@ type CreateCustomTaskMSTeamsNotificationConfig struct {
 }
 
 type CreateCustomTaskMailNotificationConfig struct {
-	UserIDs []string `json:"user_ids"`
+	UserIDs []string             `json:"user_ids"`
+	Users   []*commonmodels.User `json:"users"`
 }
 
 type CreateCustomTaskParam struct {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/types.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/types.go
@@ -140,6 +140,8 @@ type CreateCustomTaskNotifyInput struct {
 	ID int `json:"id"`
 	// 通知类型，支持：feishu 飞书群组通知（自定义机器人）、feishu_app 飞书群组通知（自建应用）、feishu_person 飞书成员通知、dingding 钉钉，wechat 企业微信、msteams Teams、mail 邮件
 	Type setting.NotifyWebHookType `json:"type"`
+	// 运行时是否启用该通知；为空时保持原有配置
+	Enabled *bool `json:"enabled,omitempty"`
 	// 飞书群组通知（自定义机器人）配置
 	LarkHookNotificationConfig *CreateCustomTaskLarkHookNotificationConfig `json:"lark_hook_notification_config"`
 	// 飞书群通知（自建应用）配置

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -693,6 +693,10 @@ func updateNotifyCtls(notifyCtls []*commonmodels.NotifyCtl, notifyInputs []*Crea
 	for i, notifyCtl := range notifyCtls {
 		notifyInput, ok := notifyInputsMap[i]
 		if ok && notifyCtl.WebHookType == notifyInput.Type {
+			if notifyInput.Enabled != nil {
+				notifyCtl.Enabled = *notifyInput.Enabled
+			}
+
 			switch notifyCtl.WebHookType {
 			case setting.NotifyWebHookTypeFeishu:
 				if notifyCtl.LarkHookNotificationConfig == nil {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -720,8 +720,10 @@ func updateNotifyCtls(notifyCtls []*commonmodels.NotifyCtl, notifyInputs []*Crea
 				targetUsers := make([]*larktool.UserInfo, 0)
 				for _, user := range notifyInput.LarkPersonNotificationConfig.Users {
 					targetUsers = append(targetUsers, &larktool.UserInfo{
-						ID:     user.ID,
-						IDType: user.IDType,
+						ID:              user.ID,
+						IDType:          user.IDType,
+						IsExecutor:      user.IsExecutor,
+						IsStageExecutor: user.IsStageExecutor,
 					})
 				}
 				config.TargetUsers = targetUsers
@@ -798,10 +800,26 @@ func updateNotifyCtls(notifyCtls []*commonmodels.NotifyCtl, notifyInputs []*Crea
 					TargetUsers: make([]*commonmodels.User, 0),
 				}
 
-				for _, userID := range notifyInput.MailNotificationConfig.UserIDs {
-					config.TargetUsers = append(config.TargetUsers, &commonmodels.User{
-						UserID: userID,
-					})
+				if len(notifyInput.MailNotificationConfig.Users) > 0 {
+					for _, user := range notifyInput.MailNotificationConfig.Users {
+						if user == nil {
+							continue
+						}
+						config.TargetUsers = append(config.TargetUsers, &commonmodels.User{
+							Type:      user.Type,
+							UserID:    user.UserID,
+							UserName:  user.UserName,
+							GroupID:   user.GroupID,
+							GroupName: user.GroupName,
+						})
+					}
+				} else {
+					for _, userID := range notifyInput.MailNotificationConfig.UserIDs {
+						config.TargetUsers = append(config.TargetUsers, &commonmodels.User{
+							Type:   setting.UserTypeUser,
+							UserID: userID,
+						})
+					}
 				}
 
 				notifyCtl.MailNotificationConfig = config

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -946,9 +946,10 @@ const (
 )
 
 const (
-	UserTypeUser        string = "user"
-	UserTypeGroup       string = "group"
-	UserTypeTaskCreator string = "task_creator"
+	UserTypeUser          string = "user"
+	UserTypeGroup         string = "group"
+	UserTypeTaskCreator   string = "task_creator"
+	UserTypeStageExecutor string = "stage_executor"
 )
 
 type ContainerType string

--- a/pkg/tool/lark/model.go
+++ b/pkg/tool/lark/model.go
@@ -23,6 +23,8 @@ type UserInfo struct {
 	Avatar string `json:"avatar,omitempty" yaml:"avatar,omitempty" bson:"avatar,omitempty"`
 	// IsExecutor marks if the user is the executor of the workflow
 	IsExecutor bool `json:"is_executor" yaml:"is_executor" bson:"is_executor"`
+	// IsStageExecutor marks if the user represents the current stage executors
+	IsStageExecutor bool `json:"is_stage_executor,omitempty" yaml:"is_stage_executor,omitempty" bson:"is_stage_executor,omitempty"`
 }
 
 type DepartmentInfo struct {
@@ -86,7 +88,7 @@ type ApprovalInstanceData struct {
 	Timeline []*InstanceTimeline `json:"timeline,omitempty" yaml:"timeline,omitempty" bson:"timeline,omitempty"` // 审批动态
 
 	// 以下是 Zadig 添加的用于展示的字段
-	UserName   *string `json:"user_name,omitempty" yaml:"user_name,omitempty" bson:"user_name,omitempty"`     // 发起人姓名
+	UserName   *string `json:"user_name,omitempty" yaml:"user_name,omitempty" bson:"user_name,omitempty"`       // 发起人姓名
 	UserAvatar *string `json:"user_avatar,omitempty" yaml:"user_avatar,omitempty" bson:"user_avatar,omitempty"` // 发起人头像
 }
 
@@ -112,7 +114,7 @@ type InstanceTask struct {
 	EndTime *string `json:"end_time,omitempty" yaml:"end_time,omitempty" bson:"end_time,omitempty"` // task 完成时间, 未完成为 0
 
 	// 以下是 Zadig 添加的用于展示的字段
-	UserName   *string `json:"user_name,omitempty" yaml:"user_name,omitempty" bson:"user_name,omitempty"`     // 审批人姓名
+	UserName   *string `json:"user_name,omitempty" yaml:"user_name,omitempty" bson:"user_name,omitempty"`       // 审批人姓名
 	UserAvatar *string `json:"user_avatar,omitempty" yaml:"user_avatar,omitempty" bson:"user_avatar,omitempty"` // 审批人头像
 }
 
@@ -166,7 +168,7 @@ type InstanceTimeline struct {
 	Files []*File `json:"files,omitempty" yaml:"files,omitempty" bson:"files,omitempty"` // 审批附件
 
 	// 以下是 Zadig 添加的用于展示的字段
-	UserName   *string `json:"user_name,omitempty" yaml:"user_name,omitempty" bson:"user_name,omitempty"`     // 动态产生用户姓名
+	UserName   *string `json:"user_name,omitempty" yaml:"user_name,omitempty" bson:"user_name,omitempty"`       // 动态产生用户姓名
 	UserAvatar *string `json:"user_avatar,omitempty" yaml:"user_avatar,omitempty" bson:"user_avatar,omitempty"` // 动态产生用户头像
 }
 
@@ -178,6 +180,6 @@ type InstanceCcUser struct {
 	OpenId *string `json:"open_id,omitempty" yaml:"open_id,omitempty" bson:"open_id,omitempty"` // 抄送人 open id
 
 	// 以下是 Zadig 添加的用于展示的字段
-	UserName   *string `json:"user_name,omitempty" yaml:"user_name,omitempty" bson:"user_name,omitempty"`     // 抄送人姓名
+	UserName   *string `json:"user_name,omitempty" yaml:"user_name,omitempty" bson:"user_name,omitempty"`       // 抄送人姓名
 	UserAvatar *string `json:"user_avatar,omitempty" yaml:"user_avatar,omitempty" bson:"user_avatar,omitempty"` // 抄送人头像
 }


### PR DESCRIPTION
## Background

When a workflow stage is configured as manual execution, Zadig pauses the workflow before entering that stage.

Previously, the manual-execution-stage notification logic had two limitations:

- it depended on the legacy stage-level Feishu config
- it could not express a dedicated `stage executor` recipient role in workflow notifications

As a result, `wait for manual execution` notifications could not be configured consistently through workflow notification settings, especially for Feishu person notifications and mail notifications.

## What changed

### 1. Use workflow notify controls for manual execution pause notifications

For the `pause` event triggered by a manual execution stage:

- notifications are now selected from workflow `notify_ctls`
- only enabled notifications with `notify_type` containing `pause` are processed
- supported channels:
  - `feishu_person`
  - `mail`

The notification trigger still happens when the stage enters manual execution pause.

### 2. Add a new dynamic recipient role: `stage executor`

This change adds support for a new recipient role: `stage executor`.

Recipient resolution for manual execution pause notifications now supports:

- workflow executor
- stage executor
- explicitly selected users

`stage executor` is resolved dynamically from the current stage `ManualExecUsers`.

If `ManualExecUsers` contains the workflow executor role, it will also be expanded at runtime.

Final recipients are deduplicated before sending.

### 3. Support both Feishu person and mail for manual execution pause notifications

For `pause` notifications triggered by manual execution stages:

- Feishu person notifications:
  - resolve recipients to Zadig users
  - resolve Zadig users to Feishu users by phone number
  - send the manual execution stage card
- Mail notifications:
  - resolve recipients to concrete Zadig users
  - send dedicated manual execution stage mail content

### 4. Remove dependency on legacy stage-level Feishu config as the send gate

Entering manual execution pause no longer depends on the old stage-level Feishu notification config to decide whether to trigger notification sending.

Instead:

- the stage pause event always enters the manual-exec notification flow once
- actual send behavior is decided by workflow notify controls

This keeps the trigger timing unchanged while making the send logic consistent with workflow notification settings.

## Implementation details

Main updates include:

- add `is_stage_executor` to the Feishu person notification user model
- add `stage_executor` user type for mail notification recipients
- extend workflow notify input parsing to preserve:
  - workflow executor
  - stage executor
- update manual execution stage notification sending logic to:
  - filter notify controls by `pause`
  - resolve recipients dynamically
  - support both Feishu person and mail

## Verification

Verified locally:

- manual execution stage pause still triggers notification at the expected timing
- `pause` not selected: manual execution pause notification is not sent
- `pause` selected: manual execution pause notification is sent
- Feishu person notification works for:
  - workflow executor
  - stage executor
  - explicit users
- mail notification works for:
  - workflow executor
  - stage executor
  - explicit users

Local validation:

```bash
go test -vet=off ./pkg/microservice/aslan/core/workflow/service/workflow ./pkg/microservice/aslan/core/common/service/instantmessage ./pkg/microservice/aslan/core/common/service/workflowcontroller
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4650)
<!-- Reviewable:end -->
