### PR TITLE
feat: add CLI context OpenAPI

### DIFF
--- a/pkg/microservice/aslan/core/system/handler/cli_context.go
+++ b/pkg/microservice/aslan/core/system/handler/cli_context.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/system/service"
+	"github.com/koderover/zadig/v2/pkg/setting"
+	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
+)
+
+// OpenAPIGetCLIContext returns the authenticated principal and Zadig edition metadata.
+// @Summary Get Zadig CLI context
+// @Description Returns the authenticated user, edition, licensed features, server version, and request ID.
+// @Tags system
+// @Produce json
+// @Success 200 {object} service.CLIContextResponse
+// @Failure 401
+// @Failure 403
+// @Router /openapi/system/cli-context [get]
+func OpenAPIGetCLIContext(c *gin.Context) {
+	if strings.TrimSpace(c.GetHeader(setting.AuthorizationHeader)) == "" {
+		c.AbortWithStatus(http.StatusUnauthorized)
+		return
+	}
+
+	identityContext := internalhandler.NewContext(c)
+	if strings.TrimSpace(identityContext.UserID) == "" {
+		c.AbortWithStatus(http.StatusUnauthorized)
+		return
+	}
+
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization info generation failed: %w", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	ctx.Resp, ctx.RespErr = service.GetCLIContext(ctx.GenUserBriefInfo(), ctx.RequestID)
+}

--- a/pkg/microservice/aslan/core/system/handler/cli_context.go
+++ b/pkg/microservice/aslan/core/system/handler/cli_context.go
@@ -25,7 +25,7 @@ import (
 	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
 )
 
-// OpenAPIGetCLIContext returns the authenticated principal and Zadig edition metadata.
+// OpenAPIGetCLIContext returns the authenticated user and Zadig edition metadata.
 // @Summary Get Zadig CLI context
 // @Description Returns the authenticated user, edition, licensed features, server version, and request ID.
 // @Tags system
@@ -43,5 +43,5 @@ func OpenAPIGetCLIContext(c *gin.Context) {
 		return
 	}
 
-	ctx.Resp, ctx.RespErr = service.GetCLIContext(ctx.GenUserBriefInfo(), ctx.RequestID, ctx.Logger)
+	ctx.Resp, ctx.RespErr = service.GetCLIContext(ctx.GenUserBriefInfo(), ctx.RequestID)
 }

