### PR TITLE
fix: update TestType and add Source field in workflow template initialization.

### DIFF
--- a/pkg/microservice/aslan/core/templatestore/service/workflow.go
+++ b/pkg/microservice/aslan/core/templatestore/service/workflow.go
@@ -1108,7 +1108,10 @@ func InitWorkflowTemplateInfos() []*commonmodels.WorkflowV4Template {
 						{
 							Name:    "code-scanning",
 							JobType: config.JobZadigScanning,
-							Spec:    commonmodels.ZadigScanningJobSpec{},
+							Spec: commonmodels.ZadigScanningJobSpec{
+								Source:       config.SourceRuntime,
+								ScanningType: config.NormalScanningType,
+							},
 						},
 					},
 				},

--- a/pkg/microservice/aslan/core/templatestore/service/workflow.go
+++ b/pkg/microservice/aslan/core/templatestore/service/workflow.go
@@ -972,7 +972,8 @@ func InitWorkflowTemplateInfos() []*commonmodels.WorkflowV4Template {
 							Name:    "test",
 							JobType: config.JobZadigTesting,
 							Spec: commonmodels.ZadigTestingJobSpec{
-								TestType: " ",
+								TestType: "",
+								Source:   config.SourceRuntime,
 							},
 						},
 					},
@@ -1214,7 +1215,8 @@ func InitWorkflowTemplateInfos() []*commonmodels.WorkflowV4Template {
 							Name:    "test",
 							JobType: config.JobZadigTesting,
 							Spec: commonmodels.ZadigTestingJobSpec{
-								TestType: " ",
+								TestType: "",
+								Source:   config.SourceRuntime,
 							},
 						},
 					},
@@ -1247,7 +1249,7 @@ func InitWorkflowTemplateInfos() []*commonmodels.WorkflowV4Template {
 							Name:    "test",
 							JobType: config.JobZadigTesting,
 							Spec: commonmodels.ZadigTestingJobSpec{
-								TestType: " ",
+								TestType: "",
 							},
 						},
 					},
@@ -1725,7 +1727,7 @@ func InitWorkflowTemplateInfos() []*commonmodels.WorkflowV4Template {
 							Name:    "test",
 							JobType: config.JobZadigTesting,
 							Spec: commonmodels.ZadigTestingJobSpec{
-								TestType: " ",
+								TestType: "",
 							},
 						},
 					},
@@ -1784,7 +1786,7 @@ func InitWorkflowTemplateInfos() []*commonmodels.WorkflowV4Template {
 							Name:    "test",
 							JobType: config.JobZadigTesting,
 							Spec: commonmodels.ZadigTestingJobSpec{
-								TestType: " ",
+								TestType: "",
 							},
 						},
 					},


### PR DESCRIPTION
### What this PR does / Why we need it:

When creating tasks that include testing and scanning using a template, update the initial default values of the task.
Also fix the issue where the product test type value is empty instead of a space.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4654)
<!-- Reviewable:end -->
