### PR TITLE
fix: skip blue-green release cleanup while waiting for manual execution

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job.go
@@ -316,6 +316,19 @@ func CleanWorkflowJobs(ctx context.Context, workflowTask *commonmodels.WorkflowT
 	}
 }
 
+func CleanPendingBlueGreenReleaseJobs(ctx context.Context, workflowTask *commonmodels.WorkflowTask, workflowCtx *commonmodels.WorkflowTaskCtx, logger *zap.SugaredLogger, ack func()) {
+	for _, stage := range workflowTask.Stages {
+		for _, job := range stage.Jobs {
+			if job.JobType != string(config.JobK8sBlueGreenRelease) || job.Status != "" {
+				continue
+			}
+
+			jobCtl := initJobCtl(job, workflowCtx, logger, ack)
+			jobCtl.Clean(ctx)
+		}
+	}
+}
+
 // Pool is a worker group that runs a number of tasks at a
 // configured concurrency.
 type Pool struct {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job.go
@@ -306,6 +306,10 @@ func RunJobs(ctx context.Context, jobs []*commonmodels.JobTask, workflowCtx *com
 func CleanWorkflowJobs(ctx context.Context, workflowTask *commonmodels.WorkflowTask, workflowCtx *commonmodels.WorkflowTaskCtx, logger *zap.SugaredLogger, ack func()) {
 	for _, stage := range workflowTask.Stages {
 		for _, job := range stage.Jobs {
+			if workflowTask.Status == config.StatusPause && job.JobType == string(config.JobK8sBlueGreenRelease) && job.Status == "" {
+				continue
+			}
+
 			jobCtl := initJobCtl(job, workflowCtx, logger, ack)
 			jobCtl.Clean(ctx)
 		}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_blue_green_release_v2.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_blue_green_release_v2.go
@@ -67,16 +67,6 @@ func NewBlueGreenReleaseV2JobCtl(job *commonmodels.JobTask, workflowCtx *commonm
 }
 
 func (c *BlueGreenReleaseV2JobCtl) Clean(ctx context.Context) {
-	if c.job.Status == "" {
-		task, err := mongodb.NewworkflowTaskv4Coll().Find(c.workflowCtx.WorkflowName, c.workflowCtx.TaskID)
-		if err == nil && task.Status == config.StatusPause {
-			return
-		}
-		if err != nil {
-			c.logger.Warnf("find workflow task error: %v", err)
-		}
-	}
-
 	env, err := mongodb.NewProductColl().Find(&mongodb.ProductFindOptions{
 		Name:    c.workflowCtx.ProjectName,
 		EnvName: c.jobTaskSpec.Env,

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_blue_green_release_v2.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_blue_green_release_v2.go
@@ -67,6 +67,16 @@ func NewBlueGreenReleaseV2JobCtl(job *commonmodels.JobTask, workflowCtx *commonm
 }
 
 func (c *BlueGreenReleaseV2JobCtl) Clean(ctx context.Context) {
+	if c.job.Status == "" {
+		task, err := mongodb.NewworkflowTaskv4Coll().Find(c.workflowCtx.WorkflowName, c.workflowCtx.TaskID)
+		if err == nil && task.Status == config.StatusPause {
+			return
+		}
+		if err != nil {
+			c.logger.Warnf("find workflow task error: %v", err)
+		}
+	}
+
 	env, err := mongodb.NewProductColl().Find(&mongodb.ProductFindOptions{
 		Name:    c.workflowCtx.ProjectName,
 		EnvName: c.jobTaskSpec.Env,

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
@@ -121,6 +121,7 @@ func CancelWorkflowTask(userName, workflowName string, taskID int64, logger *zap
 		return fmt.Errorf("task: %s:%d is passed, cannot cancel", workflowName, taskID)
 	}
 
+	wasPaused := t.Status == config.StatusPause
 	t.Status = config.StatusCancelled
 	t.TaskRevoker = userName
 
@@ -137,6 +138,26 @@ func CancelWorkflowTask(userName, workflowName string, taskID int64, logger *zap
 	}
 	if err := scmnotify.NewService().CompleteGitCheckForWorkflowV4(t.WorkflowArgs, t.TaskID, t.Status, logger); err != nil {
 		log.Warnf("Failed to update github check status for custom workflow %s, taskID: %d the error is: %s", t.WorkflowName, t.TaskID, err)
+	}
+
+	if wasPaused {
+		logger.Infof("clean cancelled paused workflow task resources: %s:%d", t.WorkflowName, t.TaskID)
+		workflowCtx := &commonmodels.WorkflowTaskCtx{
+			WorkflowName:        t.WorkflowName,
+			WorkflowDisplayName: t.WorkflowDisplayName,
+			ProjectName:         t.ProjectName,
+			ProjectDisplayName:  t.ProjectDisplayName,
+			IsDebug:             t.IsDebug,
+			Remark:              t.Remark,
+			TaskID:              t.TaskID,
+			RetryNum:            t.RetryNum,
+			Workspace:           "/workspace",
+			DistDir:             fmt.Sprintf("%s/%s/dist/%d", config.S3StoragePath(), t.WorkflowName, t.TaskID),
+			DockerMountDir:      fmt.Sprintf("/tmp/%s/docker/%d", uuid.NewString(), time.Now().Unix()),
+			ConfigMapMountDir:   fmt.Sprintf("/tmp/%s/cm/%d", uuid.NewString(), time.Now().Unix()),
+			StartTime:           time.Now(),
+		}
+		jobcontroller.CleanPendingBlueGreenReleaseJobs(context.Background(), t, workflowCtx, logger, func() {})
 	}
 
 	err = cache.NewRedisCache(config2.RedisCommonCacheTokenDB()).Publish(fmt.Sprintf("workflowctl-cancel-%s-%d", workflowName, taskID), "cancel")


### PR DESCRIPTION
### What this PR does / Why we need it:

Fixes an issue where blue-green intermediate resources were cleaned up too early when the workflow paused before manually executing the blue-green release job.

After the blue-green deploy job finishes, service details should still show the blue-green release state, including zadigx_release_type="blue-green", while waiting for manual execution of the release job. Previously, entering the manual execution waiting state could trigger cleanup for the blue-green release job before it had actually run, causing the blue deployment/service to be removed.

### What is changed and how it works?

This PR updates BlueGreenReleaseV2JobCtl.Clean to skip cleanup when:

the blue-green release job has not started yet
the workflow task is currently paused for manual execution
This keeps the blue-green intermediate resources available during the manual waiting stage. Once the release job actually runs, or the workflow is no longer in the manual pause state, the existing cleanup behavior is preserved.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4750)
<!-- Reviewable:end -->
