### PR TITLE
fix: align scanning job name validation with testing

### DIFF
--- a/pkg/microservice/aslan/core/common/util/workflow.go
+++ b/pkg/microservice/aslan/core/common/util/workflow.go
@@ -54,10 +54,7 @@ func GenerateTestingModuleJobName(name string) string {
 }
 
 func GenerateScanningModuleJobName(name string) string {
-	if len(name) >= 32 {
-		return strings.TrimSuffix(name[:31], "-")
-	}
-	return name
+	return strings.ToLower(name)
 }
 
 func ValidateGeneratedWorkflowJobName(name string, generator func(string) string) error {


### PR DESCRIPTION
### Summary
- Align scanning job name generation with testing so both use the same lowercase normalization rule before workflow job name validation.

### Why
- Scanning and testing currently treat names differently, which makes scanning reject names that testing accepts.

### Main Changes
- Update `GenerateScanningModuleJobName` to use `strings.ToLower`, matching testing module behavior.
- Remove the scanning-specific truncation path so scanning validation follows the same generated-name rule as testing.

### Risk / Compatibility
- Low risk: the change is scoped to scanning job name generation and only affects how scanning names are normalized before validation.
- Compatibility change: scanning names longer than the workflow job name limit are no longer silently truncated and will now fail validation, matching testing behavior.

### Test
- `GOCACHE=/private/tmp/zadig-go-build-cache go test -vet=off ./pkg/microservice/aslan/core/common/util`
- `GOCACHE=/private/tmp/zadig-go-build-cache go test -vet=off ./pkg/microservice/aslan/core/workflow/testing/service`

### Contact
- Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4701)
<!-- Reviewable:end -->
