### PR TITLE
feat: support daemonset

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/product.go
+++ b/pkg/microservice/aslan/core/common/repository/models/product.go
@@ -116,6 +116,7 @@ type ResourceType string
 const (
 	ResourceTypePod           ResourceType = "Pod"
 	ResourceTypeDeployment    ResourceType = "Deployment"
+	ResourceTypeDaemonSet     ResourceType = "DaemonSet"
 	ResourceTypeReplicaSet    ResourceType = "ReplicaSet"
 	ResourceTypePVC           ResourceType = "PersistentVolumeClaim"
 	ResourceTypeService       ResourceType = "Service"

--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -736,6 +736,23 @@ func ListWorkloads(envName, productName string, perPage, page int, informer info
 			Annotation: v.Annotations,
 		})
 	}
+	daemonSets, err := getter.ListDaemonSetsWithCache(nil, informer)
+	if err != nil {
+		return 0, workLoads, e.ErrListGroups.AddDesc(err.Error())
+	}
+	for _, v := range daemonSets {
+		workLoads = append(workLoads, &Workload{
+			Name:       v.Name,
+			Spec:       v.Spec.Template,
+			Selector:   v.Spec.Selector,
+			Type:       setting.DaemonSet,
+			Replicas:   v.Status.DesiredNumberScheduled,
+			Images:     wrapper.DaemonSet(v).ImageInfos(),
+			Containers: wrapper.DaemonSet(v).GetContainers(),
+			Ready:      wrapper.DaemonSet(v).Ready(),
+			Annotation: v.Annotations,
+		})
+	}
 	statefulSets, err := getter.ListStatefulSetsWithCache(nil, informer)
 	if err != nil {
 		return 0, workLoads, e.ErrListGroups.AddDesc(err.Error())

--- a/pkg/microservice/aslan/core/common/service/kube/apply.go
+++ b/pkg/microservice/aslan/core/common/service/kube/apply.go
@@ -783,7 +783,7 @@ func CreateOrPatchResource(applyParam *ResourceApplyParam, log *zap.SugaredLogge
 					continue
 				}
 			}
-		case setting.Deployment, setting.StatefulSet:
+		case setting.Deployment, setting.DaemonSet, setting.StatefulSet:
 			// compatibility flag, We add a match label in spec.selector field pre 1.10.
 			needSelectorLabel := false
 
@@ -890,6 +890,32 @@ func CreateOrPatchResource(applyParam *ResourceApplyParam, log *zap.SugaredLogge
 					if fixErr := HandleStuckDeployment(existingDeploy, clientSet, log); fixErr != nil {
 						log.Warnf("Failed to clean up stuck pods for Deployment %s/%s: %v", namespace, res.Name, fixErr)
 					}
+				}
+
+			case *appsv1.DaemonSet:
+				if applyParam.InjectSecrets {
+					ApplySystemImagePullSecrets(&res.Spec.Template.Spec)
+				}
+
+				logContent := fmt.Sprintf("Applying %s/%s in namespace %s", u.GetKind(), u.GetName(), namespace)
+				jobLogManager.SaveJobLog(logContent)
+
+				resYAML, marshalErr := yaml.Marshal(res)
+				if marshalErr != nil {
+					log.Errorf("Failed to marshal daemonset %s to YAML: %v", res.Name, marshalErr)
+					errList = multierror.Append(errList, marshalErr)
+					continue
+				}
+				gvkn := fmt.Sprintf("%s-%s", u.GetObjectKind().GroupVersionKind(), u.GetName())
+				originalYAML := ""
+				if curRes, ok := curResourceMap[gvkn]; ok {
+					originalYAML = curRes.Manifest
+				}
+				err = updater.CreateOrPatchDaemonSet(context.TODO(), productInfo.ClusterID, namespace, originalYAML, string(resYAML), applyParam.OverrideResource)
+				if err != nil {
+					log.Errorf("Failed to create or update %s, manifest is\n%v\n, error: %v", u.GetKind(), res, err)
+					errList = multierror.Append(errList, err)
+					continue
 				}
 
 			case *appsv1.StatefulSet:

