### PR TITLE
feat: support release plan metadata in workflow task history

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
@@ -66,6 +66,7 @@ type WorkflowTask struct {
 	Hash                string                        `bson:"hash"                      json:"hash"`
 	ApprovalTicketID    string                        `bson:"approval_ticket_id"        json:"approval_ticket_id"`
 	ApprovalID          string                        `bson:"approval_id"               json:"approval_id"`
+	ReleasePlan         *ReleasePlanRef               `bson:"release_plan,omitempty"    json:"release_plan,omitempty"`
 
 	LarkProjectKey        string `bson:"lark_project_key"          json:"lark_project_key"`
 	LarkProjectSimpleName string `bson:"lark_project_simple_name"  json:"lark_project_simple_name"`
@@ -160,6 +161,13 @@ type WorkflowTaskPreview struct {
 	LarkWorkItemAPIName   string          `bson:"lark_workitem_api_name"    json:"lark_workitem_api_name"`
 	LarkWorkItemID        string          `bson:"lark_workitem_id"          json:"lark_workitem_id"`
 	Hash                  string          `bson:"hash"                      json:"hash"`
+	ReleasePlan           *ReleasePlanRef `bson:"release_plan,omitempty"    json:"release_plan,omitempty"`
+}
+
+type ReleasePlanRef struct {
+	ID    string `bson:"id"    json:"id"`
+	Name  string `bson:"name"  json:"name"`
+	Index int64  `bson:"index" json:"index"`
 }
 
 type StagePreview struct {

--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -1746,6 +1746,7 @@ type CustomField struct {
 	Executor               int            `bson:"executor"                            json:"executor"`
 	Remark                 int            `bson:"remark"                              json:"remark"`
 	Branch                 int            `bson:"branch"                              json:"branch"`
+	ReleasePlan            int            `bson:"release_plan"                        json:"release_plan"`
 	LarkWorkItemLink       int            `bson:"lark_work_item_link"                 json:"lark_work_item_link"`
 	BuildServiceComponent  map[string]int `bson:"build_service_component,omitempty"   json:"build_service_component,omitempty"`
 	BuildCodeMsg           map[string]int `bson:"build_code_msg,omitempty"            json:"build_code_msg,omitempty"`

--- a/pkg/microservice/aslan/core/release_plan/service/execute.go
+++ b/pkg/microservice/aslan/core/release_plan/service/execute.go
@@ -157,6 +157,11 @@ func (e *WorkflowReleaseJobExecutor) Execute(plan *models.ReleasePlan) error {
 			Name:    ctx.UserName,
 			Account: ctx.Account,
 			UserID:  ctx.UserID,
+			ReleasePlan: &models.ReleasePlanRef{
+				ID:    plan.ID.Hex(),
+				Name:  plan.Name,
+				Index: plan.Index,
+			},
 		}, workflowController.WorkflowV4, log.SugaredLogger().With("source", "release plan"))
 		if err != nil {
 			return errors.Wrapf(err, "failed to create workflow task %s", spec.Workflow.Name)

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -83,25 +83,26 @@ type CreateTaskV4Resp struct {
 }
 
 type WorkflowTaskPreview struct {
-	TaskID              int64                 `bson:"task_id"                   json:"task_id"`
-	WorkflowName        string                `bson:"workflow_name"             json:"workflow_key"`
-	WorkflowDisplayName string                `bson:"workflow_display_name"     json:"workflow_name"`
-	Params              []*commonmodels.Param `bson:"params"                    json:"params"`
-	Status              config.Status         `bson:"status"                    json:"status,omitempty"`
-	Reverted            bool                  `bson:"reverted"                  json:"reverted"`
-	Remark              string                `bson:"remark"                    json:"remark"`
-	TaskCreator         string                `bson:"task_creator"              json:"task_creator,omitempty"`
-	TaskRevoker         string                `bson:"task_revoker,omitempty"    json:"task_revoker,omitempty"`
-	CreateTime          int64                 `bson:"create_time"               json:"create_time,omitempty"`
-	StartTime           int64                 `bson:"start_time"                json:"start_time,omitempty"`
-	EndTime             int64                 `bson:"end_time"                  json:"end_time,omitempty"`
-	Stages              []*StageTaskPreview   `bson:"stages"                    json:"stages"`
-	ProjectName         string                `bson:"project_name"              json:"project_key"`
-	Error               string                `bson:"error,omitempty"           json:"error,omitempty"`
-	IsRestart           bool                  `bson:"is_restart"                json:"is_restart"`
-	Debug               bool                  `bson:"debug"                     json:"debug"`
-	ApprovalTicketID    string                `bson:"approval_ticket_id"        json:"approval_ticket_id"`
-	ApprovalID          string                `bson:"approval_id"               json:"approval_id"`
+	TaskID              int64                        `bson:"task_id"                   json:"task_id"`
+	WorkflowName        string                       `bson:"workflow_name"             json:"workflow_key"`
+	WorkflowDisplayName string                       `bson:"workflow_display_name"     json:"workflow_name"`
+	Params              []*commonmodels.Param        `bson:"params"                    json:"params"`
+	Status              config.Status                `bson:"status"                    json:"status,omitempty"`
+	Reverted            bool                         `bson:"reverted"                  json:"reverted"`
+	Remark              string                       `bson:"remark"                    json:"remark"`
+	TaskCreator         string                       `bson:"task_creator"              json:"task_creator,omitempty"`
+	TaskRevoker         string                       `bson:"task_revoker,omitempty"    json:"task_revoker,omitempty"`
+	CreateTime          int64                        `bson:"create_time"               json:"create_time,omitempty"`
+	StartTime           int64                        `bson:"start_time"                json:"start_time,omitempty"`
+	EndTime             int64                        `bson:"end_time"                  json:"end_time,omitempty"`
+	Stages              []*StageTaskPreview          `bson:"stages"                    json:"stages"`
+	ProjectName         string                       `bson:"project_name"              json:"project_key"`
+	Error               string                       `bson:"error,omitempty"           json:"error,omitempty"`
+	IsRestart           bool                         `bson:"is_restart"                json:"is_restart"`
+	Debug               bool                         `bson:"debug"                     json:"debug"`
+	ApprovalTicketID    string                       `bson:"approval_ticket_id"        json:"approval_ticket_id"`
+	ApprovalID          string                       `bson:"approval_id"               json:"approval_id"`
+	ReleasePlan         *commonmodels.ReleasePlanRef `bson:"release_plan,omitempty"    json:"release_plan,omitempty"`
 }
 
 type StageTaskPreview struct {
@@ -457,6 +458,7 @@ type CreateWorkflowTaskV4Args struct {
 	LarkWorkItemTypeKey   string
 	LarkWorkItemAPIName   string
 	LarkWorkItemID        string
+	ReleasePlan           *commonmodels.ReleasePlanRef
 }
 
 func CreateWorkflowTaskV4ByBuildInTrigger(triggerName string, args *commonmodels.WorkflowV4, log *zap.SugaredLogger) (*CreateTaskV4Resp, error) {
@@ -614,6 +616,7 @@ func CreateWorkflowTaskV4(args *CreateWorkflowTaskV4Args, workflow *commonmodels
 	workflowTask.LarkProjectKey = args.LarkProjectKey
 	workflowTask.LarkProjectSimpleName = args.LarkProjectSimpleName
 	workflowTask.LarkWorkItemAPIName = args.LarkWorkItemAPIName
+	workflowTask.ReleasePlan = args.ReleasePlan
 
 	workflowCtrl := workflowController.CreateWorkflowController(workflow)
 	if (args.Type == config.WorkflowTaskTypeWorkflow || args.Type == "") && !args.SkipWorkflowUpdate {
@@ -2161,6 +2164,7 @@ func ListWorkflowTaskV4ByFilter(filter *TaskHistoryFilter, filterList []string, 
 			LarkWorkItemAPIName:   task.LarkWorkItemAPIName,
 			LarkWorkItemID:        task.LarkWorkItemID,
 			Hash:                  task.Hash,
+			ReleasePlan:           task.ReleasePlan,
 		}
 
 		stagePreviews := make([]*commonmodels.StagePreview, 0)
@@ -2360,6 +2364,7 @@ func GetWorkflowTaskV4(workflowName string, taskID int64, logger *zap.SugaredLog
 		Debug:               task.IsDebug,
 		ApprovalTicketID:    task.ApprovalTicketID,
 		ApprovalID:          task.ApprovalID,
+		ReleasePlan:         task.ReleasePlan,
 	}
 	timeNow := time.Now().Unix()
 	for _, stage := range task.Stages {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -151,6 +151,7 @@ func GetWorkflowTasksCustomFields(projectName, workflowName string, logger *zap.
 			Executor:               1,
 			Remark:                 0,
 			Branch:                 0,
+			ReleasePlan:            0,
 			BuildServiceComponent:  make(map[string]int),
 			BuildCodeMsg:           make(map[string]int),
 			DeployServiceComponent: make(map[string]int),


### PR DESCRIPTION
## Summary
- add release plan as an optional workflow history custom field
- persist release plan metadata on workflow tasks triggered from release plans
- expose release plan metadata from workflow task list and detail APIs for frontend linking

## Testing
- go test ./pkg/microservice/aslan/core/release_plan/service -run TestDoesNotExist
- go test -vet=off ./pkg/microservice/aslan/core/workflow/service/workflow -run TestDoesNotExist

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4663)
<!-- Reviewable:end -->
