### PR TITLE
fix: avoid injecting unresolved workflow pull secrets

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
@@ -704,16 +704,17 @@ func ensureVolumeMounts(job *batchv1.Job) {
 }
 
 func getImagePullSecrets(registries []*commonmodels.RegistryNamespace) ([]corev1.LocalObjectReference, error) {
-	ImagePullSecrets := []corev1.LocalObjectReference{
-		{
-			Name: setting.DefaultImagePullSecret,
-		},
-	}
+	ImagePullSecrets := make([]corev1.LocalObjectReference, 0, len(registries))
+	seen := make(map[string]struct{}, len(registries))
 	for _, reg := range registries {
 		secretName, err := kube.GenRegistrySecretName(reg)
 		if err != nil {
 			return ImagePullSecrets, fmt.Errorf("failed to generate registry secret name: %s", err)
 		}
+		if _, ok := seen[secretName]; ok {
+			continue
+		}
+		seen[secretName] = struct{}{}
 
 		secret := corev1.LocalObjectReference{
 			Name: secretName,


### PR DESCRIPTION
### Summary
- avoid injecting workflow image pull secrets that have not been resolved for the current build job

### Why
- external workflow jobs always injected `default-registry-secret` even when no matching registry secret had been resolved or created for the current run
- this could trigger `FailedToRetrieveImagePullSecret` warnings on non-local clusters when the secret did not exist in `koderover-agent`

### Main Changes
- change workflow job imagePullSecrets assembly to only use the registries resolved for the current job
- deduplicate generated image pull secret names before writing them into the pod spec
- stop unconditionally prepending `default-registry-secret`

### Risk / Compatibility
- low risk: the change is limited to workflow job pod spec assembly for imagePullSecrets
- jobs that actually resolve registry credentials still receive the corresponding secret names
- jobs that do not resolve any registry secret will no longer reference a missing default secret

### Test
- verified the code path statically in `pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go`
- attempted: `GOCACHE=/private/tmp/zadig-go-build-cache go test ./pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/...`
- test command was blocked by an unrelated existing build failure in `job_deploy.go:671` (`non-constant format string in call to fmt.Errorf`)

### Contact
- Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4673)
<!-- Reviewable:end -->
