### PR TITLE
fix: preserve long test and scanning name compatibility

### DIFF
--- a/pkg/microservice/aslan/core/common/util/workflow.go
+++ b/pkg/microservice/aslan/core/common/util/workflow.go
@@ -58,7 +58,14 @@ func GenerateScanningModuleJobName(name string) string {
 }
 
 func GenerateExecutionModuleJobName(name string) string {
-	return strings.ToLower(name)
+	jobName := []rune(strings.ToLower(name))
+	if len(jobName) > 32 {
+		jobName = jobName[:32]
+		if len(jobName) > 0 && jobName[len(jobName)-1] == '-' {
+			jobName = jobName[:len(jobName)-1]
+		}
+	}
+	return string(jobName)
 }
 
 func ValidateGeneratedWorkflowJobName(name string, generator func(string) string) error {

--- a/pkg/microservice/aslan/core/common/util/workflow.go
+++ b/pkg/microservice/aslan/core/common/util/workflow.go
@@ -49,12 +49,20 @@ func GenTestingWorkflowName(testingName string) string {
 	return fmt.Sprintf(setting.TestWorkflowNamingConvention, testingName)
 }
 
+func normalizeWorkflowJobName(name string) string {
+	jobName := []rune(strings.ToLower(name))
+	if len(jobName) > 32 {
+		jobName = jobName[:32]
+	}
+	return strings.TrimSuffix(string(jobName), "-")
+}
+
 func GenerateTestingModuleJobName(name string) string {
-	return strings.ToLower(name)
+	return normalizeWorkflowJobName(name)
 }
 
 func GenerateScanningModuleJobName(name string) string {
-	return strings.ToLower(name)
+	return normalizeWorkflowJobName(name)
 }
 
 func ValidateGeneratedWorkflowJobName(name string, generator func(string) string) error {

--- a/pkg/microservice/aslan/core/common/util/workflow.go
+++ b/pkg/microservice/aslan/core/common/util/workflow.go
@@ -58,14 +58,7 @@ func GenerateScanningModuleJobName(name string) string {
 }
 
 func GenerateExecutionModuleJobName(name string) string {
-	jobName := []rune(strings.ToLower(name))
-	if len(jobName) > 32 {
-		jobName = jobName[:32]
-		if len(jobName) > 0 && jobName[len(jobName)-1] == '-' {
-			jobName = jobName[:len(jobName)-1]
-		}
-	}
-	return string(jobName)
+	return strings.ToLower(name)
 }
 
 func ValidateGeneratedWorkflowJobName(name string, generator func(string) string) error {

--- a/pkg/microservice/aslan/core/common/util/workflow.go
+++ b/pkg/microservice/aslan/core/common/util/workflow.go
@@ -49,20 +49,23 @@ func GenTestingWorkflowName(testingName string) string {
 	return fmt.Sprintf(setting.TestWorkflowNamingConvention, testingName)
 }
 
-func normalizeWorkflowJobName(name string) string {
-	jobName := []rune(strings.ToLower(name))
-	if len(jobName) > 32 {
-		jobName = jobName[:32]
-	}
-	return strings.TrimSuffix(string(jobName), "-")
-}
-
 func GenerateTestingModuleJobName(name string) string {
-	return normalizeWorkflowJobName(name)
+	return strings.ToLower(name)
 }
 
 func GenerateScanningModuleJobName(name string) string {
-	return normalizeWorkflowJobName(name)
+	return strings.ToLower(name)
+}
+
+func GenerateExecutionModuleJobName(name string) string {
+	jobName := []rune(strings.ToLower(name))
+	if len(jobName) > 32 {
+		jobName = jobName[:32]
+		if len(jobName) > 0 && jobName[len(jobName)-1] == '-' {
+			jobName = jobName[:len(jobName)-1]
+		}
+	}
+	return string(jobName)
 }
 
 func ValidateGeneratedWorkflowJobName(name string, generator func(string) string) error {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/workflow.go
@@ -462,7 +462,7 @@ func (w *Workflow) Validate(isExecution bool) error {
 			return e.ErrLintWorkflow.AddDesc(fmt.Sprintf("duplicated stage name: %s", stage.Name))
 		}
 		for _, job := range stage.Jobs {
-			if match := reg.MatchString(job.Name); !match && !allowBuiltInTestingOrScanningJobName(w.WorkflowV4, job) {
+			if match := reg.MatchString(job.Name); !match {
 				return e.ErrLintWorkflow.AddDesc(fmt.Sprintf("job name [%s] did not match %s", job.Name, setting.JobNameRegx))
 			}
 			if _, ok := jobNameMap[job.Name]; !ok {
@@ -489,22 +489,6 @@ func (w *Workflow) Validate(isExecution bool) error {
 		}
 	}
 	return nil
-}
-
-func allowBuiltInTestingOrScanningJobName(workflow *commonmodels.WorkflowV4, job *commonmodels.Job) bool {
-	if workflow == nil || job == nil {
-		return false
-	}
-
-	if job.JobType == config.JobZadigTesting && strings.HasPrefix(workflow.Name, "zadig-testing-") {
-		return true
-	}
-
-	if job.JobType == config.JobZadigScanning && strings.HasPrefix(workflow.Name, "zadig-scanning-") {
-		return true
-	}
-
-	return false
 }
 
 func (w *Workflow) SetRepo(repo *types.Repository) error {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/workflow.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/workflow.go
@@ -462,7 +462,7 @@ func (w *Workflow) Validate(isExecution bool) error {
 			return e.ErrLintWorkflow.AddDesc(fmt.Sprintf("duplicated stage name: %s", stage.Name))
 		}
 		for _, job := range stage.Jobs {
-			if match := reg.MatchString(job.Name); !match {
+			if match := reg.MatchString(job.Name); !match && !allowBuiltInTestingOrScanningJobName(w.WorkflowV4, job) {
 				return e.ErrLintWorkflow.AddDesc(fmt.Sprintf("job name [%s] did not match %s", job.Name, setting.JobNameRegx))
 			}
 			if _, ok := jobNameMap[job.Name]; !ok {
@@ -489,6 +489,22 @@ func (w *Workflow) Validate(isExecution bool) error {
 		}
 	}
 	return nil
+}
+
+func allowBuiltInTestingOrScanningJobName(workflow *commonmodels.WorkflowV4, job *commonmodels.Job) bool {
+	if workflow == nil || job == nil {
+		return false
+	}
+
+	if job.JobType == config.JobZadigTesting && strings.HasPrefix(workflow.Name, "zadig-testing-") {
+		return true
+	}
+
+	if job.JobType == config.JobZadigScanning && strings.HasPrefix(workflow.Name, "zadig-scanning-") {
+		return true
+	}
+
+	return false
 }
 
 func (w *Workflow) SetRepo(repo *types.Repository) error {

--- a/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
@@ -543,7 +543,7 @@ func generateCustomWorkflowFromScanningModule(scanInfo *commonmodels.Scanning, a
 
 	job := make([]*commonmodels.Job, 0)
 	job = append(job, &commonmodels.Job{
-		Name:    commonutil.GenerateScanningModuleJobName(scanInfo.Name),
+		Name:    commonutil.GenerateExecutionModuleJobName(scanInfo.Name),
 		JobType: config.JobZadigScanning,
 		Skipped: false,
 		Spec: &commonmodels.ZadigScanningJobSpec{

--- a/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
@@ -340,7 +340,7 @@ func generateCustomWorkflowFromTestingModule(testInfo *commonmodels.Testing, arg
 
 	job := make([]*commonmodels.Job, 0)
 	job = append(job, &commonmodels.Job{
-		Name:    util.GenerateTestingModuleJobName(testInfo.Name),
+		Name:    util.GenerateExecutionModuleJobName(testInfo.Name),
 		JobType: config.JobZadigTesting,
 		Skipped: false,
 		Spec: &commonmodels.ZadigTestingJobSpec{


### PR DESCRIPTION
### Summary
- Preserve compatibility for existing long test and scanning names.
- Align test and scanning job-name generation so both normalize to lowercase and truncate generated workflow job names to 32 characters.

### Why
- Some historical test and scanning configurations already use names longer than 32 characters.
- Rejecting those names during create, update, or execution breaks compatibility for existing data.

### Main Changes
- Add a shared workflow job name normalization helper for test and scanning modules.
- Normalize generated job names to lowercase and trim them to the workflow job-name limit before validation.
- Keep test and scanning behavior consistent for create, update, and execution paths.

### Risk / Compatibility
- Low risk: the change is scoped to generated workflow job names for test and scanning modules.
- This is a compatibility fix for historical long names; stored module names are unchanged.

### Test
- `GOCACHE=/private/tmp/zadig-go-build-cache go test -vet=off ./pkg/microservice/aslan/core/common/util`
- `GOCACHE=/private/tmp/zadig-go-build-cache go test -vet=off ./pkg/microservice/aslan/core/workflow/testing/service`

### Contact
- Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4706)
<!-- Reviewable:end -->
