### PR TITLE
feat: add env_name field to ServiceDeployCountWithStatus.

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/job_info.go
+++ b/pkg/microservice/aslan/core/common/repository/models/job_info.go
@@ -52,6 +52,7 @@ type ServiceDeployCountWithStatus struct {
 	ServiceName string `bson:"service_name"           json:"service_name"`
 	ProductName string `bson:"product_name"           json:"project_key"`
 	ProjectName string `bson:"project_name,omitempty" json:"project_name,omitempty"`
+	EnvName     string `bson:"env_name"               json:"env_name"`
 	Count       int    `bson:"count"                  json:"count"`
 	Success     int    `bson:"success"                json:"success"`
 	Failed      int    `bson:"failed"                 json:"failed"`

--- a/pkg/microservice/aslan/core/common/repository/mongodb/job_info.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/job_info.go
@@ -374,6 +374,7 @@ func (c *JobInfoColl) GetTopDeployedService(startTime, endTime int64, projectNam
 				"production":   "$production",
 				"service_name": "$service_name",
 				"product_name": "$product_name",
+				"env_name":     "$target_env",
 			},
 			"count": bson.M{"$sum": 1},
 			"success": bson.M{"$sum": bson.M{
@@ -400,6 +401,7 @@ func (c *JobInfoColl) GetTopDeployedService(startTime, endTime int64, projectNam
 			"production":   "$_id.production",
 			"service_name": "$_id.service_name",
 			"product_name": "$_id.product_name",
+			"env_name":     "$_id.env_name",
 			"count":        1,
 			"success":      1,
 			"failed":       1,
@@ -427,6 +429,7 @@ func (c *JobInfoColl) GetTopDeployedService(startTime, endTime int64, projectNam
 			"production":   1,
 			"service_name": 1,
 			"product_name": 1,
+			"env_name":     1,
 			"count":        1,
 			"success":      1,
 			"failed":       1,
@@ -486,6 +489,7 @@ func (c *JobInfoColl) GetTopDeployFailedService(startTime, endTime int64, projec
 				"production":   "$production",
 				"service_name": "$service_name",
 				"product_name": "$product_name",
+				"env_name":     "$target_env",
 			},
 			"count": bson.M{"$sum": bson.M{
 				"$cond": bson.D{
@@ -504,6 +508,7 @@ func (c *JobInfoColl) GetTopDeployFailedService(startTime, endTime int64, projec
 			"production":   "$_id.production",
 			"service_name": "$_id.service_name",
 			"product_name": "$_id.product_name",
+			"env_name":     "$_id.env_name",
 			"count":        1,
 		},
 	})
@@ -528,6 +533,7 @@ func (c *JobInfoColl) GetTopDeployFailedService(startTime, endTime int64, projec
 			"production":   1,
 			"service_name": 1,
 			"product_name": 1,
+			"env_name":     1,
 			"count":        1,
 			"project_name": bson.M{"$first": "$template_product_info.project_name"},
 		},


### PR DESCRIPTION
### What this PR does / Why we need it:

feat: add env_name field to ServiceDeployCountWithStatus.


### Does this PR introduce a user-facing change?

- [x] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4708)
<!-- Reviewable:end -->
