### PR TITLE
add branch merge detection in devops+

### DIFF
--- a/pkg/microservice/aslan/core/code/client/gerrit/gerrit.go
+++ b/pkg/microservice/aslan/core/code/client/gerrit/gerrit.go
@@ -17,6 +17,8 @@ limitations under the License.
 package gerrit
 
 import (
+	"fmt"
+
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/code/client"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
@@ -54,6 +56,53 @@ func (c *Client) ListBranches(opt client.ListOpt) ([]*client.Branch, error) {
 		})
 	}
 	return res, nil
+}
+
+func (c *Client) IsBranchMerged(opt client.BranchMergeCheckOpt) (bool, error) {
+	if opt.SourceBranch == opt.TargetBranch {
+		return true, nil
+	}
+
+	sourceCommit, err := c.Client.GetCommitByBranch(opt.ProjectName, opt.SourceBranch)
+	if err != nil {
+		return false, fmt.Errorf("failed to get source branch commit: %w", err)
+	}
+	targetCommit, err := c.Client.GetCommitByBranch(opt.ProjectName, opt.TargetBranch)
+	if err != nil {
+		return false, fmt.Errorf("failed to get target branch commit: %w", err)
+	}
+	if sourceCommit.Commit == targetCommit.Commit {
+		return true, nil
+	}
+
+	queue := []string{targetCommit.Commit}
+	visited := make(map[string]struct{})
+	for len(queue) > 0 {
+		revision := queue[0]
+		queue = queue[1:]
+		if _, ok := visited[revision]; ok {
+			continue
+		}
+		visited[revision] = struct{}{}
+		if revision == sourceCommit.Commit {
+			return true, nil
+		}
+
+		commit, err := c.Client.GetCommitByRevision(opt.ProjectName, revision)
+		if err != nil {
+			return false, fmt.Errorf("failed to get commit %s: %w", revision, err)
+		}
+		for _, parent := range commit.Parents {
+			if parent.Commit == sourceCommit.Commit {
+				return true, nil
+			}
+			if parent.Commit != "" {
+				queue = append(queue, parent.Commit)
+			}
+		}
+	}
+
+	return false, nil
 }
 
 func (c *Client) ListTags(opt client.ListOpt) ([]*client.Tag, error) {

--- a/pkg/microservice/aslan/core/code/client/gitee/gitee.go
+++ b/pkg/microservice/aslan/core/code/client/gitee/gitee.go
@@ -65,6 +65,19 @@ func (c *Client) ListBranches(opt client.ListOpt) ([]*client.Branch, error) {
 	return res, nil
 }
 
+func (c *Client) IsBranchMerged(opt client.BranchMergeCheckOpt) (bool, error) {
+	if opt.SourceBranch == opt.TargetBranch {
+		return true, nil
+	}
+
+	compare, err := c.Client.GetReposOwnerRepoCompareBaseHead(c.Address, c.AccessToken, opt.Namespace, opt.ProjectName, opt.TargetBranch, opt.SourceBranch)
+	if err != nil {
+		return false, err
+	}
+
+	return len(compare.Commits) == 0, nil
+}
+
 func (c *Client) ListTags(opt client.ListOpt) ([]*client.Tag, error) {
 	tags, err := c.Client.ListTags(context.TODO(), c.Address, c.AccessToken, opt.Namespace, opt.ProjectName)
 	if err != nil {

--- a/pkg/microservice/aslan/core/code/client/gitee/gitee_ee.go
+++ b/pkg/microservice/aslan/core/code/client/gitee/gitee_ee.go
@@ -64,6 +64,19 @@ func (c *EEClient) ListBranches(opt client.ListOpt) ([]*client.Branch, error) {
 	return res, nil
 }
 
+func (c *EEClient) IsBranchMerged(opt client.BranchMergeCheckOpt) (bool, error) {
+	if opt.SourceBranch == opt.TargetBranch {
+		return true, nil
+	}
+
+	compare, err := c.Client.GetReposOwnerRepoCompareBaseHeadForEnterprise(c.Address, c.AccessToken, opt.Namespace, opt.ProjectName, opt.TargetBranch, opt.SourceBranch)
+	if err != nil {
+		return false, err
+	}
+
+	return len(compare.Commits) == 0, nil
+}
+
 func (c *EEClient) ListTags(opt client.ListOpt) ([]*client.Tag, error) {
 	tags, err := c.Client.ListTags(context.TODO(), c.Address, c.AccessToken, opt.Namespace, opt.ProjectName)
 	if err != nil {

--- a/pkg/microservice/aslan/core/code/client/github/github.go
+++ b/pkg/microservice/aslan/core/code/client/github/github.go
@@ -70,6 +70,20 @@ func (c *Client) ListBranches(opt client.ListOpt) ([]*client.Branch, error) {
 	return res, nil
 }
 
+func (c *Client) IsBranchMerged(opt client.BranchMergeCheckOpt) (bool, error) {
+	if opt.SourceBranch == opt.TargetBranch {
+		return true, nil
+	}
+
+	compare, _, err := c.Client.Repositories.CompareCommits(context.TODO(), opt.Namespace, opt.ProjectName, opt.TargetBranch, opt.SourceBranch)
+	if err != nil {
+		return false, err
+	}
+
+	status := compare.GetStatus()
+	return status == "identical" || status == "behind" || compare.GetTotalCommits() == 0, nil
+}
+
 func (c *Client) ListTags(opt client.ListOpt) ([]*client.Tag, error) {
 	tags, err := c.Client.ListTags(context.TODO(), opt.Namespace, opt.ProjectName, nil)
 	if err != nil {

--- a/pkg/microservice/aslan/core/code/client/gitlab/gitlab.go
+++ b/pkg/microservice/aslan/core/code/client/gitlab/gitlab.go
@@ -17,6 +17,8 @@ limitations under the License.
 package gitlab
 
 import (
+	"fmt"
+
 	"go.uber.org/zap"
 
 	gogitlab "github.com/xanzy/go-gitlab"
@@ -67,6 +69,22 @@ func (c *Client) ListBranches(opt client.ListOpt) ([]*client.Branch, error) {
 		})
 	}
 	return res, nil
+}
+
+func (c *Client) IsBranchMerged(opt client.BranchMergeCheckOpt) (bool, error) {
+	if opt.SourceBranch == opt.TargetBranch {
+		return true, nil
+	}
+
+	compare, _, err := c.Client.Repositories.Compare(fmt.Sprintf("%s/%s", opt.Namespace, opt.ProjectName), &gogitlab.CompareOptions{
+		From: &opt.TargetBranch,
+		To:   &opt.SourceBranch,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return len(compare.Commits) == 0, nil
 }
 
 func (c *Client) ListTags(opt client.ListOpt) ([]*client.Tag, error) {

--- a/pkg/microservice/aslan/core/code/client/interface.go
+++ b/pkg/microservice/aslan/core/code/client/interface.go
@@ -32,6 +32,17 @@ type CodeHostClient interface {
 	ListCommits(opt ListOpt) ([]*Commit, error)
 }
 
+type BranchMergeChecker interface {
+	IsBranchMerged(opt BranchMergeCheckOpt) (bool, error)
+}
+
+type BranchMergeCheckOpt struct {
+	Namespace    string
+	ProjectName  string
+	SourceBranch string
+	TargetBranch string
+}
+
 type ListOpt struct {
 	Namespace     string
 	NamespaceType string

--- a/pkg/microservice/aslan/core/plugin/service/lark_v2.go
+++ b/pkg/microservice/aslan/core/plugin/service/lark_v2.go
@@ -963,8 +963,19 @@ type LarkReleaseBindItem struct {
 	WorkItemName    string   `json:"work_item_name"`
 	WorkItemStatus  []string `json:"work_item_status,omitempty"`
 
-	Branch   string                            `json:"branch"`
-	Services []*commonmodels.ServiceWithModule `json:"services"`
+	Branch             string                            `json:"branch"`
+	BranchMerged       bool                              `json:"branch_merged"`
+	BranchMergeDetails []*LarkBranchMergeDetail          `json:"branch_merge_details,omitempty"`
+	Services           []*commonmodels.ServiceWithModule `json:"services"`
+}
+
+type LarkBranchMergeDetail struct {
+	ServiceName   string `json:"service_name"`
+	ServiceModule string `json:"service_module"`
+	SourceBranch  string `json:"source_branch"`
+	TargetBranch  string `json:"target_branch"`
+	Merged        bool   `json:"merged"`
+	Error         string `json:"error,omitempty"`
 }
 
 func ListLarkReleaseBindItemsV2(ctx *internalhandler.Context, workspaceID, releaseItemID string) (*ListLarkReleaseBindItemsV2Resp, error) {
@@ -1036,6 +1047,12 @@ func ListLarkReleaseBindItemsV2(ctx *internalhandler.Context, workspaceID, relea
 		}
 	}
 
+	releaseWorkflow, releaseWorkflowErr := getWorkflowFromWorkItem(ctx, workspaceID, releaseStageSetting.WorkItemTypeKey, releaseItemID)
+	if releaseWorkflowErr != nil {
+		ctx.Logger.Warnf("ListLarkReleaseBindItemsV2: failed to get release workflow for workitem %s: %v", releaseItemID, releaseWorkflowErr)
+	}
+	branchMergeChecker := newLarkBranchMergeChecker(ctx)
+
 	resp := make([]*LarkReleaseBindItem, 0)
 
 	for _, bind := range binds {
@@ -1051,20 +1068,63 @@ func ListLarkReleaseBindItemsV2(ctx *internalhandler.Context, workspaceID, relea
 		}
 
 		services := make([]*commonmodels.ServiceWithModule, 0)
+		mergeDetails := make([]*LarkBranchMergeDetail, 0)
 
 		configs, err := mongodb.NewLarkPluginWorkItemStageWorkflowInputConfigColl().GetByWorkItem(workspaceID, "dev", bind.WorkItemTypeKey, bind.WorkItemID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get stage service configs: %w", err)
 		}
 
+		branchMerged := len(configs) > 0 && releaseStageSetting.TargetBranch != ""
 		for _, cfg := range configs {
 			services = append(services, &commonmodels.ServiceWithModule{
 				ServiceName:   cfg.ServiceName,
 				ServiceModule: cfg.ServiceModule,
 			})
+
+			detail := &LarkBranchMergeDetail{
+				ServiceName:   cfg.ServiceName,
+				ServiceModule: cfg.ServiceModule,
+				SourceBranch:  cfg.Branch,
+				TargetBranch:  releaseStageSetting.TargetBranch,
+			}
+
+			if releaseWorkflowErr != nil {
+				detail.Error = releaseWorkflowErr.Error()
+				branchMerged = false
+				mergeDetails = append(mergeDetails, detail)
+				continue
+			}
+
+			repo, err := getFirstRepoFromWorkflow(releaseWorkflow, cfg.ServiceName, cfg.ServiceModule)
+			if err != nil {
+				detail.Error = err.Error()
+				branchMerged = false
+				ctx.Logger.Warnf("ListLarkReleaseBindItemsV2: failed to resolve repo for %s/%s: %v", cfg.ServiceName, cfg.ServiceModule, err)
+				mergeDetails = append(mergeDetails, detail)
+				continue
+			}
+
+			merged, err := branchMergeChecker.isBranchMerged(repo, cfg.Branch, releaseStageSetting.TargetBranch)
+			if err != nil {
+				detail.Error = err.Error()
+				branchMerged = false
+				ctx.Logger.Warnf("ListLarkReleaseBindItemsV2: failed to check branch merge status for %s/%s %s -> %s: %v", cfg.ServiceName, cfg.ServiceModule, cfg.Branch, releaseStageSetting.TargetBranch, err)
+				mergeDetails = append(mergeDetails, detail)
+				continue
+			}
+
+			detail.Merged = merged
+			if !merged {
+				detail.Error = fmt.Sprintf("source branch %s is not merged into target branch %s", cfg.Branch, releaseStageSetting.TargetBranch)
+				branchMerged = false
+			}
+			mergeDetails = append(mergeDetails, detail)
 		}
 
 		item.Services = services
+		item.BranchMerged = branchMerged
+		item.BranchMergeDetails = mergeDetails
 		resp = append(resp, item)
 	}
 

--- a/pkg/microservice/aslan/core/plugin/service/lark_v2.go
+++ b/pkg/microservice/aslan/core/plugin/service/lark_v2.go
@@ -1104,6 +1104,8 @@ func ListLarkReleaseBindItemsV2(ctx *internalhandler.Context, workspaceID, relea
 				mergeDetails = append(mergeDetails, detail)
 				continue
 			}
+			ctx.Logger.Infof("ListLarkReleaseBindItemsV2: resolved repo for %s/%s, codehostID: %d, source: %s, namespace: %s, owner: %s, repo: %s, sourceBranch: %s, targetBranch: %s",
+				cfg.ServiceName, cfg.ServiceModule, repo.CodehostID, repo.Source, repo.RepoNamespace, repo.RepoOwner, repo.RepoName, cfg.Branch, releaseStageSetting.TargetBranch)
 
 			merged, err := branchMergeChecker.isBranchMerged(repo, cfg.Branch, releaseStageSetting.TargetBranch)
 			if err != nil {

--- a/pkg/microservice/aslan/core/plugin/service/lark_v2.go
+++ b/pkg/microservice/aslan/core/plugin/service/lark_v2.go
@@ -1090,7 +1090,7 @@ func ListLarkReleaseBindItemsV2(ctx *internalhandler.Context, workspaceID, relea
 			}
 
 			if releaseWorkflowErr != nil {
-				detail.Error = releaseWorkflowErr.Error()
+				detail.Error = "获取发布工作流失败"
 				branchMerged = false
 				mergeDetails = append(mergeDetails, detail)
 				continue
@@ -1098,7 +1098,7 @@ func ListLarkReleaseBindItemsV2(ctx *internalhandler.Context, workspaceID, relea
 
 			repo, err := getFirstRepoFromWorkflow(releaseWorkflow, cfg.ServiceName, cfg.ServiceModule)
 			if err != nil {
-				detail.Error = err.Error()
+				detail.Error = "获取服务代码库失败"
 				branchMerged = false
 				ctx.Logger.Warnf("ListLarkReleaseBindItemsV2: failed to resolve repo for %s/%s: %v", cfg.ServiceName, cfg.ServiceModule, err)
 				mergeDetails = append(mergeDetails, detail)
@@ -1109,7 +1109,7 @@ func ListLarkReleaseBindItemsV2(ctx *internalhandler.Context, workspaceID, relea
 
 			merged, err := branchMergeChecker.isBranchMerged(repo, cfg.Branch, releaseStageSetting.TargetBranch)
 			if err != nil {
-				detail.Error = err.Error()
+				detail.Error = "检测分支合并状态失败"
 				branchMerged = false
 				ctx.Logger.Warnf("ListLarkReleaseBindItemsV2: failed to check branch merge status for %s/%s %s -> %s: %v", cfg.ServiceName, cfg.ServiceModule, cfg.Branch, releaseStageSetting.TargetBranch, err)
 				mergeDetails = append(mergeDetails, detail)
@@ -1118,7 +1118,7 @@ func ListLarkReleaseBindItemsV2(ctx *internalhandler.Context, workspaceID, relea
 
 			detail.Merged = merged
 			if !merged {
-				detail.Error = fmt.Sprintf("source branch %s is not merged into target branch %s", cfg.Branch, releaseStageSetting.TargetBranch)
+				detail.Error = "源分支未合入目标分支"
 				branchMerged = false
 			}
 			mergeDetails = append(mergeDetails, detail)

--- a/pkg/microservice/aslan/core/plugin/service/utils.go
+++ b/pkg/microservice/aslan/core/plugin/service/utils.go
@@ -19,13 +19,17 @@ package service
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/koderover/zadig/v2/pkg/config"
 	aslanconfig "github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/code/client"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/code/client/open"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	commonservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service"
+	"github.com/koderover/zadig/v2/pkg/shared/client/systemconfig"
 	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
 	"github.com/koderover/zadig/v2/pkg/tool/larkplugin"
 	"github.com/koderover/zadig/v2/pkg/tool/meego"
@@ -195,4 +199,84 @@ func getFirstRepoFromWorkflow(workflow *models.WorkflowV4, serviceName, serviceM
 	}
 
 	return buildInfo.Repos[0], nil
+}
+
+type larkBranchMergeChecker struct {
+	ctx     *internalhandler.Context
+	clients map[int]client.CodeHostClient
+	cache   map[string]bool
+}
+
+func newLarkBranchMergeChecker(ctx *internalhandler.Context) *larkBranchMergeChecker {
+	return &larkBranchMergeChecker{
+		ctx:     ctx,
+		clients: make(map[int]client.CodeHostClient),
+		cache:   make(map[string]bool),
+	}
+}
+
+func (c *larkBranchMergeChecker) isBranchMerged(repo *types.Repository, sourceBranch, targetBranch string) (bool, error) {
+	if repo == nil {
+		return false, fmt.Errorf("repo is nil")
+	}
+	if sourceBranch == "" {
+		return false, fmt.Errorf("source branch is empty")
+	}
+	if targetBranch == "" {
+		return false, fmt.Errorf("target branch is empty")
+	}
+	if sourceBranch == targetBranch {
+		return true, nil
+	}
+
+	namespace := repo.RepoNamespace
+	if namespace == "" {
+		namespace = repo.RepoOwner
+	}
+	namespace = strings.Replace(namespace, "%2F", "/", -1)
+	cacheKey := fmt.Sprintf("%d:%s:%s:%s:%s", repo.CodehostID, namespace, repo.RepoName, sourceBranch, targetBranch)
+	if merged, ok := c.cache[cacheKey]; ok {
+		return merged, nil
+	}
+
+	codehostClient, err := c.getClient(repo.CodehostID)
+	if err != nil {
+		return false, err
+	}
+
+	mergeChecker, ok := codehostClient.(client.BranchMergeChecker)
+	if !ok {
+		return false, fmt.Errorf("codehost does not support branch merge check")
+	}
+
+	merged, err := mergeChecker.IsBranchMerged(client.BranchMergeCheckOpt{
+		Namespace:    namespace,
+		ProjectName:  repo.RepoName,
+		SourceBranch: sourceBranch,
+		TargetBranch: targetBranch,
+	})
+	if err != nil {
+		return false, err
+	}
+	c.cache[cacheKey] = merged
+	return merged, nil
+}
+
+func (c *larkBranchMergeChecker) getClient(codehostID int) (client.CodeHostClient, error) {
+	if codehostClient, ok := c.clients[codehostID]; ok {
+		return codehostClient, nil
+	}
+
+	ch, err := systemconfig.New().GetCodeHost(codehostID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get codehost info: %w", err)
+	}
+
+	codehostClient, err := open.OpenClient(ch, c.ctx.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open codehost client: %w", err)
+	}
+
+	c.clients[codehostID] = codehostClient
+	return codehostClient, nil
 }

--- a/pkg/microservice/aslan/core/plugin/service/utils.go
+++ b/pkg/microservice/aslan/core/plugin/service/utils.go
@@ -236,8 +236,6 @@ func (c *larkBranchMergeChecker) isBranchMerged(repo *types.Repository, sourceBr
 	namespace = strings.Replace(namespace, "%2F", "/", -1)
 	cacheKey := fmt.Sprintf("%d:%s:%s:%s:%s", repo.CodehostID, namespace, repo.RepoName, sourceBranch, targetBranch)
 	if merged, ok := c.cache[cacheKey]; ok {
-		c.ctx.Logger.Infof("lark branch merge check cache hit, codehostID: %d, namespace: %s, repo: %s, sourceBranch: %s, targetBranch: %s, merged: %v",
-			repo.CodehostID, namespace, repo.RepoName, sourceBranch, targetBranch, merged)
 		return merged, nil
 	}
 
@@ -263,14 +261,12 @@ func (c *larkBranchMergeChecker) isBranchMerged(repo *types.Repository, sourceBr
 		return false, err
 	}
 	c.cache[cacheKey] = merged
-	c.ctx.Logger.Infof("lark branch merge check finished, codehostID: %d, namespace: %s, repo: %s, sourceBranch: %s, targetBranch: %s, merged: %v",
-		repo.CodehostID, namespace, repo.RepoName, sourceBranch, targetBranch, merged)
+
 	return merged, nil
 }
 
 func (c *larkBranchMergeChecker) getClient(codehostID int) (client.CodeHostClient, error) {
 	if codehostClient, ok := c.clients[codehostID]; ok {
-		c.ctx.Logger.Infof("lark branch merge checker reuse codehost client, codehostID: %d", codehostID)
 		return codehostClient, nil
 	}
 
@@ -278,7 +274,6 @@ func (c *larkBranchMergeChecker) getClient(codehostID int) (client.CodeHostClien
 	if err != nil {
 		return nil, fmt.Errorf("failed to get codehost info: %w", err)
 	}
-	c.ctx.Logger.Infof("lark branch merge checker open codehost client, codehostID: %d, type: %s, address: %s", ch.ID, ch.Type, ch.Address)
 
 	codehostClient, err := open.OpenClient(ch, c.ctx.Logger)
 	if err != nil {

--- a/pkg/microservice/aslan/core/plugin/service/utils.go
+++ b/pkg/microservice/aslan/core/plugin/service/utils.go
@@ -236,6 +236,8 @@ func (c *larkBranchMergeChecker) isBranchMerged(repo *types.Repository, sourceBr
 	namespace = strings.Replace(namespace, "%2F", "/", -1)
 	cacheKey := fmt.Sprintf("%d:%s:%s:%s:%s", repo.CodehostID, namespace, repo.RepoName, sourceBranch, targetBranch)
 	if merged, ok := c.cache[cacheKey]; ok {
+		c.ctx.Logger.Infof("lark branch merge check cache hit, codehostID: %d, namespace: %s, repo: %s, sourceBranch: %s, targetBranch: %s, merged: %v",
+			repo.CodehostID, namespace, repo.RepoName, sourceBranch, targetBranch, merged)
 		return merged, nil
 	}
 
@@ -248,6 +250,8 @@ func (c *larkBranchMergeChecker) isBranchMerged(repo *types.Repository, sourceBr
 	if !ok {
 		return false, fmt.Errorf("codehost does not support branch merge check")
 	}
+	c.ctx.Logger.Infof("lark branch merge check start, codehostID: %d, namespace: %s, repo: %s, sourceBranch: %s, targetBranch: %s",
+		repo.CodehostID, namespace, repo.RepoName, sourceBranch, targetBranch)
 
 	merged, err := mergeChecker.IsBranchMerged(client.BranchMergeCheckOpt{
 		Namespace:    namespace,
@@ -259,11 +263,14 @@ func (c *larkBranchMergeChecker) isBranchMerged(repo *types.Repository, sourceBr
 		return false, err
 	}
 	c.cache[cacheKey] = merged
+	c.ctx.Logger.Infof("lark branch merge check finished, codehostID: %d, namespace: %s, repo: %s, sourceBranch: %s, targetBranch: %s, merged: %v",
+		repo.CodehostID, namespace, repo.RepoName, sourceBranch, targetBranch, merged)
 	return merged, nil
 }
 
 func (c *larkBranchMergeChecker) getClient(codehostID int) (client.CodeHostClient, error) {
 	if codehostClient, ok := c.clients[codehostID]; ok {
+		c.ctx.Logger.Infof("lark branch merge checker reuse codehost client, codehostID: %d", codehostID)
 		return codehostClient, nil
 	}
 
@@ -271,6 +278,7 @@ func (c *larkBranchMergeChecker) getClient(codehostID int) (client.CodeHostClien
 	if err != nil {
 		return nil, fmt.Errorf("failed to get codehost info: %w", err)
 	}
+	c.ctx.Logger.Infof("lark branch merge checker open codehost client, codehostID: %d, type: %s, address: %s", ch.ID, ch.Type, ch.Address)
 
 	codehostClient, err := open.OpenClient(ch, c.ctx.Logger)
 	if err != nil {

--- a/pkg/tool/gerrit/client.go
+++ b/pkg/tool/gerrit/client.go
@@ -156,6 +156,12 @@ func (c *Client) GetCommitByBranch(project string, branch string) (*gerrit.Commi
 	return commit, err
 }
 
+func (c *Client) GetCommitByRevision(project string, revision string) (*gerrit.CommitInfo, error) {
+	project = Unescape(project)
+	commit, _, err := c.cli.Projects.GetCommit(project, revision)
+	return commit, err
+}
+
 func (c *Client) GetCommitByTag(project string, tag string) (*gerrit.CommitInfo, error) {
 	project = Unescape(project)
 	tagInfo, _, err := c.cli.Projects.GetTag(project, tag)


### PR DESCRIPTION
### What this PR does / Why we need it:

This PR adds branch merge status checking for Lark release bind items.

When listing release bind items, the API now checks whether each bound work item’s configured source branch has been merged into the release target branch. 

### What is changed and how it works?

Added branch merge result fields to Lark release bind item response
 1.Resolves service/module repo information from the release workflow.
2.Compares the configured source branch with the release target branch.
3.Returns per-service merge details, including merge status and error message if checking fails.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4665)
<!-- Reviewable:end -->