--- a/pkg/microservice/aslan/core/common/service/kube/render.go
+++ b/pkg/microservice/aslan/core/common/service/kube/render.go
@@ -178,6 +178,31 @@ func ReplaceWorkloadImages(rawYaml string, images []*commonmodels.Container) (st
 			if err != nil {
 				return "", nil, err
 			}
+		case setting.DaemonSet:
+			daemonSet := &appsv1.DaemonSet{}
+			if err := decoder.Decode(daemonSet); err != nil {
+				return "", nil, fmt.Errorf("unmarshal DaemonSet error: %v", err)
+			}
+			workloadRes = append(workloadRes, &WorkloadResource{
+				Name: resKind.Metadata.Name,
+				Type: resKind.Kind,
+			})
+			for i, container := range daemonSet.Spec.Template.Spec.Containers {
+				containerName := container.Name
+				if image, ok := imageMap[containerName]; ok {
+					daemonSet.Spec.Template.Spec.Containers[i].Image = image.Image
+				}
+			}
+			for i, container := range daemonSet.Spec.Template.Spec.InitContainers {
+				containerName := container.Name
+				if image, ok := imageMap[containerName]; ok {
+					daemonSet.Spec.Template.Spec.InitContainers[i].Image = image.Image
+				}
+			}
+			yamlStr, err = resourceToYaml(daemonSet)
+			if err != nil {
+				return "", nil, err
+			}
 		case setting.StatefulSet:
 			statefulSet := &appsv1.StatefulSet{}
 			if err := decoder.Decode(statefulSet); err != nil {

--- a/pkg/microservice/aslan/core/common/service/kube/workloads.go
+++ b/pkg/microservice/aslan/core/common/service/kube/workloads.go
@@ -29,9 +29,10 @@ import (
 	"github.com/koderover/zadig/v2/pkg/tool/log"
 )
 
-func FetchSelectedWorkloads(namespace string, Resource []*WorkloadResource, kubeclient crClient.Client, clientSet *kubernetes.Clientset) ([]*appsv1.Deployment, []*appsv1.StatefulSet,
+func FetchSelectedWorkloads(namespace string, Resource []*WorkloadResource, kubeclient crClient.Client, clientSet *kubernetes.Clientset) ([]*appsv1.Deployment, []*appsv1.DaemonSet, []*appsv1.StatefulSet,
 	[]*batchv1.CronJob, []*batchv1beta1.CronJob, []*batchv1.Job, error) {
 	var deployments []*appsv1.Deployment
+	var daemonSets []*appsv1.DaemonSet
 	var statefulSets []*appsv1.StatefulSet
 	var cronJobs []*batchv1.CronJob
 	var betaCronJobs []*batchv1beta1.CronJob
@@ -39,7 +40,7 @@ func FetchSelectedWorkloads(namespace string, Resource []*WorkloadResource, kube
 
 	k8sServerVersion, err := clientSet.Discovery().ServerVersion()
 	if err != nil {
-		return nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, err
 	}
 
 	for _, item := range Resource {
@@ -51,6 +52,14 @@ func FetchSelectedWorkloads(namespace string, Resource []*WorkloadResource, kube
 			}
 			if err != nil {
 				log.Errorf("failed to fetch deployment %s, error: %v", item.Name, err)
+			}
+		case setting.DaemonSet:
+			daemonSet, daemonSetExists, err := getter.GetDaemonSet(namespace, item.Name, kubeclient)
+			if daemonSetExists && err == nil {
+				daemonSets = append(daemonSets, daemonSet)
+			}
+			if err != nil {
+				log.Errorf("failed to fetch daemonset %s, error: %v", item.Name, err)
 			}
 		case setting.StatefulSet:
 			sts, stsExists, err := getter.GetStatefulSet(namespace, item.Name, kubeclient)
@@ -81,5 +90,5 @@ func FetchSelectedWorkloads(namespace string, Resource []*WorkloadResource, kube
 			}
 		}
 	}
-	return deployments, statefulSets, cronJobs, betaCronJobs, jobs, nil
+	return deployments, daemonSets, statefulSets, cronJobs, betaCronJobs, jobs, nil
 }

--- a/pkg/microservice/aslan/core/common/service/product.go
+++ b/pkg/microservice/aslan/core/common/service/product.go
@@ -86,6 +86,11 @@ func DeleteNamespacedResource(namespace string, selector labels.Selector, cluste
 		errors = multierror.Append(errors, fmt.Errorf("kubeCli.DeleteStatefulSets error: %v", err))
 	}
 
+	if err := updater.DeleteDaemonSetV2(context.Background(), clusterID, namespace, updater.WithSelector(selector.String())); err != nil {
+		log.Error(err)
+		errors = multierror.Append(errors, fmt.Errorf("kubeCli.DeleteDaemonSets error: %v", err))
+	}
+
 	if err := updater.DeleteJobsV2(context.Background(), clusterID, namespace, updater.WithSelector(selector.String())); err != nil {
 		log.Error(err)
 		errors = multierror.Append(errors, fmt.Errorf("kubeCli.DeleteJobs error: %v", err))

--- a/pkg/microservice/aslan/core/common/service/service.go
+++ b/pkg/microservice/aslan/core/common/service/service.go
@@ -1441,6 +1441,14 @@ func GetServiceImpl(serviceName string, serviceTmpl *commonmodels.Service, workL
 
 				ret.Scales = append(ret.Scales, GetDeploymentWorkloadResource(d, inf, log))
 				ret.Workloads = append(ret.Workloads, ToDeploymentWorkload(d))
+			case setting.DaemonSet:
+				daemonSet, err := getter.GetDaemonSetByNameWithCache(u.GetName(), namespace, inf)
+				if err != nil {
+					continue
+				}
+
+				ret.Scales = append(ret.Scales, GetDaemonSetWorkloadResource(daemonSet, inf, log))
+				ret.Workloads = append(ret.Workloads, ToDaemonSetWorkload(daemonSet))
 			case setting.CloneSet:
 				dc, err := clientmanager.NewKubeClientManager().GetKruiseClient(env.ClusterID)
 				if err != nil {
@@ -1533,6 +1541,15 @@ func GetCloneSetWorkloadResource(d *v1alpha1.CloneSet, informer informers.Shared
 	}
 
 	return wrapper.CloneSet(d).WorkloadResource(pods)
+}
+
+func GetDaemonSetWorkloadResource(daemonSet *appsv1.DaemonSet, informer informers.SharedInformerFactory, log *zap.SugaredLogger) *internalresource.Workload {
+	pods, err := getter.ListPodsWithCache(labels.SelectorFromValidatedSet(daemonSet.Spec.Selector.MatchLabels), informer)
+	if err != nil {
+		log.Warnf("Failed to get pods, err: %s", err)
+	}
+
+	return wrapper.DaemonSet(daemonSet).WorkloadResource(pods)
 }
 
 func getStatefulSetWorkloadResource(sts *appsv1.StatefulSet, informer informers.SharedInformerFactory, log *zap.SugaredLogger) *internalresource.Workload {

--- a/pkg/microservice/aslan/core/common/service/service.go
+++ b/pkg/microservice/aslan/core/common/service/service.go
@@ -1589,6 +1589,20 @@ func ToDeploymentWorkload(v *appsv1.Deployment) *Workload {
 	return workload
 }
 
+func ToDaemonSetWorkload(v *appsv1.DaemonSet) *Workload {
+	workload := &Workload{
+		Name:       v.Name,
+		Spec:       v.Spec.Template,
+		Selector:   v.Spec.Selector,
+		Type:       setting.DaemonSet,
+		Images:     wrapper.DaemonSet(v).ImageInfos(),
+		Containers: wrapper.DaemonSet(v).GetContainers(),
+		Ready:      wrapper.DaemonSet(v).Ready(),
+		Annotation: v.Annotations,
+	}
+	return workload
+}
+
 func ToCloneSetWorkload(v *v1alpha1.CloneSet) *Workload {
 	workload := &Workload{
 		Name:       v.Name,

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -400,7 +400,7 @@ func (c *DeployJobCtl) updateSystemService(env *commonmodels.Product, currentYam
 	}
 	for _, us := range unstructuredList {
 		switch us.GetKind() {
-		case setting.Deployment, setting.StatefulSet:
+		case setting.Deployment, setting.DaemonSet, setting.StatefulSet:
 			podLabels, _, err := unstructured.NestedStringMap(us.Object, "spec", "template", "metadata", "labels")
 			if err == nil {
 				c.jobTaskSpec.RelatedPodLabels = append(c.jobTaskSpec.RelatedPodLabels, podLabels)
@@ -416,7 +416,7 @@ func (c *DeployJobCtl) updateSystemService(env *commonmodels.Product, currentYam
 func UpdateExternalServiceModule(ctx context.Context, kubeClient client.Client, clientSet *kubernetes.Clientset, resources []*kube.WorkloadResource, env *commonmodels.Product, serviceName string, serviceModule *commonmodels.DeployServiceModule, detail, userName string, jobLogctx *joblog.JobLogContext, logger *zap.SugaredLogger) (replaceResources []commonmodels.Resource, relatedPodLabels []map[string]string, err error) {
 	var replaced bool
 
-	deployments, statefulSets, cronJobs, betaCronJobs, jobs, err := kube.FetchSelectedWorkloads(env.Namespace, resources, kubeClient, clientSet)
+	deployments, daemonSets, statefulSets, cronJobs, betaCronJobs, jobs, err := kube.FetchSelectedWorkloads(env.Namespace, resources, kubeClient, clientSet)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -480,6 +480,52 @@ L:
 				replaced = true
 				relatedPodLabels = append(relatedPodLabels, deploy.Spec.Template.Labels)
 				break L
+			}
+		}
+	}
+DaemonSetLoop:
+	for _, daemonSet := range daemonSets {
+		for _, container := range daemonSet.Spec.Template.Spec.Containers {
+			if container.Name == serviceModule.ServiceModule {
+				err = updater.UpdateDaemonSetImage(ctx, env.ClusterID, daemonSet.Namespace, daemonSet.Name, serviceModule.ServiceModule, serviceModule.Image)
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed to update container image in %s/daemonsets/%s/%s: %v", env.Namespace, daemonSet.Name, container.Name, err)
+				}
+
+				logContent := fmt.Sprintf("Update daemonset %s/%s, set container %s image to %s", daemonSet.Namespace, daemonSet.Name, container.Name, serviceModule.Image)
+				logManager.SaveJobLog(logContent)
+
+				replaceResources = append(replaceResources, commonmodels.Resource{
+					Kind:      setting.DaemonSet,
+					Container: container.Name,
+					Origin:    container.Image,
+					Name:      daemonSet.Name,
+				})
+				replaced = true
+				relatedPodLabels = append(relatedPodLabels, daemonSet.Spec.Template.Labels)
+				break DaemonSetLoop
+			}
+		}
+
+		for _, container := range daemonSet.Spec.Template.Spec.InitContainers {
+			if container.Name == serviceModule.ServiceModule {
+				err = updater.UpdateDaemonSetInitImage(ctx, env.ClusterID, daemonSet.Namespace, daemonSet.Name, serviceModule.ServiceModule, serviceModule.Image)
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed to update init container image in %s/daemonsets/%s/%s: %v", env.Namespace, daemonSet.Name, container.Name, err)
+				}
+
+				logContent := fmt.Sprintf("Update daemonset %s/%s, set init container %s image to %s", daemonSet.Namespace, daemonSet.Name, container.Name, serviceModule.Image)
+				logManager.SaveJobLog(logContent)
+
+				replaceResources = append(replaceResources, commonmodels.Resource{
+					Kind:      setting.DaemonSet,
+					Container: container.Name,
+					Origin:    container.Image,
+					Name:      daemonSet.Name,
+				})
+				replaced = true
+				relatedPodLabels = append(relatedPodLabels, daemonSet.Spec.Template.Labels)
+				break DaemonSetLoop
 			}
 		}
 	}
@@ -711,6 +757,12 @@ func getResourcesPodOwnerUIDImpl(kubeClient client.Client, namespace string, ser
 	newResources := []commonmodels.Resource{}
 	for _, resource := range replaceResources {
 		switch resource.Kind {
+		case setting.DaemonSet:
+			daemonSet, found, err := getter.GetDaemonSet(namespace, resource.Name, kubeClient)
+			if err != nil || !found || daemonSet == nil {
+				return newResources, err
+			}
+			resource.PodOwnerUID = string(daemonSet.ObjectMeta.UID)
 		case setting.StatefulSet:
 			sts, found, err := getter.GetStatefulSet(namespace, resource.Name, kubeClient)
 			if err != nil || !found || sts == nil {
@@ -880,6 +932,27 @@ func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespac
 						break L
 					} else {
 						jobLogManager.SaveJobLog(fmt.Sprintf("Deployment %s/%s is ready", namespace, resource.Name))
+					}
+				case setting.DaemonSet:
+					daemonSet, found, e := getter.GetDaemonSet(namespace, resource.Name, kubeClient)
+					if e != nil {
+						err = e
+					}
+					if e != nil || !found {
+						newErr := fmt.Errorf("Failed to check daemonSet ready status %s/%s/%s - %v", namespace, resource.Kind, resource.Name, e)
+						jobLogManager.SaveJobLog(newErr.Error())
+						logger.Error(newErr)
+						ready = false
+					} else {
+						ready = wrapper.DaemonSet(daemonSet).Ready()
+					}
+
+					if !ready {
+						jobLogManager.SaveJobLog(fmt.Sprintf("Checking DaemonSet %s/%s status ...", namespace, resource.Name))
+
+						break L
+					} else {
+						jobLogManager.SaveJobLog(fmt.Sprintf("DaemonSet %s/%s is ready", namespace, resource.Name))
 					}
 				case setting.StatefulSet:
 					sts, found, e := getter.GetStatefulSet(namespace, resource.Name, kubeClient)

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_restart.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_restart.go
@@ -25,7 +25,6 @@ import (
 	"github.com/koderover/zadig/v2/pkg/tool/clientmanager"
 	helmtool "github.com/koderover/zadig/v2/pkg/tool/helmclient"
 	"github.com/koderover/zadig/v2/pkg/tool/kube/getter"
-	"github.com/koderover/zadig/v2/pkg/tool/kube/updater"
 	"github.com/koderover/zadig/v2/pkg/util"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -42,6 +41,7 @@ import (
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/kube"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/repository"
 	"github.com/koderover/zadig/v2/pkg/setting"
+	"github.com/koderover/zadig/v2/pkg/tool/kube/updater"
 )
 
 type RestartJobCtl struct {
@@ -221,7 +221,7 @@ func (c *RestartJobCtl) restartHelmService(ctx context.Context, env *commonmodel
 
 	for _, u := range unstructuredList {
 		switch u.GetKind() {
-		case setting.Deployment, setting.StatefulSet:
+		case setting.Deployment, setting.DaemonSet, setting.StatefulSet:
 			resources = append(resources, &kube.WorkloadResource{
 				Type: u.GetKind(),
 				Name: u.GetName(),
@@ -300,6 +300,15 @@ func restartWorkloadResources(ctx context.Context, clusterID string, resources [
 		relatedPodLabels = append(relatedPodLabels, sts.Spec.Template.Labels)
 	}
 
+	for _, resource := range resources {
+		switch resource.Type {
+		case setting.DaemonSet:
+			if err := updater.RestartDaemonSet(ctx, clusterID, env.Namespace, resource.Name); err != nil {
+				return nil, nil, fmt.Errorf("failed to restart daemonset %s/%s: %v", env.Namespace, resource.Name, err)
+			}
+			replaceResources = append(replaceResources, commonmodels.Resource{Kind: setting.DaemonSet, Name: resource.Name})
+		}
+	}
 	return replaceResources, relatedPodLabels, nil
 }
 

--- a/pkg/microservice/aslan/core/common/util/service.go
+++ b/pkg/microservice/aslan/core/common/util/service.go
@@ -192,6 +192,7 @@ func SetCurrentContainerImages(args *commonmodels.Service) error {
 			}
 
 			if resKind.Kind == setting.Deployment ||
+				resKind.Kind == setting.DaemonSet ||
 				resKind.Kind == setting.StatefulSet ||
 				resKind.Kind == setting.Job ||
 				resKind.Kind == setting.CloneSet {

--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -1911,7 +1911,7 @@ func ListWorkloads(c *gin.Context) {
 		for _, env := range sharedNSEnvs {
 			for _, svc := range env.GetSvcList() {
 				for _, res := range svc.Resources {
-					if res.Kind == setting.Deployment || res.Kind == setting.StatefulSet || res.Kind == setting.CronJob {
+					if res.Kind == setting.Deployment || res.Kind == setting.DaemonSet || res.Kind == setting.StatefulSet || res.Kind == setting.CronJob {
 						workloadM[res.Name] = commonmodels.Workload{
 							EnvName:     env.EnvName,
 							ProductName: env.ProductName,

--- a/pkg/microservice/aslan/core/environment/handler/image.go
+++ b/pkg/microservice/aslan/core/environment/handler/image.go
@@ -208,6 +208,102 @@ func UpdateDeploymentContainerImage(c *gin.Context) {
 	ctx.RespErr = service.UpdateContainerImage(ctx.RequestID, ctx.UserName, args, ctx.Logger)
 }
 
+func UpdateDaemonSetContainerImage(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	args := new(service.UpdateContainerImageArgs)
+	args.Type = setting.DaemonSet
+
+	data, err := c.GetRawData()
+	if err != nil {
+		log.Errorf("UpdateDaemonSetContainerImage c.GetRawData() err : %v", err)
+	}
+	if err = json.Unmarshal(data, args); err != nil {
+		log.Errorf("UpdateDaemonSetContainerImage json.Unmarshal err : %v", err)
+	}
+
+	detail := fmt.Sprintf("环境名称:%s,服务名称:%s,DaemonSet:%s", args.EnvName, args.ServiceName, args.Name)
+	detailEn := fmt.Sprintf("Environment Name: %s, Service Name: %s, DaemonSet: %s", args.EnvName, args.ServiceName, args.Name)
+	internalhandler.InsertDetailedOperationLog(
+		c, ctx.UserName, args.ProductName, setting.OperationSceneEnv,
+		"更新", "环境-服务镜像",
+		detail,
+		detailEn,
+		string(data), types.RequestBodyTypeJSON, ctx.Logger, args.EnvName)
+
+	production := c.Query("production") == "true"
+	args.Production = production
+
+	permitted := false
+	if ctx.Resources.IsSystemAdmin {
+		permitted = true
+	} else if projectAuthInfo, ok := ctx.Resources.ProjectAuthInfo[args.ProductName]; ok {
+		if production {
+			if projectAuthInfo.IsProjectAdmin {
+				permitted = true
+			} else if projectAuthInfo.ProductionEnv.EditConfig || projectAuthInfo.ProductionEnv.ManagePods {
+				permitted = true
+			} else {
+				collabPermittedConfig, err := internalhandler.GetCollaborationModePermission(ctx.UserID, args.ProductName, types.ResourceTypeEnvironment, args.EnvName, types.ProductionEnvActionEditConfig)
+				if err == nil {
+					permitted = collabPermittedConfig
+				}
+				if !permitted {
+					collabPermittedManagePod, err := internalhandler.GetCollaborationModePermission(ctx.UserID, args.ProductName, types.ResourceTypeEnvironment, args.EnvName, types.ProductionEnvActionManagePod)
+					if err == nil {
+						permitted = collabPermittedManagePod
+					}
+				}
+			}
+
+			err = commonutil.CheckZadigProfessionalLicense()
+			if err != nil {
+				ctx.RespErr = err
+				return
+			}
+		} else {
+			if projectAuthInfo.IsProjectAdmin {
+				permitted = true
+			} else if projectAuthInfo.Env.EditConfig || projectAuthInfo.Env.ManagePods {
+				permitted = true
+			} else {
+				collabPermittedConfig, err := internalhandler.GetCollaborationModePermission(ctx.UserID, args.ProductName, types.ResourceTypeEnvironment, args.EnvName, types.EnvActionEditConfig)
+				if err == nil {
+					permitted = collabPermittedConfig
+				}
+
+				if !permitted {
+					collabPermittedManagePod, err := internalhandler.GetCollaborationModePermission(ctx.UserID, args.ProductName, types.ResourceTypeEnvironment, args.EnvName, types.EnvActionManagePod)
+					if err == nil {
+						permitted = collabPermittedManagePod
+					}
+				}
+			}
+		}
+	}
+
+	if !permitted {
+		ctx.UnAuthorized = true
+		return
+	}
+
+	c.Request.Body = io.NopCloser(bytes.NewBuffer(data))
+
+	if err := c.BindJSON(args); err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+
+	ctx.RespErr = service.UpdateContainerImage(ctx.RequestID, ctx.UserName, args, ctx.Logger)
+}
+
 func UpdateCronJobContainerImage(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -84,6 +84,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 	image := router.Group("image")
 	{
 		image.POST("/deployment/:envName", UpdateDeploymentContainerImage)
+		image.POST("/daemonset/:envName", UpdateDaemonSetContainerImage)
 		image.POST("/statefulset/:envName", UpdateStatefulSetContainerImage)
 		image.POST("/cronjob/:envName", UpdateCronJobContainerImage)
 	}

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2941,8 +2941,13 @@ func restartRelatedWorkloads(env *commonmodels.Product, service *commonmodels.Pr
 		case setting.Deployment:
 			err = updater.RestartDeploymentV2(context.Background(), clusterID, env.Namespace, u.GetName())
 			return errors.Wrapf(err, "failed to restart deployment %s", u.GetName())
+		case setting.DaemonSet:
+			err = updater.RestartDaemonSet(context.Background(), clusterID, env.Namespace, u.GetName())
+			return errors.Wrapf(err, "failed to restart daemonset %s", u.GetName())
 		case setting.StatefulSet:
 			err = updater.RestartStatefulSetV2(context.Background(), clusterID, env.Namespace, u.GetName())
+			// err = updater.RestartStatefulSet(env.Namespace, u.GetName(), kubeClient)
+
 			return errors.Wrapf(err, "failed to restart statefulset %s", u.GetName())
 		}
 	}

--- a/pkg/microservice/aslan/core/environment/service/export.go
+++ b/pkg/microservice/aslan/core/environment/service/export.go
@@ -124,7 +124,7 @@ func ExportYaml(envName, productName, serviceName, source string, production boo
 				continue
 			}
 			switch u.GetKind() {
-			case setting.Deployment, setting.StatefulSet, setting.ConfigMap, setting.Service, setting.Ingress, setting.CronJob:
+			case setting.Deployment, setting.DaemonSet, setting.StatefulSet, setting.ConfigMap, setting.Service, setting.Ingress, setting.CronJob:
 				resource, exists, err := getter.GetResourceYamlInCache(namespace, u.GetName(), u.GroupVersionKind(), kubeClient)
 				if err != nil {
 					log.Errorf("failed to get resource yaml, err: %s", err)

--- a/pkg/microservice/aslan/core/environment/service/export.go
+++ b/pkg/microservice/aslan/core/environment/service/export.go
@@ -87,13 +87,15 @@ func ExportYaml(envName, productName, serviceName, source string, production boo
 		yamls = append(yamls, getServiceYaml(kubeClient, namespace, selector, log)...)
 		deploys := getDeploymentYaml(kubeClient, namespace, selector, log)
 		yamls = append(yamls, deploys...)
+		daemonSets := getDaemonSetYaml(kubeClient, namespace, selector, log)
+		yamls = append(yamls, daemonSets...)
 		stss := getStatefulSetYaml(kubeClient, namespace, selector, log)
 		yamls = append(yamls, stss...)
 		cronJobs := getCronJobYaml(kubeClient, namespace, selector, VersionLessThan121(clusterVersion), log)
 		yamls = append(yamls, cronJobs...)
 		cloneSets := getKruiseYaml(kruise, namespace, selector, log)
 		yamls = append(yamls, cloneSets...)
-		if len(deploys) == 0 && len(stss) == 0 && len(cronJobs) == 0 {
+		if len(deploys) == 0 && len(daemonSets) == 0 && len(stss) == 0 && len(cronJobs) == 0 {
 			if source == "wd" {
 				needFetchByRenderedManifest = true
 			}
@@ -177,6 +179,15 @@ func getDeploymentYaml(kubeClient client.Client, namespace string, selector labe
 	resources, err := getter.ListDeploymentsYaml(namespace, selector, kubeClient)
 	if err != nil {
 		log.Errorf("ListDeployments error: %v", err)
+		return nil
+	}
+	return resources
+}
+
+func getDaemonSetYaml(kubeClient client.Client, namespace string, selector labels.Selector, log *zap.SugaredLogger) [][]byte {
+	resources, err := getter.ListDaemonSetsYaml(namespace, selector, kubeClient)
+	if err != nil {
+		log.Errorf("ListDaemonSets error: %v", err)
 		return nil
 	}
 	return resources

--- a/pkg/microservice/aslan/core/environment/service/image.go
+++ b/pkg/microservice/aslan/core/environment/service/image.go
@@ -146,6 +146,11 @@ func UpdateContainerImage(requestID, username string, args *UpdateContainerImage
 				log.Errorf("[%s] UpdateDeploymentImageByName error: %s", namespace, err.Error())
 				return e.ErrUpdateConainterImage.AddDesc("更新 Deployment 容器镜像失败")
 			}
+		case setting.DaemonSet:
+			if err := updater.UpdateDaemonSetImage(context.TODO(), product.ClusterID, namespace, args.Name, args.ContainerName, args.Image); err != nil {
+				log.Errorf("[%s] UpdateDaemonSetImageByName error: %s", namespace, err.Error())
+				return e.ErrUpdateConainterImage.AddDesc("更新 DaemonSet 容器镜像失败")
+			}
 		case setting.StatefulSet:
 			if err := updater.UpdateStatefulSetImageV2(context.TODO(), product.ClusterID, namespace, args.Name, args.ContainerName, args.Image); err != nil {
 				log.Errorf("[%s] UpdateStatefulsetImageByName error: %s", namespace, err.Error())

--- a/pkg/microservice/aslan/core/environment/service/k8s.go
+++ b/pkg/microservice/aslan/core/environment/service/k8s.go
@@ -574,6 +574,13 @@ func fetchWorkloadImages(productService *commonmodels.ProductService, product *c
 				continue
 			}
 			containers = append(containers, wrapper.Deployment(deployment).GetContainers()...)
+		} else if u.GetKind() == setting.DaemonSet {
+			daemonSet, exist, err := getter.GetDaemonSet(namespace, u.GetName(), kubeClient)
+			if err != nil || !exist {
+				log.Errorf("failed to find daemonset with name: %s", u.GetName())
+				continue
+			}
+			containers = append(containers, wrapper.DaemonSet(daemonSet).GetContainers()...)
 		} else if u.GetKind() == setting.StatefulSet {
 			sts, exist, err := getter.GetStatefulSet(namespace, u.GetName(), kubeClient)
 			if err != nil || !exist {
@@ -627,6 +634,12 @@ func waitResourceRunning(
 				j, found, err = getter.GetJob(namespace, r.GetName(), kubeClient)
 				if err == nil && found {
 					ready = wrapper.Job(j).Complete()
+				}
+			case setting.DaemonSet:
+				var d *appsv1.DaemonSet
+				d, found, err = getter.GetDaemonSet(namespace, r.GetName(), kubeClient)
+				if err == nil && found {
+					ready = wrapper.DaemonSet(d).Ready()
 				}
 			default:
 				ready = true

--- a/pkg/microservice/aslan/core/environment/service/kube.go
+++ b/pkg/microservice/aslan/core/environment/service/kube.go
@@ -831,7 +831,7 @@ func ListK8sResOverview(args *FetchResourceArgs, log *zap.SugaredLogger) (*K8sRe
 		return ListDeployments(page, pageSize, namespace, kubeClient, inf)
 	case "statefulsets":
 		return ListStatefulSets(page, pageSize, namespace, kubeClient, inf)
-	case "daemonSets":
+	case "daemonsets":
 		return ListDaemonSets(page, pageSize, namespace, kubeClient)
 	case "jobs":
 		return ListJobs(page, pageSize, namespace, kubeClient)

--- a/pkg/microservice/aslan/core/environment/service/kube.go
+++ b/pkg/microservice/aslan/core/environment/service/kube.go
@@ -600,6 +600,23 @@ func ListWorkloadsInfo(clusterID, namespace string, log *zap.SugaredLogger) ([]*
 			})
 		}
 	}
+	daemonSets, err := getter.ListDaemonSets(namespace, labels.Everything(), kubeClient)
+	if err != nil {
+		log.Errorf("ListDaemonSets err:%v", err)
+		if apierrors.IsForbidden(err) {
+			return resp, err
+		}
+		return resp, err
+	}
+	for _, daemonSet := range daemonSets {
+		for _, container := range daemonSet.Spec.Template.Spec.Containers {
+			resp = append(resp, &WorkloadInfo{
+				WorkloadType:  setting.DaemonSet,
+				WorkloadName:  daemonSet.Name,
+				ContainerName: container.Name,
+			})
+		}
+	}
 	return resp, nil
 }
 
@@ -626,6 +643,19 @@ func ListCustomWorkload(clusterID, namespace string, log *zap.SugaredLogger) ([]
 	for _, deployment := range deployments {
 		for _, container := range deployment.Spec.Template.Spec.Containers {
 			resp = append(resp, &WorkloadImageTarget{strings.Join([]string{setting.Deployment, deployment.Name, container.Name}, "/"), util.ExtractImageName(container.Image)})
+		}
+	}
+	daemonSets, err := getter.ListDaemonSets(namespace, labels.Everything(), kubeClient)
+	if err != nil {
+		log.Errorf("ListDaemonSets err:%v", err)
+		if apierrors.IsForbidden(err) {
+			return resp, err
+		}
+		return resp, err
+	}
+	for _, daemonSet := range daemonSets {
+		for _, container := range daemonSet.Spec.Template.Spec.Containers {
+			resp = append(resp, &WorkloadImageTarget{strings.Join([]string{setting.DaemonSet, daemonSet.Name, container.Name}, "/"), util.ExtractImageName(container.Image)})
 		}
 	}
 	statefulsets, err := getter.ListStatefulSets(namespace, labels.Everything(), kubeClient)
@@ -801,7 +831,7 @@ func ListK8sResOverview(args *FetchResourceArgs, log *zap.SugaredLogger) (*K8sRe
 		return ListDeployments(page, pageSize, namespace, kubeClient, inf)
 	case "statefulsets":
 		return ListStatefulSets(page, pageSize, namespace, kubeClient, inf)
-	case "daemonsets":
+	case "daemonSets":
 		return ListDaemonSets(page, pageSize, namespace, kubeClient)
 	case "jobs":
 		return ListJobs(page, pageSize, namespace, kubeClient)

--- a/pkg/microservice/aslan/core/environment/service/kube_fetcher.go
+++ b/pkg/microservice/aslan/core/environment/service/kube_fetcher.go
@@ -296,7 +296,7 @@ func ListStatefulSets(page, pageSize int, namespace string, kc client.Client, in
 }
 
 func ListDaemonSets(page, pageSize int, namespace string, kc client.Client) (*K8sResourceResp, error) {
-	dss, err := getter.ListDaemonsets(namespace, nil, kc)
+	dss, err := getter.ListDaemonSets(namespace, nil, kc)
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +307,7 @@ func ListDaemonSets(page, pageSize int, namespace string, kc client.Client) (*K8
 	}
 
 	for _, ds := range dss {
-		wrappedRes := wrapper.Daemenset(ds)
+		wrappedRes := wrapper.DaemonSet(ds)
 		resp.Workloads = append(resp.Workloads, &WorkloadDaemonSet{
 			ResourceCommon: getWorkloadCommonInfo(wrappedRes, "DaemonSet", ds.CreationTimestamp.Time),
 			Desired:        int(ds.Status.DesiredNumberScheduled),
@@ -806,7 +806,7 @@ func getDaemonSetWorkloadResource(d *appsv1.DaemonSet, matchLabels map[string]st
 	}
 	services := getRelatedServices(d.Namespace, kubeClient, d.Spec.Template.GetLabels(), log)
 	ingresses := getRelatedIngress(d.Namespace, services, kubeClient, cs, log)
-	return wrapper.Daemenset(d).WorkloadResource(pods), services, ingresses
+	return wrapper.DaemonSet(d).WorkloadResource(pods), services, ingresses
 }
 
 func getJobWorkloadResource(d *batchv1.Job, matchLabels map[string]string, kubeClient client.Client, cs *kubernetes.Clientset, log *zap.SugaredLogger) (*resource.Workload, []*resource.Service, []*resource.Ingress) {

--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -83,6 +83,8 @@ func RestartScale(args *RestartScaleArgs, production bool, _ *zap.SugaredLogger)
 	switch args.Type {
 	case setting.Deployment:
 		err = updater.RestartDeploymentV2(context.Background(), prod.ClusterID, prod.Namespace, args.Name)
+	case setting.DaemonSet:
+		err = updater.RestartDaemonSet(context.Background(), prod.ClusterID, prod.Namespace, args.Name)
 	case setting.StatefulSet:
 		err = updater.RestartStatefulSetV2(context.Background(), prod.ClusterID, prod.Namespace, args.Name)
 	}
@@ -209,6 +211,25 @@ func GetServiceWorkloads(svcTmpl *commonmodels.Service, env *commonmodels.Produc
 				Spec:       wd.Spec.Template,
 				Selector:   wd.Spec.Selector,
 				Type:       setting.Deployment,
+				Images:     wd.ImageInfos(),
+				Containers: wd.GetContainers(),
+				Ready:      wd.Ready(),
+				Annotation: wd.Annotations,
+			})
+
+		case setting.DaemonSet:
+			daemonSet, err := getter.GetDaemonSetByNameWithCache(u.GetName(), namespace, inf)
+			if err != nil {
+				log.Errorf("failed to get daemonset %s, err: %s", u.GetName(), err)
+				continue
+			}
+			wd := wrapper.DaemonSet(daemonSet)
+			ret = append(ret, &commonservice.Workload{
+				Name:       wd.Name,
+				Spec:       wd.Spec.Template,
+				Selector:   wd.Spec.Selector,
+				Type:       setting.DaemonSet,
+				Replicas:   wd.Status.DesiredNumberScheduled,
 				Images:     wd.ImageInfos(),
 				Containers: wd.GetContainers(),
 				Ready:      wd.Ready(),
@@ -445,6 +466,14 @@ func RestartService(envName string, args *SvcOptArgs, production bool, log *zap.
 		}
 		if found {
 			return updater.RestartDeploymentV2(context.Background(), productObj.ClusterID, productObj.Namespace, deploy.Name)
+		}
+
+		daemonSet, found, err := getter.GetDaemonSet(productObj.Namespace, args.ServiceName, kubeClient)
+		if err != nil {
+			return fmt.Errorf("failed to find resource %s, type %s, err %s", args.ServiceName, setting.DaemonSet, err.Error())
+		}
+		if found {
+			return updater.RestartDaemonSet(context.Background(), productObj.ClusterID, productObj.Namespace, daemonSet.Name)
 		}
 
 		sts, found, err := getter.GetStatefulSet(productObj.Namespace, args.ServiceName, kubeClient)

--- a/pkg/microservice/aslan/core/service/service/environment.go
+++ b/pkg/microservice/aslan/core/service/service/environment.go
@@ -110,6 +110,16 @@ func GetKubeWorkloads(namespace, clusterID string, log *zap.SugaredLogger) (*Get
 		deployNames = append(deployNames, deployment.Name)
 	}
 	workloadsMap["deployment"] = deployNames
+	daemonSets, err := getter.ListDaemonSets(namespace, nil, kubeClient)
+	if err != nil {
+		log.Errorf("GetKubeWorkloads ListDaemonSets error, error msg:%s", err)
+		return nil, err
+	}
+	var daemonsetNames []string
+	for _, daemonSet := range daemonSets {
+		daemonsetNames = append(daemonsetNames, daemonSet.Name)
+	}
+	workloadsMap["daemonset"] = daemonsetNames
 	configMaps, err := getter.ListConfigMaps(namespace, nil, kubeClient)
 	if err != nil {
 		log.Errorf("GetKubeWorkloads ListConfigMaps error, error msg:%s", err)
@@ -236,6 +246,16 @@ func LoadKubeWorkloadsYaml(username string, params *LoadKubeWorkloadsYamlReq, fo
 					if len(bs) == 0 || err != nil {
 						log.Errorf("not found yaml %v", err)
 						return e.ErrGetService.AddDesc(fmt.Sprintf("get deploy/deployment failed err:%s", err))
+					}
+
+					yamls = append(yamls, string(bs))
+				}
+			case "daemonset":
+				for _, workload := range workloads {
+					bs, _, err := getter.GetDaemonSetYamlFormat(params.Namespace, workload, kubeClient)
+					if len(bs) == 0 || err != nil {
+						log.Errorf("not found yaml %v", err)
+						return e.ErrGetService.AddDesc(fmt.Sprintf("get daemonset failed err:%s", err))
 					}
 
 					yamls = append(yamls, string(bs))

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -281,6 +281,8 @@ func CreateK8sWorkLoads(ctx context.Context, requestID, userName string, args *K
 			switch tempWorkload.Type {
 			case setting.Deployment:
 				bs, _, err = getter.GetDeploymentYamlFormat(args.Namespace, tempWorkload.Name, kubeClient)
+			case setting.DaemonSet:
+				bs, _, err = getter.GetDaemonSetYamlFormat(args.Namespace, tempWorkload.Name, kubeClient)
 			case setting.StatefulSet:
 				bs, _, err = getter.GetStatefulSetYamlFormat(args.Namespace, tempWorkload.Name, kubeClient)
 			case setting.CronJob:
@@ -445,6 +447,8 @@ func UpdateWorkloads(ctx context.Context, requestID, username, productName, envN
 		switch v.Type {
 		case setting.Deployment:
 			bs, _, err = getter.GetDeploymentYamlFormat(args.Namespace, v.Name, kubeClient)
+		case setting.DaemonSet:
+			bs, _, err = getter.GetDaemonSetYamlFormat(args.Namespace, v.Name, kubeClient)
 		case setting.StatefulSet:
 			bs, _, err = getter.GetStatefulSetYamlFormat(args.Namespace, v.Name, kubeClient)
 		case setting.CronJob:

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -136,6 +136,7 @@ const (
 	Service               = "Service"
 	Deployment            = "Deployment"
 	CloneSet              = "CloneSet"
+	DaemonSet             = "DaemonSet"
 	StatefulSet           = "StatefulSet"
 	Pod                   = "Pod"
 	ReplicaSet            = "ReplicaSet"

--- a/pkg/shared/kube/wrapper/daemonset.go
+++ b/pkg/shared/kube/wrapper/daemonset.go
@@ -20,50 +20,78 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/shared/kube/resource"
+	"github.com/koderover/zadig/v2/pkg/util"
 )
 
-// deployment is the wrapper for appsv1.Deployment type.
-type daemonset struct {
+// daemonSet is the wrapper for appsv1.DaemonSet type.
+type daemonSet struct {
 	*appsv1.DaemonSet
 }
 
-func Daemenset(d *appsv1.DaemonSet) *daemonset {
+func DaemonSet(d *appsv1.DaemonSet) *daemonSet {
 	if d == nil {
 		return nil
 	}
 
-	return &daemonset{
+	return &daemonSet{
 		DaemonSet: d,
 	}
 }
 
 // Unwrap returns the appsv1.DaemonSet object.
-func (d *daemonset) Unwrap() *appsv1.DaemonSet {
+func (d *daemonSet) Unwrap() *appsv1.DaemonSet {
 	return d.DaemonSet
 }
 
-func (d *daemonset) ImageInfos() (images []string) {
+func (d *daemonSet) Ready() bool {
+	return d.Status.ObservedGeneration >= d.Generation &&
+		d.Status.DesiredNumberScheduled == d.Status.UpdatedNumberScheduled &&
+		d.Status.DesiredNumberScheduled == d.Status.NumberReady &&
+		d.Status.NumberUnavailable == 0
+}
+
+func (d *daemonSet) ImageInfos() (images []string) {
 	for _, v := range d.Spec.Template.Spec.Containers {
 		images = append(images, v.Image)
 	}
 	return
 }
 
-func (d *daemonset) WorkloadResource(pods []*corev1.Pod) *resource.Workload {
+func (d *daemonSet) WorkloadResource(pods []*corev1.Pod) *resource.Workload {
 	wl := &resource.Workload{
 		Name:     d.Name,
-		Type:     "DaemonSet",
+		Type:     setting.DaemonSet,
 		Replicas: d.Status.NumberReady,
 		Pods:     make([]*resource.Pod, 0, len(pods)),
 	}
 
 	for _, c := range d.Spec.Template.Spec.Containers {
-		wl.Images = append(wl.Images, resource.ContainerImage{Name: c.Name, Image: c.Image})
+		wl.Images = append(wl.Images, resource.ContainerImage{Name: c.Name, Image: c.Image, ImageName: util.ExtractImageName(c.Image)})
 	}
 
 	for _, p := range pods {
 		wl.Pods = append(wl.Pods, Pod(p).Resource())
 	}
 	return wl
+}
+
+func (d *daemonSet) Images() (images []string) {
+	for _, v := range d.Spec.Template.Spec.Containers {
+		images = append(images, v.Name)
+	}
+	return
+}
+
+func (d *daemonSet) GetKind() string {
+	return d.Kind
+}
+
+func (d *daemonSet) GetContainers() []*resource.ContainerImage {
+	containers := make([]*resource.ContainerImage, 0, len(d.Spec.Template.Spec.Containers))
+	for _, c := range d.Spec.Template.Spec.Containers {
+		containers = append(containers, &resource.ContainerImage{Name: c.Name, Image: c.Image, ImageName: util.ExtractImageName(c.Image)})
+	}
+	return containers
 }

--- a/pkg/tool/clientmanager/kube.go
+++ b/pkg/tool/clientmanager/kube.go
@@ -341,6 +341,7 @@ func (cm *KubeClientManager) GetInformer(clusterID, namespace string) (informers
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(clientset, time.Minute, opts)
 	// register the resources to be watched
 	informerFactory.Apps().V1().Deployments().Lister()
+	informerFactory.Apps().V1().DaemonSets().Lister()
 	informerFactory.Apps().V1().StatefulSets().Lister()
 	informerFactory.Core().V1().Services().Lister()
 	informerFactory.Core().V1().Pods().Lister()

--- a/pkg/tool/kube/getter/daemonset.go
+++ b/pkg/tool/kube/getter/daemonset.go
@@ -20,37 +20,67 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ListDaemonsets(ns string, selector labels.Selector, cl client.Client) ([]*appsv1.DaemonSet, error) {
-	dss := &appsv1.DaemonSetList{}
-	err := ListResourceInCache(ns, selector, nil, dss, cl)
+var DaemonSetGVK = schema.GroupVersionKind{
+	Group:   "apps",
+	Kind:    "DaemonSet",
+	Version: "v1",
+}
+
+func GetDaemonSet(ns, name string, cl client.Client) (*appsv1.DaemonSet, bool, error) {
+	daemonSet := &appsv1.DaemonSet{}
+	found, err := GetResourceInCache(ns, name, daemonSet, cl)
+	if err != nil || !found {
+		daemonSet = nil
+	}
+	setDaemonSetGVK(daemonSet)
+	return daemonSet, found, err
+}
+
+func ListDaemonSets(ns string, selector labels.Selector, cl client.Client) ([]*appsv1.DaemonSet, error) {
+	daemonSetList := &appsv1.DaemonSetList{}
+	err := ListResourceInCache(ns, selector, nil, daemonSetList, cl)
 	if err != nil {
 		return nil, err
 	}
 
-	var res []*appsv1.DaemonSet
-	for i := range dss.Items {
-		res = append(res, &dss.Items[i])
+	daemonSets := make([]*appsv1.DaemonSet, 0, len(daemonSetList.Items))
+	for i := range daemonSetList.Items {
+		setDaemonSetGVK(&daemonSetList.Items[i])
+		daemonSets = append(daemonSets, &daemonSetList.Items[i])
 	}
-	return res, err
+	return daemonSets, err
 }
 
-func GetDaemonSet(ns, name string, cl client.Client) (*appsv1.DaemonSet, bool, error) {
-	ss := &appsv1.DaemonSet{}
-	found, err := GetResourceInCache(ns, name, ss, cl)
-	if err != nil || !found {
-		ss = nil
+func ListDaemonSetsWithCache(selector labels.Selector, lister informers.SharedInformerFactory) ([]*appsv1.DaemonSet, error) {
+	if selector == nil {
+		selector = labels.NewSelector()
 	}
-	return ss, found, err
+	return lister.Apps().V1().DaemonSets().Lister().List(selector)
+}
+
+func GetDaemonSetByNameWithCache(name, namespace string, lister informers.SharedInformerFactory) (*appsv1.DaemonSet, error) {
+	return lister.Apps().V1().DaemonSets().Lister().DaemonSets(namespace).Get(name)
+}
+
+func ListDaemonSetsYaml(ns string, selector labels.Selector, cl client.Client) ([][]byte, error) {
+	return ListResourceYamlInCache(ns, selector, nil, DaemonSetGVK, cl)
 }
 
 func GetDaemonSetYaml(ns, name string, cl client.Client) ([]byte, bool, error) {
-	gvk := schema.GroupVersionKind{
-		Group:   "apps",
-		Kind:    "DaemonSet",
-		Version: "v1",
+	return GetResourceYamlInCache(ns, name, DaemonSetGVK, cl)
+}
+
+func GetDaemonSetYamlFormat(ns string, name string, cl client.Client) ([]byte, bool, error) {
+	return GetResourceYamlInCacheFormat(ns, name, DaemonSetGVK, cl)
+}
+
+func setDaemonSetGVK(daemonSet *appsv1.DaemonSet) {
+	if daemonSet == nil {
+		return
 	}
-	return GetResourceYamlInCache(ns, name, gvk, cl)
+	daemonSet.SetGroupVersionKind(DaemonSetGVK)
 }

--- a/pkg/tool/kube/updater/daemonset.go
+++ b/pkg/tool/kube/updater/daemonset.go
@@ -20,9 +20,13 @@ import (
 	"encoding/json"
 	"fmt"
 
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/yaml"
 
 	"github.com/koderover/zadig/v2/pkg/tool/clientmanager"
 )
@@ -55,6 +59,101 @@ func UpdateDaemonSetImage(ctx context.Context, clusterID, namespace, daemonSetNa
 
 func UpdateDaemonSetInitImage(ctx context.Context, clusterID, namespace, daemonSetName, containerName, newImage string) error {
 	return patchDaemonSetImage(ctx, clusterID, namespace, daemonSetName, containerName, newImage, "initContainers")
+}
+
+func CreateOrPatchDaemonSet(ctx context.Context, clusterID, namespace, originalYAML, targetYAML string, resourceOverride bool) error {
+	c, err := clientmanager.NewKubeClientManager().GetKubernetesClientSet(clusterID)
+	if err != nil {
+		return fmt.Errorf("failed to get kube client: %w", err)
+	}
+
+	if resourceOverride {
+		originalYAML = ""
+	}
+
+	targetJSON, err := yaml.YAMLToJSON([]byte(targetYAML))
+	if err != nil {
+		return fmt.Errorf("failed to convert target YAML to JSON: %w", err)
+	}
+
+	var targetObj appsv1.DaemonSet
+	if err := json.Unmarshal(targetJSON, &targetObj); err != nil {
+		return fmt.Errorf("failed to unmarshal target JSON to DaemonSet: %w", err)
+	}
+
+	name := targetObj.GetName()
+	if name == "" {
+		return fmt.Errorf("daemonset name cannot be empty in target YAML")
+	}
+
+	targetObj.SetNamespace(namespace)
+	targetJSONMutated, err := json.Marshal(targetObj)
+	if err != nil {
+		return fmt.Errorf("failed to re-marshal mutated target object: %w", err)
+	}
+
+	originalJSONMutated := []byte("{}")
+	if originalYAML != "" {
+		originalJSON, err := yaml.YAMLToJSON([]byte(originalYAML))
+		if err != nil {
+			return fmt.Errorf("failed to convert original YAML to JSON: %w", err)
+		}
+
+		var originalObj appsv1.DaemonSet
+		if err := json.Unmarshal(originalJSON, &originalObj); err != nil {
+			return fmt.Errorf("failed to unmarshal original JSON: %w", err)
+		}
+		originalObj.SetNamespace(namespace)
+		originalJSONMutated, err = json.Marshal(originalObj)
+		if err != nil {
+			return fmt.Errorf("failed to re-marshal mutated original object: %w", err)
+		}
+	}
+
+	_, err = c.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, createErr := c.AppsV1().DaemonSets(namespace).Create(ctx, &targetObj, metav1.CreateOptions{})
+		if createErr != nil {
+			return fmt.Errorf("failed to create daemonset: %w", createErr)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to check daemonset existence: %w", err)
+	}
+
+	if resourceOverride {
+		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			existing, err := c.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to get daemonset for replace: %w", err)
+			}
+			targetObj.ResourceVersion = existing.ResourceVersion
+			_, err = c.AppsV1().DaemonSets(namespace).Update(ctx, &targetObj, metav1.UpdateOptions{})
+			return err
+		})
+	}
+
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(originalJSONMutated, targetJSONMutated, &appsv1.DaemonSet{})
+	if err != nil {
+		return fmt.Errorf("failed to calculate 2-way merge patch: %w", err)
+	}
+	if string(patchBytes) == "{}" {
+		return nil
+	}
+
+	_, err = c.AppsV1().DaemonSets(namespace).Patch(
+		ctx,
+		name,
+		types.StrategicMergePatchType,
+		patchBytes,
+		metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("daemonset patch failed: %w", err)
+	}
+
+	return nil
 }
 
 func patchDaemonSetImage(ctx context.Context, clusterID, namespace, daemonSetName, containerName, newImage, field string) error {

--- a/pkg/tool/kube/updater/daemonset.go
+++ b/pkg/tool/kube/updater/daemonset.go
@@ -23,12 +23,15 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	"github.com/koderover/zadig/v2/pkg/tool/clientmanager"
+	kubeutil "github.com/koderover/zadig/v2/pkg/tool/kube/util"
 )
 
 func RestartDaemonSet(ctx context.Context, clusterID, namespace, name string) error {
@@ -51,6 +54,57 @@ func RestartDaemonSet(ctx context.Context, clusterID, namespace, name string) er
 		_, err = c.AppsV1().DaemonSets(namespace).Update(ctx, daemonSet, metav1.UpdateOptions{})
 		return err
 	})
+}
+
+func DeleteDaemonSetV2(ctx context.Context, clusterID, namespace string, opts ...DeleteOption) error {
+	config := &deleteConfig{}
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	if config.name == "" && config.selector == "" {
+		return fmt.Errorf("must specify either a name or a selector for deletion to prevent accidental namespace wipeout")
+	}
+	if config.name != "" && config.selector != "" {
+		return fmt.Errorf("cannot specify both name and selector simultaneously")
+	}
+
+	c, err := clientmanager.NewKubeClientManager().GetControllerRuntimeClient(clusterID)
+	if err != nil {
+		return fmt.Errorf("failed to get kube client: %w", err)
+	}
+
+	if config.name != "" {
+		daemonSet := &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      config.name,
+			},
+		}
+
+		propagationPolicy := metav1.DeletePropagationBackground
+		deleteOpts := &client.DeleteOptions{
+			PropagationPolicy: &propagationPolicy,
+		}
+
+		err = c.Delete(ctx, daemonSet, deleteOpts)
+		return kubeutil.IgnoreNotFoundError(err)
+	}
+
+	selector, err := labels.Parse(config.selector)
+	if err != nil {
+		return fmt.Errorf("failed to parse selector %q: %w", config.selector, err)
+	}
+
+	daemonSet := &appsv1.DaemonSet{}
+	propagationPolicy := metav1.DeletePropagationBackground
+	deleteOpts := &client.DeleteAllOfOptions{
+		DeleteOptions: client.DeleteOptions{PropagationPolicy: &propagationPolicy},
+		ListOptions:   client.ListOptions{LabelSelector: selector, Namespace: namespace},
+	}
+
+	err = c.DeleteAllOf(ctx, daemonSet, deleteOpts)
+	return kubeutil.IgnoreNotFoundError(err)
 }
 
 func UpdateDaemonSetImage(ctx context.Context, clusterID, namespace, daemonSetName, containerName, newImage string) error {

--- a/pkg/tool/kube/updater/daemonset.go
+++ b/pkg/tool/kube/updater/daemonset.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package updater
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/koderover/zadig/v2/pkg/tool/clientmanager"
+)
+
+func RestartDaemonSet(ctx context.Context, clusterID, namespace, name string) error {
+	c, err := clientmanager.NewKubeClientManager().GetKubernetesClientSet(clusterID)
+	if err != nil {
+		return fmt.Errorf("failed to get kube client: %w", err)
+	}
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		daemonSet, err := c.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get live daemonset: %w", err)
+		}
+
+		if daemonSet.Spec.Template.Annotations == nil {
+			daemonSet.Spec.Template.Annotations = make(map[string]string)
+		}
+		daemonSet.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = metav1.Now().Format("2006-01-02T15:04:05Z07:00")
+
+		_, err = c.AppsV1().DaemonSets(namespace).Update(ctx, daemonSet, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func UpdateDaemonSetImage(ctx context.Context, clusterID, namespace, daemonSetName, containerName, newImage string) error {
+	return patchDaemonSetImage(ctx, clusterID, namespace, daemonSetName, containerName, newImage, "containers")
+}
+
+func UpdateDaemonSetInitImage(ctx context.Context, clusterID, namespace, daemonSetName, containerName, newImage string) error {
+	return patchDaemonSetImage(ctx, clusterID, namespace, daemonSetName, containerName, newImage, "initContainers")
+}
+
+func patchDaemonSetImage(ctx context.Context, clusterID, namespace, daemonSetName, containerName, newImage, field string) error {
+	c, err := clientmanager.NewKubeClientManager().GetKubernetesClientSet(clusterID)
+	if err != nil {
+		return fmt.Errorf("failed to get kube client: %w", err)
+	}
+
+	patchPayload := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					field: []map[string]interface{}{
+						{
+							"name":  containerName,
+							"image": newImage,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	patchBytes, err := json.Marshal(patchPayload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal image update patch payload: %w", err)
+	}
+
+	_, err = c.AppsV1().DaemonSets(namespace).Patch(
+		ctx,
+		daemonSetName,
+		types.StrategicMergePatchType,
+		patchBytes,
+		metav1.PatchOptions{},
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to patch %s image for daemonset %s/%s: %w", field, namespace, daemonSetName, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
### What this PR does / Why we need it:
Support DaemonSet resources in the normal Kubernetes YAML / managed service workflow.

This PR adds DaemonSet support for the standard service flow, so users can import existing DaemonSets from a cluster and manage them like other supported workload resources.
### What is changed and how it works?
Add DaemonSet as a supported resource type.
Add DaemonSet getter support, including list/get and YAML format retrieval.
Add DaemonSet wrapper support.
Support importing DaemonSets from cluster workloads via workloads_map.daemonset.
Support loading DaemonSet YAML and creating/updating K8s service templates.
Support parsing DaemonSet containers and initContainers from spec.template.spec.
Show DaemonSet workloads in environment service detail and workload lists.
Support DaemonSet image update in the normal environment image update flow.
Support DaemonSet restart in manual and normal workflow restart paths.
Support DaemonSet deploy status checking by waiting until the DaemonSet is ready.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4731)
<!-- Reviewable:end -->