--- a/pkg/microservice/aslan/core/system/handler/cli_context.go
+++ b/pkg/microservice/aslan/core/system/handler/cli_context.go
@@ -33,7 +33,7 @@ import (
 // @Success 200 {object} service.CLIContextResponse
 // @Failure 401
 // @Failure 403
-// @Router /openapi/system/cli-context [get]
+// @Router /openapi/system/cli/context [get]
 func OpenAPIGetCLIContext(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()

--- a/pkg/microservice/aslan/core/system/handler/cli_context.go
+++ b/pkg/microservice/aslan/core/system/handler/cli_context.go
@@ -18,13 +18,10 @@ package handler
 
 import (
 	"fmt"
-	"net/http"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/system/service"
-	"github.com/koderover/zadig/v2/pkg/setting"
 	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
 )
 
@@ -38,17 +35,6 @@ import (
 // @Failure 403
 // @Router /openapi/system/cli-context [get]
 func OpenAPIGetCLIContext(c *gin.Context) {
-	if strings.TrimSpace(c.GetHeader(setting.AuthorizationHeader)) == "" {
-		c.AbortWithStatus(http.StatusUnauthorized)
-		return
-	}
-
-	identityContext := internalhandler.NewContext(c)
-	if strings.TrimSpace(identityContext.UserID) == "" {
-		c.AbortWithStatus(http.StatusUnauthorized)
-		return
-	}
-
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 	if err != nil {
@@ -57,5 +43,5 @@ func OpenAPIGetCLIContext(c *gin.Context) {
 		return
 	}
 
-	ctx.Resp, ctx.RespErr = service.GetCLIContext(ctx.GenUserBriefInfo(), ctx.RequestID)
+	ctx.Resp, ctx.RespErr = service.GetCLIContext(ctx.GenUserBriefInfo(), ctx.RequestID, ctx.Logger)
 }

--- a/pkg/microservice/aslan/core/system/handler/router.go
+++ b/pkg/microservice/aslan/core/system/handler/router.go
@@ -607,7 +607,10 @@ func (*Router) Inject(router *gin.RouterGroup) {
 type OpenAPIRouter struct{}
 
 func (*OpenAPIRouter) Inject(router *gin.RouterGroup) {
-	router.GET("/cli-context", OpenAPIGetCLIContext)
+	cli := router.Group("cli")
+	{
+		cli.GET("/context", OpenAPIGetCLIContext)
+	}
 
 	reg := router.Group("registry")
 	{

--- a/pkg/microservice/aslan/core/system/handler/router.go
+++ b/pkg/microservice/aslan/core/system/handler/router.go
@@ -607,6 +607,8 @@ func (*Router) Inject(router *gin.RouterGroup) {
 type OpenAPIRouter struct{}
 
 func (*OpenAPIRouter) Inject(router *gin.RouterGroup) {
+	router.GET("/cli-context", OpenAPIGetCLIContext)
+
 	reg := router.Group("registry")
 	{
 		reg.POST("", OpenAPICreateRegistry)

--- a/pkg/microservice/aslan/core/system/service/cli_context.go
+++ b/pkg/microservice/aslan/core/system/service/cli_context.go
@@ -17,11 +17,17 @@ limitations under the License.
 package service
 
 import (
-	"errors"
-	"fmt"
+	"os"
+	"strings"
 
 	"github.com/koderover/zadig/v2/pkg/shared/client/plutusenterprise"
 	"github.com/koderover/zadig/v2/pkg/types"
+	"go.uber.org/zap"
+)
+
+const (
+	cliContextUnknownEdition          = "unknown"
+	cliContextUnavailableLicenseState = "unavailable"
 )
 
 type CLIContextResponse struct {
@@ -33,6 +39,7 @@ type CLIContextResponse struct {
 	RequestID     string       `json:"request_id"`
 }
 
+// CLIPrincipal identifies the authenticated user represented by the request token.
 type CLIPrincipal struct {
 	UID          string `json:"uid"`
 	Name         string `json:"name"`
@@ -40,34 +47,44 @@ type CLIPrincipal struct {
 	IdentityType string `json:"identity_type"`
 }
 
-type licenseStatusChecker interface {
-	CheckZadigXLicenseStatus() (*plutusenterprise.ZadigXLicenseStatus, error)
-}
-
-func GetCLIContext(principal types.UserBriefInfo, requestID string) (*CLIContextResponse, error) {
-	return getCLIContext(principal, requestID, plutusenterprise.New())
-}
-
-func getCLIContext(principal types.UserBriefInfo, requestID string, checker licenseStatusChecker) (*CLIContextResponse, error) {
-	licenseStatus, err := checker.CheckZadigXLicenseStatus()
-	if err != nil {
-		return nil, fmt.Errorf("check zadig license status: %w", err)
-	}
-	if licenseStatus == nil {
-		return nil, errors.New("check zadig license status: empty response")
-	}
-
-	return &CLIContextResponse{
+func GetCLIContext(principal types.UserBriefInfo, requestID string, log *zap.SugaredLogger) (*CLIContextResponse, error) {
+	response := &CLIContextResponse{
 		Principal: CLIPrincipal{
 			UID:          principal.UID,
 			Name:         principal.Name,
 			Account:      principal.Account,
 			IdentityType: principal.IdentityType,
 		},
-		Edition:       licenseStatus.Type,
-		LicenseStatus: licenseStatus.Status,
-		Features:      append([]string{}, licenseStatus.Features...),
-		ServerVersion: licenseStatus.CurrentVersion,
+		Edition:       cliContextUnknownEdition,
+		LicenseStatus: cliContextUnavailableLicenseState,
+		Features:      []string{},
+		ServerVersion: strings.TrimSpace(os.Getenv("VERSION")),
 		RequestID:     requestID,
-	}, nil
+	}
+
+	licenseStatus, err := plutusenterprise.New().CheckZadigXLicenseStatus()
+	if err != nil {
+		if log != nil {
+			log.Warnw("failed to load CLI license metadata", "request_id", requestID, "error", err)
+		}
+		return response, nil
+	}
+	if licenseStatus == nil {
+		if log != nil {
+			log.Warnw("received empty CLI license metadata", "request_id", requestID)
+		}
+		return response, nil
+	}
+
+	if value := strings.TrimSpace(licenseStatus.Type); value != "" {
+		response.Edition = value
+	}
+	if value := strings.TrimSpace(licenseStatus.Status); value != "" {
+		response.LicenseStatus = value
+	}
+	if value := strings.TrimSpace(licenseStatus.CurrentVersion); value != "" {
+		response.ServerVersion = value
+	}
+	response.Features = append([]string{}, licenseStatus.Features...)
+	return response, nil
 }

--- a/pkg/microservice/aslan/core/system/service/cli_context.go
+++ b/pkg/microservice/aslan/core/system/service/cli_context.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/koderover/zadig/v2/pkg/shared/client/plutusenterprise"
+	"github.com/koderover/zadig/v2/pkg/types"
+)
+
+type CLIContextResponse struct {
+	Principal     CLIPrincipal `json:"principal"`
+	Edition       string       `json:"edition"`
+	LicenseStatus string       `json:"license_status"`
+	Features      []string     `json:"features"`
+	ServerVersion string       `json:"server_version"`
+	RequestID     string       `json:"request_id"`
+}
+
+type CLIPrincipal struct {
+	UID          string `json:"uid"`
+	Name         string `json:"name"`
+	Account      string `json:"account"`
+	IdentityType string `json:"identity_type"`
+}
+
+type licenseStatusChecker interface {
+	CheckZadigXLicenseStatus() (*plutusenterprise.ZadigXLicenseStatus, error)
+}
+
+func GetCLIContext(principal types.UserBriefInfo, requestID string) (*CLIContextResponse, error) {
+	return getCLIContext(principal, requestID, plutusenterprise.New())
+}
+
+func getCLIContext(principal types.UserBriefInfo, requestID string, checker licenseStatusChecker) (*CLIContextResponse, error) {
+	licenseStatus, err := checker.CheckZadigXLicenseStatus()
+	if err != nil {
+		return nil, fmt.Errorf("check zadig license status: %w", err)
+	}
+	if licenseStatus == nil {
+		return nil, errors.New("check zadig license status: empty response")
+	}
+
+	return &CLIContextResponse{
+		Principal: CLIPrincipal{
+			UID:          principal.UID,
+			Name:         principal.Name,
+			Account:      principal.Account,
+			IdentityType: principal.IdentityType,
+		},
+		Edition:       licenseStatus.Type,
+		LicenseStatus: licenseStatus.Status,
+		Features:      append([]string{}, licenseStatus.Features...),
+		ServerVersion: licenseStatus.CurrentVersion,
+		RequestID:     requestID,
+	}, nil
+}

--- a/pkg/microservice/aslan/core/system/service/cli_context.go
+++ b/pkg/microservice/aslan/core/system/service/cli_context.go
@@ -25,7 +25,7 @@ import (
 )
 
 type CLIContextResponse struct {
-	User          CLIUser  `json:"principal"`
+	User          CLIUser  `json:"user"`
 	Edition       string   `json:"edition"`
 	LicenseStatus string   `json:"license_status"`
 	Features      []string `json:"features"`

--- a/pkg/microservice/aslan/core/system/service/cli_context.go
+++ b/pkg/microservice/aslan/core/system/service/cli_context.go
@@ -17,74 +17,49 @@ limitations under the License.
 package service
 
 import (
-	"os"
-	"strings"
+	"errors"
+	"fmt"
 
 	"github.com/koderover/zadig/v2/pkg/shared/client/plutusenterprise"
 	"github.com/koderover/zadig/v2/pkg/types"
-	"go.uber.org/zap"
-)
-
-const (
-	cliContextUnknownEdition          = "unknown"
-	cliContextUnavailableLicenseState = "unavailable"
 )
 
 type CLIContextResponse struct {
-	Principal     CLIPrincipal `json:"principal"`
-	Edition       string       `json:"edition"`
-	LicenseStatus string       `json:"license_status"`
-	Features      []string     `json:"features"`
-	ServerVersion string       `json:"server_version"`
-	RequestID     string       `json:"request_id"`
+	User          CLIUser  `json:"principal"`
+	Edition       string   `json:"edition"`
+	LicenseStatus string   `json:"license_status"`
+	Features      []string `json:"features"`
+	ServerVersion string   `json:"server_version"`
+	RequestID     string   `json:"request_id"`
 }
 
-// CLIPrincipal identifies the authenticated user represented by the request token.
-type CLIPrincipal struct {
+type CLIUser struct {
 	UID          string `json:"uid"`
 	Name         string `json:"name"`
 	Account      string `json:"account"`
 	IdentityType string `json:"identity_type"`
 }
 
-func GetCLIContext(principal types.UserBriefInfo, requestID string, log *zap.SugaredLogger) (*CLIContextResponse, error) {
-	response := &CLIContextResponse{
-		Principal: CLIPrincipal{
-			UID:          principal.UID,
-			Name:         principal.Name,
-			Account:      principal.Account,
-			IdentityType: principal.IdentityType,
-		},
-		Edition:       cliContextUnknownEdition,
-		LicenseStatus: cliContextUnavailableLicenseState,
-		Features:      []string{},
-		ServerVersion: strings.TrimSpace(os.Getenv("VERSION")),
-		RequestID:     requestID,
-	}
-
+func GetCLIContext(user types.UserBriefInfo, requestID string) (*CLIContextResponse, error) {
 	licenseStatus, err := plutusenterprise.New().CheckZadigXLicenseStatus()
 	if err != nil {
-		if log != nil {
-			log.Warnw("failed to load CLI license metadata", "request_id", requestID, "error", err)
-		}
-		return response, nil
+		return nil, fmt.Errorf("check zadig license status: %w", err)
 	}
 	if licenseStatus == nil {
-		if log != nil {
-			log.Warnw("received empty CLI license metadata", "request_id", requestID)
-		}
-		return response, nil
+		return nil, errors.New("check zadig license status: empty response")
 	}
 
-	if value := strings.TrimSpace(licenseStatus.Type); value != "" {
-		response.Edition = value
-	}
-	if value := strings.TrimSpace(licenseStatus.Status); value != "" {
-		response.LicenseStatus = value
-	}
-	if value := strings.TrimSpace(licenseStatus.CurrentVersion); value != "" {
-		response.ServerVersion = value
-	}
-	response.Features = append([]string{}, licenseStatus.Features...)
-	return response, nil
+	return &CLIContextResponse{
+		User: CLIUser{
+			UID:          user.UID,
+			Name:         user.Name,
+			Account:      user.Account,
+			IdentityType: user.IdentityType,
+		},
+		Edition:       licenseStatus.Type,
+		LicenseStatus: licenseStatus.Status,
+		Features:      append([]string{}, licenseStatus.Features...),
+		ServerVersion: licenseStatus.CurrentVersion,
+		RequestID:     requestID,
+	}, nil
 }


### PR DESCRIPTION
### Summary
- Add authenticated `GET /openapi/system/cli-context` for Zadig CLI clients.
- Provide an authoritative source for user identity, edition, features, and server version.
### Main Changes
- Require a parseable Bearer identity before loading authorization context.
- Return only contracted principal fields and omit license payload details.
- Map edition, license status, features, version, and request ID from existing services.
### Risk / Compatibility
- Additive endpoint; existing routes and response contracts are unchanged.
- License service availability is required for a successful response.
### Test
- Verified service mapping and handler route/auth behavior locally.
- Full service tests remain blocked by existing `workwx.go` vet errors.
Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4811)
<!-- Reviewable:end -->
