### PR TITLE
feat(workflow): allow custom repos for OpenAPI freestyle task runs

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/types.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/types.go
@@ -402,6 +402,66 @@ func OpenAPIRepoInputToRepository(originalRepos []*types.Repository, repoInpus [
 	return newRepo, nil
 }
 
+func OpenAPIFreestyleRepoInputToRepository(originalRepos []*types.Repository, repoInpus []*types.OpenAPIRepoInput) ([]*types.Repository, error) {
+	if len(repoInpus) == 0 {
+		return originalRepos, nil
+	}
+
+	repoInfoMap, err := getCodeHostInfoMap(repoInpus)
+	if err != nil {
+		return nil, err
+	}
+
+	newRepo := make([]*types.Repository, 0)
+	for _, inputRepo := range repoInpus {
+		repoInfo := repoInfoMap[inputRepo.CodeHostName]
+
+		if repoInfo.Type != "perforce" {
+			remoteName := inputRepo.RemoteName
+			if remoteName == "" {
+				remoteName = "origin"
+			}
+			newRepo = append(newRepo, &types.Repository{
+				Source:        repoInfo.Type,
+				RepoOwner:     inputRepo.RepoNamespace,
+				RepoNamespace: inputRepo.RepoNamespace,
+				RepoName:      inputRepo.RepoName,
+				Branch:        inputRepo.Branch,
+				PR:            inputRepo.PR,
+				PRs:           inputRepo.PRs,
+				EnableCommit:  inputRepo.EnableCommit,
+				CommitID:      inputRepo.CommitID,
+				CodehostID:    repoInfo.ID,
+				RemoteName:    remoteName,
+				CheckoutPath:  inputRepo.CheckoutPath,
+				SubModules:    inputRepo.SubModules,
+			})
+		} else {
+			var depotType string
+			if inputRepo.Stream != "" {
+				depotType = "stream"
+			} else {
+				depotType = "local"
+			}
+			newRepo = append(newRepo, &types.Repository{
+				Source:       repoInfo.Type,
+				CodehostID:   repoInfo.ID,
+				Username:     repoInfo.Username,
+				Password:     repoInfo.Password,
+				PerforceHost: repoInfo.P4Host,
+				PerforcePort: repoInfo.P4Port,
+				DepotType:    depotType,
+				Stream:       inputRepo.Stream,
+				ViewMapping:  inputRepo.ViewMapping,
+				ChangeListID: inputRepo.ChangelistID,
+				ShelveID:     inputRepo.ShelveID,
+			})
+		}
+	}
+
+	return newRepo, nil
+}
+
 func (p *FreestyleJobInput) UpdateJobSpec(job *commonmodels.Job) (*commonmodels.Job, error) {
 	newSpec := new(commonmodels.FreestyleJobSpec)
 	if err := commonmodels.IToi(job.Spec, newSpec); err != nil {
@@ -417,7 +477,7 @@ func (p *FreestyleJobInput) UpdateJobSpec(job *commonmodels.Job) (*commonmodels.
 		} else {
 			services := make([]*commonmodels.FreeStyleServiceInfo, 0)
 			for _, service := range p.Services {
-				newRepos, err := OpenAPIRepoInputToRepository(newSpec.Repos, service.RepoInfo)
+				newRepos, err := OpenAPIFreestyleRepoInputToRepository(newSpec.Repos, service.RepoInfo)
 				if err != nil {
 					return nil, err
 				}
@@ -436,7 +496,7 @@ func (p *FreestyleJobInput) UpdateJobSpec(job *commonmodels.Job) (*commonmodels.
 	} else if newSpec.FreestyleJobType == config.NormalFreeStyleJobType {
 		newSpec.Envs = OpenAPIKVInputToKeyValList(newSpec.Envs, p.KVs)
 
-		newRepos, err := OpenAPIRepoInputToRepository(newSpec.Repos, p.RepoInfo)
+		newRepos, err := OpenAPIFreestyleRepoInputToRepository(newSpec.Repos, p.RepoInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -482,7 +542,7 @@ func (p *FreestyleJobInput) getReferredJobTargets(jobSpec *commonmodels.Freestyl
 					}
 
 					if _, ok := serviceInputMap[target.GetKey()]; ok {
-						newRepos, err := OpenAPIRepoInputToRepository(jobSpec.Repos, serviceInputMap[target.GetKey()].RepoInfo)
+						newRepos, err := OpenAPIFreestyleRepoInputToRepository(jobSpec.Repos, serviceInputMap[target.GetKey()].RepoInfo)
 						if err != nil {
 							return err
 						}
@@ -514,7 +574,7 @@ func (p *FreestyleJobInput) getReferredJobTargets(jobSpec *commonmodels.Freestyl
 					}
 
 					if _, ok := serviceInputMap[target.GetKey()]; ok {
-						newRepos, err := OpenAPIRepoInputToRepository(jobSpec.Repos, serviceInputMap[target.GetKey()].RepoInfo)
+						newRepos, err := OpenAPIFreestyleRepoInputToRepository(jobSpec.Repos, serviceInputMap[target.GetKey()].RepoInfo)
 						if err != nil {
 							return err
 						}
@@ -546,7 +606,7 @@ func (p *FreestyleJobInput) getReferredJobTargets(jobSpec *commonmodels.Freestyl
 					}
 
 					if _, ok := serviceInputMap[target.GetKey()]; ok {
-						newRepos, err := OpenAPIRepoInputToRepository(jobSpec.Repos, serviceInputMap[target.GetKey()].RepoInfo)
+						newRepos, err := OpenAPIFreestyleRepoInputToRepository(jobSpec.Repos, serviceInputMap[target.GetKey()].RepoInfo)
 						if err != nil {
 							return err
 						}
@@ -578,7 +638,7 @@ func (p *FreestyleJobInput) getReferredJobTargets(jobSpec *commonmodels.Freestyl
 					}
 
 					if _, ok := serviceInputMap[target.GetKey()]; ok {
-						newRepos, err := OpenAPIRepoInputToRepository(jobSpec.Repos, serviceInputMap[target.GetKey()].RepoInfo)
+						newRepos, err := OpenAPIFreestyleRepoInputToRepository(jobSpec.Repos, serviceInputMap[target.GetKey()].RepoInfo)
 						if err != nil {
 							return err
 						}


### PR DESCRIPTION
### What this PR does / Why we need it:

Allow OpenAPI-triggered freestyle workflow jobs to use the repository information provided in the request body.Previously, freestyle jobs could only update branch/PR/commit information for repositories already configured in the workflow. If users passed a different repository through OpenAPI, it would be filtered out.

### What is changed and how it works?

For freestyle jobs, when repo_info is provided, the task now builds repository configs directly from the OpenAPI input, including code host, namespace, repository name, branch, PRs, commit, checkout path, submodules, and Perforce fields.

When repo_info is empty, the job still uses the repositories configured in the workflow.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4705)
<!-- Reviewable:end -->
