### PR TITLE
fix deploy helm service panic if only update image and service not online yet

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_deploy.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_deploy.go
@@ -647,11 +647,11 @@ func (j DeployJobController) ToTask(taskID int64) ([]*commonmodels.JobTask, erro
 				if pSvc.GetServiceRender().OverrideYaml.AutoSync {
 					autoSyncFlag = true
 				}
-			}
 
-			if len(j.jobSpec.DeployContents) == 1 && slices.Contains(j.jobSpec.DeployContents, config.DeployImage) &&
-				commonutil.GetChartDeployed(pSvc.GetServiceRender(), product.ServiceDeployStrategy) == setting.ServiceDeployStrategyDraft {
-				return nil, fmt.Errorf("service %s is in draft, cannot deploy image only", svc.ServiceName)
+				if len(j.jobSpec.DeployContents) == 1 && slices.Contains(j.jobSpec.DeployContents, config.DeployImage) &&
+					commonutil.GetChartDeployed(pSvc.GetServiceRender(), product.ServiceDeployStrategy) == setting.ServiceDeployStrategyDraft {
+					return nil, fmt.Errorf("service %s is in draft, cannot deploy image only", svc.ServiceName)
+				}
 			}
 
 			revisionSvc, err := repository.QueryTemplateService(&commonrepo.ServiceFindOption{


### PR DESCRIPTION
### What this PR does / Why we need it:
fix deploy helm service panic if only update image and service not online yet

### What is changed and how it works?
fix deploy helm service panic if only update image and service not online yet

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4752)
<!-- Reviewable:end -->
