### PR TITLE
feat: show running pod count after workflow deploy

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -866,12 +866,6 @@ func (c *DeployJobCtl) wait(ctx context.Context) {
 func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespace string, relatedPodLabels []map[string]string, replaceResources []commonmodels.Resource, jobLogCtx *joblog.JobLogContext, timeout <-chan time.Time, logger *zap.SugaredLogger) (config.Status, error) {
 	jobLogManager := joblog.NewJobLogManager(jobLogCtx)
 	jobLogManager.SaveJobLog("Checking workloads' pod status ...")
-	ownerUIDs := make(map[string]bool)
-	for _, resource := range replaceResources {
-		if resource.PodOwnerUID != "" {
-			ownerUIDs[resource.PodOwnerUID] = true
-		}
-	}
 
 	for {
 		select {
@@ -910,46 +904,51 @@ func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespac
 			return config.StatusTimeout, nil
 		default:
 			time.Sleep(time.Second * 2)
-			podUIDs := make(map[string]bool)
-			runningPods := 0
+			readyPods := 0
 			totalPods := 0
 			countErr := false
-			for _, label := range relatedPodLabels {
-				if len(label) == 0 {
+			for _, resource := range replaceResources {
+				switch resource.Kind {
+				case setting.Deployment:
+					d, found, err := getter.GetDeployment(namespace, resource.Name, kubeClient)
+					if err != nil || !found {
+						jobLogManager.SaveJobLog(fmt.Sprintf("Failed to get ready replica count: failed to get deployment %s/%s - %v", namespace, resource.Name, err))
+						countErr = true
+						break
+					}
+					if d.Spec.Replicas != nil {
+						totalPods += int(*d.Spec.Replicas)
+					}
+					readyPods += int(d.Status.AvailableReplicas)
+				case setting.DaemonSet:
+					daemonSet, found, err := getter.GetDaemonSet(namespace, resource.Name, kubeClient)
+					if err != nil || !found {
+						jobLogManager.SaveJobLog(fmt.Sprintf("Failed to get ready replica count: failed to get daemonSet %s/%s - %v", namespace, resource.Name, err))
+						countErr = true
+						break
+					}
+					totalPods += int(daemonSet.Status.DesiredNumberScheduled)
+					readyPods += int(daemonSet.Status.NumberReady)
+				case setting.StatefulSet:
+					sts, found, err := getter.GetStatefulSet(namespace, resource.Name, kubeClient)
+					if err != nil || !found {
+						jobLogManager.SaveJobLog(fmt.Sprintf("Failed to get ready replica count: failed to get statefulSet %s/%s - %v", namespace, resource.Name, err))
+						countErr = true
+						break
+					}
+					if sts.Spec.Replicas != nil {
+						totalPods += int(*sts.Spec.Replicas)
+					}
+					readyPods += int(sts.Status.ReadyReplicas)
+				default:
 					continue
 				}
-				selector := labels.Set(label).AsSelector()
-				pods, err := getter.ListPods(namespace, selector, kubeClient)
-				if err != nil {
-					jobLogManager.SaveJobLog(fmt.Sprintf("Failed to get running pod count: %v", err))
-					countErr = true
+				if countErr {
 					break
-				}
-				for _, pod := range pods {
-					if len(ownerUIDs) > 0 {
-						ownerMatched := false
-						for _, owner := range pod.OwnerReferences {
-							if ownerUIDs[string(owner.UID)] {
-								ownerMatched = true
-								break
-							}
-						}
-						if !ownerMatched {
-							continue
-						}
-					}
-					if podUIDs[string(pod.UID)] {
-						continue
-					}
-					podUIDs[string(pod.UID)] = true
-					totalPods++
-					if pod.Status.Phase == corev1.PodRunning {
-						runningPods++
-					}
 				}
 			}
 			if !countErr {
-				jobLogManager.SaveJobLog(fmt.Sprintf("Running pods: %d/%d", runningPods, totalPods))
+				jobLogManager.SaveJobLog(fmt.Sprintf("Ready replicas: %d/%d", readyPods, totalPods))
 			}
 
 			ready := true

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -912,7 +912,7 @@ func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespac
 				case setting.Deployment:
 					d, found, err := getter.GetDeployment(namespace, resource.Name, kubeClient)
 					if err != nil || !found {
-						jobLogManager.SaveJobLog(fmt.Sprintf("Failed to get ready replica count: failed to get deployment %s/%s - %v", namespace, resource.Name, err))
+						jobLogManager.SaveJobLog(fmt.Sprintf("Failed to get ready pod count: failed to get deployment %s/%s - %v", namespace, resource.Name, err))
 						countErr = true
 						break
 					}
@@ -922,7 +922,7 @@ func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespac
 				case setting.DaemonSet:
 					daemonSet, found, err := getter.GetDaemonSet(namespace, resource.Name, kubeClient)
 					if err != nil || !found {
-						jobLogManager.SaveJobLog(fmt.Sprintf("Failed to get ready replica count: failed to get daemonSet %s/%s - %v", namespace, resource.Name, err))
+						jobLogManager.SaveJobLog(fmt.Sprintf("Failed to get ready pod count: failed to get daemonSet %s/%s - %v", namespace, resource.Name, err))
 						countErr = true
 						break
 					}
@@ -930,7 +930,7 @@ func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespac
 				case setting.StatefulSet:
 					sts, found, err := getter.GetStatefulSet(namespace, resource.Name, kubeClient)
 					if err != nil || !found {
-						jobLogManager.SaveJobLog(fmt.Sprintf("Failed to get ready replica count: failed to get statefulSet %s/%s - %v", namespace, resource.Name, err))
+						jobLogManager.SaveJobLog(fmt.Sprintf("Failed to get ready pod count: failed to get statefulSet %s/%s - %v", namespace, resource.Name, err))
 						countErr = true
 						break
 					}
@@ -951,7 +951,7 @@ func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespac
 					selector := labels.Set(label).AsSelector()
 					pods, err := getter.ListPods(namespace, selector, kubeClient)
 					if err != nil {
-						jobLogManager.SaveJobLog(fmt.Sprintf("Failed to get ready replica count: %v", err))
+						jobLogManager.SaveJobLog(fmt.Sprintf("Failed to get ready pod count: %v", err))
 						countErr = true
 						break
 					}
@@ -973,7 +973,7 @@ func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespac
 				}
 			}
 			if !countErr {
-				jobLogManager.SaveJobLog(fmt.Sprintf("Ready replicas: %d/%d", readyPods, totalPods))
+				jobLogManager.SaveJobLog(fmt.Sprintf("Ready pods: %d/%d", readyPods, totalPods))
 			}
 
 			ready := true

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -919,7 +919,6 @@ func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespac
 					if d.Spec.Replicas != nil {
 						totalPods += int(*d.Spec.Replicas)
 					}
-					readyPods += int(d.Status.AvailableReplicas)
 				case setting.DaemonSet:
 					daemonSet, found, err := getter.GetDaemonSet(namespace, resource.Name, kubeClient)
 					if err != nil || !found {
@@ -928,7 +927,6 @@ func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespac
 						break
 					}
 					totalPods += int(daemonSet.Status.DesiredNumberScheduled)
-					readyPods += int(daemonSet.Status.NumberReady)
 				case setting.StatefulSet:
 					sts, found, err := getter.GetStatefulSet(namespace, resource.Name, kubeClient)
 					if err != nil || !found {
@@ -939,9 +937,36 @@ func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespac
 					if sts.Spec.Replicas != nil {
 						totalPods += int(*sts.Spec.Replicas)
 					}
-					readyPods += int(sts.Status.ReadyReplicas)
 				default:
 					continue
+				}
+				if countErr {
+					break
+				}
+				podUIDs := make(map[string]bool)
+				for _, label := range relatedPodLabels {
+					if len(label) == 0 {
+						continue
+					}
+					selector := labels.Set(label).AsSelector()
+					pods, err := getter.ListPods(namespace, selector, kubeClient)
+					if err != nil {
+						jobLogManager.SaveJobLog(fmt.Sprintf("Failed to get ready replica count: %v", err))
+						countErr = true
+						break
+					}
+					for _, pod := range pods {
+						if !wrapper.Pod(pod).IsOwnerMatched(resource.PodOwnerUID) {
+							continue
+						}
+						if podUIDs[string(pod.UID)] {
+							continue
+						}
+						podUIDs[string(pod.UID)] = true
+						if wrapper.Pod(pod).Ready() {
+							readyPods++
+						}
+					}
 				}
 				if countErr {
 					break

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -860,6 +860,57 @@ func (c *DeployJobCtl) wait(ctx context.Context) {
 		logError(c.job, err.Error(), c.logger)
 		return
 	}
+	if status == config.StatusPassed {
+		jobLogManager := joblog.NewJobLogManager(jobLogCtx)
+		ownerUIDs := make(map[string]bool)
+		for _, resource := range c.jobTaskSpec.ReplaceResources {
+			if resource.PodOwnerUID != "" {
+				ownerUIDs[resource.PodOwnerUID] = true
+			}
+		}
+
+		podUIDs := make(map[string]bool)
+		runningPods := 0
+		totalPods := 0
+		countErr := false
+		for _, label := range c.jobTaskSpec.RelatedPodLabels {
+			if len(label) == 0 {
+				continue
+			}
+			selector := labels.Set(label).AsSelector()
+			pods, err := getter.ListPods(c.namespace, selector, c.kubeClient)
+			if err != nil {
+				jobLogManager.SaveJobLog(fmt.Sprintf("Failed to get running pod count: %v", err))
+				countErr = true
+				break
+			}
+			for _, pod := range pods {
+				if len(ownerUIDs) > 0 {
+					ownerMatched := false
+					for _, owner := range pod.OwnerReferences {
+						if ownerUIDs[string(owner.UID)] {
+							ownerMatched = true
+							break
+						}
+					}
+					if !ownerMatched {
+						continue
+					}
+				}
+				if podUIDs[string(pod.UID)] {
+					continue
+				}
+				podUIDs[string(pod.UID)] = true
+				totalPods++
+				if pod.Status.Phase == corev1.PodRunning {
+					runningPods++
+				}
+			}
+		}
+		if !countErr {
+			jobLogManager.SaveJobLog(fmt.Sprintf("Running pods: %d/%d", runningPods, totalPods))
+		}
+	}
 	c.job.Status = status
 }
 

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -904,10 +904,15 @@ func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespac
 			return config.StatusTimeout, nil
 		default:
 			time.Sleep(time.Second * 2)
-			readyPods := 0
-			totalPods := 0
+			type readyPodCount struct {
+				resource  commonmodels.Resource
+				readyPods int
+				totalPods int
+			}
+			readyPodCounts := make([]readyPodCount, 0, len(replaceResources))
 			countErr := false
 			for _, resource := range replaceResources {
+				podCount := readyPodCount{resource: resource}
 				switch resource.Kind {
 				case setting.Deployment:
 					d, found, err := getter.GetDeployment(namespace, resource.Name, kubeClient)
@@ -917,7 +922,7 @@ func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespac
 						break
 					}
 					if d.Spec.Replicas != nil {
-						totalPods += int(*d.Spec.Replicas)
+						podCount.totalPods = int(*d.Spec.Replicas)
 					}
 				case setting.DaemonSet:
 					daemonSet, found, err := getter.GetDaemonSet(namespace, resource.Name, kubeClient)
@@ -926,7 +931,7 @@ func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespac
 						countErr = true
 						break
 					}
-					totalPods += int(daemonSet.Status.DesiredNumberScheduled)
+					podCount.totalPods = int(daemonSet.Status.DesiredNumberScheduled)
 				case setting.StatefulSet:
 					sts, found, err := getter.GetStatefulSet(namespace, resource.Name, kubeClient)
 					if err != nil || !found {
@@ -935,7 +940,7 @@ func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespac
 						break
 					}
 					if sts.Spec.Replicas != nil {
-						totalPods += int(*sts.Spec.Replicas)
+						podCount.totalPods = int(*sts.Spec.Replicas)
 					}
 				default:
 					continue
@@ -964,16 +969,24 @@ func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespac
 						}
 						podUIDs[string(pod.UID)] = true
 						if wrapper.Pod(pod).Ready() {
-							readyPods++
+							podCount.readyPods++
 						}
 					}
 				}
 				if countErr {
 					break
 				}
+				readyPodCounts = append(readyPodCounts, podCount)
 			}
 			if !countErr {
-				jobLogManager.SaveJobLog(fmt.Sprintf("Ready pods: %d/%d", readyPods, totalPods))
+				if len(readyPodCounts) == 1 {
+					podCount := readyPodCounts[0]
+					jobLogManager.SaveJobLog(fmt.Sprintf("Ready pods: %d/%d", podCount.readyPods, podCount.totalPods))
+				} else {
+					for _, podCount := range readyPodCounts {
+						jobLogManager.SaveJobLog(fmt.Sprintf("Ready pods for %s %s: %d/%d", podCount.resource.Kind, podCount.resource.Name, podCount.readyPods, podCount.totalPods))
+					}
+				}
 			}
 
 			ready := true

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -979,13 +979,8 @@ func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespac
 				readyPodCounts = append(readyPodCounts, podCount)
 			}
 			if !countErr {
-				if len(readyPodCounts) == 1 {
-					podCount := readyPodCounts[0]
-					jobLogManager.SaveJobLog(fmt.Sprintf("Ready pods: %d/%d", podCount.readyPods, podCount.totalPods))
-				} else {
-					for _, podCount := range readyPodCounts {
-						jobLogManager.SaveJobLog(fmt.Sprintf("Ready pods for %s %s: %d/%d", podCount.resource.Kind, podCount.resource.Name, podCount.readyPods, podCount.totalPods))
-					}
+				for _, podCount := range readyPodCounts {
+					jobLogManager.SaveJobLog(fmt.Sprintf("Ready pods for %s %s: %d/%d", podCount.resource.Kind, podCount.resource.Name, podCount.readyPods, podCount.totalPods))
 				}
 			}
 

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -860,63 +860,18 @@ func (c *DeployJobCtl) wait(ctx context.Context) {
 		logError(c.job, err.Error(), c.logger)
 		return
 	}
-	if status == config.StatusPassed {
-		jobLogManager := joblog.NewJobLogManager(jobLogCtx)
-		ownerUIDs := make(map[string]bool)
-		for _, resource := range c.jobTaskSpec.ReplaceResources {
-			if resource.PodOwnerUID != "" {
-				ownerUIDs[resource.PodOwnerUID] = true
-			}
-		}
-
-		podUIDs := make(map[string]bool)
-		runningPods := 0
-		totalPods := 0
-		countErr := false
-		for _, label := range c.jobTaskSpec.RelatedPodLabels {
-			if len(label) == 0 {
-				continue
-			}
-			selector := labels.Set(label).AsSelector()
-			pods, err := getter.ListPods(c.namespace, selector, c.kubeClient)
-			if err != nil {
-				jobLogManager.SaveJobLog(fmt.Sprintf("Failed to get running pod count: %v", err))
-				countErr = true
-				break
-			}
-			for _, pod := range pods {
-				if len(ownerUIDs) > 0 {
-					ownerMatched := false
-					for _, owner := range pod.OwnerReferences {
-						if ownerUIDs[string(owner.UID)] {
-							ownerMatched = true
-							break
-						}
-					}
-					if !ownerMatched {
-						continue
-					}
-				}
-				if podUIDs[string(pod.UID)] {
-					continue
-				}
-				podUIDs[string(pod.UID)] = true
-				totalPods++
-				if pod.Status.Phase == corev1.PodRunning {
-					runningPods++
-				}
-			}
-		}
-		if !countErr {
-			jobLogManager.SaveJobLog(fmt.Sprintf("Running pods: %d/%d", runningPods, totalPods))
-		}
-	}
 	c.job.Status = status
 }
 
 func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespace string, relatedPodLabels []map[string]string, replaceResources []commonmodels.Resource, jobLogCtx *joblog.JobLogContext, timeout <-chan time.Time, logger *zap.SugaredLogger) (config.Status, error) {
 	jobLogManager := joblog.NewJobLogManager(jobLogCtx)
 	jobLogManager.SaveJobLog("Checking workloads' pod status ...")
+	ownerUIDs := make(map[string]bool)
+	for _, resource := range replaceResources {
+		if resource.PodOwnerUID != "" {
+			ownerUIDs[resource.PodOwnerUID] = true
+		}
+	}
 
 	for {
 		select {
@@ -955,6 +910,48 @@ func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespac
 			return config.StatusTimeout, nil
 		default:
 			time.Sleep(time.Second * 2)
+			podUIDs := make(map[string]bool)
+			runningPods := 0
+			totalPods := 0
+			countErr := false
+			for _, label := range relatedPodLabels {
+				if len(label) == 0 {
+					continue
+				}
+				selector := labels.Set(label).AsSelector()
+				pods, err := getter.ListPods(namespace, selector, kubeClient)
+				if err != nil {
+					jobLogManager.SaveJobLog(fmt.Sprintf("Failed to get running pod count: %v", err))
+					countErr = true
+					break
+				}
+				for _, pod := range pods {
+					if len(ownerUIDs) > 0 {
+						ownerMatched := false
+						for _, owner := range pod.OwnerReferences {
+							if ownerUIDs[string(owner.UID)] {
+								ownerMatched = true
+								break
+							}
+						}
+						if !ownerMatched {
+							continue
+						}
+					}
+					if podUIDs[string(pod.UID)] {
+						continue
+					}
+					podUIDs[string(pod.UID)] = true
+					totalPods++
+					if pod.Status.Phase == corev1.PodRunning {
+						runningPods++
+					}
+				}
+			}
+			if !countErr {
+				jobLogManager.SaveJobLog(fmt.Sprintf("Running pods: %d/%d", runningPods, totalPods))
+			}
+
 			ready := true
 			var err error
 		L:

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -864,6 +864,10 @@ func (c *DeployJobCtl) wait(ctx context.Context) {
 }
 
 func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespace string, relatedPodLabels []map[string]string, replaceResources []commonmodels.Resource, jobLogCtx *joblog.JobLogContext, timeout <-chan time.Time, logger *zap.SugaredLogger) (config.Status, error) {
+	return checkDeployStatus(ctx, kubeClient, namespace, relatedPodLabels, replaceResources, replaceResources, jobLogCtx, timeout, logger)
+}
+
+func checkDeployStatus(ctx context.Context, kubeClient crClient.Client, namespace string, relatedPodLabels []map[string]string, replaceResources, readyPodResources []commonmodels.Resource, jobLogCtx *joblog.JobLogContext, timeout <-chan time.Time, logger *zap.SugaredLogger) (config.Status, error) {
 	jobLogManager := joblog.NewJobLogManager(jobLogCtx)
 	jobLogManager.SaveJobLog("Checking workloads' pod status ...")
 
@@ -909,9 +913,9 @@ func CheckDeployStatus(ctx context.Context, kubeClient crClient.Client, namespac
 				readyPods int
 				totalPods int
 			}
-			readyPodCounts := make([]readyPodCount, 0, len(replaceResources))
+			readyPodCounts := make([]readyPodCount, 0, len(readyPodResources))
 			countErr := false
-			for _, resource := range replaceResources {
+			for _, resource := range readyPodResources {
 				podCount := readyPodCount{resource: resource}
 				switch resource.Kind {
 				case setting.Deployment:

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
@@ -428,16 +428,16 @@ func (c *HelmDeployJobCtl) checkWorkloadStatus(ctx context.Context, productInfo 
 
 	relatedPodLabels := make([]map[string]string, 0)
 	resources := []commonmodels.Resource{}
-	selectedModules := make(map[string]struct{}, len(c.jobTaskSpec.ImageAndModules))
+	selectedImages := make(map[string]struct{}, len(c.jobTaskSpec.ImageAndModules))
 	for _, imageAndModule := range c.jobTaskSpec.ImageAndModules {
-		selectedModules[imageAndModule.ServiceModule] = struct{}{}
+		selectedImages[imageAndModule.Image] = struct{}{}
 	}
-	filterByModule := len(c.jobTaskSpec.DeployContents) == 1 && c.jobTaskSpec.DeployContents[0] == config.DeployImage && len(selectedModules) > 0
+	filterByImage := len(c.jobTaskSpec.DeployContents) == 1 && c.jobTaskSpec.DeployContents[0] == config.DeployImage && len(selectedImages) > 0
 
 	for _, u := range unstructuredList {
 		switch u.GetKind() {
 		case setting.Deployment, setting.DaemonSet, setting.StatefulSet:
-			if filterByModule && !workloadContainsServiceModule(u, selectedModules) {
+			if filterByImage && !workloadContainsImage(u, selectedImages) {
 				continue
 			}
 			resources = append(resources, commonmodels.Resource{
@@ -464,7 +464,7 @@ func (c *HelmDeployJobCtl) checkWorkloadStatus(ctx context.Context, productInfo 
 	return status, nil
 }
 
-func workloadContainsServiceModule(workload *unstructured.Unstructured, selectedModules map[string]struct{}) bool {
+func workloadContainsImage(workload *unstructured.Unstructured, selectedImages map[string]struct{}) bool {
 	for _, containerField := range []string{"containers", "initContainers"} {
 		containers, found, err := unstructured.NestedSlice(workload.Object, "spec", "template", "spec", containerField)
 		if err != nil || !found {
@@ -475,8 +475,8 @@ func workloadContainsServiceModule(workload *unstructured.Unstructured, selected
 			if !ok {
 				continue
 			}
-			name, _, _ := unstructured.NestedString(containerMap, "name")
-			if _, ok := selectedModules[name]; ok {
+			image, _, _ := unstructured.NestedString(containerMap, "image")
+			if _, ok := selectedImages[image]; ok {
 				return true
 			}
 		}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
@@ -428,10 +428,18 @@ func (c *HelmDeployJobCtl) checkWorkloadStatus(ctx context.Context, productInfo 
 
 	relatedPodLabels := make([]map[string]string, 0)
 	resources := []commonmodels.Resource{}
+	selectedModules := make(map[string]struct{}, len(c.jobTaskSpec.ImageAndModules))
+	for _, imageAndModule := range c.jobTaskSpec.ImageAndModules {
+		selectedModules[imageAndModule.ServiceModule] = struct{}{}
+	}
+	filterByModule := len(c.jobTaskSpec.DeployContents) == 1 && c.jobTaskSpec.DeployContents[0] == config.DeployImage && len(selectedModules) > 0
 
 	for _, u := range unstructuredList {
 		switch u.GetKind() {
 		case setting.Deployment, setting.DaemonSet, setting.StatefulSet:
+			if filterByModule && !workloadContainsServiceModule(u, selectedModules) {
+				continue
+			}
 			resources = append(resources, commonmodels.Resource{
 				Kind: u.GetKind(),
 				Name: u.GetName(),
@@ -454,6 +462,26 @@ func (c *HelmDeployJobCtl) checkWorkloadStatus(ctx context.Context, productInfo 
 		return status, fmt.Errorf("failed to check workload status, err: %v", err)
 	}
 	return status, nil
+}
+
+func workloadContainsServiceModule(workload *unstructured.Unstructured, selectedModules map[string]struct{}) bool {
+	for _, containerField := range []string{"containers", "initContainers"} {
+		containers, found, err := unstructured.NestedSlice(workload.Object, "spec", "template", "spec", containerField)
+		if err != nil || !found {
+			continue
+		}
+		for _, container := range containers {
+			containerMap, ok := container.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			name, _, _ := unstructured.NestedString(containerMap, "name")
+			if _, ok := selectedModules[name]; ok {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (c *HelmDeployJobCtl) timeout() int {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
@@ -432,13 +432,14 @@ func (c *HelmDeployJobCtl) checkWorkloadStatus(ctx context.Context, productInfo 
 	for _, imageAndModule := range c.jobTaskSpec.ImageAndModules {
 		selectedImages[imageAndModule.Image] = struct{}{}
 	}
-	filterByImage := len(c.jobTaskSpec.DeployContents) == 1 && c.jobTaskSpec.DeployContents[0] == config.DeployImage && len(selectedImages) > 0
+	filterReadyPods := len(c.jobTaskSpec.DeployContents) == 1 && c.jobTaskSpec.DeployContents[0] == config.DeployImage && len(selectedImages) > 0
+	readyPodResourceKeys := make(map[string]struct{})
 
 	for _, u := range unstructuredList {
 		switch u.GetKind() {
 		case setting.Deployment, setting.DaemonSet, setting.StatefulSet:
-			if filterByImage && !workloadContainsImage(u, selectedImages) {
-				continue
+			if !filterReadyPods || workloadContainsImage(u, selectedImages) {
+				readyPodResourceKeys[fmt.Sprintf("%s/%s", u.GetKind(), u.GetName())] = struct{}{}
 			}
 			resources = append(resources, commonmodels.Resource{
 				Kind: u.GetKind(),
@@ -456,8 +457,14 @@ func (c *HelmDeployJobCtl) checkWorkloadStatus(ctx context.Context, productInfo 
 	if err != nil {
 		return config.StatusFailed, fmt.Errorf("failed to get resources pod owner uid, err: %v", err)
 	}
+	readyPodResources := make([]commonmodels.Resource, 0, len(resources))
+	for _, resource := range resources {
+		if _, ok := readyPodResourceKeys[fmt.Sprintf("%s/%s", resource.Kind, resource.Name)]; ok {
+			readyPodResources = append(readyPodResources, resource)
+		}
+	}
 
-	status, err := CheckDeployStatus(ctx, c.kubeClient, c.namespace, relatedPodLabels, resources, jobLogCtx, timeout, c.logger)
+	status, err := checkDeployStatus(ctx, c.kubeClient, c.namespace, relatedPodLabels, resources, readyPodResources, jobLogCtx, timeout, c.logger)
 	if err != nil {
 		return status, fmt.Errorf("failed to check workload status, err: %v", err)
 	}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_helm_deploy.go
@@ -431,12 +431,15 @@ func (c *HelmDeployJobCtl) checkWorkloadStatus(ctx context.Context, productInfo 
 
 	for _, u := range unstructuredList {
 		switch u.GetKind() {
-		case setting.Deployment, setting.StatefulSet:
+		case setting.Deployment, setting.DaemonSet, setting.StatefulSet:
 			resources = append(resources, commonmodels.Resource{
 				Kind: u.GetKind(),
 				Name: u.GetName(),
 			})
-			relatedPodLabels = append(relatedPodLabels, u.GetLabels())
+			podLabels, _, err := unstructured.NestedStringMap(u.Object, "spec", "template", "metadata", "labels")
+			if err == nil {
+				relatedPodLabels = append(relatedPodLabels, podLabels)
+			}
 		}
 	}
 


### PR DESCRIPTION
### What this PR does / Why we need it:

Show the running pod count in workflow container service deploy logs after the deployment succeeds.

### What is changed and how it works?

After `CheckDeployStatus` returns `StatusPassed` in the deploy job wait phase, the deploy job now:

- Collects the pod owner UIDs from the deployed resources.
- Lists pods by the related pod labels collected during deployment.
- Filters pods by owner UID to avoid counting pods from old ReplicaSets or unrelated workloads.
- Deduplicates pods by pod UID.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4814)
<!-- Reviewable:end -->
