### PR TITLE
add release job owner to release plan webhook payload

### DIFF
--- a/pkg/microservice/aslan/core/common/service/webhooknotify/types.go
+++ b/pkg/microservice/aslan/core/common/service/webhooknotify/types.go
@@ -180,6 +180,10 @@ type ReleasePlanHookJob struct {
 	ID string `json:"id"`
 	// 发布任务名称
 	Name string `json:"name"`
+	// 发布任务负责人
+	Manager string `json:"manager"`
+	// 发布任务负责人 ID
+	ManagerID string `json:"manager_id"`
 	// 发布任务类型
 	Type config.ReleasePlanJobType `json:"type"`
 	// 发布任务规格

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -1772,9 +1772,11 @@ func convertReleasePlanToHookBody(plan *models.ReleasePlan, hookEvent commonmode
 	jobs := []*webhooknotify.ReleasePlanHookJob{}
 	for _, job := range plan.Jobs {
 		hookJob := &webhooknotify.ReleasePlanHookJob{
-			ID:   job.ID,
-			Name: job.Name,
-			Type: job.Type,
+			ID:        job.ID,
+			Name:      job.Name,
+			Manager:   job.Manager,
+			ManagerID: job.ManagerID,
+			Type:      job.Type,
 			ReleasePlanHookJobRuntime: webhooknotify.ReleasePlanHookJobRuntime{
 				Status:       job.Status,
 				ExecutedBy:   job.ExecutedBy,


### PR DESCRIPTION
### What this PR does / Why we need it:

Adds release item owner information to the release plan webhook payload, so external systems receiving release plan hooks can identify the responsible person for each release item.

### What is changed and how it works?

Adds manager and manager_id fields to ReleasePlanHookJob.
Updates convertReleasePlanToHookBody to map each release job’s Manager and ManagerID into the webhook payload.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4703)
<!-- Reviewable:end -->
