### PR TITLE
fix(workflow): use product envs in task filters

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -3152,8 +3152,6 @@ func ListWorkflowFilterInfo(project, workflow, typeName string, jobName string, 
 		return []*ListWorkflowFilterInfoResponse{}, fmt.Errorf("paramerter is empty")
 	}
 
-	envMap := make(map[string]*commonmodels.Product)
-
 	switch typeName {
 	case "creator":
 		creators, err := commonrepo.NewworkflowTaskv4Coll().ListCreator(project, workflow)
@@ -3171,37 +3169,30 @@ func ListWorkflowFilterInfo(project, workflow, typeName string, jobName string, 
 		}
 		return resp, nil
 	case "envName":
-		workflow, err := commonrepo.NewWorkflowV4Coll().Find(workflow)
+		productList, err := commonrepo.NewProductColl().List(&commonrepo.ProductListOptions{
+			Name: project,
+		})
 		if err != nil {
-			logger.Errorf("failed to find workflow %s: %v", workflow, err)
-			return []*ListWorkflowFilterInfoResponse{}, fmt.Errorf("failed to find workflow %s: %v", workflow, err)
+			logger.Errorf("failed to list envs from product for project %s: %v", project, err)
+			return []*ListWorkflowFilterInfoResponse{}, fmt.Errorf("failed to list envs from product for project %s: %v", project, err)
 		}
 
-		resp := make([]*ListWorkflowFilterInfoResponse, 0)
-		for _, stage := range workflow.Stages {
-			for _, job := range stage.Jobs {
-				if job.Name == jobName && job.JobType == config.JobZadigDeploy {
-					deploy := &commonmodels.ZadigDeployJobSpec{}
-					if err := commonmodels.IToi(job.Spec, deploy); err != nil {
-						return nil, err
-					}
-
-					env, _ := CheckFixedMarkReturnNoFixedEnv(deploy.Env)
-					if envMap[env] == nil {
-						envInfo, err := commonutil.GetEnvInfo(project, env, envMap)
-						if err != nil {
-							return nil, err
-						}
-
-						resp = append(resp, &ListWorkflowFilterInfoResponse{
-							Key:  envInfo.EnvName,
-							Name: envInfo.Alias,
-						})
-					}
-					return resp, nil
-				}
+		resp := make([]*ListWorkflowFilterInfoResponse, 0, len(productList))
+		for _, envInfo := range productList {
+			if envInfo == nil {
+				continue
 			}
+			name := envInfo.EnvName
+			if envInfo.Alias != "" {
+				name = envInfo.Alias
+			}
+
+			resp = append(resp, &ListWorkflowFilterInfoResponse{
+				Key:  envInfo.EnvName,
+				Name: name,
+			})
 		}
+
 		return resp, nil
 	case "serviceName":
 		services := make([]string, 0)


### PR DESCRIPTION
## Summary
- change workflow task env filter options to read envs from the `product` collection instead of workflow task history
- determine the target env type from the workflow job config and use it to list current project envs from `product`
- return env alias when present and fall back to env name otherwise

## Background
The workflow execution record page calls `GET /api/aslan/workflow/v4/workflowtask/filter/workflow/:name?queryType=envName&jobName=...` to fetch env filter options. The correct data source for the env list is the `product` collection rather than workflow task history. This change aligns the filter options with the current env list stored in `product`.

## Verification
- `/usr/local/go/bin/go build ./pkg/microservice/aslan/core/workflow/service/workflow`
- `/usr/local/go/bin/go test -vet=off ./pkg/microservice/aslan/core/workflow/service/workflow`
- note: plain `go test` still hits pre-existing vet issues in this package unrelated to this change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4653)
<!-- Reviewable:end -->
