### PR TITLE
fix helm template chart not set kube version

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/helm.go
+++ b/pkg/microservice/aslan/core/common/service/kube/helm.go
@@ -161,7 +161,12 @@ func InstallOrUpgradeHelmChartWithValues(param *ReleaseInstallParam, isRetry boo
 }
 
 func getStuckWorkload(helmClient *helmtool.HelmClient, chartSpec *helmclient.ChartSpec) ([]*appsv1.Deployment, []*appsv1.StatefulSet, error) {
-	manifestBytes, err := helmClient.TemplateChart(chartSpec, nil)
+	var templateOptions *helmclient.HelmTemplateOptions
+	if helmClient != nil && helmClient.KubeVersion != nil {
+		templateOptions = &helmclient.HelmTemplateOptions{KubeVersion: helmClient.KubeVersion}
+	}
+
+	manifestBytes, err := helmClient.TemplateChart(chartSpec, templateOptions)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to template chart %s/%s, err: %s", chartSpec.ReleaseName, chartSpec.ChartName, err)
 	}

--- a/pkg/microservice/aslan/core/common/service/kube/share_env.go
+++ b/pkg/microservice/aslan/core/common/service/kube/share_env.go
@@ -465,7 +465,12 @@ func EnsureDeletePreCreatedServices(ctx context.Context, productName, namespace 
 		return nil
 	}
 
-	manifestBytes, err := helmClient.TemplateChart(chartSpec, nil)
+	var templateOptions *helmclient.HelmTemplateOptions
+	if helmClient != nil && helmClient.KubeVersion != nil {
+		templateOptions = &helmclient.HelmTemplateOptions{KubeVersion: helmClient.KubeVersion}
+	}
+
+	manifestBytes, err := helmClient.TemplateChart(chartSpec, templateOptions)
 	if err != nil {
 		return fmt.Errorf("failed template chart %q for release %q in namespace %q: %s", chartSpec.ChartName, chartSpec.ReleaseName, chartSpec.Namespace, err)
 	}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
@@ -375,7 +375,12 @@ func genHelmResourceMap(helmDeploySvc *helmservice.HelmDeployService, env *commo
 		ValuesYaml:  valuesYaml,
 	}
 
-	manifestBytes, err := helmClient.TemplateChart(chartSpec, nil)
+	var templateOptions *helmclient.HelmTemplateOptions
+	if helmClient != nil && helmClient.KubeVersion != nil {
+		templateOptions = &helmclient.HelmTemplateOptions{KubeVersion: helmClient.KubeVersion}
+	}
+
+	manifestBytes, err := helmClient.TemplateChart(chartSpec, templateOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to template chart %s/%s, chartPath: %s, err: %s", tmplSvc.ServiceName, envSvc.GetServiceRender().ChartVersion, chartPath, err)
 	}


### PR DESCRIPTION
### What this PR does / Why we need it:
fix helm template chart not set kube version

### What is changed and how it works?
fix helm template chart not set kube version

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4721)
<!-- Reviewable:end -->
