### PR TITLE
fix(testing): validate generated workflow job names

### DIFF
--- a/pkg/microservice/aslan/core/common/util/workflow.go
+++ b/pkg/microservice/aslan/core/common/util/workflow.go
@@ -18,10 +18,14 @@ package util
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/v2/pkg/setting"
 )
+
+var workflowJobNameRegx = regexp.MustCompile(setting.JobNameRegx)
 
 func CalcWorkflowTaskRunningTime(task *commonmodels.WorkflowTask) int64 {
 	runningTime := int64(0)
@@ -43,4 +47,23 @@ func GenScanningWorkflowName(scanningID string) string {
 
 func GenTestingWorkflowName(testingName string) string {
 	return fmt.Sprintf(setting.TestWorkflowNamingConvention, testingName)
+}
+
+func GenerateTestingModuleJobName(name string) string {
+	return strings.ToLower(name)
+}
+
+func GenerateScanningModuleJobName(name string) string {
+	if len(name) >= 32 {
+		return strings.TrimSuffix(name[:31], "-")
+	}
+	return name
+}
+
+func ValidateGeneratedWorkflowJobName(name string, generator func(string) string) error {
+	jobName := generator(name)
+	if !workflowJobNameRegx.MatchString(jobName) {
+		return fmt.Errorf("name [%s] cannot be used to generate a workflow job name, generated job name [%s] did not match %s", name, jobName, setting.JobNameRegx)
+	}
+	return nil
 }

--- a/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
@@ -19,7 +19,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.uber.org/zap"
@@ -45,6 +44,9 @@ import (
 func CreateScanningModule(username string, args *Scanning, log *zap.SugaredLogger) error {
 	if len(args.Name) == 0 {
 		return e.ErrCreateScanningModule.AddDesc("empty Name")
+	}
+	if err := commonutil.ValidateGeneratedWorkflowJobName(args.Name, commonutil.GenerateScanningModuleJobName); err != nil {
+		return e.ErrCreateScanningModule.AddDesc(err.Error())
 	}
 
 	err := util.CheckDefineResourceParam(args.AdvancedSetting.ResReq, args.AdvancedSetting.ResReqSpec)
@@ -73,6 +75,9 @@ func CreateScanningModule(username string, args *Scanning, log *zap.SugaredLogge
 func UpdateScanningModule(id, username string, args *Scanning, log *zap.SugaredLogger) error {
 	if len(args.Name) == 0 {
 		return e.ErrUpdateScanningModule.AddDesc("empty Name")
+	}
+	if err := commonutil.ValidateGeneratedWorkflowJobName(args.Name, commonutil.GenerateScanningModuleJobName); err != nil {
+		return e.ErrUpdateScanningModule.AddDesc(err.Error())
 	}
 
 	scanning, err := commonrepo.NewScanningColl().GetByID(id)
@@ -537,12 +542,8 @@ func generateCustomWorkflowFromScanningModule(scanInfo *commonmodels.Scanning, a
 	}
 
 	job := make([]*commonmodels.Job, 0)
-	name := scanInfo.Name
-	if len(name) >= 32 {
-		name = strings.TrimSuffix(scanInfo.Name[:31], "-")
-	}
 	job = append(job, &commonmodels.Job{
-		Name:    name,
+		Name:    commonutil.GenerateScanningModuleJobName(scanInfo.Name),
 		JobType: config.JobZadigScanning,
 		Skipped: false,
 		Spec: &commonmodels.ZadigScanningJobSpec{

--- a/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
@@ -19,7 +19,6 @@ package service
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/koderover/zadig/v2/pkg/types"
 	"go.uber.org/zap"
@@ -341,7 +340,7 @@ func generateCustomWorkflowFromTestingModule(testInfo *commonmodels.Testing, arg
 
 	job := make([]*commonmodels.Job, 0)
 	job = append(job, &commonmodels.Job{
-		Name:    strings.ToLower(testInfo.Name),
+		Name:    util.GenerateTestingModuleJobName(testInfo.Name),
 		JobType: config.JobZadigTesting,
 		Skipped: false,
 		Spec: &commonmodels.ZadigTestingJobSpec{

--- a/pkg/microservice/aslan/core/workflow/testing/service/testing.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/testing.go
@@ -52,6 +52,9 @@ func CreateTesting(username string, testing *commonmodels.Testing, log *zap.Suga
 	if len(testing.Name) == 0 {
 		return e.ErrCreateTestModule.AddDesc("empty Name")
 	}
+	if err := commonutil.ValidateGeneratedWorkflowJobName(testing.Name, commonutil.GenerateTestingModuleJobName); err != nil {
+		return e.ErrCreateTestModule.AddDesc(err.Error())
+	}
 	if err := commonutil.CheckDefineResourceParam(testing.PreTest.ResReq, testing.PreTest.ResReqSpec); err != nil {
 		return e.ErrCreateTestModule.AddDesc(err.Error())
 	}
@@ -114,6 +117,9 @@ func HandleCronjob(testing *commonmodels.Testing, log *zap.SugaredLogger) error 
 func UpdateTesting(username string, testing *commonmodels.Testing, log *zap.SugaredLogger) error {
 	if len(testing.Name) == 0 {
 		return e.ErrUpdateTestModule.AddDesc("empty Name")
+	}
+	if err := commonutil.ValidateGeneratedWorkflowJobName(testing.Name, commonutil.GenerateTestingModuleJobName); err != nil {
+		return e.ErrUpdateTestModule.AddDesc(err.Error())
 	}
 	if err := commonutil.CheckDefineResourceParam(testing.PreTest.ResReq, testing.PreTest.ResReqSpec); err != nil {
 		return e.ErrUpdateTestModule.AddDesc(err.Error())


### PR DESCRIPTION
Summary:
- validate testing and scanning module names before create/update so they can generate valid workflow job names
- move generated workflow job name helpers into core/common/util for reuse
- reuse the same helpers when generating standalone testing/scanning workflows to keep behavior consistent

Background:
Testing and scanning modules could previously be created with names that were valid in the UI but invalid after being transformed into workflow job names. This caused standalone execution to fail later during workflow linting with job-name validation errors.

Verification:
- /usr/local/go/bin/go test -vet=off ./pkg/microservice/aslan/core/workflow/testing/service ./pkg/microservice/aslan/core/common/util

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4655)
<!-- Reviewable:end -->
