### PR TITLE
feat: support regex matching for git tag triggers

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/scanning.go
+++ b/pkg/microservice/aslan/core/common/repository/models/scanning.go
@@ -82,18 +82,22 @@ type ScanningHookCtl struct {
 }
 
 type ScanningHook struct {
-	CodehostID   int                    `bson:"codehost_id"   json:"codehost_id"`
-	Source       string                 `bson:"source"        json:"source"`
-	RepoOwner    string                 `bson:"repo_owner"    json:"repo_owner"`
-	RepoName     string                 `bson:"repo_name"     json:"repo_name"`
-	Branch       string                 `bson:"branch"        json:"branch"`
-	Tag          string                 `bson:"tag"           json:"tag"`
-	Events       []config.HookEventType `bson:"events"        json:"events"`
-	MatchFolders []string               `bson:"match_folders" json:"match_folders"`
-	IsRegular    bool                   `bson:"is_regular"    json:"is_regular"`
-	TagIsRegular bool                   `bson:"tag_is_regular" json:"tag_is_regular"`
-	IsManual     bool                   `bson:"is_manual"     json:"is_manual"`
-	AutoCancel   bool                   `bson:"auto_cancel"   json:"auto_cancel"`
+	CodehostID    int                    `bson:"codehost_id"   json:"codehost_id"`
+	Source        string                 `bson:"source"        json:"source"`
+	RepoOwner     string                 `bson:"repo_owner"    json:"repo_owner"`
+	RepoName      string                 `bson:"repo_name"     json:"repo_name"`
+	Branch        string                 `bson:"branch"        json:"branch"`
+	PushBranch    string                 `bson:"push_branch"   json:"push_branch"`
+	PrBranch      string                 `bson:"pr_branch"     json:"pr_branch"`
+	Tag           string                 `bson:"tag"           json:"tag"`
+	Events        []config.HookEventType `bson:"events"        json:"events"`
+	MatchFolders  []string               `bson:"match_folders" json:"match_folders"`
+	IsRegular     bool                   `bson:"is_regular"    json:"is_regular"`
+	PushIsRegular bool                   `bson:"push_is_regular" json:"push_is_regular"`
+	PrIsRegular   bool                   `bson:"pr_is_regular" json:"pr_is_regular"`
+	TagIsRegular  bool                   `bson:"tag_is_regular" json:"tag_is_regular"`
+	IsManual      bool                   `bson:"is_manual"     json:"is_manual"`
+	AutoCancel    bool                   `bson:"auto_cancel"   json:"auto_cancel"`
 }
 
 type SonarInfo struct {

--- a/pkg/microservice/aslan/core/common/repository/models/scanning.go
+++ b/pkg/microservice/aslan/core/common/repository/models/scanning.go
@@ -87,9 +87,11 @@ type ScanningHook struct {
 	RepoOwner    string                 `bson:"repo_owner"    json:"repo_owner"`
 	RepoName     string                 `bson:"repo_name"     json:"repo_name"`
 	Branch       string                 `bson:"branch"        json:"branch"`
+	Tag          string                 `bson:"tag"           json:"tag"`
 	Events       []config.HookEventType `bson:"events"        json:"events"`
 	MatchFolders []string               `bson:"match_folders" json:"match_folders"`
 	IsRegular    bool                   `bson:"is_regular"    json:"is_regular"`
+	TagIsRegular bool                   `bson:"tag_is_regular" json:"tag_is_regular"`
 	IsManual     bool                   `bson:"is_manual"     json:"is_manual"`
 	AutoCancel   bool                   `bson:"auto_cancel"   json:"auto_cancel"`
 }

--- a/pkg/microservice/aslan/core/common/repository/models/workflow.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow.go
@@ -95,6 +95,7 @@ type MainHookRepo struct {
 	Label         string                 `bson:"label"                     json:"label"`
 	Revision      string                 `bson:"revision"                  json:"revision"`
 	IsRegular     bool                   `bson:"is_regular"                json:"is_regular"`
+	TagIsRegular  bool                   `bson:"tag_is_regular"            json:"tag_is_regular"`
 }
 
 func (m *MainHookRepo) GetRepoNamespace() string {

--- a/pkg/microservice/aslan/core/common/repository/models/workflow.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow.go
@@ -87,6 +87,8 @@ type MainHookRepo struct {
 	RepoNamespace string                 `bson:"repo_namespace"            json:"repo_namespace"`
 	RepoName      string                 `bson:"repo_name"                 json:"repo_name"`
 	Branch        string                 `bson:"branch"                    json:"branch"`
+	PushBranch    string                 `bson:"push_branch"               json:"push_branch"`
+	PrBranch      string                 `bson:"pr_branch"                 json:"pr_branch"`
 	Tag           string                 `bson:"tag"                       json:"tag"`
 	Committer     string                 `bson:"committer"                 json:"committer"`
 	MatchFolders  []string               `bson:"match_folders"             json:"match_folders,omitempty"`
@@ -95,6 +97,8 @@ type MainHookRepo struct {
 	Label         string                 `bson:"label"                     json:"label"`
 	Revision      string                 `bson:"revision"                  json:"revision"`
 	IsRegular     bool                   `bson:"is_regular"                json:"is_regular"`
+	PushIsRegular bool                   `bson:"push_is_regular"           json:"push_is_regular"`
+	PrIsRegular   bool                   `bson:"pr_is_regular"             json:"pr_is_regular"`
 	TagIsRegular  bool                   `bson:"tag_is_regular"            json:"tag_is_regular"`
 }
 

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflowv4_task.go
@@ -19,7 +19,6 @@ package webhook
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -142,16 +141,8 @@ func (gruem *gerritChangeMergedEventMatcherForWorkflowV4) Match(hookRepo *common
 
 	if event.Project.Name == gruem.Item.MainRepo.RepoName {
 		refName := getBranchFromRef(event.RefName)
-		isRegular := gruem.Item.MainRepo.IsRegular
-		if !isRegular && hookRepo.Branch != refName {
+		if !MatchBranch(gruem.Item.MainRepo, config.HookEventPr, refName) {
 			return false, nil
-		}
-		if isRegular {
-			// Do not use regexp.MustCompile to avoid panic
-			matched, err := regexp.MatchString(gruem.Item.MainRepo.Branch, refName)
-			if err != nil || !matched {
-				return false, nil
-			}
 		}
 		hookRepo.Branch = refName
 		existEventNames := make([]string, 0)
@@ -192,16 +183,8 @@ func (gpcem *gerritPatchsetCreatedEventMatcherForWorkflowV4) Match(hookRepo *com
 
 	if event.Project.Name == gpcem.Item.MainRepo.RepoName {
 		refName := getBranchFromRef(event.RefName)
-		isRegular := gpcem.Item.MainRepo.IsRegular
-		if !isRegular && hookRepo.Branch != refName {
+		if !MatchBranch(gpcem.Item.MainRepo, config.HookEventPr, refName) {
 			return false, nil
-		}
-		if isRegular {
-			// Do not use regexp.MustCompile to avoid panic
-			matched, err := regexp.MatchString(gpcem.Item.MainRepo.Branch, refName)
-			if err != nil || !matched {
-				return false, nil
-			}
 		}
 		hookRepo.Branch = refName
 		existEventNames := make([]string, 0)

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitee_testing_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitee_testing_task.go
@@ -17,7 +17,6 @@ limitations under the License.
 package webhook
 
 import (
-	"regexp"
 	"strconv"
 
 	"github.com/hashicorp/go-multierror"
@@ -56,18 +55,11 @@ func (gpem *giteePushEventMatcherForTesting) Match(hookRepo *commonmodels.MainHo
 		if !EventConfigured(hookRepo, config.HookEventPush) {
 			return false, nil
 		}
-		isRegular := hookRepo.IsRegular
-		if !isRegular && hookRepo.Branch != getBranchFromRef(ev.Ref) {
+		branch := getBranchFromRef(ev.Ref)
+		if !MatchBranch(hookRepo, config.HookEventPush, branch) {
 			return false, nil
 		}
-
-		if isRegular {
-			matched, err := regexp.MatchString(hookRepo.Branch, getBranchFromRef(ev.Ref))
-			if err != nil || !matched {
-				return false, nil
-			}
-		}
-		hookRepo.Branch = getBranchFromRef(ev.Ref)
+		hookRepo.Branch = branch
 		var changedFiles []string
 		for _, commit := range ev.Commits {
 			changedFiles = append(changedFiles, commit.Added...)
@@ -114,17 +106,6 @@ func (gtem giteeTagEventMatcherForTesting) Match(hookRepo *commonmodels.MainHook
 	if (hookRepo.RepoOwner + "/" + hookRepo.RepoName) == ev.Project.PathWithNamespace {
 		if !EventConfigured(hookRepo, config.HookEventTag) {
 			return false, nil
-		}
-		isRegular := hookRepo.IsRegular
-		if !isRegular && hookRepo.Branch != ev.Project.DefaultBranch {
-			return false, nil
-		}
-
-		if isRegular {
-			matched, err := regexp.MatchString(hookRepo.Branch, ev.Project.DefaultBranch)
-			if err != nil || !matched {
-				return false, nil
-			}
 		}
 		hookRepo.Branch = ev.Project.DefaultBranch
 
@@ -177,18 +158,11 @@ func (gmem *giteeMergeEventMatcherForTesting) Match(hookRepo *commonmodels.MainH
 			return false, nil
 		}
 
-		isRegular := hookRepo.IsRegular
-		if !isRegular && hookRepo.Branch != ev.PullRequest.Base.Ref {
+		branch := ev.PullRequest.Base.Ref
+		if !MatchBranch(hookRepo, config.HookEventPr, branch) {
 			return false, nil
 		}
-
-		if isRegular {
-			matched, err := regexp.MatchString(hookRepo.Branch, ev.PullRequest.Base.Ref)
-			if err != nil || !matched {
-				return false, nil
-			}
-		}
-		hookRepo.Branch = ev.PullRequest.Base.Ref
+		hookRepo.Branch = branch
 		if ev.PullRequest.State == "open" {
 			var changedFiles []string
 			changedFiles, err := gmem.diffFunc(ev, hookRepo.CodehostID)

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitee_testing_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitee_testing_task.go
@@ -127,6 +127,13 @@ func (gtem giteeTagEventMatcherForTesting) Match(hookRepo *commonmodels.MainHook
 			}
 		}
 		hookRepo.Branch = ev.Project.DefaultBranch
+
+		tag := getTagFromRef(ev.Ref)
+		if !MatchTag(hookRepo, tag) {
+			return false, nil
+		}
+
+		hookRepo.Tag = tag
 		return true, nil
 	}
 

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitee_workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitee_workflow_task.go
@@ -18,7 +18,6 @@ package webhook
 
 import (
 	"fmt"
-	"regexp"
 
 	"go.uber.org/zap"
 
@@ -46,18 +45,11 @@ func (gpem *giteePushEventMatcher) Match(hookRepo *commonmodels.MainHookRepo) (b
 			return false, nil
 		}
 
-		isRegular := hookRepo.IsRegular
-		if !isRegular && hookRepo.Branch != getBranchFromRef(ev.Ref) {
+		branch := getBranchFromRef(ev.Ref)
+		if !MatchBranch(hookRepo, config.HookEventPush, branch) {
 			return false, nil
 		}
-		if isRegular {
-			// Do not use regexp.MustCompile to avoid panic
-			matched, err := regexp.MatchString(hookRepo.Branch, getBranchFromRef(ev.Ref))
-			if err != nil || !matched {
-				return false, nil
-			}
-		}
-		hookRepo.Branch = getBranchFromRef(ev.Ref)
+		hookRepo.Branch = branch
 		hookRepo.Committer = ev.Pusher.Name
 		var changedFiles []string
 		for _, commit := range ev.Commits {
@@ -103,17 +95,11 @@ func (gmem *giteeMergeEventMatcher) Match(hookRepo *commonmodels.MainHookRepo) (
 			return false, nil
 		}
 
-		isRegular := hookRepo.IsRegular
-		if !isRegular && hookRepo.Branch != ev.PullRequest.Base.Ref {
+		branch := ev.PullRequest.Base.Ref
+		if !MatchBranch(hookRepo, config.HookEventPr, branch) {
 			return false, nil
 		}
-		if isRegular {
-			matched, err := regexp.MatchString(hookRepo.Branch, ev.PullRequest.Base.Ref)
-			if err != nil || !matched {
-				return false, nil
-			}
-		}
-		hookRepo.Branch = ev.PullRequest.Base.Ref
+		hookRepo.Branch = branch
 		hookRepo.Committer = ev.PullRequest.User.Login
 		if ev.PullRequest.State == "open" {
 			var changedFiles []string
@@ -162,7 +148,12 @@ func (gtem giteeTagEventMatcher) Match(hookRepo *commonmodels.MainHookRepo) (boo
 			return false, nil
 		}
 
-		hookRepo.Tag = getTagFromRef(ev.Ref)
+		tag := getTagFromRef(ev.Ref)
+		if !MatchTag(hookRepo, tag) {
+			return false, nil
+		}
+
+		hookRepo.Tag = tag
 		hookRepo.Committer = ev.Sender.Name
 
 		return true, nil

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitee_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitee_workflowv4_task.go
@@ -157,7 +157,12 @@ func (gtem giteeTagEventMatcherForWorkflowV4) Match(hookRepo *commonmodels.MainH
 			return false, nil
 		}
 
-		hookRepo.Tag = getTagFromRef(ev.Ref)
+		tag := getTagFromRef(ev.Ref)
+		if !MatchTag(hookRepo, tag) {
+			return false, nil
+		}
+
+		hookRepo.Tag = tag
 		hookRepo.Committer = ev.Sender.Name
 
 		return true, nil

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitee_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitee_workflowv4_task.go
@@ -18,7 +18,6 @@ package webhook
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/workflow/service/workflow/controller"
@@ -55,18 +54,11 @@ func (gpem *giteePushEventMatcherForWorkflowV4) Match(hookRepo *commonmodels.Mai
 			return false, nil
 		}
 
-		isRegular := hookRepo.IsRegular
-		if !isRegular && hookRepo.Branch != getBranchFromRef(ev.Ref) {
+		branch := getBranchFromRef(ev.Ref)
+		if !MatchBranch(hookRepo, config.HookEventPush, branch) {
 			return false, nil
 		}
-		if isRegular {
-			// Do not use regexp.MustCompile to avoid panic
-			matched, err := regexp.MatchString(hookRepo.Branch, getBranchFromRef(ev.Ref))
-			if err != nil || !matched {
-				return false, nil
-			}
-		}
-		hookRepo.Branch = getBranchFromRef(ev.Ref)
+		hookRepo.Branch = branch
 		hookRepo.Committer = ev.Pusher.Name
 		var changedFiles []string
 		for _, commit := range ev.Commits {
@@ -105,17 +97,11 @@ func (gmem *giteeMergeEventMatcherForWorkflowV4) Match(hookRepo *commonmodels.Ma
 			return false, nil
 		}
 
-		isRegular := hookRepo.IsRegular
-		if !isRegular && hookRepo.Branch != ev.PullRequest.Base.Ref {
+		branch := ev.PullRequest.Base.Ref
+		if !MatchBranch(hookRepo, config.HookEventPr, branch) {
 			return false, nil
 		}
-		if isRegular {
-			matched, err := regexp.MatchString(hookRepo.Branch, ev.PullRequest.Base.Ref)
-			if err != nil || !matched {
-				return false, nil
-			}
-		}
-		hookRepo.Branch = ev.PullRequest.Base.Ref
+		hookRepo.Branch = branch
 		hookRepo.Committer = ev.PullRequest.User.Login
 		if ev.PullRequest.State == "open" {
 			var changedFiles []string

--- a/pkg/microservice/aslan/core/workflow/service/webhook/github_scanning_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github_scanning_task.go
@@ -144,6 +144,7 @@ func TriggerScanningByGithubEvent(event interface{}, requestID string, log *zap.
 							RepoOwner:  scanningRepo.RepoOwner,
 							RepoName:   scanningRepo.RepoName,
 							Branch:     scanningRepo.Branch,
+							Tag:        scanningRepo.Tag,
 						})
 					}
 
@@ -153,6 +154,7 @@ func TriggerScanningByGithubEvent(event interface{}, requestID string, log *zap.
 						RepoOwner:  item.RepoOwner,
 						RepoName:   item.RepoName,
 						Branch:     item.Branch,
+						Tag:        item.Tag,
 						PR:         prID,
 					}
 
@@ -316,6 +318,12 @@ func (gtem githubTagEventMatcherForScanning) Match(hookRepo *commonmodels.Scanni
 
 		hookRepo.Branch = *ev.Repo.DefaultBranch
 
+		tag := getTagFromRef(*ev.Ref)
+		if !MatchTag(hookInfo, tag) {
+			return false, nil
+		}
+
+		hookRepo.Tag = tag
 		return true, nil
 	}
 

--- a/pkg/microservice/aslan/core/workflow/service/webhook/github_scanning_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github_scanning_task.go
@@ -17,7 +17,6 @@ limitations under the License.
 package webhook
 
 import (
-	"regexp"
 	"strconv"
 
 	"github.com/google/go-github/v35/github"
@@ -209,11 +208,12 @@ func (gpem githubPushEventMatcherForScanning) Match(hookRepo *commonmodels.Scann
 			return false, nil
 		}
 
-		if hookRepo.Branch != getBranchFromRef(*ev.Ref) {
+		branch := getBranchFromRef(*ev.Ref)
+		if !MatchBranch(matchRepo, config.HookEventPush, branch) {
 			return false, nil
 		}
 
-		hookRepo.Branch = getBranchFromRef(*ev.Ref)
+		hookRepo.Branch = branch
 		var changedFiles []string
 		for _, commit := range ev.Commits {
 			changedFiles = append(changedFiles, commit.Added...)
@@ -260,19 +260,11 @@ func (gmem githubMergeEventMatcherForScanning) Match(hookRepo *commonmodels.Scan
 			return false, nil
 		}
 
-		hookRepo.Branch = *ev.PullRequest.Base.Ref
-
-		isRegExp := matchRepo.IsRegular
-
-		if !isRegExp {
-			if *ev.PullRequest.Base.Ref != hookRepo.Branch {
-				return false, nil
-			}
-		} else {
-			if matched, _ := regexp.MatchString(hookRepo.Branch, *ev.PullRequest.Base.Ref); !matched {
-				return false, nil
-			}
+		branch := *ev.PullRequest.Base.Ref
+		if !MatchBranch(matchRepo, config.HookEventPr, branch) {
+			return false, nil
 		}
+		hookRepo.Branch = branch
 
 		if *ev.PullRequest.State == "open" {
 			var changedFiles []string

--- a/pkg/microservice/aslan/core/workflow/service/webhook/github_testing_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github_testing_task.go
@@ -250,6 +250,12 @@ func (gtem githubTagEventMatcherForTesting) Match(hookRepo *commonmodels.MainHoo
 	}
 	hookRepo.Branch = *ev.Repo.DefaultBranch
 
+	tag := getTagFromRef(*ev.Ref)
+	if !MatchTag(hookRepo, tag) {
+		return false, nil
+	}
+
+	hookRepo.Tag = tag
 	return true, nil
 }
 

--- a/pkg/microservice/aslan/core/workflow/service/webhook/github_testing_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github_testing_task.go
@@ -17,7 +17,6 @@ limitations under the License.
 package webhook
 
 import (
-	"regexp"
 	"strconv"
 
 	"github.com/google/go-github/v35/github"
@@ -181,17 +180,11 @@ func (gpem *githubPushEventMatcherForTesting) Match(hookRepo *commonmodels.MainH
 	if !EventConfigured(hookRepo, config.HookEventPush) {
 		return false, nil
 	}
-	isRegular := hookRepo.IsRegular
-	if !isRegular && hookRepo.Branch != getBranchFromRef(*ev.Ref) {
+	branch := getBranchFromRef(*ev.Ref)
+	if !MatchBranch(hookRepo, config.HookEventPush, branch) {
 		return false, nil
 	}
-
-	if isRegular {
-		if matched, _ := regexp.MatchString(hookRepo.Branch, getBranchFromRef(*ev.Ref)); !matched {
-			return false, nil
-		}
-	}
-	hookRepo.Branch = getBranchFromRef(*ev.Ref)
+	hookRepo.Branch = branch
 	var changedFiles []string
 	for _, commit := range ev.Commits {
 		changedFiles = append(changedFiles, commit.Added...)
@@ -237,16 +230,6 @@ func (gtem githubTagEventMatcherForTesting) Match(hookRepo *commonmodels.MainHoo
 	}
 	if !EventConfigured(hookRepo, config.HookEventTag) {
 		return false, nil
-	}
-	isRegular := hookRepo.IsRegular
-	if !isRegular && hookRepo.Branch != *ev.Repo.DefaultBranch {
-		return false, nil
-	}
-
-	if isRegular {
-		if matched, _ := regexp.MatchString(hookRepo.Branch, *ev.Repo.DefaultBranch); !matched {
-			return false, nil
-		}
 	}
 	hookRepo.Branch = *ev.Repo.DefaultBranch
 
@@ -323,17 +306,11 @@ func (gmem *githubMergeEventMatcherForTesting) Match(hookRepo *commonmodels.Main
 		return false, nil
 	}
 
-	isRegular := hookRepo.IsRegular
-	if !isRegular && hookRepo.Branch != *ev.PullRequest.Base.Ref {
+	branch := *ev.PullRequest.Base.Ref
+	if !MatchBranch(hookRepo, config.HookEventPr, branch) {
 		return false, nil
 	}
-
-	if isRegular {
-		if matched, _ := regexp.MatchString(hookRepo.Branch, *ev.PullRequest.Base.Ref); !matched {
-			return false, nil
-		}
-	}
-	hookRepo.Branch = *ev.PullRequest.Base.Ref
+	hookRepo.Branch = branch
 
 	if *ev.PullRequest.State == "open" {
 		var changedFiles []string

--- a/pkg/microservice/aslan/core/workflow/service/webhook/github_workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github_workflow_task.go
@@ -19,7 +19,6 @@ package webhook
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/google/go-github/v35/github"
@@ -60,17 +59,11 @@ func (gpem *githubPushEventMatcher) Match(hookRepo *commonmodels.MainHookRepo) (
 		return false, nil
 	}
 
-	isRegular := hookRepo.IsRegular
-	if !isRegular && hookRepo.Branch != getBranchFromRef(*ev.Ref) {
+	branch := getBranchFromRef(*ev.Ref)
+	if !MatchBranch(hookRepo, config.HookEventPush, branch) {
 		return false, nil
 	}
-	if isRegular {
-		// Do not use regexp.MustCompile to avoid panic
-		if matched, _ := regexp.MatchString(hookRepo.Branch, getBranchFromRef(*ev.Ref)); !matched {
-			return false, nil
-		}
-	}
-	hookRepo.Branch = getBranchFromRef(*ev.Ref)
+	hookRepo.Branch = branch
 	hookRepo.Committer = *ev.Pusher.Name
 	var changedFiles []string
 	for _, commit := range ev.Commits {
@@ -135,16 +128,11 @@ func (gmem *githubMergeEventMatcher) Match(hookRepo *commonmodels.MainHookRepo) 
 		return false, nil
 	}
 
-	isRegular := hookRepo.IsRegular
-	if !isRegular && hookRepo.Branch != *ev.PullRequest.Base.Ref {
+	branch := *ev.PullRequest.Base.Ref
+	if !MatchBranch(hookRepo, config.HookEventPr, branch) {
 		return false, nil
 	}
-	if isRegular {
-		if matched, _ := regexp.MatchString(hookRepo.Branch, *ev.PullRequest.Base.Ref); !matched {
-			return false, nil
-		}
-	}
-	hookRepo.Branch = *ev.PullRequest.Base.Ref
+	hookRepo.Branch = branch
 	hookRepo.Committer = *ev.PullRequest.User.Login
 	if *ev.PullRequest.State == "open" {
 		var changedFiles []string

--- a/pkg/microservice/aslan/core/workflow/service/webhook/github_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github_workflowv4_task.go
@@ -18,7 +18,6 @@ package webhook
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 
 	"github.com/google/go-github/v35/github"
@@ -58,17 +57,11 @@ func (gpem *githubPushEventMatcheForWorkflowV4) Match(hookRepo *commonmodels.Mai
 		return false, nil
 	}
 
-	isRegular := hookRepo.IsRegular
-	if !isRegular && hookRepo.Branch != getBranchFromRef(*ev.Ref) {
+	branch := getBranchFromRef(*ev.Ref)
+	if !MatchBranch(hookRepo, config.HookEventPush, branch) {
 		return false, nil
 	}
-	if isRegular {
-		// Do not use regexp.MustCompile to avoid panic
-		if matched, _ := regexp.MatchString(hookRepo.Branch, getBranchFromRef(*ev.Ref)); !matched {
-			return false, nil
-		}
-	}
-	hookRepo.Branch = getBranchFromRef(*ev.Ref)
+	hookRepo.Branch = branch
 	hookRepo.Committer = *ev.Pusher.Name
 	var changedFiles []string
 	for _, commit := range ev.Commits {
@@ -110,16 +103,11 @@ func (gmem *githubMergeEventMatcherForWorkflowV4) Match(hookRepo *commonmodels.M
 		return false, nil
 	}
 
-	isRegular := hookRepo.IsRegular
-	if !isRegular && hookRepo.Branch != *ev.PullRequest.Base.Ref {
+	branch := *ev.PullRequest.Base.Ref
+	if !MatchBranch(hookRepo, config.HookEventPr, branch) {
 		return false, nil
 	}
-	if isRegular {
-		if matched, _ := regexp.MatchString(hookRepo.Branch, *ev.PullRequest.Base.Ref); !matched {
-			return false, nil
-		}
-	}
-	hookRepo.Branch = *ev.PullRequest.Base.Ref
+	hookRepo.Branch = branch
 	hookRepo.Committer = *ev.PullRequest.User.Login
 	if *ev.PullRequest.State == "open" {
 		var changedFiles []string

--- a/pkg/microservice/aslan/core/workflow/service/webhook/github_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github_workflowv4_task.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
 
-	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
@@ -33,6 +32,7 @@ import (
 	workflowservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/workflow/service/workflow"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/workflow/service/workflow/controller"
 	"github.com/koderover/zadig/v2/pkg/setting"
+	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
 	"github.com/koderover/zadig/v2/pkg/types"
 )
 
@@ -167,7 +167,12 @@ func (gtem githubTagEventMatcherForWorkflowV4) Match(hookRepo *commonmodels.Main
 		return false, nil
 	}
 
-	hookRepo.Tag = getTagFromRef(*ev.Ref)
+	tag := getTagFromRef(*ev.Ref)
+	if !MatchTag(hookRepo, tag) {
+		return false, nil
+	}
+
+	hookRepo.Tag = tag
 	if ev.Sender.Name != nil {
 		hookRepo.Committer = *ev.Sender.Name
 	}

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_scanning_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_scanning_task.go
@@ -148,6 +148,7 @@ func TriggerScanningByGitlabEvent(event interface{}, baseURI, requestID string, 
 							RepoOwner:  scanningRepo.RepoOwner,
 							RepoName:   scanningRepo.RepoName,
 							Branch:     scanningRepo.Branch,
+							Tag:        scanningRepo.Tag,
 						})
 					}
 
@@ -157,6 +158,7 @@ func TriggerScanningByGitlabEvent(event interface{}, baseURI, requestID string, 
 						RepoOwner:  item.RepoOwner,
 						RepoName:   item.RepoName,
 						Branch:     item.Branch,
+						Tag:        item.Tag,
 					}
 					triggerRepoInfo = append(triggerRepoInfo, repoInfo)
 
@@ -341,6 +343,7 @@ func (gmem *gitlabTagEventMatcherForScanning) GetHookRepo(hookRepo *commonmodels
 		RepoOwner:     hookRepo.RepoOwner,
 		RepoNamespace: hookRepo.GetRepoNamespace(),
 		Branch:        hookRepo.Branch,
+		Tag:           hookRepo.Tag,
 		Source:        hookRepo.Source,
 	}
 }
@@ -354,6 +357,13 @@ func (gtem *gitlabTagEventMatcherForScanning) Match(hookRepo *commonmodels.Scann
 		}
 
 		hookRepo.Branch = ev.Project.DefaultBranch
+
+		tag := getTagFromRef(ev.Ref)
+		if !MatchTag(hookInfo, tag) {
+			return false, nil
+		}
+
+		hookRepo.Tag = tag
 		return true, nil
 	}
 

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_scanning_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_scanning_task.go
@@ -17,7 +17,6 @@ limitations under the License.
 package webhook
 
 import (
-	"regexp"
 	"strconv"
 
 	"github.com/xanzy/go-gitlab"
@@ -245,17 +244,12 @@ func (gpem *gitlabPushEventMatcherForScanning) Match(hookRepo *commonmodels.Scan
 			return false, nil
 		}
 
-		if !matchRepo.IsRegular {
-			if getBranchFromRef(ev.Ref) != hookRepo.Branch {
-				return false, nil
-			}
-		} else {
-			if matched, _ := regexp.MatchString(hookRepo.Branch, getBranchFromRef(ev.Ref)); !matched {
-				return false, nil
-			}
+		branch := getBranchFromRef(ev.Ref)
+		if !MatchBranch(matchRepo, config.HookEventPush, branch) {
+			return false, nil
 		}
 
-		hookRepo.Branch = getBranchFromRef(ev.Ref)
+		hookRepo.Branch = branch
 		var changedFiles []string
 		for _, commit := range ev.Commits {
 			changedFiles = append(changedFiles, commit.Added...)
@@ -300,19 +294,12 @@ func (gmem *gitlabMergeEventMatcherForScanning) Match(hookRepo *commonmodels.Sca
 			return false, nil
 		}
 
-		isRegExp := matchRepo.IsRegular
-
-		if !isRegExp {
-			if ev.ObjectAttributes.TargetBranch != hookRepo.Branch {
-				return false, nil
-			}
-		} else {
-			if matched, _ := regexp.MatchString(hookRepo.Branch, ev.ObjectAttributes.TargetBranch); !matched {
-				return false, nil
-			}
+		branch := ev.ObjectAttributes.TargetBranch
+		if !MatchBranch(matchRepo, config.HookEventPr, branch) {
+			return false, nil
 		}
 
-		hookRepo.Branch = ev.ObjectAttributes.TargetBranch
+		hookRepo.Branch = branch
 
 		if ev.ObjectAttributes.State == "opened" {
 			var changedFiles []string

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_testing_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_testing_task.go
@@ -17,7 +17,6 @@ limitations under the License.
 package webhook
 
 import (
-	"regexp"
 	"strconv"
 
 	"github.com/hashicorp/go-multierror"
@@ -79,17 +78,11 @@ func (gpem *gitlabPushEventMatcherForTesting) Match(hookRepo *commonmodels.MainH
 	if !EventConfigured(hookRepo, config.HookEventPush) {
 		return false, nil
 	}
-	isRegular := hookRepo.IsRegular
-	if !isRegular && hookRepo.Branch != getBranchFromRef(ev.Ref) {
+	branch := getBranchFromRef(ev.Ref)
+	if !MatchBranch(hookRepo, config.HookEventPush, branch) {
 		return false, nil
 	}
-
-	if isRegular {
-		if matched, _ := regexp.MatchString(hookRepo.Branch, getBranchFromRef(ev.Ref)); !matched {
-			return false, nil
-		}
-	}
-	hookRepo.Branch = getBranchFromRef(ev.Ref)
+	hookRepo.Branch = branch
 	var changedFiles []string
 	for _, commit := range ev.Commits {
 		changedFiles = append(changedFiles, commit.Added...)
@@ -136,16 +129,6 @@ func (gtem gitlabTagEventMatcherForTesting) Match(hookRepo *commonmodels.MainHoo
 
 	if !EventConfigured(hookRepo, config.HookEventTag) {
 		return false, nil
-	}
-	isRegular := hookRepo.IsRegular
-	if !isRegular && hookRepo.Branch != ev.Project.DefaultBranch {
-		return false, nil
-	}
-
-	if isRegular {
-		if matched, _ := regexp.MatchString(hookRepo.Branch, ev.Project.DefaultBranch); !matched {
-			return false, nil
-		}
 	}
 	hookRepo.Branch = ev.Project.DefaultBranch
 
@@ -366,17 +349,11 @@ func (gmem *gitlabMergeEventMatcherForTesting) Match(hookRepo *commonmodels.Main
 		return false, nil
 	}
 
-	isRegular := hookRepo.IsRegular
-	if !isRegular && hookRepo.Branch != ev.ObjectAttributes.TargetBranch {
+	branch := ev.ObjectAttributes.TargetBranch
+	if !MatchBranch(hookRepo, config.HookEventPr, branch) {
 		return false, nil
 	}
-
-	if isRegular {
-		if matched, _ := regexp.MatchString(hookRepo.Branch, ev.ObjectAttributes.TargetBranch); !matched {
-			return false, nil
-		}
-	}
-	hookRepo.Branch = ev.ObjectAttributes.TargetBranch
+	hookRepo.Branch = branch
 
 	if ev.ObjectAttributes.State == "opened" {
 		var changedFiles []string

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_testing_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_testing_task.go
@@ -122,6 +122,7 @@ func (gmem *gitlabTagEventMatcherForTesting) GetHookRepo(hookRepo *commonmodels.
 		RepoOwner:     hookRepo.RepoOwner,
 		RepoNamespace: hookRepo.GetRepoNamespace(),
 		Branch:        hookRepo.Branch,
+		Tag:           hookRepo.Tag,
 		Source:        hookRepo.Source,
 	}
 }
@@ -147,6 +148,13 @@ func (gtem gitlabTagEventMatcherForTesting) Match(hookRepo *commonmodels.MainHoo
 		}
 	}
 	hookRepo.Branch = ev.Project.DefaultBranch
+
+	tag := getTagFromRef(ev.Ref)
+	if !MatchTag(hookRepo, tag) {
+		return false, nil
+	}
+
+	hookRepo.Tag = tag
 	return true, nil
 }
 

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflow_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflow_task.go
@@ -74,14 +74,8 @@ func (gmem *gitlabMergeEventMatcher) Match(hookRepo *commonmodels.MainHookRepo) 
 			return false, nil
 		}
 	} else {
-		isRegular := hookRepo.IsRegular
-		if !isRegular && hookRepo.Branch != ev.ObjectAttributes.TargetBranch {
+		if !MatchBranch(hookRepo, config.HookEventPr, ev.ObjectAttributes.TargetBranch) {
 			return false, nil
-		}
-		if isRegular {
-			if matched, _ := regexp.MatchString(hookRepo.Branch, ev.ObjectAttributes.TargetBranch); !matched {
-				return false, nil
-			}
 		}
 	}
 	hookRepo.Branch = ev.ObjectAttributes.TargetBranch
@@ -200,14 +194,8 @@ func (gpem *gitlabPushEventMatcher) Match(hookRepo *commonmodels.MainHookRepo) (
 			return false, nil
 		}
 	} else {
-		isRegular := hookRepo.IsRegular
-		if !isRegular && hookRepo.Branch != getBranchFromRef(ev.Ref) {
+		if !MatchBranch(hookRepo, config.HookEventPush, getBranchFromRef(ev.Ref)) {
 			return false, nil
-		}
-		if isRegular {
-			if matched, _ := regexp.MatchString(hookRepo.Branch, getBranchFromRef(ev.Ref)); !matched {
-				return false, nil
-			}
 		}
 	}
 
@@ -306,8 +294,13 @@ func (gtem gitlabTagEventMatcher) Match(hookRepo *commonmodels.MainHookRepo) (bo
 		return false, nil
 	}
 
+	tag := getTagFromRef(ev.Ref)
+	if !MatchTag(hookRepo, tag) {
+		return false, nil
+	}
+
 	hookRepo.Committer = ev.UserName
-	hookRepo.Tag = getTagFromRef(ev.Ref)
+	hookRepo.Tag = tag
 
 	return true, nil
 }

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflowv4_task.go
@@ -255,8 +255,13 @@ func (gtem gitlabTagEventMatcherForWorkflowV4) Match(hookRepo *commonmodels.Main
 		return false, nil
 	}
 
+	tag := getTagFromRef(ev.Ref)
+	if !MatchTag(hookRepo, tag) {
+		return false, nil
+	}
+
 	hookRepo.Committer = ev.UserName
-	hookRepo.Tag = getTagFromRef(ev.Ref)
+	hookRepo.Tag = tag
 
 	return true, nil
 }

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflowv4_task.go
@@ -71,14 +71,8 @@ func (gmem *gitlabMergeEventMatcherForWorkflowV4) Match(hookRepo *commonmodels.M
 			return false, nil
 		}
 	} else {
-		isRegular := hookRepo.IsRegular
-		if !isRegular && hookRepo.Branch != ev.ObjectAttributes.TargetBranch {
+		if !MatchBranch(hookRepo, config.HookEventPr, ev.ObjectAttributes.TargetBranch) {
 			return false, nil
-		}
-		if isRegular {
-			if matched, _ := regexp.MatchString(hookRepo.Branch, ev.ObjectAttributes.TargetBranch); !matched {
-				return false, nil
-			}
 		}
 	}
 	hookRepo.Branch = ev.ObjectAttributes.TargetBranch
@@ -170,14 +164,8 @@ func (gpem *gitlabPushEventMatcherForWorkflowV4) Match(hookRepo *commonmodels.Ma
 			return false, nil
 		}
 	} else {
-		isRegular := hookRepo.IsRegular
-		if !isRegular && hookRepo.Branch != getBranchFromRef(ev.Ref) {
+		if !MatchBranch(hookRepo, config.HookEventPush, getBranchFromRef(ev.Ref)) {
 			return false, nil
-		}
-		if isRegular {
-			if matched, _ := regexp.MatchString(hookRepo.Branch, getBranchFromRef(ev.Ref)); !matched {
-				return false, nil
-			}
 		}
 	}
 

--- a/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -499,6 +500,19 @@ func MatchChanges(m *commonmodels.MainHookRepo, files []string) bool {
 		}
 	}
 	return false
+}
+
+func MatchTag(m *commonmodels.MainHookRepo, tag string) bool {
+	if m.Tag == "" {
+		return true
+	}
+
+	if !m.TagIsRegular {
+		return m.Tag == tag
+	}
+
+	matched, err := regexp.MatchString(m.Tag, tag)
+	return err == nil && matched
 }
 
 func ConvertScanningHookToMainHookRepo(hook *commonmodels.ScanningHook) *commonmodels.MainHookRepo {

--- a/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
@@ -517,10 +517,12 @@ func ConvertScanningHookToMainHookRepo(hook *commonmodels.ScanningHook) *commonm
 		RepoOwner:    hook.RepoOwner,
 		RepoName:     hook.RepoName,
 		Branch:       hook.Branch,
+		Tag:          hook.Tag,
 		MatchFolders: hook.MatchFolders,
 		CodehostID:   hook.CodehostID,
 		Events:       hook.Events,
 		IsRegular:    hook.IsRegular,
+		TagIsRegular: hook.TagIsRegular,
 	}
 }
 

--- a/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
@@ -503,12 +503,8 @@ func MatchChanges(m *commonmodels.MainHookRepo, files []string) bool {
 }
 
 func MatchTag(m *commonmodels.MainHookRepo, tag string) bool {
-	if m.Tag == "" {
+	if !m.TagIsRegular || m.Tag == "" {
 		return true
-	}
-
-	if !m.TagIsRegular {
-		return m.Tag == tag
 	}
 
 	matched, err := regexp.MatchString(m.Tag, tag)

--- a/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/utils.go
@@ -511,18 +511,47 @@ func MatchTag(m *commonmodels.MainHookRepo, tag string) bool {
 	return err == nil && matched
 }
 
+func MatchBranch(m *commonmodels.MainHookRepo, event config.HookEventType, branch string) bool {
+	configuredBranch, isRegular := branchConfigForEvent(m, event)
+	if !isRegular {
+		return configuredBranch == branch
+	}
+
+	matched, err := regexp.MatchString(configuredBranch, branch)
+	return err == nil && matched
+}
+
+func branchConfigForEvent(m *commonmodels.MainHookRepo, event config.HookEventType) (string, bool) {
+	switch event {
+	case config.HookEventPush:
+		if m.PushBranch != "" {
+			return m.PushBranch, m.PushIsRegular
+		}
+	case config.HookEventPr:
+		if m.PrBranch != "" {
+			return m.PrBranch, m.PrIsRegular
+		}
+	}
+
+	return m.Branch, m.IsRegular
+}
+
 func ConvertScanningHookToMainHookRepo(hook *commonmodels.ScanningHook) *commonmodels.MainHookRepo {
 	return &commonmodels.MainHookRepo{
-		Source:       hook.Source,
-		RepoOwner:    hook.RepoOwner,
-		RepoName:     hook.RepoName,
-		Branch:       hook.Branch,
-		Tag:          hook.Tag,
-		MatchFolders: hook.MatchFolders,
-		CodehostID:   hook.CodehostID,
-		Events:       hook.Events,
-		IsRegular:    hook.IsRegular,
-		TagIsRegular: hook.TagIsRegular,
+		Source:        hook.Source,
+		RepoOwner:     hook.RepoOwner,
+		RepoName:      hook.RepoName,
+		Branch:        hook.Branch,
+		PushBranch:    hook.PushBranch,
+		PrBranch:      hook.PrBranch,
+		Tag:           hook.Tag,
+		MatchFolders:  hook.MatchFolders,
+		CodehostID:    hook.CodehostID,
+		Events:        hook.Events,
+		IsRegular:     hook.IsRegular,
+		PushIsRegular: hook.PushIsRegular,
+		PrIsRegular:   hook.PrIsRegular,
+		TagIsRegular:  hook.TagIsRegular,
 	}
 }
 


### PR DESCRIPTION
### What this PR does / Why we need it:

This PR adds regex matching support for Workflow V4 Git tag triggers.
Previously, when a Git tag event was enabled, any pushed tag could trigger the workflow. Users could configure regex matching for target branches, but tag trigger matching did not support an independent regex mode. 

### What is changed and how it works?

Added tag_is_regular to MainHookRepo to represent whether the configured tag should be treated as a regex.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4764)
<!-- Reviewable:end -->
