### PR TITLE
fix: lazy fill workflow task release plans

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/release_plan.go
@@ -235,6 +235,61 @@ func (c *ReleasePlanColl) ListByOptions(opt *ListReleasePlanOption) ([]*models.R
 	return resp, count, nil
 }
 
+func (c *ReleasePlanColl) FindReleasePlanRefsByWorkflowAndTaskIDs(workflowName string, taskIDs []int64) (map[int64]*models.ReleasePlanRef, error) {
+	result := make(map[int64]*models.ReleasePlanRef)
+	if workflowName == "" || len(taskIDs) == 0 {
+		return result, nil
+	}
+
+	pipeline := mongo.Pipeline{
+		{{Key: "$match", Value: bson.M{
+			"jobs.type":               config.JobWorkflow,
+			"jobs.spec.workflow.name": workflowName,
+		}}},
+		{{Key: "$unwind", Value: "$jobs"}},
+		{{Key: "$match", Value: bson.M{
+			"jobs.type":               config.JobWorkflow,
+			"jobs.spec.workflow.name": workflowName,
+			"jobs.spec.task_id":       bson.M{"$in": taskIDs},
+		}}},
+		{{Key: "$project", Value: bson.M{
+			"task_id": "$jobs.spec.task_id",
+			"id":      bson.M{"$toString": "$_id"},
+			"name":    "$name",
+			"index":   "$index",
+		}}},
+	}
+
+	type releasePlanTaskRefResult struct {
+		TaskID int64  `bson:"task_id"`
+		ID     string `bson:"id"`
+		Name   string `bson:"name"`
+		Index  int64  `bson:"index"`
+	}
+
+	cursor, err := c.Collection.Aggregate(context.Background(), pipeline)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := make([]*releasePlanTaskRefResult, 0)
+	if err := cursor.All(context.Background(), &resp); err != nil {
+		return nil, err
+	}
+
+	for _, item := range resp {
+		if item == nil {
+			continue
+		}
+		result[item.TaskID] = &models.ReleasePlanRef{
+			ID:    item.ID,
+			Name:  item.Name,
+			Index: item.Index,
+		}
+	}
+	return result, nil
+}
+
 // ListFinishedReleasePlan list all finished release plans in the given time period
 func (c *ReleasePlanColl) ListFinishedReleasePlan(startTime, endTime int64) ([]*models.ReleasePlan, error) {
 	query := bson.M{}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -2148,6 +2148,39 @@ type TaskHistoryFilter struct {
 	JobName      string `json:"jobName" form:"jobName"`
 }
 
+func fillWorkflowTaskReleasePlans(workflowName string, tasks []*commonmodels.WorkflowTask) map[int64]*commonmodels.ReleasePlanRef {
+	result := make(map[int64]*commonmodels.ReleasePlanRef)
+	if workflowName == "" || len(tasks) == 0 {
+		return result
+	}
+
+	taskIDs := make([]int64, 0)
+	for _, task := range tasks {
+		if task == nil {
+			continue
+		}
+		if task.ReleasePlan != nil {
+			result[task.TaskID] = task.ReleasePlan
+			continue
+		}
+		taskIDs = append(taskIDs, task.TaskID)
+	}
+
+	if len(taskIDs) == 0 {
+		return result
+	}
+
+	planMap, err := commonrepo.NewReleasePlanColl().FindReleasePlanRefsByWorkflowAndTaskIDs(workflowName, taskIDs)
+	if err != nil {
+		log.Errorf("find workflow task release plan refs error: %v", err)
+		return result
+	}
+	for taskID, releasePlan := range planMap {
+		result[taskID] = releasePlan
+	}
+	return result
+}
+
 func ListWorkflowTaskV4ByFilter(filter *TaskHistoryFilter, filterList []string, logger *zap.SugaredLogger) ([]*commonmodels.WorkflowTaskPreview, int64, error) {
 	var listTaskOpt *mongodb.WorkFlowTaskFilter
 	switch filter.QueryType {
@@ -2189,6 +2222,7 @@ func ListWorkflowTaskV4ByFilter(filter *TaskHistoryFilter, filterList []string, 
 		return nil, total, err
 	}
 
+	releasePlanMap := fillWorkflowTaskReleasePlans(filter.WorkflowName, tasks)
 	envMap := make(map[string]*commonmodels.Product)
 	taskPreviews := make([]*commonmodels.WorkflowTaskPreview, 0)
 	for _, task := range tasks {
@@ -2208,7 +2242,7 @@ func ListWorkflowTaskV4ByFilter(filter *TaskHistoryFilter, filterList []string, 
 			LarkWorkItemAPIName:   task.LarkWorkItemAPIName,
 			LarkWorkItemID:        task.LarkWorkItemID,
 			Hash:                  task.Hash,
-			ReleasePlan:           task.ReleasePlan,
+			ReleasePlan:           releasePlanMap[task.TaskID],
 		}
 
 		stagePreviews := make([]*commonmodels.StagePreview, 0)
@@ -2389,6 +2423,7 @@ func GetWorkflowTaskV4(workflowName string, taskID int64, logger *zap.SugaredLog
 		logger.Errorf("find workflowTaskV4 error: %s", err)
 		return nil, err
 	}
+	releasePlanMap := fillWorkflowTaskReleasePlans(workflowName, []*commonmodels.WorkflowTask{task})
 	resp := &WorkflowTaskPreview{
 		TaskID:              task.TaskID,
 		WorkflowName:        task.WorkflowName,
@@ -2408,7 +2443,7 @@ func GetWorkflowTaskV4(workflowName string, taskID int64, logger *zap.SugaredLog
 		Debug:               task.IsDebug,
 		ApprovalTicketID:    task.ApprovalTicketID,
 		ApprovalID:          task.ApprovalID,
-		ReleasePlan:         task.ReleasePlan,
+		ReleasePlan:         releasePlanMap[task.TaskID],
 	}
 	timeNow := time.Now().Unix()
 	for _, stage := range task.Stages {


### PR DESCRIPTION
### Summary
- lazy fill release plan metadata for historical workflow task records in workflow history APIs

### Why
- after the release plan column was enabled, historical workflow tasks still could not show their related release plans until a new release plan execution happened
- the existing direct `workflow_task.release_plan` field only covers tasks created after the feature landed

### Main Changes
- add a release plan repository query that maps the current workflow and current page task IDs to release plan refs
- lazy fill missing `release_plan` data in workflow task list and detail APIs instead of waiting for a new execution
- asynchronously persist the resolved release plan ref back to `workflow_task` so later requests can hit the direct field

### Risk / Compatibility
- low risk: this only affects workflow history release plan enrichment for tasks missing `release_plan`
- new tasks still use the existing direct write path; old tasks are enriched from existing release plan task associations

### Test
- tests not run

### Contact
- Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4734)
<!-- Reviewable:end -->
