### PR TITLE
feat(workflow): support custom external approval titles

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/im_app.go
+++ b/pkg/microservice/aslan/core/common/repository/models/im_app.go
@@ -48,13 +48,14 @@ type IMApp struct {
 	DingTalkDefaultApprovalFormCode string `json:"-" bson:"dingtalk_default_approval_form_code"`
 
 	// workwx fields
-	Host                     string `json:"host"                        bson:"host"`
-	CorpID                   string `json:"corp_id"                     bson:"corp_id"`
-	AgentID                  int    `json:"agent_id"                    bson:"agent_id"`
-	AgentSecret              string `json:"agent_secret"                bson:"agent_secret"`
-	WorkWXApprovalTemplateID string `json:"workwx_approval_template_id" bson:"workwx_approval_template_id"`
-	WorkWXToken              string `json:"workwx_token"                bson:"workwx_token"`
-	WorkWXAESKey             string `json:"workwx_aes_key"              bson:"workwx_aes_key"`
+	Host                         string            `json:"host"                        bson:"host"`
+	CorpID                       string            `json:"corp_id"                     bson:"corp_id"`
+	AgentID                      int               `json:"agent_id"                    bson:"agent_id"`
+	AgentSecret                  string            `json:"agent_secret"                bson:"agent_secret"`
+	WorkWXApprovalTemplateID     string            `json:"workwx_approval_template_id" bson:"workwx_approval_template_id"`
+	WorkWXApprovalTemplateIDList map[string]string `json:"-"                           bson:"workwx_approval_template_id_list"`
+	WorkWXToken                  string            `json:"workwx_token"                bson:"workwx_token"`
+	WorkWXAESKey                 string            `json:"workwx_aes_key"              bson:"workwx_aes_key"`
 }
 
 func (IMApp) TableName() string {

--- a/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
@@ -700,6 +700,7 @@ type JobTaskApprovalSpec struct {
 	DingTalkApproval *DingTalkApproval   `bson:"dingtalk_approval"           yaml:"dingtalk_approval,omitempty"   json:"dingtalk_approval,omitempty"`
 	WorkWXApproval   *WorkWXApproval     `bson:"workwx_approval"             yaml:"workwx_approval,omitempty"     json:"workwx_approval,omitempty"`
 	ApprovalMessage  string              `bson:"approval_message"            yaml:"approval_message,omitempty"    json:"approval_message,omitempty"`
+	ApprovalTitle    string              `bson:"approval_title"              yaml:"approval_title,omitempty"      json:"approval_title,omitempty"`
 }
 
 type JobTaskWorkflowTriggerSpec struct {

--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -232,7 +232,7 @@ func (l LarkApproval) GetNodeTypeTitleKey(title string) string {
 		return nodeTypeKey
 	}
 
-	return fmt.Sprintf("%s-%x", nodeTypeKey, md5.Sum([]byte(title)))
+	return fmt.Sprintf("%s-%s", nodeTypeKey, title)
 }
 
 // GetLarkApprovalNode convert approval node to lark sdk approval node

--- a/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/workflow_v4.go
@@ -225,6 +225,16 @@ func (l LarkApproval) GetNodeTypeKey() string {
 	return strings.Join(keys, "-")
 }
 
+func (l LarkApproval) GetNodeTypeTitleKey(title string) string {
+	nodeTypeKey := l.GetNodeTypeKey()
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return nodeTypeKey
+	}
+
+	return fmt.Sprintf("%s-%x", nodeTypeKey, md5.Sum([]byte(title)))
+}
+
 // GetLarkApprovalNode convert approval node to lark sdk approval node
 func (l LarkApproval) GetLarkApprovalNode() (resp []*lark.ApprovalNode) {
 	for _, node := range l.ApprovalNodes {
@@ -1165,6 +1175,7 @@ type ApprovalJobSpec struct {
 	WorkWXApproval        *WorkWXApproval         `bson:"workwx_approval"             yaml:"workwx_approval,omitempty"         json:"workwx_approval,omitempty"`
 	ApprovalMessage       string                  `bson:"approval_message"            yaml:"approval_message,omitempty"        json:"approval_message,omitempty"`
 	ApprovalMessageSource config.DeploySourceType `bson:"approval_message_source"     yaml:"approval_message_source,omitempty" json:"approval_message_source,omitempty"`
+	ApprovalTitle         string                  `bson:"approval_title"              yaml:"approval_title,omitempty"          json:"approval_title,omitempty"`
 }
 
 type NotificationJobSpec struct {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/koderover/zadig/v2/pkg/util"
@@ -94,6 +95,47 @@ func (c *ApprovalJobCtl) Run(ctx context.Context) {
 	}
 
 	return
+}
+
+func getDingTalkApprovalProcessCode(client *dingtalk.Client, defaultProcessCode, approvalTitle string) (string, error) {
+	formName := strings.TrimSpace(approvalTitle)
+	if formName == "" {
+		formName = dingtalk.DefaultApprovalFormName
+		if defaultProcessCode != "" {
+			return defaultProcessCode, nil
+		}
+	}
+
+	formList, err := client.GetAllApprovalFormDefinitionList()
+	if err != nil {
+		return "", fmt.Errorf("get dingtalk approval form definition list error: %s", err)
+	}
+	for _, form := range formList {
+		if form.Name == formName {
+			return form.ProcessCode, nil
+		}
+	}
+
+	resp, err := client.CreateApproval(formName)
+	if err == dingtalk.ErrApprovalFormNameExists {
+		formList, listErr := client.GetAllApprovalFormDefinitionList()
+		if listErr != nil {
+			return "", fmt.Errorf("get dingtalk approval form definition list after create conflict error: %s", listErr)
+		}
+		for _, form := range formList {
+			if form.Name == formName {
+				return form.ProcessCode, nil
+			}
+		}
+	}
+	if err != nil {
+		return "", fmt.Errorf("create dingtalk approval form %s error: %s", formName, err)
+	}
+	if resp == nil || resp.ProcessCode == "" {
+		return "", fmt.Errorf("create dingtalk approval form %s returned empty process code", formName)
+	}
+
+	return resp.ProcessCode, nil
 }
 
 func waitForNativeApprove(ctx context.Context, spec *commonmodels.JobTaskApprovalSpec, workflowName, jobName string, taskID int64, ack func()) (config.Status, error) {
@@ -174,10 +216,11 @@ func waitForLarkApprove(ctx context.Context, spec *commonmodels.JobTaskApprovalS
 		return config.StatusFailed, fmt.Errorf("get lark im app data error: %s", err)
 	}
 
-	approvalCode := data.LarkApprovalCodeList[approval.GetNodeTypeKey()]
+	approvalNodeTypeKey := approval.GetNodeTypeTitleKey(spec.ApprovalTitle)
+	approvalCode := data.LarkApprovalCodeList[approvalNodeTypeKey]
 	if approvalCode == "" {
-		log.Errorf("failed to find approval code for node type %s", approval.GetNodeTypeKey())
-		return config.StatusFailed, fmt.Errorf("failed to find approval code for node type %s", approval.GetNodeTypeKey())
+		log.Errorf("failed to find approval code for node type %s", approvalNodeTypeKey)
+		return config.StatusFailed, fmt.Errorf("failed to find approval code for node type %s", approvalNodeTypeKey)
 	}
 
 	client := lark.NewClient(data.AppID, data.AppSecret, data.Type)
@@ -346,9 +389,14 @@ func waitForDingTalkApprove(ctx context.Context, spec *commonmodels.JobTaskAppro
 		formContent = spec.ApprovalMessage
 	}
 
+	processCode, err := getDingTalkApprovalProcessCode(client, data.DingTalkDefaultApprovalFormCode, spec.ApprovalTitle)
+	if err != nil {
+		return config.StatusFailed, err
+	}
+
 	log.Infof("waitForDingTalkApprove: ApproveNode num %d", len(approval.ApprovalNodes))
 	instanceResp, err := client.CreateApprovalInstance(&dingtalk.CreateApprovalInstanceArgs{
-		ProcessCode:      data.DingTalkDefaultApprovalFormCode,
+		ProcessCode:      processCode,
 		OriginatorUserID: userID,
 		ApproverNodeList: func() (nodeList []*dingtalk.ApprovalNode) {
 			for _, node := range approval.ApprovalNodes {
@@ -638,6 +686,7 @@ func waitForWorkWXApprove(ctx context.Context, spec *commonmodels.JobTaskApprova
 	if spec.ApprovalMessage != "" {
 		formContent = spec.ApprovalMessage
 	}
+	approvalTitle := strings.TrimSpace(spec.ApprovalTitle)
 
 	log.Infof("waitforWorkWXApprove: ApproveNode num %d", len(approval.ApprovalNodes))
 
@@ -656,13 +705,25 @@ func waitForWorkWXApprove(ctx context.Context, spec *commonmodels.JobTaskApprova
 		node.UserID = userIDList
 	}
 
+	summaryList := make([]*workwx.ApprovalSummary, 0)
+	if approvalTitle != "" {
+		summaryList = append(summaryList, &workwx.ApprovalSummary{
+			SummaryInfo: []*workwx.GeneralText{
+				{
+					Text: approvalTitle,
+					Lang: workwx.LanguageCN,
+				},
+			},
+		})
+	}
+
 	instanceID, err := client.CreateApprovalInstance(
 		data.WorkWXApprovalTemplateID,
 		applicant,
 		false,
 		applydata,
 		approval.ApprovalNodes,
-		make([]*workwx.ApprovalSummary, 0),
+		summaryList,
 	)
 	if err != nil {
 		log.Errorf("waitForWorkWXApprove: create instance failed: %v", err)

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
@@ -138,6 +138,61 @@ func getDingTalkApprovalProcessCode(client *dingtalk.Client, defaultProcessCode,
 	return resp.ProcessCode, nil
 }
 
+func getWorkWXApprovalTemplateID(client *workwx.Client, imApp *commonmodels.IMApp, approvalTitle string) (string, error) {
+	approvalTitle = strings.TrimSpace(approvalTitle)
+	if approvalTitle == "" {
+		return imApp.WorkWXApprovalTemplateID, nil
+	}
+
+	if imApp.WorkWXApprovalTemplateIDList == nil {
+		imApp.WorkWXApprovalTemplateIDList = make(map[string]string)
+	}
+	if templateID := imApp.WorkWXApprovalTemplateIDList[approvalTitle]; templateID != "" {
+		return templateID, nil
+	}
+
+	templateName, controls := generateWorkWXApprovalTemplate(approvalTitle)
+	templateID, err := client.CreateApprovalTemplate(templateName, controls)
+	if err != nil {
+		return "", fmt.Errorf("create workwx approval template %s error: %s", approvalTitle, err)
+	}
+
+	imApp.WorkWXApprovalTemplateIDList[approvalTitle] = templateID
+	if err := mongodb.NewIMAppColl().Update(context.Background(), imApp.ID.Hex(), imApp); err != nil {
+		return "", fmt.Errorf("update workwx approval template %s error: %s", approvalTitle, err)
+	}
+
+	return templateID, nil
+}
+
+func generateWorkWXApprovalTemplate(title string) ([]*workwx.GeneralText, []*workwx.ApprovalControl) {
+	templateName := []*workwx.GeneralText{
+		{
+			Text: title,
+			Lang: workwx.LanguageCN,
+		},
+	}
+
+	controls := []*workwx.ApprovalControl{
+		{
+			Property: &workwx.ApprovalControlProperty{
+				Type: config.DefaultWorkWXApprovalControlType,
+				ID:   config.DefaultWorkWXApprovalControlID,
+				Title: []*workwx.GeneralText{
+					{
+						Text: "审批内容",
+						Lang: workwx.LanguageCN,
+					},
+				},
+				Require: 1,
+				UnPrint: 0,
+			},
+		},
+	}
+
+	return templateName, controls
+}
+
 func waitForNativeApprove(ctx context.Context, spec *commonmodels.JobTaskApprovalSpec, workflowName, jobName string, taskID int64, ack func()) (config.Status, error) {
 	log.Infof("waitForNativeApprove start")
 
@@ -687,6 +742,10 @@ func waitForWorkWXApprove(ctx context.Context, spec *commonmodels.JobTaskApprova
 		formContent = spec.ApprovalMessage
 	}
 	approvalTitle := strings.TrimSpace(spec.ApprovalTitle)
+	templateID, err := getWorkWXApprovalTemplateID(client, data, approvalTitle)
+	if err != nil {
+		return config.StatusFailed, err
+	}
 
 	log.Infof("waitforWorkWXApprove: ApproveNode num %d", len(approval.ApprovalNodes))
 
@@ -718,7 +777,7 @@ func waitForWorkWXApprove(ctx context.Context, spec *commonmodels.JobTaskApprova
 	}
 
 	instanceID, err := client.CreateApprovalInstance(
-		data.WorkWXApprovalTemplateID,
+		templateID,
 		applicant,
 		false,
 		applydata,

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
@@ -52,8 +52,6 @@ type ApprovalJobCtl struct {
 	ack         func()
 }
 
-const workWXApprovalDetailPollInterval = 10 * time.Second
-
 func NewApprovalJobCtl(job *commonmodels.JobTask, workflowCtx *commonmodels.WorkflowTaskCtx, ack func(), logger *zap.SugaredLogger) *ApprovalJobCtl {
 	jobTaskSpec := &commonmodels.JobTaskApprovalSpec{}
 	if err := commonmodels.IToi(job.Spec, jobTaskSpec); err != nil {
@@ -784,7 +782,6 @@ func waitForWorkWXApprove(ctx context.Context, spec *commonmodels.JobTaskApprova
 	}()
 
 	timeoutChan := time.After(time.Duration(timeout) * time.Minute)
-	nextApprovalDetailQueryTime := time.Now()
 	for {
 		time.Sleep(1 * time.Second)
 		select {
@@ -793,38 +790,16 @@ func waitForWorkWXApprove(ctx context.Context, spec *commonmodels.JobTaskApprova
 		case <-timeoutChan:
 			return config.StatusTimeout, fmt.Errorf("workflow timeout")
 		default:
-			userApprovalResult, err := workwxservice.GetWorkWXApprovalEvent(instanceID)
+			detail, err := client.GetApprovalDetail(instanceID)
 			if err != nil {
-				if time.Now().Before(nextApprovalDetailQueryTime) {
-					continue
-				}
-
-				nextApprovalDetailQueryTime = time.Now().Add(workWXApprovalDetailPollInterval)
-				detail, detailErr := client.GetApprovalDetail(instanceID)
-				if detailErr != nil {
-					log.Warnf("failed to get workwx approval detail, error: %s", detailErr)
-					continue
-				}
-				if detail == nil {
-					continue
-				}
-				userApprovalResult = &workwx.ApprovalWebhookMessage{
-					ID:           detail.ID,
-					TemplateName: detail.TemplateName,
-					TemplateID:   detail.TemplateID,
-					Status:       detail.Status,
-					ApplyTime:    detail.ApplyTime,
-				}
-				userApprovalResult.Applyer.UserID = detail.Applyer.UserID
-				userApprovalResult.Applyer.DepartmentID = detail.Applyer.DepartmentID
+				log.Warnf("failed to get workwx approval detail, error: %s", err)
+				continue
+			}
+			if detail == nil {
+				continue
 			}
 
-			if userApprovalResult.ProcessList != nil {
-				spec.WorkWXApproval.ApprovalNodeDetails = userApprovalResult.ProcessList.NodeList
-				ack()
-			}
-
-			switch userApprovalResult.Status {
+			switch detail.Status {
 			case workwx.ApprovalStatusApproved:
 				return config.StatusPassed, nil
 			case workwx.ApprovalStatusRejected:

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
@@ -127,6 +127,7 @@ func getDingTalkApprovalProcessCode(client *dingtalk.Client, defaultProcessCode,
 				return form.ProcessCode, nil
 			}
 		}
+		return "", fmt.Errorf("dingtalk approval form %s exists but not found in form list", formName)
 	}
 	if err != nil {
 		return "", fmt.Errorf("create dingtalk approval form %s error: %s", formName, err)

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
@@ -52,6 +52,8 @@ type ApprovalJobCtl struct {
 	ack         func()
 }
 
+const workWXApprovalDetailPollInterval = 10 * time.Second
+
 func NewApprovalJobCtl(job *commonmodels.JobTask, workflowCtx *commonmodels.WorkflowTaskCtx, ack func(), logger *zap.SugaredLogger) *ApprovalJobCtl {
 	jobTaskSpec := &commonmodels.JobTaskApprovalSpec{}
 	if err := commonmodels.IToi(job.Spec, jobTaskSpec); err != nil {
@@ -191,6 +193,24 @@ func generateWorkWXApprovalTemplate(title string) ([]*workwx.GeneralText, []*wor
 	}
 
 	return templateName, controls
+}
+
+func workWXApprovalDetailToWebhookMessage(detail *workwx.ApprovalDetail) *workwx.ApprovalWebhookMessage {
+	if detail == nil {
+		return nil
+	}
+
+	msg := &workwx.ApprovalWebhookMessage{
+		ID:           detail.ID,
+		TemplateName: detail.TemplateName,
+		TemplateID:   detail.TemplateID,
+		Status:       detail.Status,
+		ApplyTime:    detail.ApplyTime,
+	}
+	msg.Applyer.UserID = detail.Applyer.UserID
+	msg.Applyer.DepartmentID = detail.Applyer.DepartmentID
+
+	return msg
 }
 
 func waitForNativeApprove(ctx context.Context, spec *commonmodels.JobTaskApprovalSpec, workflowName, jobName string, taskID int64, ack func()) (config.Status, error) {
@@ -789,6 +809,7 @@ func waitForWorkWXApprove(ctx context.Context, spec *commonmodels.JobTaskApprova
 	}()
 
 	timeoutChan := time.After(time.Duration(timeout) * time.Minute)
+	nextApprovalDetailQueryTime := time.Now()
 	for {
 		time.Sleep(1 * time.Second)
 		select {
@@ -799,8 +820,20 @@ func waitForWorkWXApprove(ctx context.Context, spec *commonmodels.JobTaskApprova
 		default:
 			userApprovalResult, err := workwxservice.GetWorkWXApprovalEvent(instanceID)
 			if err != nil {
-				log.Warnf("failed to handle workwx approval event, error: %s", err)
-				continue
+				if time.Now().Before(nextApprovalDetailQueryTime) {
+					continue
+				}
+
+				nextApprovalDetailQueryTime = time.Now().Add(workWXApprovalDetailPollInterval)
+				detail, detailErr := client.GetApprovalDetail(instanceID)
+				if detailErr != nil {
+					log.Warnf("failed to get workwx approval detail, error: %s", detailErr)
+					continue
+				}
+				userApprovalResult = workWXApprovalDetailToWebhookMessage(detail)
+				if userApprovalResult == nil {
+					continue
+				}
 			}
 
 			if userApprovalResult.ProcessList != nil {
@@ -813,8 +846,8 @@ func waitForWorkWXApprove(ctx context.Context, spec *commonmodels.JobTaskApprova
 				return config.StatusPassed, nil
 			case workwx.ApprovalStatusRejected:
 				return config.StatusReject, errors.New("Approval has been rejected")
-			case workwx.ApprovalStatusDeleted:
-				return config.StatusCancelled, errors.New("Approval has been deleted")
+			case workwx.ApprovalStatusRecant, workwx.ApprovalStatusApprovedThenRecant, workwx.ApprovalStatusDeleted:
+				return config.StatusCancelled, errors.New("Approval has been cancelled")
 			default:
 				continue
 			}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
@@ -764,25 +764,13 @@ func waitForWorkWXApprove(ctx context.Context, spec *commonmodels.JobTaskApprova
 		node.UserID = userIDList
 	}
 
-	summaryList := make([]*workwx.ApprovalSummary, 0)
-	if approvalTitle != "" {
-		summaryList = append(summaryList, &workwx.ApprovalSummary{
-			SummaryInfo: []*workwx.GeneralText{
-				{
-					Text: approvalTitle,
-					Lang: workwx.LanguageCN,
-				},
-			},
-		})
-	}
-
 	instanceID, err := client.CreateApprovalInstance(
 		templateID,
 		applicant,
 		false,
 		applydata,
 		approval.ApprovalNodes,
-		summaryList,
+		make([]*workwx.ApprovalSummary, 0),
 	)
 	if err != nil {
 		log.Errorf("waitForWorkWXApprove: create instance failed: %v", err)
@@ -815,8 +803,10 @@ func waitForWorkWXApprove(ctx context.Context, spec *commonmodels.JobTaskApprova
 				continue
 			}
 
-			spec.WorkWXApproval.ApprovalNodeDetails = userApprovalResult.ProcessList.NodeList
-			ack()
+			if userApprovalResult.ProcessList != nil {
+				spec.WorkWXApproval.ApprovalNodeDetails = userApprovalResult.ProcessList.NodeList
+				ack()
+			}
 
 			switch userApprovalResult.Status {
 			case workwx.ApprovalStatusApproved:

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
@@ -526,7 +526,7 @@ func waitForDingTalkApprove(ctx context.Context, spec *commonmodels.JobTaskAppro
 
 	timeoutChan := time.After(time.Duration(timeout) * time.Minute)
 	for {
-		time.Sleep(1 * time.Second)
+		time.Sleep(3 * time.Second)
 		select {
 		case <-ctx.Done():
 			return config.StatusCancelled, fmt.Errorf("workflow was canceled")

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
@@ -153,28 +153,12 @@ func getWorkWXApprovalTemplateID(client *workwx.Client, imApp *commonmodels.IMAp
 		return templateID, nil
 	}
 
-	templateName, controls := generateWorkWXApprovalTemplate(approvalTitle)
-	templateID, err := client.CreateApprovalTemplate(templateName, controls)
-	if err != nil {
-		return "", fmt.Errorf("create workwx approval template %s error: %s", approvalTitle, err)
-	}
-
-	imApp.WorkWXApprovalTemplateIDList[approvalTitle] = templateID
-	if err := mongodb.NewIMAppColl().Update(context.Background(), imApp.ID.Hex(), imApp); err != nil {
-		return "", fmt.Errorf("update workwx approval template %s error: %s", approvalTitle, err)
-	}
-
-	return templateID, nil
-}
-
-func generateWorkWXApprovalTemplate(title string) ([]*workwx.GeneralText, []*workwx.ApprovalControl) {
 	templateName := []*workwx.GeneralText{
 		{
-			Text: title,
+			Text: approvalTitle,
 			Lang: workwx.LanguageCN,
 		},
 	}
-
 	controls := []*workwx.ApprovalControl{
 		{
 			Property: &workwx.ApprovalControlProperty{
@@ -191,26 +175,17 @@ func generateWorkWXApprovalTemplate(title string) ([]*workwx.GeneralText, []*wor
 			},
 		},
 	}
-
-	return templateName, controls
-}
-
-func workWXApprovalDetailToWebhookMessage(detail *workwx.ApprovalDetail) *workwx.ApprovalWebhookMessage {
-	if detail == nil {
-		return nil
+	templateID, err := client.CreateApprovalTemplate(templateName, controls)
+	if err != nil {
+		return "", fmt.Errorf("create workwx approval template %s error: %s", approvalTitle, err)
 	}
 
-	msg := &workwx.ApprovalWebhookMessage{
-		ID:           detail.ID,
-		TemplateName: detail.TemplateName,
-		TemplateID:   detail.TemplateID,
-		Status:       detail.Status,
-		ApplyTime:    detail.ApplyTime,
+	imApp.WorkWXApprovalTemplateIDList[approvalTitle] = templateID
+	if err := mongodb.NewIMAppColl().Update(context.Background(), imApp.ID.Hex(), imApp); err != nil {
+		return "", fmt.Errorf("update workwx approval template %s error: %s", approvalTitle, err)
 	}
-	msg.Applyer.UserID = detail.Applyer.UserID
-	msg.Applyer.DepartmentID = detail.Applyer.DepartmentID
 
-	return msg
+	return templateID, nil
 }
 
 func waitForNativeApprove(ctx context.Context, spec *commonmodels.JobTaskApprovalSpec, workflowName, jobName string, taskID int64, ack func()) (config.Status, error) {
@@ -830,10 +805,18 @@ func waitForWorkWXApprove(ctx context.Context, spec *commonmodels.JobTaskApprova
 					log.Warnf("failed to get workwx approval detail, error: %s", detailErr)
 					continue
 				}
-				userApprovalResult = workWXApprovalDetailToWebhookMessage(detail)
-				if userApprovalResult == nil {
+				if detail == nil {
 					continue
 				}
+				userApprovalResult = &workwx.ApprovalWebhookMessage{
+					ID:           detail.ID,
+					TemplateName: detail.TemplateName,
+					TemplateID:   detail.TemplateID,
+					Status:       detail.Status,
+					ApplyTime:    detail.ApplyTime,
+				}
+				userApprovalResult.Applyer.UserID = detail.Applyer.UserID
+				userApprovalResult.Applyer.DepartmentID = detail.Applyer.DepartmentID
 			}
 
 			if userApprovalResult.ProcessList != nil {

--- a/pkg/microservice/aslan/core/system/service/im_app.go
+++ b/pkg/microservice/aslan/core/system/service/im_app.go
@@ -75,7 +75,7 @@ func createDingTalkIMApp(args *commonmodels.IMApp, log *zap.SugaredLogger) error
 	}
 
 	if args.DingTalkDefaultApprovalFormCode == "" {
-		resp, err := client.CreateApproval()
+		resp, err := client.CreateApproval(dingtalk.DefaultApprovalFormName)
 		if err != nil {
 			return e.ErrCreateIMApp.AddErr(errors.Wrap(err, "create approval form"))
 		}
@@ -157,7 +157,7 @@ func updateDingTalkIMApp(id string, args *commonmodels.IMApp, log *zap.SugaredLo
 		}
 	}
 	if args.DingTalkDefaultApprovalFormCode == "" {
-		resp, err := client.CreateApproval()
+		resp, err := client.CreateApproval(dingtalk.DefaultApprovalFormName)
 		if err != nil {
 			return e.ErrUpdateIMApp.AddErr(errors.Wrap(err, "create approval form"))
 		}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_approval.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_approval.go
@@ -107,6 +107,7 @@ func (j ApprovalJobController) Update(useUserInput bool, ticket *commonmodels.Ap
 	j.jobSpec.OriginJobName = latestJobSpec.OriginJobName
 	j.jobSpec.Source = latestJobSpec.Source
 	j.jobSpec.Description = latestJobSpec.Description
+	j.jobSpec.ApprovalTitle = latestJobSpec.ApprovalTitle
 
 	if latestJobSpec.Source != config.SourceFixed {
 		if latestJobSpec.NativeApproval != nil && j.jobSpec.NativeApproval != nil {
@@ -162,6 +163,7 @@ func (j ApprovalJobController) ToTask(taskID int64) ([]*commonmodels.JobTask, er
 		DingTalkApproval: j.jobSpec.DingTalkApproval,
 		WorkWXApproval:   j.jobSpec.WorkWXApproval,
 		ApprovalMessage:  j.jobSpec.ApprovalMessage,
+		ApprovalTitle:    j.jobSpec.ApprovalTitle,
 	}
 	jobTask := &commonmodels.JobTask{
 		Name:        GenJobName(j.workflow, j.name, 0),

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -1575,8 +1575,13 @@ func createLarkApprovalDefinition(workflow *commonmodels.WorkflowV4) error {
 					if larkInfo.LarkApprovalCodeList == nil {
 						larkInfo.LarkApprovalCodeList = make(map[string]string)
 					}
+					approvalTitle := strings.TrimSpace(spec.ApprovalTitle)
+					if approvalTitle == "" {
+						approvalTitle = "Zadig 工作流"
+					}
+					approvalNodeTypeKey := data.GetNodeTypeTitleKey(spec.ApprovalTitle)
 					// skip if this node type approval definition already created
-					if approvalNodeTypeID := larkInfo.LarkApprovalCodeList[data.GetNodeTypeKey()]; approvalNodeTypeID != "" {
+					if approvalNodeTypeID := larkInfo.LarkApprovalCodeList[approvalNodeTypeKey]; approvalNodeTypeID != "" {
 						log.Infof("lark approval definition %s already created", approvalNodeTypeID)
 						continue
 					}
@@ -1600,8 +1605,8 @@ func createLarkApprovalDefinition(workflow *commonmodels.WorkflowV4) error {
 					}
 
 					approvalCode, err := client.CreateApprovalDefinition(&lark.CreateApprovalDefinitionArgs{
-						Name:        "Zadig 工作流",
-						Description: "Zadig 工作流-" + data.GetNodeTypeKey(),
+						Name:        approvalTitle,
+						Description: approvalTitle + "-" + data.GetNodeTypeKey(),
 						Nodes:       nodesArgs,
 					})
 					if err != nil {
@@ -1613,11 +1618,11 @@ func createLarkApprovalDefinition(workflow *commonmodels.WorkflowV4) error {
 					if err != nil {
 						return errors.Wrap(err, "subscribe lark approval definition")
 					}
-					larkInfo.LarkApprovalCodeList[data.GetNodeTypeKey()] = approvalCode
+					larkInfo.LarkApprovalCodeList[approvalNodeTypeKey] = approvalCode
 					if err := commonrepo.NewIMAppColl().Update(context.Background(), data.ID, larkInfo); err != nil {
 						return errors.Wrap(err, "update lark approval data")
 					}
-					log.Infof("create lark approval definition %s, key: %s", approvalCode, data.GetNodeTypeKey())
+					log.Infof("create lark approval definition %s, key: %s", approvalCode, approvalNodeTypeKey)
 				}
 			}
 		}

--- a/pkg/tool/dingtalk/approval.go
+++ b/pkg/tool/dingtalk/approval.go
@@ -73,9 +73,9 @@ func (c *Client) CreateApproval(formName string) (resp *CreateApprovalResponse, 
 }
 
 func getRandNameDefaultApprovalFormDefinition(formName string) ApprovalFormDefinition {
-	name := DefaultApprovalFormName
-	if formName != "" {
-		name = strings.TrimSpace(formName)
+	name := strings.TrimSpace(formName)
+	if name == "" {
+		name = DefaultApprovalFormName
 	}
 
 	return ApprovalFormDefinition{

--- a/pkg/tool/dingtalk/approval.go
+++ b/pkg/tool/dingtalk/approval.go
@@ -62,8 +62,8 @@ type CreateApprovalResponse struct {
 	ProcessCode string `json:"processCode"`
 }
 
-func (c *Client) CreateApproval() (resp *CreateApprovalResponse, err error) {
-	_, err = c.R().SetBodyJsonMarshal(getRandNameDefaultApprovalFormDefinition()).
+func (c *Client) CreateApproval(formName string) (resp *CreateApprovalResponse, err error) {
+	_, err = c.R().SetBodyJsonMarshal(getRandNameDefaultApprovalFormDefinition(formName)).
 		SetSuccessResult(&resp).
 		Post("https://api.dingtalk.com/v1.0/workflow/forms")
 	if err != nil && strings.Contains(err.Error(), "已有相同名称表单") {
@@ -72,9 +72,14 @@ func (c *Client) CreateApproval() (resp *CreateApprovalResponse, err error) {
 	return
 }
 
-func getRandNameDefaultApprovalFormDefinition() ApprovalFormDefinition {
+func getRandNameDefaultApprovalFormDefinition(formName string) ApprovalFormDefinition {
+	name := DefaultApprovalFormName
+	if formName != "" {
+		name = strings.TrimSpace(formName)
+	}
+
 	return ApprovalFormDefinition{
-		Name:        DefaultApprovalFormName,
+		Name:        name,
 		Description: "用于 Zadig Workflow 审批",
 		FormComponents: []FormComponents{
 			{

--- a/pkg/tool/workwx/oa.go
+++ b/pkg/tool/workwx/oa.go
@@ -119,3 +119,41 @@ func (c *Client) CreateApprovalInstance(templateID, applicant string, useTemplat
 
 	return resp.ApprovalInstanceID, nil
 }
+
+func (c *Client) GetApprovalDetail(instanceID string) (*ApprovalDetail, error) {
+	if instanceID == "" {
+		return nil, fmt.Errorf("approval instance id cannot be empty")
+	}
+
+	url := fmt.Sprintf("%s/%s", c.Host, getApprovalDetailAPI)
+
+	accessToken, err := c.getAccessToken(false)
+	if err != nil {
+		return nil, err
+	}
+
+	requestQuery := map[string]string{
+		"access_token": accessToken,
+	}
+
+	resp := new(getApprovalDetailResp)
+
+	_, err = httpclient.Post(
+		url,
+		httpclient.SetQueryParams(requestQuery),
+		httpclient.SetBody(&getApprovalDetailReq{ApprovalInstanceID: instanceID}),
+		httpclient.SetResult(&resp),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if wxErr := resp.ToError(); wxErr != nil {
+		return nil, wxErr
+	}
+	if resp.Info == nil {
+		return nil, fmt.Errorf("approval detail is empty")
+	}
+
+	return resp.Info, nil
+}

--- a/pkg/tool/workwx/types.go
+++ b/pkg/tool/workwx/types.go
@@ -24,6 +24,7 @@ const (
 	listDepartmentUserAPI           = "cgi-bin/user/simplelist"
 	getUserIDByPhoneAPI             = "cgi-bin/user/getuserid"
 	createApprovalInstanceAPI       = "cgi-bin/oa/applyevent"
+	getApprovalDetailAPI            = "cgi-bin/oa/getapprovaldetail"
 	createApprovalTemplateDetailAPI = "cgi-bin/oa/approval/create_template"
 )
 
@@ -231,6 +232,28 @@ type createApprovalInstanceResp struct {
 	generalResponse `json:",inline"`
 
 	ApprovalInstanceID string `json:"sp_no"`
+}
+
+type getApprovalDetailReq struct {
+	ApprovalInstanceID string `json:"sp_no"`
+}
+
+type getApprovalDetailResp struct {
+	generalResponse `json:",inline"`
+
+	Info *ApprovalDetail `json:"info"`
+}
+
+type ApprovalDetail struct {
+	ID           string         `json:"sp_no"`
+	TemplateName string         `json:"sp_name"`
+	TemplateID   string         `json:"template_id"`
+	Status       ApprovalStatus `json:"sp_status"`
+	ApplyTime    int64          `json:"apply_time"`
+	Applyer      struct {
+		UserID       string `json:"userid"`
+		DepartmentID string `json:"partyid"`
+	} `json:"applyer"`
 }
 
 type EncryptedWebhookMessage struct {


### PR DESCRIPTION
### What this PR does / Why we need it:

Supports custom approval titles for external approval jobs, so users can define clearer titles for Lark, DingTalk, and WorkWX approvals.

### What is changed and how it works?

- Adds `approval_title` to workflow approval job specs and task specs.
- Uses the custom title when creating Lark approval definitions.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4813)
<!-- Reviewable:end -->
