### PR TITLE
fix: sync product update_by with update_time

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/product.go
@@ -391,11 +391,11 @@ func (c *ProductColl) Delete(owner, productName string) error {
 
 func (c *ProductColl) UpdateGlobalVariable(args *models.Product) error {
 	query := bson.M{"env_name": args.EnvName, "product_name": args.ProductName}
-	changePayload := bson.M{
+	change := bson.M{"$set": bson.M{
 		"update_time":      time.Now().Unix(),
+		"update_by":        args.UpdateBy,
 		"global_variables": args.GlobalVariables,
-	}
-	change := bson.M{"$set": changePayload}
+	}}
 	_, err := c.UpdateOne(mongotool.SessionContext(context.TODO(), c.Session), query, change)
 	return err
 }
@@ -405,6 +405,7 @@ func (c *ProductColl) Update(args *models.Product) error {
 	query := bson.M{"env_name": args.EnvName, "product_name": args.ProductName}
 	changePayload := bson.M{
 		"update_time":      time.Now().Unix(),
+		"update_by":        args.UpdateBy,
 		"services":         args.Services,
 		"status":           args.Status,
 		"revision":         args.Revision,
@@ -445,7 +446,7 @@ func (c *ProductColl) Create(args *models.Product) error {
 
 // @todo UpdateGroup needs to be optimized
 // Service info may be override when updating multiple services in same group at the sametime
-func (c *ProductColl) UpdateServicesGroup(productName, envName string, groupIndex int, group []*models.ProductService) error {
+func (c *ProductColl) UpdateServicesGroup(productName, envName string, groupIndex int, group []*models.ProductService, updateBy string) error {
 	serviceGroup := fmt.Sprintf("services.%d", groupIndex)
 	query := bson.M{
 		"env_name":     envName,
@@ -453,6 +454,7 @@ func (c *ProductColl) UpdateServicesGroup(productName, envName string, groupInde
 	}
 	change := bson.M{
 		"update_time": time.Now().Unix(),
+		"update_by":   updateBy,
 		serviceGroup:  group,
 	}
 
@@ -463,13 +465,14 @@ func (c *ProductColl) UpdateServicesGroup(productName, envName string, groupInde
 
 // @todo UpdateServices needs to be optimized
 // Service info may be override when updating multiple services at the sametime
-func (c *ProductColl) UpdateAllServices(productName, envName string, services [][]*models.ProductService) error {
+func (c *ProductColl) UpdateAllServices(productName, envName string, services [][]*models.ProductService, updateBy string) error {
 	query := bson.M{
 		"env_name":     envName,
 		"product_name": productName,
 	}
 	change := bson.M{
 		"update_time": time.Now().Unix(),
+		"update_by":   updateBy,
 		"services":    services,
 	}
 
@@ -480,7 +483,7 @@ func (c *ProductColl) UpdateAllServices(productName, envName string, services []
 
 // Note: Only use for update a service
 // UpdateOneService updates a specific service in a group by its index
-func (c *ProductColl) UpdateOneService(productName, envName string, groupIndex, serviceIndex int, service *models.ProductService) error {
+func (c *ProductColl) UpdateOneService(productName, envName string, groupIndex, serviceIndex int, service *models.ProductService, updateBy string) error {
 	servicePath := fmt.Sprintf("services.%d.%d", groupIndex, serviceIndex)
 	query := bson.M{
 		"env_name":     envName,
@@ -488,12 +491,11 @@ func (c *ProductColl) UpdateOneService(productName, envName string, groupIndex, 
 		fmt.Sprintf("%s.service_name", servicePath): service.ServiceName, // ensure service_name equals
 		servicePath: bson.M{"$exists": true}, // ensure the service exists
 	}
-	change := bson.M{
-		"$set": bson.M{
-			servicePath:   service,
-			"update_time": time.Now().Unix(),
-		},
-	}
+	change := bson.M{"$set": bson.M{
+		"update_time": time.Now().Unix(),
+		"update_by":   updateBy,
+		servicePath:   service,
+	}}
 
 	result, err := c.UpdateOne(mongotool.SessionContext(context.TODO(), c.Session), query, change)
 	if err != nil {
@@ -509,19 +511,18 @@ func (c *ProductColl) UpdateOneService(productName, envName string, groupIndex, 
 
 // Note: Only use for add a service
 // AddOneService adds a specific service in a group by its index if it does not already exist
-func (c *ProductColl) AddOneService(productName, envName string, groupIndex, serviceIndex int, service *models.ProductService) error {
+func (c *ProductColl) AddOneService(productName, envName string, groupIndex, serviceIndex int, service *models.ProductService, updateBy string) error {
 	servicePath := fmt.Sprintf("services.%d.%d", groupIndex, serviceIndex)
 	query := bson.M{
 		"env_name":     envName,
 		"product_name": productName,
 		servicePath:    bson.M{"$exists": false}, // ensure the service does not exist
 	}
-	change := bson.M{
-		"$set": bson.M{
-			servicePath:   service,
-			"update_time": time.Now().Unix(),
-		},
-	}
+	change := bson.M{"$set": bson.M{
+		"update_time": time.Now().Unix(),
+		"update_by":   updateBy,
+		servicePath:   service,
+	}}
 
 	result, err := c.UpdateOne(mongotool.SessionContext(context.TODO(), c.Session), query, change)
 	if err != nil {
@@ -535,13 +536,14 @@ func (c *ProductColl) AddOneService(productName, envName string, groupIndex, ser
 	return nil
 }
 
-func (c *ProductColl) UpdateDeployStrategyAndGlobalVariable(envName, productName string, deployStrategy map[string]setting.ServiceDeployStrategy, globalVariables []*types.GlobalVariableKV) error {
+func (c *ProductColl) UpdateDeployStrategyAndGlobalVariable(envName, productName string, deployStrategy map[string]setting.ServiceDeployStrategy, globalVariables []*types.GlobalVariableKV, updateBy string) error {
 	query := bson.M{
 		"env_name":     envName,
 		"product_name": productName,
 	}
 	change := bson.M{
 		"update_time":             time.Now().Unix(),
+		"update_by":               updateBy,
 		"global_variables":        globalVariables,
 		"service_deploy_strategy": deployStrategy,
 	}
@@ -551,13 +553,14 @@ func (c *ProductColl) UpdateDeployStrategyAndGlobalVariable(envName, productName
 	return err
 }
 
-func (c *ProductColl) UpdateDeployStrategy(envName, productName string, deployStrategy map[string]setting.ServiceDeployStrategy) error {
+func (c *ProductColl) UpdateDeployStrategy(envName, productName string, deployStrategy map[string]setting.ServiceDeployStrategy, updateBy string) error {
 	query := bson.M{
 		"env_name":     envName,
 		"product_name": productName,
 	}
 	change := bson.M{
 		"update_time":             time.Now().Unix(),
+		"update_by":               updateBy,
 		"service_deploy_strategy": deployStrategy,
 	}
 
@@ -600,10 +603,11 @@ func (c *ProductColl) UpdateProductAlias(envName, productName, alias string) err
 	return err
 }
 
-func (c *ProductColl) UpdateIsPublic(envName, productName string, isPublic bool) error {
+func (c *ProductColl) UpdateIsPublic(envName, productName string, isPublic bool, updateBy string) error {
 	query := bson.M{"env_name": envName, "product_name": productName}
 	change := bson.M{"$set": bson.M{
 		"update_time": time.Now().Unix(),
+		"update_by":   updateBy,
 		"is_public":   isPublic,
 	}}
 	_, err := c.UpdateOne(context.TODO(), query, change)
@@ -611,10 +615,11 @@ func (c *ProductColl) UpdateIsPublic(envName, productName string, isPublic bool)
 	return err
 }
 
-func (c *ProductColl) UpdateIstioGrayscale(envName, productName string, istioGrayscale models.IstioGrayscale) error {
+func (c *ProductColl) UpdateIstioGrayscale(envName, productName string, istioGrayscale models.IstioGrayscale, updateBy string) error {
 	query := bson.M{"env_name": envName, "product_name": productName}
 	change := bson.M{"$set": bson.M{
 		"update_time":     time.Now().Unix(),
+		"update_by":       updateBy,
 		"istio_grayscale": istioGrayscale,
 	}}
 	_, err := c.UpdateOne(context.TODO(), query, change)
@@ -741,13 +746,14 @@ func (c *ProductColl) ListEnvByNamespace(clusterID, namespace string) ([]*models
 	return resp, nil
 }
 
-func (c *ProductColl) UpdateConfigs(envName, productName string, analysisConfig *models.AnalysisConfig, notificationConfigs []*models.NotificationConfig) error {
+func (c *ProductColl) UpdateConfigs(envName, productName string, analysisConfig *models.AnalysisConfig, notificationConfigs []*models.NotificationConfig, updateBy string) error {
 	query := bson.M{"env_name": envName, "product_name": productName}
 
 	change := bson.M{"$set": bson.M{
 		"analysis_config":      analysisConfig,
 		"notification_configs": notificationConfigs,
 		"update_time":          time.Now().Unix(),
+		"update_by":            updateBy,
 	}}
 	_, err := c.UpdateOne(context.TODO(), query, change)
 

--- a/pkg/microservice/aslan/core/common/service/helm/helm.go
+++ b/pkg/microservice/aslan/core/common/service/helm/helm.go
@@ -210,6 +210,7 @@ func UpdateServiceInEnv(product *commonmodels.Product, productSvc *commonmodels.
 		}
 	}
 
+	newProductInfo.UpdateBy = user
 	if err = productColl.Update(newProductInfo); err != nil {
 		log.Errorf("update product %s error: %s", newProductInfo.ProductName, err.Error())
 		mongo.AbortTransaction(session)
@@ -220,7 +221,7 @@ func UpdateServiceInEnv(product *commonmodels.Product, productSvc *commonmodels.
 }
 
 // Update all services in environment
-func UpdateAllServicesInEnv(productName, envName string, services [][]*models.ProductService, production bool) error {
+func UpdateAllServicesInEnv(productName, envName string, services [][]*models.ProductService, production bool, updateBy string) error {
 	session := mongo.Session()
 	defer session.EndSession(context.TODO())
 
@@ -275,7 +276,7 @@ func UpdateAllServicesInEnv(productName, envName string, services [][]*models.Pr
 		newServices[len(newServices)-1] = append(newServices[len(newServices)-1], service)
 	}
 
-	if err = productColl.UpdateAllServices(productName, envName, newServices); err != nil {
+	if err = productColl.UpdateAllServices(productName, envName, newServices, updateBy); err != nil {
 		err = fmt.Errorf("failed to update %s/%s product services, err %s", productName, envName, err)
 		mongo.AbortTransaction(session)
 		log.Error(err)
@@ -286,7 +287,7 @@ func UpdateAllServicesInEnv(productName, envName string, services [][]*models.Pr
 }
 
 // Update a services group in environment
-func UpdateServicesGroupInEnv(productName, envName string, index int, group []*models.ProductService, production bool) error {
+func UpdateServicesGroupInEnv(productName, envName string, index int, group []*models.ProductService, production bool, updateBy string) error {
 	session := mongo.Session()
 	defer session.EndSession(context.TODO())
 
@@ -357,7 +358,7 @@ func UpdateServicesGroupInEnv(productName, envName string, index int, group []*m
 		}
 	}
 
-	if err = productColl.UpdateServicesGroup(productName, envName, index, newGroup); err != nil {
+	if err = productColl.UpdateServicesGroup(productName, envName, index, newGroup, updateBy); err != nil {
 		err = fmt.Errorf("failed to update %s/%s product services, err %s", productName, envName, err)
 		mongo.AbortTransaction(session)
 		log.Error(err)

--- a/pkg/microservice/aslan/core/common/service/kube/helm.go
+++ b/pkg/microservice/aslan/core/common/service/kube/helm.go
@@ -375,7 +375,7 @@ func DeleteHelmReleaseFromEnv(userName, requestID string, productInfo *commonmod
 		newSevices = append(newSevices, group)
 	}
 	productInfo.Services = newSevices
-	err = helmservice.UpdateAllServicesInEnv(productInfo.ProductName, productInfo.EnvName, productInfo.Services, productInfo.Production)
+	err = helmservice.UpdateAllServicesInEnv(productInfo.ProductName, productInfo.EnvName, productInfo.Services, productInfo.Production, userName)
 	if err != nil {
 		log.Errorf("UpdateHelmProductServices error: %v", err)
 		return err
@@ -396,7 +396,7 @@ func DeleteHelmReleaseFromEnv(userName, requestID string, productInfo *commonmod
 		delete(productInfo.ServiceDeployStrategy, commonutil.GetReleaseDeployStrategyKey(prodSvc.ReleaseName))
 	}
 
-	err = commonrepo.NewProductColl().UpdateDeployStrategy(productInfo.EnvName, productInfo.ProductName, productInfo.ServiceDeployStrategy)
+	err = commonrepo.NewProductColl().UpdateDeployStrategy(productInfo.EnvName, productInfo.ProductName, productInfo.ServiceDeployStrategy, userName)
 	if err != nil {
 		log.Errorf("failed to update product deploy strategy, err: %s", err)
 	}
@@ -508,7 +508,7 @@ func DeleteHelmServiceFromEnv(userName, requestID string, productInfo *commonmod
 		newServices = append(newServices, group)
 	}
 	productInfo.Services = newServices
-	err = helmservice.UpdateAllServicesInEnv(productInfo.ProductName, productInfo.EnvName, productInfo.Services, productInfo.Production)
+	err = helmservice.UpdateAllServicesInEnv(productInfo.ProductName, productInfo.EnvName, productInfo.Services, productInfo.Production, userName)
 	if err != nil {
 		err = fmt.Errorf("UpdateHelmProductServices error: %v", err)
 		log.Error(err)
@@ -527,7 +527,7 @@ func DeleteHelmServiceFromEnv(userName, requestID string, productInfo *commonmod
 	for _, singleName := range serviceNames {
 		delete(productInfo.ServiceDeployStrategy, singleName)
 	}
-	err = commonrepo.NewProductColl().UpdateDeployStrategy(productInfo.EnvName, productInfo.ProductName, productInfo.ServiceDeployStrategy)
+	err = commonrepo.NewProductColl().UpdateDeployStrategy(productInfo.EnvName, productInfo.ProductName, productInfo.ServiceDeployStrategy, userName)
 	if err != nil {
 		log.Errorf("failed to update product deploy strategy, err: %s", err)
 	}
@@ -918,7 +918,7 @@ func DeployMultiHelmRelease(productResp *commonmodels.Product, helmClient *helmt
 			errList = multierror.Append(errList, groupServiceErr...)
 		}
 
-		err := helmservice.UpdateServicesGroupInEnv(productName, envName, groupIndex, groupServices, productResp.Production)
+		err := helmservice.UpdateServicesGroupInEnv(productName, envName, groupIndex, groupServices, productResp.Production, user)
 		if err != nil {
 			log.Errorf("failed to UpdateHelmProductServices %s/%s, error: %v", productName, envName, err)
 			mongotool.AbortTransaction(session)

--- a/pkg/microservice/aslan/core/common/service/kube/istio_grayscale.go
+++ b/pkg/microservice/aslan/core/common/service/kube/istio_grayscale.go
@@ -1121,7 +1121,7 @@ type SetIstioGrayscaleConfigRequest struct {
 	HeaderMatchConfigs []commonmodels.IstioHeaderMatchConfig `bson:"header_match_configs" json:"header_match_configs"`
 }
 
-func SetIstioGrayscaleConfig(ctx context.Context, envName, productName string, req SetIstioGrayscaleConfigRequest) error {
+func SetIstioGrayscaleConfig(ctx context.Context, envName, productName, userName string, req SetIstioGrayscaleConfigRequest) error {
 	opt := &commonrepo.ProductFindOptions{Name: productName, EnvName: envName, Production: boolptr.True()}
 	baseEnv, err := commonrepo.NewProductColl().Find(opt)
 	if err != nil {
@@ -1179,7 +1179,7 @@ func SetIstioGrayscaleConfig(ctx context.Context, envName, productName string, r
 	baseEnv.IstioGrayscale.WeightConfigs = req.WeightConfigs
 	baseEnv.IstioGrayscale.HeaderMatchConfigs = req.HeaderMatchConfigs
 
-	err = commonrepo.NewProductColl().UpdateIstioGrayscale(baseEnv.EnvName, baseEnv.ProductName, baseEnv.IstioGrayscale)
+	err = commonrepo.NewProductColl().UpdateIstioGrayscale(baseEnv.EnvName, baseEnv.ProductName, baseEnv.IstioGrayscale, userName)
 	if err != nil {
 		return fmt.Errorf("failed to update istio grayscale config of %s/%s environment: %s", baseEnv.ProductName, baseEnv.EnvName, err)
 	}

--- a/pkg/microservice/aslan/core/common/service/version.go
+++ b/pkg/microservice/aslan/core/common/service/version.go
@@ -568,6 +568,7 @@ func RollbackEnvServiceVersion(ctx *internalhandler.Context, projectName, envNam
 				}
 				globalKV.RelatedServices = relatedServiceSet.List()
 			}
+			env.UpdateBy = ctx.UserName
 			err = commonrepo.NewProductCollWithSession(session).UpdateGlobalVariable(env)
 			if err != nil {
 				mongotool.AbortTransaction(session)

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_env.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_env.go
@@ -209,6 +209,7 @@ func UpdateProductServiceDeployInfo(deployInfo *ProductServiceDeployInfo) error 
 		}
 	}
 
+	productInfo.UpdateBy = deployInfo.UserName
 	err = commonrepo.NewProductCollWithSession(session).Update(productInfo)
 	if err != nil {
 		mongo.AbortTransaction(session)

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_update_env_istio_config.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_update_env_istio_config.go
@@ -62,7 +62,7 @@ func (c *UpdateEnvIstioConfigJobCtl) Run(ctx context.Context) {
 		WeightConfigs:      c.jobTaskSpec.WeightConfigs,
 		HeaderMatchConfigs: c.jobTaskSpec.HeaderMatchConfigs,
 	}
-	err := kube.SetIstioGrayscaleConfig(context.TODO(), c.jobTaskSpec.BaseEnv, c.workflowCtx.ProjectName, req)
+	err := kube.SetIstioGrayscaleConfig(context.TODO(), c.jobTaskSpec.BaseEnv, c.workflowCtx.ProjectName, c.workflowCtx.WorkflowTaskCreatorUsername, req)
 	if err != nil {
 		c.Errorf("Failed to set istio config, error: %v", err)
 		return

--- a/pkg/microservice/aslan/core/common/util/enviroment.go
+++ b/pkg/microservice/aslan/core/common/util/enviroment.go
@@ -213,6 +213,7 @@ func UpdateProductImage(envName, productName, serviceName string, targets map[st
 		log.Errorf("service %s not found in prod %s/%s", serviceName, prod.ProductName, prod.EnvName)
 	}
 
+	prod.UpdateBy = userName
 	if err := commonrepo.NewProductCollWithSession(session).Update(prod); err != nil {
 		errMsg := fmt.Sprintf("[%s][%s] update product image error: %v", prod.EnvName, prod.ProductName, err)
 		logger.Errorf(errMsg)

--- a/pkg/microservice/aslan/core/environment/handler/environment.go
+++ b/pkg/microservice/aslan/core/environment/handler/environment.go
@@ -2193,7 +2193,7 @@ func UpdateEnvConfigs(c *gin.Context) {
 		return
 	}
 
-	ctx.RespErr = service.UpdateEnvConfigs(projectKey, envName, arg, &production, ctx.Logger)
+	ctx.RespErr = service.UpdateEnvConfigs(projectKey, envName, ctx.UserName, arg, &production, ctx.Logger)
 }
 
 // @Summary Run environment Analysis
@@ -2550,7 +2550,7 @@ func EnvSleep(c *gin.Context) {
 		return
 	}
 
-	ctx.RespErr = service.EnvSleep(projectName, envName, action == "enable", production, ctx.Logger)
+	ctx.RespErr = service.EnvSleep(projectName, envName, action == "enable", production, ctx.UserName, ctx.Logger)
 }
 
 // @Summary Get Env Sleep Cron

--- a/pkg/microservice/aslan/core/environment/handler/istio_grayscale.go
+++ b/pkg/microservice/aslan/core/environment/handler/istio_grayscale.go
@@ -77,7 +77,7 @@ func EnableIstioGrayscale(c *gin.Context) {
 		return
 	}
 
-	ctx.RespErr = service.EnableIstioGrayscale(c, envName, projectKey)
+	ctx.RespErr = service.EnableIstioGrayscale(c, envName, projectKey, ctx.UserName)
 }
 
 // @Summary Disable Istio Grayscale
@@ -126,7 +126,7 @@ func DisableIstioGrayscale(c *gin.Context) {
 		}
 	}
 
-	ctx.RespErr = service.DisableIstioGrayscale(c, envName, projectKey)
+	ctx.RespErr = service.DisableIstioGrayscale(c, envName, projectKey, ctx.UserName)
 }
 
 // @Summary Check Istio Grayscale Ready
@@ -278,7 +278,7 @@ func SetIstioGrayscaleConfig(c *gin.Context) {
 		return
 	}
 
-	ctx.RespErr = service.SetIstioGrayscaleConfig(c, envName, projectKey, req)
+	ctx.RespErr = service.SetIstioGrayscaleConfig(c, envName, projectKey, ctx.UserName, req)
 }
 
 // @Summary Get Portal Service for Istio Grayscale

--- a/pkg/microservice/aslan/core/environment/handler/openapi.go
+++ b/pkg/microservice/aslan/core/environment/handler/openapi.go
@@ -1904,7 +1904,7 @@ func OpenAPIEnableBaseEnv(c *gin.Context) {
 		return
 	}
 
-	ctx.RespErr = service.EnableBaseEnv(c, envName, projectKey)
+	ctx.RespErr = service.EnableBaseEnv(c, envName, projectKey, ctx.UserName)
 }
 
 func OpenAPIDsiableBaseEnv(c *gin.Context) {
@@ -1949,7 +1949,7 @@ func OpenAPIDsiableBaseEnv(c *gin.Context) {
 		return
 	}
 
-	ctx.RespErr = service.DisableBaseEnv(c, envName, projectKey)
+	ctx.RespErr = service.DisableBaseEnv(c, envName, projectKey, ctx.UserName)
 }
 
 type OpenAPIShareEnvReadyResponse struct {

--- a/pkg/microservice/aslan/core/environment/handler/share_env.go
+++ b/pkg/microservice/aslan/core/environment/handler/share_env.go
@@ -121,7 +121,7 @@ func EnableBaseEnv(c *gin.Context) {
 		return
 	}
 
-	ctx.RespErr = service.EnableBaseEnv(c, envName, projectKey)
+	ctx.RespErr = service.EnableBaseEnv(c, envName, projectKey, ctx.UserName)
 }
 
 func DisableBaseEnv(c *gin.Context) {
@@ -167,7 +167,7 @@ func DisableBaseEnv(c *gin.Context) {
 		return
 	}
 
-	ctx.RespErr = service.DisableBaseEnv(c, envName, projectKey)
+	ctx.RespErr = service.DisableBaseEnv(c, envName, projectKey, ctx.UserName)
 }
 
 func CheckShareEnvReady(c *gin.Context) {

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -876,7 +876,7 @@ func updateProductImpl(updateRevisionSvcs []string, deployStrategy map[string]se
 		}
 		wg.Wait()
 
-		err = helmservice.UpdateServicesGroupInEnv(productName, envName, groupIndex, groupSvcs, updateProd.Production)
+		err = helmservice.UpdateServicesGroupInEnv(productName, envName, groupIndex, groupSvcs, updateProd.Production, user)
 		if err != nil {
 			log.Errorf("Failed to update %s/%s - service group %d. Error: %v", productName, envName, groupIndex, err)
 			err = e.ErrUpdateEnv.AddDesc(err.Error())
@@ -885,6 +885,7 @@ func updateProductImpl(updateRevisionSvcs []string, deployStrategy map[string]se
 		}
 	}
 
+	updateProd.UpdateBy = user
 	err = commonrepo.NewProductCollWithSession(session).UpdateGlobalVariable(updateProd)
 	if err != nil {
 		log.Errorf("failed to update product globalvariable error: %v", err)
@@ -902,7 +903,7 @@ func updateProductImpl(updateRevisionSvcs []string, deployStrategy map[string]se
 				existedProd.ServiceDeployStrategy[k] = v
 			}
 		}
-		err = commonrepo.NewProductCollWithSession(session).UpdateDeployStrategy(envName, productName, existedProd.ServiceDeployStrategy)
+		err = commonrepo.NewProductCollWithSession(session).UpdateDeployStrategy(envName, productName, existedProd.ServiceDeployStrategy, user)
 		if err != nil {
 			log.Errorf("Failed to update deploy strategy data, error: %v", err)
 			err = e.ErrUpdateEnv.AddDesc(err.Error())
@@ -2185,7 +2186,7 @@ func UpdateProductVariable(productName, envName, username, requestID string, upd
 	}
 
 	if needUpdateStrategy {
-		err = commonrepo.NewProductColl().UpdateDeployStrategy(envName, productResp.ProductName, productResp.ServiceDeployStrategy)
+		err = commonrepo.NewProductColl().UpdateDeployStrategy(envName, productResp.ProductName, productResp.ServiceDeployStrategy, username)
 		if err != nil {
 			log.Errorf("[%s][P:%s] failed to update product deploy strategy: %s", productResp.EnvName, productResp.ProductName, err)
 			if syncLock != nil {
@@ -2627,7 +2628,7 @@ func DeleteProductServices(userName, requestID, envName, productName string, ser
 	if getProjectType(productName) == setting.HelmDeployType {
 		return deleteHelmProductServices(userName, requestID, productInfo, serviceNames, isDelete, log)
 	}
-	return deleteK8sProductServices(productInfo, serviceNames, isDelete, log)
+	return deleteK8sProductServices(userName, productInfo, serviceNames, isDelete, log)
 }
 
 func DeleteProductHelmReleases(userName, requestID, envName, productName string, releases []string, production, isDelete bool, log *zap.SugaredLogger) (err error) {
@@ -2643,7 +2644,7 @@ func deleteHelmProductServices(userName, requestID string, productInfo *commonmo
 	return kube.DeleteHelmServiceFromEnv(userName, requestID, productInfo, serviceNames, isDelete, log)
 }
 
-func deleteK8sProductServices(productInfo *commonmodels.Product, serviceNames []string, isDelete bool, log *zap.SugaredLogger) error {
+func deleteK8sProductServices(userName string, productInfo *commonmodels.Product, serviceNames []string, isDelete bool, log *zap.SugaredLogger) error {
 	serviceRelatedYaml := make(map[string]string)
 	for _, service := range productInfo.GetServiceMap() {
 		if !commonutil.ServiceIsDeployed(service.ServiceName, productInfo.ServiceDeployStrategy) || !isDelete {
@@ -2674,7 +2675,7 @@ func deleteK8sProductServices(productInfo *commonmodels.Product, serviceNames []
 		}
 		newServices = append(newServices, group)
 	}
-	err := helmservice.UpdateAllServicesInEnv(productInfo.ProductName, productInfo.EnvName, newServices, productInfo.Production)
+	err := helmservice.UpdateAllServicesInEnv(productInfo.ProductName, productInfo.EnvName, newServices, productInfo.Production, userName)
 	if err != nil {
 		log.Errorf("failed to UpdateHelmProductServices %s/%s, error: %v", productInfo.ProductName, productInfo.EnvName, err)
 		return err
@@ -2686,7 +2687,7 @@ func deleteK8sProductServices(productInfo *commonmodels.Product, serviceNames []
 	for _, singleName := range serviceNames {
 		delete(productInfo.ServiceDeployStrategy, singleName)
 	}
-	err = commonrepo.NewProductColl().UpdateDeployStrategyAndGlobalVariable(productInfo.EnvName, productInfo.ProductName, productInfo.ServiceDeployStrategy, productInfo.GlobalVariables)
+	err = commonrepo.NewProductColl().UpdateDeployStrategyAndGlobalVariable(productInfo.EnvName, productInfo.ProductName, productInfo.ServiceDeployStrategy, productInfo.GlobalVariables, userName)
 	if err != nil {
 		log.Errorf("failed to update product deploy strategy, err: %s", err)
 	}
@@ -2869,7 +2870,7 @@ func createGroups(user, requestID string, args *commonmodels.Product, eventStart
 			log.Errorf("createGroup error :%+v", err)
 			return
 		}
-		err = helmservice.UpdateServicesGroupInEnv(args.ProductName, args.EnvName, groupIndex, group, args.Production)
+		err = helmservice.UpdateServicesGroupInEnv(args.ProductName, args.EnvName, groupIndex, group, args.Production, user)
 		if err != nil {
 			log.Errorf("Failed to update helm product %s/%s - service group %d. Error: %v", args.ProductName, args.EnvName, groupIndex, err)
 			err = e.ErrUpdateEnv.AddDesc(err.Error())
@@ -3239,7 +3240,7 @@ func updateHelmProductGroup(username, productName, envName string, productResp *
 		}
 	}
 
-	if err = commonrepo.NewProductColl().UpdateDeployStrategy(productResp.EnvName, productResp.ProductName, productResp.ServiceDeployStrategy); err != nil {
+	if err = commonrepo.NewProductColl().UpdateDeployStrategy(productResp.EnvName, productResp.ProductName, productResp.ServiceDeployStrategy, username); err != nil {
 		log.Errorf("Failed to update env, err: %s", err)
 		return err
 	}
@@ -3705,7 +3706,7 @@ func UpdateProductGlobalVariablesWithRender(templateProduct *templatemodels.Prod
 		}
 	}
 	if needUpdateStrategy {
-		err = commonrepo.NewProductColl().UpdateDeployStrategy(product.EnvName, product.ProductName, product.ServiceDeployStrategy)
+		err = commonrepo.NewProductColl().UpdateDeployStrategy(product.EnvName, product.ProductName, product.ServiceDeployStrategy, userName)
 		if err != nil {
 			log.Errorf("[%s][P:%s] failed to update product deploy strategy: %s", product.EnvName, product.ProductName, err)
 			return e.ErrUpdateEnv.AddErr(err)
@@ -3753,7 +3754,7 @@ func GetEnvConfigs(projectName, envName string, production *bool, logger *zap.Su
 	return configs, nil
 }
 
-func UpdateEnvConfigs(projectName, envName string, arg *EnvConfigsArgs, production *bool, logger *zap.SugaredLogger) error {
+func UpdateEnvConfigs(projectName, envName, userName string, arg *EnvConfigsArgs, production *bool, logger *zap.SugaredLogger) error {
 	opt := &commonrepo.ProductFindOptions{
 		EnvName:    envName,
 		Name:       projectName,
@@ -3771,7 +3772,7 @@ func UpdateEnvConfigs(projectName, envName string, arg *EnvConfigsArgs, producti
 		}
 	}
 
-	err = commonrepo.NewProductColl().UpdateConfigs(envName, projectName, arg.AnalysisConfig, arg.NotificationConfigs)
+	err = commonrepo.NewProductColl().UpdateConfigs(envName, projectName, arg.AnalysisConfig, arg.NotificationConfigs, userName)
 	if err != nil {
 		return e.ErrUpdateEnvConfigs.AddErr(fmt.Errorf("failed to update environment %s/%s, err: %w", projectName, envName, err))
 	}
@@ -3783,8 +3784,8 @@ func GetProductionEnvConfigs(projectName, envName string, logger *zap.SugaredLog
 	return GetEnvConfigs(projectName, envName, boolptr.True(), logger)
 }
 
-func UpdateProductionEnvConfigs(projectName, envName string, arg *EnvConfigsArgs, logger *zap.SugaredLogger) error {
-	return UpdateEnvConfigs(projectName, envName, arg, boolptr.True(), logger)
+func UpdateProductionEnvConfigs(projectName, envName, userName string, arg *EnvConfigsArgs, logger *zap.SugaredLogger) error {
+	return UpdateEnvConfigs(projectName, envName, userName, arg, boolptr.True(), logger)
 }
 
 type EnvAnalysisRespone struct {
@@ -4313,7 +4314,7 @@ func EnsureProductionNamespace(createArgs []*CreateSingleProductArg) error {
 	return nil
 }
 
-func EnvSleep(productName, envName string, isEnable, isProduction bool, log *zap.SugaredLogger) error {
+func EnvSleep(productName, envName string, isEnable, isProduction bool, userName string, log *zap.SugaredLogger) error {
 	tempProd, err := templaterepo.NewProductColl().Find(productName)
 	if err != nil {
 		err = fmt.Errorf("failed to find template product %s, err: %s", productName, err)
@@ -4556,6 +4557,7 @@ func EnvSleep(productName, envName string, isEnable, isProduction bool, log *zap
 	}
 
 	prod.PreSleepStatus = newScaleNumMap
+	prod.UpdateBy = userName
 	err = commonrepo.NewProductColl().Update(prod)
 	if err != nil {
 		wrapErr := fmt.Errorf("failed to update product, err: %w", err)

--- a/pkg/microservice/aslan/core/environment/service/environment_update.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_update.go
@@ -61,7 +61,7 @@ func InstallService(helmClient *helmtool.HelmClient, param *kube.ReleaseInstallP
 	return nil
 }
 
-func setProductServiceError(productInfo *commonmodels.Product, serviceName string, err error) error {
+func setProductServiceError(productInfo *commonmodels.Product, serviceName string, err error, updateBy string) error {
 	foundSvc := false
 	// update service revision data in product
 	for _, svcGroup := range productInfo.Services {
@@ -82,7 +82,7 @@ func setProductServiceError(productInfo *commonmodels.Product, serviceName strin
 		}
 	}
 	if foundSvc {
-		err := helmservice.UpdateAllServicesInEnv(productInfo.ProductName, productInfo.EnvName, productInfo.Services, productInfo.Production)
+		err := helmservice.UpdateAllServicesInEnv(productInfo.ProductName, productInfo.EnvName, productInfo.Services, productInfo.Production, updateBy)
 		if err != nil {
 			return fmt.Errorf("failed to update %s/%s product services, err: %s ", productInfo.ProductName, productInfo.EnvName, err)
 		}
@@ -90,7 +90,7 @@ func setProductServiceError(productInfo *commonmodels.Product, serviceName strin
 	return nil
 }
 
-func updateServiceRevisionInProduct(productInfo *commonmodels.Product, serviceName string, serviceRevision int64) error {
+func updateServiceRevisionInProduct(productInfo *commonmodels.Product, serviceName string, serviceRevision int64, updateBy string) error {
 	foundSvc := false
 	// update service revision data in product
 	for _, svcGroup := range productInfo.Services {
@@ -107,7 +107,7 @@ func updateServiceRevisionInProduct(productInfo *commonmodels.Product, serviceNa
 		}
 	}
 	if foundSvc {
-		err := helmservice.UpdateAllServicesInEnv(productInfo.ProductName, productInfo.EnvName, productInfo.Services, productInfo.Production)
+		err := helmservice.UpdateAllServicesInEnv(productInfo.ProductName, productInfo.EnvName, productInfo.Services, productInfo.Production, updateBy)
 		if err != nil {
 			return fmt.Errorf("failed to update %s/%s product services, err: %s ", productInfo.ProductName, productInfo.EnvName, err)
 		}

--- a/pkg/microservice/aslan/core/environment/service/image.go
+++ b/pkg/microservice/aslan/core/environment/service/image.go
@@ -186,6 +186,7 @@ func UpdateContainerImage(requestID, username string, args *UpdateContainerImage
 			return e.ErrUpdateConainterImage.AddErr(err)
 		}
 
+		product.UpdateBy = username
 		if err := commonrepo.NewProductCollWithSession(session).Update(product); err != nil {
 			log.Errorf("[%s] update product %s error: %s", namespace, args.ProductName, err.Error())
 			mongotool.AbortTransaction(session)

--- a/pkg/microservice/aslan/core/environment/service/istio_grayscale.go
+++ b/pkg/microservice/aslan/core/environment/service/istio_grayscale.go
@@ -36,7 +36,7 @@ import (
 	"github.com/koderover/zadig/v2/pkg/util/boolptr"
 )
 
-func EnableIstioGrayscale(ctx context.Context, envName, productName string) error {
+func EnableIstioGrayscale(ctx context.Context, envName, productName, userName string) error {
 	opt := &commonrepo.ProductFindOptions{Name: productName, EnvName: envName}
 	prod, err := commonrepo.NewProductColl().Find(opt)
 	if err != nil {
@@ -77,6 +77,7 @@ func EnableIstioGrayscale(ctx context.Context, envName, productName string) erro
 		return e.ErrEnableIstioGrayscale.AddErr(fmt.Errorf("failed to ensure EnvoyFilter in namespace `%s`: %s", setting.IstioNamespace, err))
 	}
 
+	prod.UpdateBy = userName
 	// 4. Update the environment configuration.
 	err = commonutil.EnsureIstioGrayConfig(ctx, prod)
 	if err != nil {
@@ -86,7 +87,7 @@ func EnableIstioGrayscale(ctx context.Context, envName, productName string) erro
 	return nil
 }
 
-func DisableIstioGrayscale(ctx context.Context, envName, productName string) error {
+func DisableIstioGrayscale(ctx context.Context, envName, productName, userName string) error {
 	opt := &commonrepo.ProductFindOptions{Name: productName, EnvName: envName}
 	prod, err := commonrepo.NewProductColl().Find(opt)
 	if err != nil {
@@ -145,6 +146,7 @@ func DisableIstioGrayscale(ctx context.Context, envName, productName string) err
 		return e.ErrDisableIstioGrayscale.AddErr(fmt.Errorf("failed to remove istio-proxy from pods in ns `%s`: %s", ns, err))
 	}
 
+	prod.UpdateBy = userName
 	// 7. Update the environment configuration.
 	err = ensureDisableGrayscaleEnvConfig(ctx, prod)
 	if err != nil {
@@ -221,8 +223,8 @@ func GetIstioGrayscaleConfig(ctx context.Context, envName, productName string) (
 	return prod.IstioGrayscale, nil
 }
 
-func SetIstioGrayscaleConfig(ctx context.Context, envName, productName string, req kube.SetIstioGrayscaleConfigRequest) error {
-	err := kube.SetIstioGrayscaleConfig(ctx, envName, productName, req)
+func SetIstioGrayscaleConfig(ctx context.Context, envName, productName, userName string, req kube.SetIstioGrayscaleConfigRequest) error {
+	err := kube.SetIstioGrayscaleConfig(ctx, envName, productName, userName, req)
 	if err != nil {
 		return e.ErrSetIstioGrayscaleConfig.AddErr(err)
 	}

--- a/pkg/microservice/aslan/core/environment/service/k8s.go
+++ b/pkg/microservice/aslan/core/environment/service/k8s.go
@@ -259,6 +259,7 @@ func (k *K8sService) updateService(args *SvcOptArgs) error {
 	productColl := commonrepo.NewProductCollWithSession(session)
 
 	// Note update logic need to be optimized since we only need to update one service
+	prodinfo.UpdateBy = args.UpdateBy
 	if err := productColl.Update(prodinfo); err != nil {
 		k.log.Errorf("[%s][%s] Product.Update error: %v", args.EnvName, args.ProductName, err)
 		mongotool.AbortTransaction(session)

--- a/pkg/microservice/aslan/core/environment/service/pm.go
+++ b/pkg/microservice/aslan/core/environment/service/pm.go
@@ -80,6 +80,7 @@ func (p *PMService) updateService(args *SvcOptArgs) error {
 		}
 	}
 
+	exitedProd.UpdateBy = args.UpdateBy
 	if err := commonrepo.NewProductColl().Update(exitedProd); err != nil {
 		p.log.Errorf("[%s][%s] Product.Update error: %v", args.EnvName, args.ProductName, err)
 		return e.ErrUpdateProduct
@@ -246,6 +247,7 @@ func (p *PMService) createGroup(username string, product *commonmodels.Product, 
 					}
 				}
 			}
+			prod.UpdateBy = username
 			if err := commonrepo.NewProductColl().Update(prod); err != nil {
 				log.Errorf("[%s][%s] Product.Update error: %v", envName, productName, err)
 				errList = multierror.Append(errList, err)

--- a/pkg/microservice/aslan/core/environment/service/service_scale.go
+++ b/pkg/microservice/aslan/core/environment/service/service_scale.go
@@ -150,6 +150,7 @@ func Scale(args *ScaleArgs, updateBy string, logger *zap.SugaredLogger) error {
 	}
 
 	productColl := commonrepo.NewProductCollWithSession(session)
+	prod.UpdateBy = updateBy
 	if err := productColl.Update(prod); err != nil {
 		mongotool.AbortTransaction(session)
 		return e.ErrScaleService.AddErr(err)

--- a/pkg/microservice/aslan/core/environment/service/share_env.go
+++ b/pkg/microservice/aslan/core/environment/service/share_env.go
@@ -78,7 +78,7 @@ func CheckWorkloadsK8sServices(ctx context.Context, envName, productName string,
 	return checkWorkloadsHaveK8sService(ctx, kclient, ns)
 }
 
-func EnableBaseEnv(ctx context.Context, envName, productName string) error {
+func EnableBaseEnv(ctx context.Context, envName, productName, userName string) error {
 	opt := &commonrepo.ProductFindOptions{Name: productName, EnvName: envName}
 	prod, err := commonrepo.NewProductColl().Find(opt)
 	if err != nil {
@@ -125,11 +125,12 @@ func EnableBaseEnv(ctx context.Context, envName, productName string) error {
 		return fmt.Errorf("failed to ensure EnvoyFilter in namespace `%s`: %s", setting.IstioNamespace, err)
 	}
 
+	prod.UpdateBy = userName
 	// 5. Update the environment configuration.
 	return ensureBaseEnvConfig(ctx, prod)
 }
 
-func DisableBaseEnv(ctx context.Context, envName, productName string) error {
+func DisableBaseEnv(ctx context.Context, envName, productName, userName string) error {
 	opt := &commonrepo.ProductFindOptions{Name: productName, EnvName: envName}
 	prod, err := commonrepo.NewProductColl().Find(opt)
 	if err != nil {
@@ -188,6 +189,7 @@ func DisableBaseEnv(ctx context.Context, envName, productName string) error {
 		return fmt.Errorf("failed to remove istio-proxy from pods in ns `%s`: %s", ns, err)
 	}
 
+	prod.UpdateBy = userName
 	// 7. Update the environment configuration.
 	return ensureDisableBaseEnvConfig(ctx, prod)
 }

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -493,6 +493,7 @@ func UpdateWorkloads(ctx context.Context, requestID, username, productName, envN
 		filteredSvcs = append(filteredSvcs, productSvc)
 	}
 	productInfo.Services = [][]*commonmodels.ProductService{filteredSvcs}
+	productInfo.UpdateBy = username
 	err = commonrepo.NewProductCollWithSession(session).Update(productInfo)
 	if err != nil {
 		log.Errorf("failed to update product: %s error: %s", productName, err)


### PR DESCRIPTION
### What this PR does / Why we need it:

Fixes inconsistent project overview audit info where environment `update_time` could change while `update_by` still showed the previous operator.

### What is changed and how it works?

Propagates the current user through environment update paths and writes `update_by` together with `update_time` when updating product records. This covers service/env updates, Helm updates, image updates, scaling, sleep/wake, share env, and Istio grayscale config changes.


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4810)
<!-- Reviewable:end -->
