### PR TITLE
feat: jira status change task display

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
@@ -519,11 +519,12 @@ type IssueID struct {
 }
 
 type JobTaskJiraSpec struct {
-	ProjectID    string     `bson:"project_id"  json:"project_id"  yaml:"project_id"`
-	JiraID       string     `bson:"jira_id"  json:"jira_id"  yaml:"jira_id"`
-	IssueType    string     `bson:"issue_type"  json:"issue_type"  yaml:"issue_type"`
-	Issues       []*IssueID `bson:"issues" json:"issues" yaml:"issues"`
-	TargetStatus string     `bson:"target_status" json:"target_status" yaml:"target_status"`
+	ProjectID     string              `bson:"project_id"  json:"project_id"  yaml:"project_id"`
+	JiraID        string              `bson:"jira_id"  json:"jira_id"  yaml:"jira_id"`
+	IssueType     string              `bson:"issue_type"  json:"issue_type"  yaml:"issue_type"`
+	Issues        []*IssueID          `bson:"issues" json:"issues" yaml:"issues"`
+	TargetStatus  string              `bson:"target_status" json:"target_status" yaml:"target_status"`
+	FieldMappings []*JiraFieldMapping `bson:"field_mappings" json:"field_mappings" yaml:"field_mappings"`
 }
 
 type JobTaskCommonRevertSpec struct {

--- a/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
@@ -512,10 +512,12 @@ type JobTasK8sPatchSpec struct {
 }
 
 type IssueID struct {
-	Key    string `bson:"key" json:"key" yaml:"key"`
-	Name   string `bson:"name" json:"name" yaml:"name"`
-	Status string `bson:"status,omitempty" json:"status,omitempty" yaml:"status,omitempty"`
-	Link   string `bson:"link,omitempty" json:"link,omitempty" yaml:"link,omitempty"`
+	Key           string `bson:"key" json:"key" yaml:"key"`
+	Name          string `bson:"name" json:"name" yaml:"name"`
+	CurrentStatus string `bson:"current_status,omitempty" json:"current_status,omitempty" yaml:"current_status,omitempty"`
+	TargetStatus  string `bson:"target_status,omitempty" json:"target_status,omitempty" yaml:"target_status,omitempty"`
+	Status        string `bson:"status,omitempty" json:"status,omitempty" yaml:"status,omitempty"`
+	Link          string `bson:"link,omitempty" json:"link,omitempty" yaml:"link,omitempty"`
 }
 
 type JobTaskJiraSpec struct {
@@ -566,7 +568,7 @@ type ApisixItemUpdateSpec struct {
 
 func (s *ApisixItemUpdateSpec) GetConfigName() (string, error) {
 	if s == nil {
-		return "", errors.New("ApisixItemUpdateSpec is nil") 
+		return "", errors.New("ApisixItemUpdateSpec is nil")
 	}
 	return getApisixConfigName(s.UserSpec)
 }

--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -973,9 +973,15 @@ type JiraJobSpec struct {
 	// JQL: when query type is advanced, use this
 	JQL string `bson:"jql" json:"jql" yaml:"jql"`
 
-	IssueType    string     `bson:"issue_type"  json:"issue_type"  yaml:"issue_type"`
-	Issues       []*IssueID `bson:"issues" json:"issues" yaml:"issues"`
-	TargetStatus string     `bson:"target_status" json:"target_status" yaml:"target_status"`
+	IssueType     string              `bson:"issue_type"  json:"issue_type"  yaml:"issue_type"`
+	Issues        []*IssueID          `bson:"issues" json:"issues" yaml:"issues"`
+	TargetStatus  string              `bson:"target_status" json:"target_status" yaml:"target_status"`
+	FieldMappings []*JiraFieldMapping `bson:"field_mappings" json:"field_mappings" yaml:"field_mappings"`
+}
+
+type JiraFieldMapping struct {
+	JiraFieldID string `bson:"jira_field_id" json:"jira_field_id" yaml:"jira_field_id"`
+	ValueSource string `bson:"value_source" json:"value_source" yaml:"value_source"`
 }
 
 type IstioJobSpec struct {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jira_field_update.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jira_field_update.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflowcontroller
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"go.uber.org/zap"
+
+	configbase "github.com/koderover/zadig/v2/pkg/config"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
+	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
+	"github.com/koderover/zadig/v2/pkg/tool/jira"
+)
+
+const (
+	jiraFieldValueSourceWorkflowName = "workflow_name"
+	jiraFieldValueSourceTaskStatus   = "task_status"
+	jiraFieldValueSourceTaskURL      = "task_url"
+)
+
+func updateJiraFieldsForWorkflowTask(task *commonmodels.WorkflowTask, logger *zap.SugaredLogger) {
+	if task == nil {
+		return
+	}
+
+	for _, stage := range task.Stages {
+		for _, job := range stage.Jobs {
+			if job.JobType != string(config.JobJira) {
+				continue
+			}
+
+			jobTaskSpec := &commonmodels.JobTaskJiraSpec{}
+			if err := commonmodels.IToi(job.Spec, jobTaskSpec); err != nil {
+				logger.Errorf("failed to convert jira job spec for job %s: %v", job.Name, err)
+				continue
+			}
+			if len(jobTaskSpec.FieldMappings) == 0 || len(jobTaskSpec.Issues) == 0 {
+				continue
+			}
+
+			fields := buildJiraIssueFields(task, jobTaskSpec.FieldMappings)
+			if len(fields) == 0 {
+				continue
+			}
+
+			spec, err := commonrepo.NewProjectManagementColl().GetJiraSpec(jobTaskSpec.JiraID)
+			if err != nil {
+				logger.Errorf("failed to get jira spec for job %s: %v", job.Name, err)
+				continue
+			}
+			client := jira.NewJiraClientWithAuthType(spec.JiraHost, spec.JiraUser, spec.JiraToken, spec.JiraPersonalAccessToken, spec.JiraAuthType)
+
+			for _, issue := range jobTaskSpec.Issues {
+				if issue == nil || strings.TrimSpace(issue.Key) == "" {
+					continue
+				}
+				if err := client.Issue.UpdateFields(issue.Key, fields); err != nil {
+					logger.Errorf("failed to update jira issue %s fields for workflow %s task %d: %v", issue.Key, task.WorkflowName, task.TaskID, err)
+				}
+			}
+		}
+	}
+}
+
+func buildJiraIssueFields(task *commonmodels.WorkflowTask, mappings []*commonmodels.JiraFieldMapping) map[string]interface{} {
+	fields := make(map[string]interface{})
+	if task == nil {
+		return fields
+	}
+
+	for _, mapping := range mappings {
+		if mapping == nil {
+			continue
+		}
+		fieldID := strings.TrimSpace(mapping.JiraFieldID)
+		if fieldID == "" {
+			continue
+		}
+
+		value, ok := jiraFieldValue(task, mapping.ValueSource)
+		if !ok {
+			continue
+		}
+		fields[fieldID] = value
+	}
+	return fields
+}
+
+func jiraFieldValue(task *commonmodels.WorkflowTask, valueSource string) (string, bool) {
+	switch valueSource {
+	case jiraFieldValueSourceWorkflowName:
+		return workflowTaskDisplayName(task), true
+	case jiraFieldValueSourceTaskStatus:
+		return workflowTaskStatusText(task.Status), true
+	case jiraFieldValueSourceTaskURL:
+		return workflowTaskURL(task), true
+	default:
+		return "", false
+	}
+}
+
+func workflowTaskDisplayName(task *commonmodels.WorkflowTask) string {
+	if task.WorkflowDisplayName != "" {
+		return task.WorkflowDisplayName
+	}
+	return task.WorkflowName
+}
+
+func workflowTaskStatusText(status config.Status) string {
+	switch status {
+	case config.StatusPassed:
+		return "成功"
+	case config.StatusFailed:
+		return "失败"
+	case config.StatusTimeout:
+		return "超时"
+	case config.StatusCancelled:
+		return "取消"
+	case config.StatusReject:
+		return "拒绝"
+	default:
+		return string(status)
+	}
+}
+
+func workflowTaskURL(task *commonmodels.WorkflowTask) string {
+	return fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d?display_name=%s",
+		configbase.SystemAddress(),
+		task.ProjectName,
+		task.WorkflowName,
+		task.TaskID,
+		url.QueryEscape(workflowTaskDisplayName(task)),
+	)
+}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jira_field_update.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jira_field_update.go
@@ -31,7 +31,6 @@ import (
 )
 
 const (
-	jiraFieldValueSourceTaskStatus  = "task_status"
 	jiraFieldValueSourceWorkflowURL = "workflow_url"
 )
 
@@ -145,8 +144,6 @@ func buildJiraIssueFields(task *commonmodels.WorkflowTask, mappings []*commonmod
 
 func jiraFieldValue(task *commonmodels.WorkflowTask, valueSource string) (string, bool) {
 	switch valueSource {
-	case jiraFieldValueSourceTaskStatus:
-		return workflowTaskStatusText(task.Status), true
 	case jiraFieldValueSourceWorkflowURL:
 		return workflowURL(task), true
 	default:
@@ -198,10 +195,10 @@ func workflowTaskURL(task *commonmodels.WorkflowTask) string {
 }
 
 func buildJiraWorkflowTaskComment(task *commonmodels.WorkflowTask, issue *commonmodels.IssueID) string {
-	return fmt.Sprintf("在 Jira 状态「%s」下执行 Zadig 工作流「%s」，执行结果：%s。任务链接：%s",
+	return fmt.Sprintf("JIRA 状态：%s\n[%s]工作流：%s\n任务链接：%s",
 		jiraIssueStatusForComment(issue),
-		workflowDisplayName(task),
 		workflowTaskStatusText(task.Status),
+		workflowDisplayName(task),
 		workflowTaskURL(task),
 	)
 }
@@ -210,13 +207,7 @@ func jiraIssueStatusForComment(issue *commonmodels.IssueID) string {
 	if issue == nil {
 		return ""
 	}
-	if issue.CurrentStatus != "" {
-		return issue.CurrentStatus
-	}
-	if issue.TargetStatus != "" {
-		return issue.TargetStatus
-	}
-	return ""
+	return issue.CurrentStatus
 }
 
 func fillJiraIssueCurrentStatus(issue *commonmodels.IssueID, client *jira.Client, logger *zap.SugaredLogger) {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jira_field_update.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jira_field_update.go
@@ -31,9 +31,8 @@ import (
 )
 
 const (
-	jiraFieldValueSourceWorkflowName = "workflow_name"
-	jiraFieldValueSourceTaskStatus   = "task_status"
-	jiraFieldValueSourceTaskURL      = "task_url"
+	jiraFieldValueSourceTaskStatus  = "task_status"
+	jiraFieldValueSourceWorkflowURL = "workflow_url"
 )
 
 func updateJiraFieldsForWorkflowTask(task *commonmodels.WorkflowTask, logger *zap.SugaredLogger) {
@@ -106,18 +105,16 @@ func buildJiraIssueFields(task *commonmodels.WorkflowTask, mappings []*commonmod
 
 func jiraFieldValue(task *commonmodels.WorkflowTask, valueSource string) (string, bool) {
 	switch valueSource {
-	case jiraFieldValueSourceWorkflowName:
-		return workflowTaskDisplayName(task), true
 	case jiraFieldValueSourceTaskStatus:
 		return workflowTaskStatusText(task.Status), true
-	case jiraFieldValueSourceTaskURL:
-		return workflowTaskURL(task), true
+	case jiraFieldValueSourceWorkflowURL:
+		return workflowURL(task), true
 	default:
 		return "", false
 	}
 }
 
-func workflowTaskDisplayName(task *commonmodels.WorkflowTask) string {
+func workflowDisplayName(task *commonmodels.WorkflowTask) string {
 	if task.WorkflowDisplayName != "" {
 		return task.WorkflowDisplayName
 	}
@@ -141,12 +138,11 @@ func workflowTaskStatusText(status config.Status) string {
 	}
 }
 
-func workflowTaskURL(task *commonmodels.WorkflowTask) string {
-	return fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d?display_name=%s",
+func workflowURL(task *commonmodels.WorkflowTask) string {
+	return fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s?display_name=%s",
 		configbase.SystemAddress(),
 		task.ProjectName,
 		task.WorkflowName,
-		task.TaskID,
-		url.QueryEscape(workflowTaskDisplayName(task)),
+		url.QueryEscape(workflowDisplayName(task)),
 	)
 }

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jira_field_update.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jira_field_update.go
@@ -158,21 +158,11 @@ func workflowDisplayName(task *commonmodels.WorkflowTask) string {
 	return task.WorkflowName
 }
 
-func workflowTaskStatusText(status config.Status) string {
-	switch status {
-	case config.StatusPassed:
-		return "成功"
-	case config.StatusFailed:
-		return "失败"
-	case config.StatusTimeout:
-		return "超时"
-	case config.StatusCancelled:
-		return "取消"
-	case config.StatusReject:
-		return "拒绝"
-	default:
-		return string(status)
+func workflowTaskStatusIcon(status config.Status) string {
+	if status == config.StatusPassed {
+		return "✅"
 	}
+	return "❌"
 }
 
 func workflowURL(task *commonmodels.WorkflowTask) string {
@@ -195,9 +185,9 @@ func workflowTaskURL(task *commonmodels.WorkflowTask) string {
 }
 
 func buildJiraWorkflowTaskComment(task *commonmodels.WorkflowTask, issue *commonmodels.IssueID) string {
-	return fmt.Sprintf("JIRA 状态：%s\n[%s]工作流：%s\n任务链接：%s",
+	return fmt.Sprintf("JIRA 状态：%s\n%s 工作流：%s\n任务链接：%s",
 		jiraIssueStatusForComment(issue),
-		workflowTaskStatusText(task.Status),
+		workflowTaskStatusIcon(task.Status),
 		workflowDisplayName(task),
 		workflowTaskURL(task),
 	)

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jira_field_update.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jira_field_update.go
@@ -51,7 +51,7 @@ func updateJiraFieldsForWorkflowTask(task *commonmodels.WorkflowTask, logger *za
 				logger.Errorf("failed to convert jira job spec for job %s: %v", job.Name, err)
 				continue
 			}
-			if len(jobTaskSpec.FieldMappings) == 0 || len(jobTaskSpec.Issues) == 0 {
+			if len(jobTaskSpec.Issues) == 0 || len(jobTaskSpec.FieldMappings) == 0 {
 				continue
 			}
 
@@ -73,6 +73,46 @@ func updateJiraFieldsForWorkflowTask(task *commonmodels.WorkflowTask, logger *za
 				}
 				if err := client.Issue.UpdateFields(issue.Key, fields); err != nil {
 					logger.Errorf("failed to update jira issue %s fields for workflow %s task %d: %v", issue.Key, task.WorkflowName, task.TaskID, err)
+				}
+			}
+		}
+	}
+}
+
+func addJiraCommentForWorkflowTask(task *commonmodels.WorkflowTask, logger *zap.SugaredLogger) {
+	if task == nil {
+		return
+	}
+
+	for _, stage := range task.Stages {
+		for _, job := range stage.Jobs {
+			if job.JobType != string(config.JobJira) {
+				continue
+			}
+
+			jobTaskSpec := &commonmodels.JobTaskJiraSpec{}
+			if err := commonmodels.IToi(job.Spec, jobTaskSpec); err != nil {
+				logger.Errorf("failed to convert jira job spec for job %s: %v", job.Name, err)
+				continue
+			}
+			if len(jobTaskSpec.Issues) == 0 {
+				continue
+			}
+
+			spec, err := commonrepo.NewProjectManagementColl().GetJiraSpec(jobTaskSpec.JiraID)
+			if err != nil {
+				logger.Errorf("failed to get jira spec for job %s: %v", job.Name, err)
+				continue
+			}
+			client := jira.NewJiraClientWithAuthType(spec.JiraHost, spec.JiraUser, spec.JiraToken, spec.JiraPersonalAccessToken, spec.JiraAuthType)
+
+			for _, issue := range jobTaskSpec.Issues {
+				if issue == nil || strings.TrimSpace(issue.Key) == "" {
+					continue
+				}
+				fillJiraIssueCurrentStatus(issue, client, logger)
+				if err := client.Issue.AddCommentV2(issue.Key, buildJiraWorkflowTaskComment(task, issue)); err != nil {
+					logger.Errorf("failed to add jira issue %s workflow task comment for workflow %s task %d: %v", issue.Key, task.WorkflowName, task.TaskID, err)
 				}
 			}
 		}
@@ -145,4 +185,51 @@ func workflowURL(task *commonmodels.WorkflowTask) string {
 		task.WorkflowName,
 		url.QueryEscape(workflowDisplayName(task)),
 	)
+}
+
+func workflowTaskURL(task *commonmodels.WorkflowTask) string {
+	return fmt.Sprintf("%s/v1/projects/detail/%s/pipelines/custom/%s/%d?display_name=%s",
+		configbase.SystemAddress(),
+		task.ProjectName,
+		task.WorkflowName,
+		task.TaskID,
+		url.QueryEscape(workflowDisplayName(task)),
+	)
+}
+
+func buildJiraWorkflowTaskComment(task *commonmodels.WorkflowTask, issue *commonmodels.IssueID) string {
+	return fmt.Sprintf("在 Jira 状态「%s」下执行 Zadig 工作流「%s」，执行结果：%s。任务链接：%s",
+		jiraIssueStatusForComment(issue),
+		workflowDisplayName(task),
+		workflowTaskStatusText(task.Status),
+		workflowTaskURL(task),
+	)
+}
+
+func jiraIssueStatusForComment(issue *commonmodels.IssueID) string {
+	if issue == nil {
+		return ""
+	}
+	if issue.CurrentStatus != "" {
+		return issue.CurrentStatus
+	}
+	if issue.TargetStatus != "" {
+		return issue.TargetStatus
+	}
+	return ""
+}
+
+func fillJiraIssueCurrentStatus(issue *commonmodels.IssueID, client *jira.Client, logger *zap.SugaredLogger) {
+	if issue == nil || client == nil || strings.TrimSpace(issue.CurrentStatus) != "" {
+		return
+	}
+
+	jiraIssue, err := client.Issue.GetByKeyOrID(issue.Key, "status")
+	if err != nil {
+		logger.Errorf("failed to get jira issue %s current status for workflow task comment: %v", issue.Key, err)
+		return
+	}
+	if jiraIssue != nil && jiraIssue.Fields != nil && jiraIssue.Fields.Status != nil {
+		issue.CurrentStatus = jiraIssue.Fields.Status.Name
+	}
 }

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_jira.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_jira.go
@@ -19,7 +19,6 @@ package jobcontroller
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"go.uber.org/zap"
 
@@ -77,19 +76,19 @@ func (c *JiraJobCtl) Run(ctx context.Context) {
 
 	client := jira.NewJiraClientWithAuthType(spec.JiraHost, spec.JiraUser, spec.JiraToken, spec.JiraPersonalAccessToken, spec.JiraAuthType)
 	for _, issue := range c.jobTaskSpec.Issues {
-		if issue == nil || strings.TrimSpace(issue.Key) == "" {
+		if issue == nil || issue.Key == "" {
 			continue
 		}
-		targetStatus := strings.TrimSpace(issue.TargetStatus)
+		targetStatus := issue.TargetStatus
 		if targetStatus == "" {
-			targetStatus = strings.TrimSpace(c.jobTaskSpec.TargetStatus)
+			targetStatus = c.jobTaskSpec.TargetStatus
 		}
 		if targetStatus == "" {
 			issue.Status = string(config.StatusPassed)
 			continue
 		}
 
-		currentStatus := strings.TrimSpace(issue.CurrentStatus)
+		currentStatus := issue.CurrentStatus
 		if currentStatus == "" {
 			jiraIssue, err := client.Issue.GetByKeyOrID(issue.Key, "status")
 			if err != nil {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_jira.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_jira.go
@@ -19,6 +19,7 @@ package jobcontroller
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"go.uber.org/zap"
 
@@ -76,6 +77,36 @@ func (c *JiraJobCtl) Run(ctx context.Context) {
 
 	client := jira.NewJiraClientWithAuthType(spec.JiraHost, spec.JiraUser, spec.JiraToken, spec.JiraPersonalAccessToken, spec.JiraAuthType)
 	for _, issue := range c.jobTaskSpec.Issues {
+		if issue == nil || strings.TrimSpace(issue.Key) == "" {
+			continue
+		}
+		targetStatus := strings.TrimSpace(issue.TargetStatus)
+		if targetStatus == "" {
+			targetStatus = strings.TrimSpace(c.jobTaskSpec.TargetStatus)
+		}
+		if targetStatus == "" {
+			issue.Status = string(config.StatusPassed)
+			continue
+		}
+
+		currentStatus := strings.TrimSpace(issue.CurrentStatus)
+		if currentStatus == "" {
+			jiraIssue, err := client.Issue.GetByKeyOrID(issue.Key, "status")
+			if err != nil {
+				logError(c.job, fmt.Sprintf("Get issue %s status error: %v", issue.Key, err), c.logger)
+				issue.Status = string(config.StatusFailed)
+				return
+			}
+			if jiraIssue != nil && jiraIssue.Fields != nil && jiraIssue.Fields.Status != nil {
+				currentStatus = jiraIssue.Fields.Status.Name
+				issue.CurrentStatus = currentStatus
+			}
+		}
+		if currentStatus == targetStatus {
+			issue.Status = string(config.StatusPassed)
+			continue
+		}
+
 		list, err := client.Issue.GetTransitions(issue.Key)
 		if err != nil {
 			logError(c.job, fmt.Sprintf("GetTransitions issue %s error: %v", issue.Key, err), c.logger)
@@ -84,13 +115,13 @@ func (c *JiraJobCtl) Run(ctx context.Context) {
 		}
 		var id string
 		for _, transition := range list {
-			if transition.To.Name == c.jobTaskSpec.TargetStatus {
+			if transition.To.Name == targetStatus {
 				id = transition.ID
 				break
 			}
 		}
 		if id == "" {
-			logError(c.job, fmt.Sprintf("Issue %s failed to find status %s transition id", issue.Key, c.jobTaskSpec.TargetStatus), c.logger)
+			logError(c.job, fmt.Sprintf("Issue %s failed to find status %s transition id", issue.Key, targetStatus), c.logger)
 			issue.Status = string(config.StatusFailed)
 			return
 		}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_jira.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_jira.go
@@ -88,18 +88,17 @@ func (c *JiraJobCtl) Run(ctx context.Context) {
 			continue
 		}
 
-		currentStatus := issue.CurrentStatus
-		if currentStatus == "" {
-			jiraIssue, err := client.Issue.GetByKeyOrID(issue.Key, "status")
-			if err != nil {
-				logError(c.job, fmt.Sprintf("Get issue %s status error: %v", issue.Key, err), c.logger)
-				issue.Status = string(config.StatusFailed)
-				return
-			}
-			if jiraIssue != nil && jiraIssue.Fields != nil && jiraIssue.Fields.Status != nil {
-				currentStatus = jiraIssue.Fields.Status.Name
-				issue.CurrentStatus = currentStatus
-			}
+		jiraIssue, err := client.Issue.GetByKeyOrID(issue.Key, "status")
+		if err != nil {
+			logError(c.job, fmt.Sprintf("Get issue %s status error: %v", issue.Key, err), c.logger)
+			issue.Status = string(config.StatusFailed)
+			return
+		}
+
+		currentStatus := ""
+		if jiraIssue != nil && jiraIssue.Fields != nil && jiraIssue.Fields.Status != nil {
+			currentStatus = jiraIssue.Fields.Status.Name
+			issue.CurrentStatus = currentStatus
 		}
 		if currentStatus == targetStatus {
 			issue.Status = string(config.StatusPassed)

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
@@ -131,6 +131,8 @@ func CancelWorkflowTask(userName, workflowName string, taskID int64, logger *zap
 		return err
 	}
 
+	updateJiraFieldsForWorkflowTask(t, logger)
+
 	// Updating the comment in the git repository, this will not cause the function to return error if this function call fails
 	if err := scmnotify.NewService().UpdateWebhookCommentForWorkflowV4(t, logger); err != nil {
 		log.Warnf("Failed to update comment for custom workflow %s, taskID: %d the error is: %s", t.WorkflowName, t.TaskID, err)

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
@@ -131,8 +131,6 @@ func CancelWorkflowTask(userName, workflowName string, taskID int64, logger *zap
 		return err
 	}
 
-	updateJiraFieldsForWorkflowTask(t, logger)
-
 	// Updating the comment in the git repository, this will not cause the function to return error if this function call fails
 	if err := scmnotify.NewService().UpdateWebhookCommentForWorkflowV4(t, logger); err != nil {
 		log.Warnf("Failed to update comment for custom workflow %s, taskID: %d the error is: %s", t.WorkflowName, t.TaskID, err)
@@ -559,8 +557,9 @@ func (c *workflowCtl) updateWorkflowTask() {
 	}
 
 	c.workflowTask.Remark = ""
-	shouldUpdateJiraFields := taskInColl.Status != c.workflowTask.Status
-	shouldSendCompleteHook := c.workflowTask.Finished() && taskInColl.EndTime == 0 && c.workflowTask.EndTime > 0
+	isFirstComplete := c.workflowTask.Finished() && taskInColl.EndTime == 0 && c.workflowTask.EndTime > 0
+	shouldSendCompleteHook := isFirstComplete
+	shouldUpdateJiraIssue := isFirstComplete || (c.workflowTask.Status == config.StatusReject && taskInColl.Status != config.StatusReject)
 
 	c.workflowTaskMutex.Lock()
 	if err := commonrepo.NewworkflowTaskv4Coll().Update(c.workflowTask.ID.Hex(), c.workflowTask); err != nil {
@@ -569,10 +568,6 @@ func (c *workflowCtl) updateWorkflowTask() {
 		return
 	}
 	c.workflowTaskMutex.Unlock()
-
-	if shouldUpdateJiraFields {
-		updateJiraFieldsForWorkflowTask(c.workflowTask, c.logger)
-	}
 
 	if c.workflowTask.Status == config.StatusPassed || c.workflowTask.Status == config.StatusFailed || c.workflowTask.Status == config.StatusTimeout || c.workflowTask.Status == config.StatusCancelled || c.workflowTask.Status == config.StatusReject || c.workflowTask.Status == config.StatusPause {
 		c.logger.Infof("%s:%d:%v task done", c.workflowTask.WorkflowName, c.workflowTask.TaskID, c.workflowTask.Status)
@@ -583,6 +578,10 @@ func (c *workflowCtl) updateWorkflowTask() {
 			if err := SendSystemWorkflowHook(c.workflowTask, commonmodels.WorkflowHookEventCompleteExecute); err != nil {
 				c.logger.Errorf("send system workflow complete hook failed, workflow: %s, taskID: %d, error: %v", c.workflowTask.WorkflowName, c.workflowTask.TaskID, err)
 			}
+		}
+		if shouldUpdateJiraIssue {
+			updateJiraFieldsForWorkflowTask(c.workflowTask, c.logger)
+			addJiraCommentForWorkflowTask(c.workflowTask, c.logger)
 		}
 		q := ConvertTaskToQueue(c.workflowTask)
 		if err := Remove(q); err != nil {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
@@ -557,6 +557,7 @@ func (c *workflowCtl) updateWorkflowTask() {
 	}
 
 	c.workflowTask.Remark = ""
+	shouldUpdateJiraFields := taskInColl.Status != c.workflowTask.Status
 	shouldSendCompleteHook := c.workflowTask.Finished() && taskInColl.EndTime == 0 && c.workflowTask.EndTime > 0
 
 	c.workflowTaskMutex.Lock()
@@ -566,6 +567,10 @@ func (c *workflowCtl) updateWorkflowTask() {
 		return
 	}
 	c.workflowTaskMutex.Unlock()
+
+	if shouldUpdateJiraFields {
+		updateJiraFieldsForWorkflowTask(c.workflowTask, c.logger)
+	}
 
 	if c.workflowTask.Status == config.StatusPassed || c.workflowTask.Status == config.StatusFailed || c.workflowTask.Status == config.StatusTimeout || c.workflowTask.Status == config.StatusCancelled || c.workflowTask.Status == config.StatusReject || c.workflowTask.Status == config.StatusPause {
 		c.logger.Infof("%s:%d:%v task done", c.workflowTask.WorkflowName, c.workflowTask.TaskID, c.workflowTask.Status)

--- a/pkg/microservice/aslan/core/system/handler/project_management.go
+++ b/pkg/microservice/aslan/core/system/handler/project_management.go
@@ -356,6 +356,32 @@ func SearchJiraProjectIssuesWithJQL(c *gin.Context) {
 	ctx.Resp, ctx.RespErr = service.SearchJiraProjectIssuesWithJQL(c.Param("id"), c.Query("project"), strings.ReplaceAll(c.Query("jql"), "{{.system.username}}", ctx.UserName), c.Query("summary"))
 }
 
+func GetJiraIssueStatus(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	issueKey := c.Query("issueKey")
+	if issueKey == "" {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("issueKey cannot be empty")
+		return
+	}
+
+	ctx.Resp, ctx.RespErr = service.GetJiraIssueStatus(c.Param("id"), issueKey)
+}
+
+func ListJiraIssueTransitions(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	issueKey := c.Query("issueKey")
+	if issueKey == "" {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("issueKey cannot be empty")
+		return
+	}
+
+	ctx.Resp, ctx.RespErr = service.ListJiraIssueTransitions(c.Param("id"), issueKey)
+}
+
 // @Summary Get Jira Types
 // @Description Get Jira Types
 // @Tags 	system

--- a/pkg/microservice/aslan/core/system/handler/router.go
+++ b/pkg/microservice/aslan/core/system/handler/router.go
@@ -381,6 +381,8 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		pm.GET("/:id/jira/sprint/:sprintID/issue", ListJiraSprintIssues)
 		pm.GET("/:id/jira/issue", SearchJiraIssues)
 		pm.GET("/:id/jira/issue/jql", SearchJiraProjectIssuesWithJQL)
+		pm.GET("/:id/jira/issue/status", GetJiraIssueStatus)
+		pm.GET("/:id/jira/issue/transitions", ListJiraIssueTransitions)
 		pm.GET("/:id/jira/type", GetJiraTypes)
 		pm.GET("/:id/jira/status", GetJiraProjectStatus)
 		pm.GET("/:id/jira/allStatus", GetJiraAllStatus)

--- a/pkg/microservice/aslan/core/system/service/project_management.go
+++ b/pkg/microservice/aslan/core/system/service/project_management.go
@@ -446,10 +446,7 @@ func GetJiraIssueStatus(id, issueKey string) (*JiraIssueStatusResp, error) {
 }
 
 type JiraIssueTransitionResp struct {
-	ID               string `json:"id"`
-	Name             string `json:"name"`
-	TargetStatusID   string `json:"target_status_id"`
-	TargetStatusName string `json:"target_status_name"`
+	Name string `json:"name"`
 }
 
 func ListJiraIssueTransitions(id, issueKey string) ([]*JiraIssueTransitionResp, error) {
@@ -469,10 +466,7 @@ func ListJiraIssueTransitions(id, issueKey string) ([]*JiraIssueTransitionResp, 
 			continue
 		}
 		resp = append(resp, &JiraIssueTransitionResp{
-			ID:               transition.ID,
-			Name:             transition.Name,
-			TargetStatusID:   transition.To.ID,
-			TargetStatusName: transition.To.Name,
+			Name: transition.To.Name,
 		})
 	}
 	return resp, nil

--- a/pkg/microservice/aslan/core/system/service/project_management.go
+++ b/pkg/microservice/aslan/core/system/service/project_management.go
@@ -417,6 +417,67 @@ func SearchJiraProjectIssuesWithJQL(id, project, jql, summary string) ([]*jira.I
 	return jira.NewJiraClientWithAuthType(spec.JiraHost, spec.JiraUser, spec.JiraToken, spec.JiraPersonalAccessToken, spec.JiraAuthType).Issue.SearchByJQL(jql, true)
 }
 
+type JiraIssueStatusResp struct {
+	Key           string `json:"key"`
+	Name          string `json:"name"`
+	CurrentStatus string `json:"current_status"`
+}
+
+func GetJiraIssueStatus(id, issueKey string) (*JiraIssueStatusResp, error) {
+	spec, err := mongodb.NewProjectManagementColl().GetJiraSpec(id)
+	if err != nil {
+		return nil, err
+	}
+
+	issue, err := jira.NewJiraClientWithAuthType(spec.JiraHost, spec.JiraUser, spec.JiraToken, spec.JiraPersonalAccessToken, spec.JiraAuthType).Issue.GetByKeyOrID(issueKey, "summary,status")
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &JiraIssueStatusResp{Key: issueKey}
+	if issue == nil || issue.Fields == nil {
+		return resp, nil
+	}
+	resp.Name = issue.Fields.Summary
+	if issue.Fields.Status != nil {
+		resp.CurrentStatus = issue.Fields.Status.Name
+	}
+	return resp, nil
+}
+
+type JiraIssueTransitionResp struct {
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	TargetStatusID   string `json:"target_status_id"`
+	TargetStatusName string `json:"target_status_name"`
+}
+
+func ListJiraIssueTransitions(id, issueKey string) ([]*JiraIssueTransitionResp, error) {
+	spec, err := mongodb.NewProjectManagementColl().GetJiraSpec(id)
+	if err != nil {
+		return nil, err
+	}
+
+	transitions, err := jira.NewJiraClientWithAuthType(spec.JiraHost, spec.JiraUser, spec.JiraToken, spec.JiraPersonalAccessToken, spec.JiraAuthType).Issue.GetTransitions(issueKey)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := make([]*JiraIssueTransitionResp, 0)
+	for _, transition := range transitions {
+		if transition == nil {
+			continue
+		}
+		resp = append(resp, &JiraIssueTransitionResp{
+			ID:               transition.ID,
+			Name:             transition.Name,
+			TargetStatusID:   transition.To.ID,
+			TargetStatusName: transition.To.Name,
+		})
+	}
+	return resp, nil
+}
+
 func HandleJiraHookEvent(workflowName, hookName string, event *jira.Event, logger *zap.SugaredLogger) error {
 	if event.Issue == nil || event.Issue.Key == "" {
 		logger.Errorf("HandleJiraHookEvent: nil issue or issue key, skip")

--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_jira.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_jira.go
@@ -90,6 +90,7 @@ func (j JiraJobController) Update(useUserInput bool, ticket *commonmodels.Approv
 	j.jobSpec.JQL = currJobSpec.JQL
 	j.jobSpec.IssueType = currJobSpec.IssueType
 	j.jobSpec.TargetStatus = currJobSpec.TargetStatus
+	j.jobSpec.FieldMappings = currJobSpec.FieldMappings
 
 	if !useUserInput {
 		j.jobSpec.Issues = currJobSpec.Issues
@@ -133,11 +134,12 @@ func (j JiraJobController) ToTask(taskID int64) ([]*commonmodels.JobTask, error)
 		},
 		JobType: string(config.JobJira),
 		Spec: &commonmodels.JobTaskJiraSpec{
-			ProjectID:    j.jobSpec.ProjectID,
-			JiraID:       j.jobSpec.JiraID,
-			IssueType:    j.jobSpec.IssueType,
-			Issues:       j.jobSpec.Issues,
-			TargetStatus: j.jobSpec.TargetStatus,
+			ProjectID:     j.jobSpec.ProjectID,
+			JiraID:        j.jobSpec.JiraID,
+			IssueType:     j.jobSpec.IssueType,
+			Issues:        j.jobSpec.Issues,
+			TargetStatus:  j.jobSpec.TargetStatus,
+			FieldMappings: j.jobSpec.FieldMappings,
 		},
 		Timeout:       0,
 		ErrorPolicy:   j.errorPolicy,

--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_jira.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_jira.go
@@ -89,11 +89,11 @@ func (j JiraJobController) Update(useUserInput bool, ticket *commonmodels.Approv
 	j.jobSpec.QueryType = currJobSpec.QueryType
 	j.jobSpec.JQL = currJobSpec.JQL
 	j.jobSpec.IssueType = currJobSpec.IssueType
-	j.jobSpec.TargetStatus = currJobSpec.TargetStatus
 	j.jobSpec.FieldMappings = currJobSpec.FieldMappings
 
 	if !useUserInput {
 		j.jobSpec.Issues = currJobSpec.Issues
+		j.jobSpec.TargetStatus = currJobSpec.TargetStatus
 	}
 
 	return nil
@@ -108,7 +108,8 @@ func (j JiraJobController) ClearOptions() {
 }
 
 func (j JiraJobController) ClearSelection() {
-	return
+	j.jobSpec.Issues = make([]*commonmodels.IssueID, 0)
+	j.jobSpec.TargetStatus = ""
 }
 
 func (j JiraJobController) ToTask(taskID int64) ([]*commonmodels.JobTask, error) {

--- a/pkg/tool/jira/issue.go
+++ b/pkg/tool/jira/issue.go
@@ -199,6 +199,20 @@ func (s *IssueService) UpdateStatus(key, statusID string) error {
 	return nil
 }
 
+func (s *IssueService) UpdateFields(key string, fields map[string]interface{}) error {
+	url := s.client.Host + "/rest/api/2/issue/" + key
+	resp, err := s.client.R().SetBodyJsonMarshal(map[string]interface{}{
+		"fields": fields,
+	}).Put(url)
+	if err != nil {
+		return err
+	}
+	if resp.GetStatusCode()/100 != 2 {
+		return errors.Errorf("unexpected status code %d, body: %s", resp.GetStatusCode(), resp.String())
+	}
+	return nil
+}
+
 type Transition struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`


### PR DESCRIPTION
### What this PR does / Why we need it:

Supports syncing Zadig workflow execution information back to Jira issue custom fields.

Users can configure Jira custom field IDs in the Jira issue status change job. When the workflow status changes, Zadig updates the selected Jira issues with the latest workflow information, such as workflow name, workflow status, and workflow task URL.

### What is changed and how it works?

- Added `field_mappings` to Jira workflow job specs and Jira job task specs.
- Added Jira issue field update support via `PUT /rest/api/2/issue/{issueKey}`.
- Jira fields are updated when the workflow status changes.
- Cancellation flow also triggers Jira field sync after the task is marked as `cancelled`.
- Jira field sync failures are logged only and do not affect the workflow execution result.


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4759)
<!-- Reviewable:end -->
