### PR TITLE
fix: add permission for reordering release jobs in update release plan.

### DIFF
--- a/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
@@ -174,7 +174,7 @@ func UpdateReleasePlan(c *gin.Context) {
 			permitted = ctx.Resources.SystemActions.ReleasePlan.EditMetadata
 		case service.ActionUpdateApproval, service.ActionDeleteApproval:
 			permitted = ctx.Resources.SystemActions.ReleasePlan.EditApproval
-		case service.ActionUpdateReleaseJob, service.ActionCreateReleaseJob, service.ActionDeleteReleaseJob:
+		case service.ActionUpdateReleaseJob, service.ActionCreateReleaseJob, service.ActionDeleteReleaseJob, service.ActionReorderReleaseJob:
 			permitted = ctx.Resources.SystemActions.ReleasePlan.EditSubtasks
 		default:
 			ctx.RespErr = e.ErrInvalidParam.AddDesc(fmt.Sprintf("unknown verb: %s", req.Verb))


### PR DESCRIPTION
### What this PR does / Why we need it:

Non-admin users hit "unknown verb: reorder_release_job" when moving release jobs, even if they had EditSubtasks permission. The permission switch did not include the reorder verb, so the request failed before checking the existing subtask edit permission.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4799)
<!-- Reviewable:end -->
