### PR TITLE
fix(workflow): fetch prepare pod events from kubernetes

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/task/model.go
+++ b/pkg/microservice/aslan/core/common/repository/models/task/model.go
@@ -85,7 +85,6 @@ type Task struct {
 	Features         []string                     `bson:"features"               json:"features"`
 	IsRestart        bool                         `bson:"is_restart"             json:"is_restart"`
 	StorageEndpoint  string                       `bson:"storage_endpoint"       json:"storage_endpoint"`
-	Events           *models.Events               `bson:"-"                         json:"events,omitempty"`
 }
 
 func (Task) TableName() string {

--- a/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/models/wokflow_task_v4.go
@@ -346,13 +346,11 @@ type ImageAndServiceModule struct {
 type JobTaskFreestyleSpec struct {
 	Properties JobProperties `bson:"properties"          json:"properties"        yaml:"properties"`
 	Steps      []*StepTask   `bson:"steps"               json:"steps"             yaml:"steps"`
-	Events     *Events       `bson:"-"                   json:"events"            yaml:"events"`
 }
 
 type JobTaskPluginSpec struct {
 	Properties JobProperties   `bson:"properties"          json:"properties"        yaml:"properties"`
 	Plugin     *PluginTemplate `bson:"plugin"              json:"plugin"            yaml:"plugin"`
-	Events     *Events         `bson:"-"                   json:"events"            yaml:"events"`
 }
 
 type JobTaskBlueGreenDeploySpec struct {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_freestyle.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_freestyle.go
@@ -97,9 +97,6 @@ func NewFreestyleJobCtl(job *commonmodels.JobTask, workflowCtx *commonmodels.Wor
 	if err := commonmodels.IToi(job.Spec, jobTaskSpec); err != nil {
 		logger.Error(err)
 	}
-	if jobTaskSpec.Events == nil {
-		jobTaskSpec.Events = &commonmodels.Events{}
-	}
 	job.Spec = jobTaskSpec
 	return &FreestyleJobCtl{
 		job:             job,

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_freestyle.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_freestyle.go
@@ -156,6 +156,13 @@ func (c *FreestyleJobCtl) prepare(ctx context.Context) error {
 	if c.jobTaskSpec.Properties.ClusterID == "" {
 		c.jobTaskSpec.Properties.ClusterID = setting.LocalClusterID
 	}
+	if c.job.Infrastructure != setting.JobVMInfrastructure && c.jobTaskSpec.Properties.Namespace == "" {
+		if c.jobTaskSpec.Properties.ClusterID == setting.LocalClusterID {
+			c.jobTaskSpec.Properties.Namespace = zadigconfig.Namespace()
+		} else {
+			c.jobTaskSpec.Properties.Namespace = setting.AttachedClusterNamespace
+		}
+	}
 
 	// Check if there are file type environment variables
 	if err := c.checkAndPrepareFileTypes(ctx); err != nil {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_freestyle.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_freestyle.go
@@ -1167,10 +1167,7 @@ func (c *FreestyleJobCtl) cleanupHelperPod(ctx context.Context, client crClient.
 func (c *FreestyleJobCtl) wait(ctx context.Context) {
 	var err error
 	taskTimeout := time.After(time.Duration(c.jobTaskSpec.Properties.Timeout) * time.Minute)
-	c.job.Status, err = waitJobStart(ctx, c.jobTaskSpec.Properties.Namespace, c.job.K8sJobName, c.kubeclient, c.apiServer, taskTimeout, c.logger, func(events *commonmodels.Events) {
-		c.jobTaskSpec.Events = events
-		c.ack()
-	})
+	c.job.Status, err = waitJobStart(ctx, c.jobTaskSpec.Properties.Namespace, c.job.K8sJobName, c.kubeclient, c.apiServer, taskTimeout, c.logger, nil)
 	if err != nil {
 		c.job.Error = err.Error()
 	}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_freestyle.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_freestyle.go
@@ -1167,7 +1167,7 @@ func (c *FreestyleJobCtl) cleanupHelperPod(ctx context.Context, client crClient.
 func (c *FreestyleJobCtl) wait(ctx context.Context) {
 	var err error
 	taskTimeout := time.After(time.Duration(c.jobTaskSpec.Properties.Timeout) * time.Minute)
-	c.job.Status, err = waitJobStart(ctx, c.jobTaskSpec.Properties.Namespace, c.job.K8sJobName, c.kubeclient, c.apiServer, taskTimeout, c.logger, nil)
+	c.job.Status, err = waitJobStart(ctx, c.jobTaskSpec.Properties.Namespace, c.job.K8sJobName, c.kubeclient, c.apiServer, taskTimeout, c.logger)
 	if err != nil {
 		c.job.Error = err.Error()
 	}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_plugin.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_plugin.go
@@ -153,7 +153,7 @@ func (c *PluginJobCtl) run(ctx context.Context) error {
 func (c *PluginJobCtl) wait(ctx context.Context) {
 	var err error
 	timeout := time.After(time.Duration(c.jobTaskSpec.Properties.Timeout) * time.Minute)
-	c.job.Status, err = waitJobStart(ctx, c.jobTaskSpec.Properties.Namespace, c.job.K8sJobName, c.kubeclient, c.apiServer, timeout, c.logger, nil)
+	c.job.Status, err = waitJobStart(ctx, c.jobTaskSpec.Properties.Namespace, c.job.K8sJobName, c.kubeclient, c.apiServer, timeout, c.logger)
 	if err != nil {
 		c.logger.Errorf("wait job start error: %v", err)
 	}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_plugin.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_plugin.go
@@ -74,6 +74,14 @@ func (c *PluginJobCtl) prepare(ctx context.Context) {
 	if c.jobTaskSpec.Properties.ClusterID == "" {
 		c.jobTaskSpec.Properties.ClusterID = setting.LocalClusterID
 	}
+	if c.jobTaskSpec.Properties.Namespace == "" {
+		if c.jobTaskSpec.Properties.ClusterID == setting.LocalClusterID {
+			c.jobTaskSpec.Properties.Namespace = zadigconfig.Namespace()
+		} else {
+			c.jobTaskSpec.Properties.Namespace = setting.AttachedClusterNamespace
+		}
+	}
+	c.ack()
 }
 
 func (c *PluginJobCtl) Clean(ctx context.Context) {}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_plugin.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_plugin.go
@@ -153,10 +153,7 @@ func (c *PluginJobCtl) run(ctx context.Context) error {
 func (c *PluginJobCtl) wait(ctx context.Context) {
 	var err error
 	timeout := time.After(time.Duration(c.jobTaskSpec.Properties.Timeout) * time.Minute)
-	c.job.Status, err = waitJobStart(ctx, c.jobTaskSpec.Properties.Namespace, c.job.K8sJobName, c.kubeclient, c.apiServer, timeout, c.logger, func(events *commonmodels.Events) {
-		c.jobTaskSpec.Events = events
-		c.ack()
-	})
+	c.job.Status, err = waitJobStart(ctx, c.jobTaskSpec.Properties.Namespace, c.job.K8sJobName, c.kubeclient, c.apiServer, timeout, c.logger, nil)
 	if err != nil {
 		c.logger.Errorf("wait job start error: %v", err)
 	}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_plugin.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_plugin.go
@@ -48,9 +48,6 @@ func NewPluginsJobCtl(job *commonmodels.JobTask, workflowCtx *commonmodels.Workf
 	if err := commonmodels.IToi(job.Spec, jobTaskSpec); err != nil {
 		logger.Error(err)
 	}
-	if jobTaskSpec.Events == nil {
-		jobTaskSpec.Events = &commonmodels.Events{}
-	}
 	job.Spec = jobTaskSpec
 	return &PluginJobCtl{
 		job:         job,

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/kubernetes.go
@@ -933,7 +933,7 @@ func int64Ptr(i int64) *int64 { return &i }
 
 func WaitPlainJobEnd(ctx context.Context, taskTimeout int, namespace, jobName string, kubeClient crClient.Client, apiServer crClient.Reader, xl *zap.SugaredLogger) config.Status {
 	timeout := time.After(time.Duration(taskTimeout) * time.Minute)
-	status, err := waitJobStart(ctx, namespace, jobName, kubeClient, apiServer, timeout, xl, nil)
+	status, err := waitJobStart(ctx, namespace, jobName, kubeClient, apiServer, timeout, xl)
 	if err != nil {
 		xl.Errorf("wait job start error: %v", err)
 	}
@@ -973,67 +973,12 @@ func waitPlainJobEnd(ctx context.Context, taskTimeout int, timeout <-chan time.T
 	}
 }
 
-func appendPendingPodEvents(podName, namespace string, apiReader client.Reader, events *commonmodels.Events, reported map[string]struct{}, onUpdate func(*commonmodels.Events), xl *zap.SugaredLogger) {
-	if events == nil {
-		return
-	}
-
-	selector := fields.Set{"involvedObject.name": podName, "involvedObject.kind": setting.Pod}.AsSelector()
-	kubeEvents, err := getter.ListEvents(namespace, selector, apiReader)
-	if err != nil {
-		xl.Errorf("list events failed for pod %s/%s: %s", namespace, podName, err)
-		return
-	}
-
-	sort.SliceStable(kubeEvents, func(i, j int) bool {
-		return kubeEvents[i].CreationTimestamp.Unix() < kubeEvents[j].CreationTimestamp.Unix()
-	})
-
-	changed := false
-	for _, kubeEvent := range kubeEvents {
-		eventKey := fmt.Sprintf("%s|%s|%s", kubeEvent.Type, kubeEvent.Reason, kubeEvent.Message)
-		if _, ok := reported[eventKey]; ok {
-			continue
-		}
-		reported[eventKey] = struct{}{}
-
-		eventType := "info"
-		if kubeEvent.Type == corev1.EventTypeWarning {
-			eventType = "error"
-		}
-
-		eventTime := kubeEvent.LastTimestamp
-		if eventTime.IsZero() {
-			eventTime = kubeEvent.FirstTimestamp
-		}
-		if eventTime.IsZero() && !kubeEvent.EventTime.IsZero() {
-			eventTime = metav1.NewTime(kubeEvent.EventTime.Time)
-		}
-		if eventTime.IsZero() {
-			eventTime = metav1.NewTime(time.Now())
-		}
-
-		*events = append(*events, &commonmodels.Event{
-			EventType: eventType,
-			Time:      eventTime.Format("2006-01-02 15:04:05"),
-			Message:   fmt.Sprintf("Pod event [%s/%s]: %s", kubeEvent.Type, kubeEvent.Reason, kubeEvent.Message),
-		})
-		changed = true
-	}
-
-	if changed && onUpdate != nil {
-		onUpdate(events)
-	}
-}
-
-func waitJobStart(ctx context.Context, namespace, jobName string, kubeClient crClient.Client, apiReader client.Reader, timeout <-chan time.Time, xl *zap.SugaredLogger, onEventsUpdate func(*commonmodels.Events)) (config.Status, error) {
+func waitJobStart(ctx context.Context, namespace, jobName string, kubeClient crClient.Client, apiReader client.Reader, timeout <-chan time.Time, xl *zap.SugaredLogger) (config.Status, error) {
 	xl.Infof("wait job to start: %s/%s", namespace, jobName)
 	xl.Infof("Timeout of preparing Pod: %s.", 120*time.Second)
 	waitPodReadyTimeout := time.After(120 * time.Second)
 
 	var podReadyTimeout bool
-	reportedEvents := make(map[string]struct{})
-	events := &commonmodels.Events{}
 	for {
 		select {
 		case <-ctx.Done():
@@ -1058,8 +1003,6 @@ func waitJobStart(ctx context.Context, namespace, jobName string, kubeClient crC
 					continue
 				}
 				for _, pod := range podList {
-					appendPendingPodEvents(pod.Name, namespace, apiReader, events, reportedEvents, onEventsUpdate, xl)
-
 					if pod.Status.Phase == corev1.PodFailed {
 						msg := ""
 						for _, condition := range pod.Status.Conditions {

--- a/pkg/microservice/aslan/core/workflow/handler/router.go
+++ b/pkg/microservice/aslan/core/workflow/handler/router.go
@@ -128,6 +128,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		taskV4.GET("/filter/workflow/:name", GetWorkflowTaskFilters)
 		taskV4.GET("", ListWorkflowTaskV4ByFilter)
 		taskV4.GET("/workflow/:workflowName/task/:taskID", GetWorkflowTaskV4)
+		taskV4.GET("/workflow/:workflowName/task/:taskID/job/:jobName/events", GetWorkflowTaskV4JobEvents)
 		taskV4.DELETE("/workflow/:workflowName/task/:taskID", CancelWorkflowTaskV4)
 		taskV4.GET("/clone/workflow/:workflowName/task/:taskID", CloneWorkflowTaskV4)
 		taskV4.GET("/view/workflow/:workflowName/task/:taskID", ViewWorkflowTaskV4)

--- a/pkg/microservice/aslan/core/workflow/handler/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/handler/workflow_task_v4.go
@@ -219,6 +219,51 @@ func GetWorkflowTaskV4(c *gin.Context) {
 	ctx.Resp, ctx.RespErr = workflow.GetWorkflowTaskV4(workflowName, taskID, ctx.Logger)
 }
 
+func GetWorkflowTaskV4JobEvents(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	taskID, err := strconv.ParseInt(c.Param("taskID"), 10, 64)
+	if err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("invalid task id")
+		return
+	}
+
+	workflowName := c.Param("workflowName")
+	jobName := c.Param("jobName")
+
+	w, err := workflow.FindWorkflowV4Raw(workflowName, ctx.Logger)
+	if err != nil {
+		ctx.Logger.Errorf("GetWorkflowTaskV4JobEvents error: %v", err)
+		ctx.RespErr = e.ErrInvalidParam.AddErr(err)
+		return
+	}
+
+	if !ctx.Resources.IsSystemAdmin {
+		if _, ok := ctx.Resources.ProjectAuthInfo[w.Project]; !ok {
+			ctx.UnAuthorized = true
+			return
+		}
+
+		if !ctx.Resources.ProjectAuthInfo[w.Project].IsProjectAdmin &&
+			!ctx.Resources.ProjectAuthInfo[w.Project].Workflow.View {
+			permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, w.Project, types.ResourceTypeWorkflow, w.Name, types.WorkflowActionView)
+			if err != nil || !permitted {
+				ctx.UnAuthorized = true
+				return
+			}
+		}
+	}
+
+	ctx.Resp, ctx.RespErr = workflow.GetWorkflowTaskV4JobEvents(workflowName, jobName, taskID, ctx.Logger)
+}
+
 func CancelWorkflowTaskV4(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -2681,7 +2681,7 @@ func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, 
 			}
 		}
 		events := extractRuntimeJobEvents(job)
-		if job.Status == config.StatusPrepare {
+		if job.Status == config.StatusPrepare || job.Status == config.StatusRunning {
 			if kubeEvents := listRuntimeJobEventsFromKube(job, logger); kubeEvents != nil {
 				events = kubeEvents
 			}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -2631,15 +2631,8 @@ func ListRuntimeJobEventsFromKube(job *commonmodels.JobTask, logger *zap.Sugared
 		return kubeEvents[i].CreationTimestamp.Unix() < kubeEvents[j].CreationTimestamp.Unix()
 	})
 
-	reported := make(map[string]struct{})
 	events := &commonmodels.Events{}
 	for _, kubeEvent := range kubeEvents {
-		eventKey := fmt.Sprintf("%s|%s|%s|%s", kubeEvent.InvolvedObject.Name, kubeEvent.Type, kubeEvent.Reason, kubeEvent.Message)
-		if _, ok := reported[eventKey]; ok {
-			continue
-		}
-		reported[eventKey] = struct{}{}
-
 		eventType := "info"
 		if kubeEvent.Type == corev1.EventTypeWarning {
 			eventType = "error"
@@ -2668,6 +2661,28 @@ func ListRuntimeJobEventsFromKube(job *commonmodels.JobTask, logger *zap.Sugared
 	return events
 }
 
+func GetWorkflowTaskV4JobEvents(workflowName, jobName string, taskID int64, logger *zap.SugaredLogger) (*commonmodels.Events, error) {
+	task, err := commonrepo.NewworkflowTaskv4Coll().Find(workflowName, taskID)
+	if err != nil {
+		logger.Errorf("failed to find workflow task %d for workflow: %s, error: %s", taskID, workflowName, err)
+		return nil, e.ErrGetTask.AddErr(err)
+	}
+
+	for _, stage := range task.Stages {
+		for _, job := range stage.Jobs {
+			if job.Name != jobName {
+				continue
+			}
+			if events := ListRuntimeJobEventsFromKube(job, logger); events != nil {
+				return events, nil
+			}
+			return &commonmodels.Events{}, nil
+		}
+	}
+
+	return nil, e.ErrGetTask.AddDesc(fmt.Sprintf("job %s not found", jobName))
+}
+
 func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, now int64, projectName string, logger *zap.SugaredLogger) []*JobTaskPreview {
 	envMap := make(map[string]*commonmodels.Product)
 	resp := []*JobTaskPreview{}
@@ -2681,11 +2696,6 @@ func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, 
 			}
 		}
 		events := extractRuntimeJobEvents(job)
-		if job.Status == config.StatusPrepare {
-			if kubeEvents := ListRuntimeJobEventsFromKube(job, logger); kubeEvents != nil {
-				events = kubeEvents
-			}
-		}
 		jobPreview := &JobTaskPreview{
 			Name:                 job.Name,
 			Key:                  job.Key,

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -2584,6 +2584,11 @@ func listRuntimeJobEventsFromKube(job *commonmodels.JobTask, logger *zap.Sugared
 		logger.Errorf("get kube client failed for job %s, clusterID:%s, err:%v", job.Name, clusterID, err)
 		return nil
 	}
+	apiReader, err := clientmanager.NewKubeClientManager().GetControllerRuntimeAPIReader(clusterID)
+	if err != nil {
+		logger.Errorf("get kube api reader failed for job %s, clusterID:%s, err:%v", job.Name, clusterID, err)
+		return nil
+	}
 
 	podSelector := k8slabels.Set{setting.JobLabelNameKey: strings.Replace(job.K8sJobName, "_", "-", -1)}.AsSelector()
 	pods, err := getter.ListPods(namespace, podSelector, kubeClient)
@@ -2602,7 +2607,7 @@ func listRuntimeJobEventsFromKube(job *commonmodels.JobTask, logger *zap.Sugared
 	kubeEvents := make([]*corev1.Event, 0)
 	for _, pod := range pods {
 		selector := fields.Set{"involvedObject.name": pod.Name, "involvedObject.kind": setting.Pod}.AsSelector()
-		podEvents, err := getter.ListEvents(namespace, selector, kubeClient)
+		podEvents, err := getter.ListEvents(namespace, selector, apiReader)
 		if err != nil {
 			logger.Errorf("list events failed for pod %s/%s: %s", namespace, pod.Name, err)
 			continue

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -2568,12 +2568,16 @@ func listRuntimeJobEventsFromKube(job *commonmodels.JobTask, workflowName string
 			namespace = taskJobSpec.Properties.Namespace
 		}
 	}
-	if namespace == "" {
-		logger.Infof("skip listing runtime pod events because namespace is empty, workflow:%s, taskID:%d, job:%s, jobType:%s, k8sJobName:%s", workflowName, taskID, job.Name, job.JobType, job.K8sJobName)
-		return nil
-	}
 	if clusterID == "" {
 		clusterID = setting.LocalClusterID
+	}
+	if namespace == "" {
+		if clusterID == setting.LocalClusterID {
+			namespace = config2.Namespace()
+		} else {
+			namespace = setting.AttachedClusterNamespace
+		}
+		logger.Infof("fallback runtime pod events namespace, workflow:%s, taskID:%d, job:%s, jobType:%s, k8sJobName:%s, clusterID:%s, namespace:%s", workflowName, taskID, job.Name, job.JobType, job.K8sJobName, clusterID, namespace)
 	}
 	logger.Infof("listing runtime pod events, workflow:%s, taskID:%d, job:%s, jobType:%s, k8sJobName:%s, clusterID:%s, namespace:%s", workflowName, taskID, job.Name, job.JobType, job.K8sJobName, clusterID, namespace)
 

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -2460,7 +2460,7 @@ func GetWorkflowTaskV4(workflowName string, taskID int64, logger *zap.SugaredLog
 			EndTime:    stage.EndTime,
 			Parallel:   stage.Parallel,
 			ManualExec: stage.ManualExec,
-			Jobs:       jobsToJobPreviews(stage.Jobs, task.GlobalContext, timeNow, task.ProjectName, logger),
+			Jobs:       jobsToJobPreviews(stage.Jobs, task.GlobalContext, timeNow, task.ProjectName, task.WorkflowName, task.TaskID, logger),
 			Error:      stage.Error,
 		})
 	}
@@ -2552,11 +2552,7 @@ func extractRuntimeJobEvents(job *commonmodels.JobTask) *commonmodels.Events {
 	return nil
 }
 
-func listRuntimeJobEventsFromKube(job *commonmodels.JobTask, logger *zap.SugaredLogger) *commonmodels.Events {
-	if job.K8sJobName == "" {
-		return nil
-	}
-
+func listRuntimeJobEventsFromKube(job *commonmodels.JobTask, workflowName string, taskID int64, logger *zap.SugaredLogger) *commonmodels.Events {
 	var clusterID, namespace string
 	switch job.JobType {
 	case string(config.JobFreestyle), string(config.JobZadigBuild), string(config.JobZadigTesting), string(config.JobZadigScanning), string(config.JobZadigDistributeImage):
@@ -2573,11 +2569,13 @@ func listRuntimeJobEventsFromKube(job *commonmodels.JobTask, logger *zap.Sugared
 		}
 	}
 	if namespace == "" {
+		logger.Infof("skip listing runtime pod events because namespace is empty, workflow:%s, taskID:%d, job:%s, jobType:%s, k8sJobName:%s", workflowName, taskID, job.Name, job.JobType, job.K8sJobName)
 		return nil
 	}
 	if clusterID == "" {
 		clusterID = setting.LocalClusterID
 	}
+	logger.Infof("listing runtime pod events, workflow:%s, taskID:%d, job:%s, jobType:%s, k8sJobName:%s, clusterID:%s, namespace:%s", workflowName, taskID, job.Name, job.JobType, job.K8sJobName, clusterID, namespace)
 
 	kubeClient, err := clientmanager.NewKubeClientManager().GetControllerRuntimeClient(clusterID)
 	if err != nil {
@@ -2590,20 +2588,24 @@ func listRuntimeJobEventsFromKube(job *commonmodels.JobTask, logger *zap.Sugared
 		return nil
 	}
 
-	podSelector := k8slabels.Set{setting.JobLabelNameKey: strings.Replace(job.K8sJobName, "_", "-", -1)}.AsSelector()
-	pods, err := getter.ListPods(namespace, podSelector, kubeClient)
-	if err != nil {
-		logger.Errorf("list pods failed for job %s/%s, namespace:%s, err:%v", job.Name, job.K8sJobName, namespace, err)
-		return nil
-	}
-	if len(pods) == 0 {
-		pods, err = getter.ListPods(namespace, k8slabels.Set{"job-name": job.K8sJobName}.AsSelector(), kubeClient)
+	pods := make([]*corev1.Pod, 0)
+	if job.K8sJobName != "" {
+		podSelector := k8slabels.Set{setting.JobLabelNameKey: strings.Replace(job.K8sJobName, "_", "-", -1)}.AsSelector()
+		pods, err = getter.ListPods(namespace, podSelector, kubeClient)
 		if err != nil {
-			logger.Errorf("list pods by job-name failed for job %s/%s, namespace:%s, err:%v", job.Name, job.K8sJobName, namespace, err)
+			logger.Errorf("list pods failed for job %s/%s, namespace:%s, err:%v", job.Name, job.K8sJobName, namespace, err)
 			return nil
 		}
+		logger.Infof("listed runtime pods by s-name, workflow:%s, taskID:%d, job:%s, k8sJobName:%s, namespace:%s, podCount:%d", workflowName, taskID, job.Name, job.K8sJobName, namespace, len(pods))
+		if len(pods) == 0 {
+			pods, err = getter.ListPods(namespace, k8slabels.Set{"job-name": job.K8sJobName}.AsSelector(), kubeClient)
+			if err != nil {
+				logger.Errorf("list pods by job-name failed for job %s/%s, namespace:%s, err:%v", job.Name, job.K8sJobName, namespace, err)
+				return nil
+			}
+			logger.Infof("listed runtime pods by job-name, workflow:%s, taskID:%d, job:%s, k8sJobName:%s, namespace:%s, podCount:%d", workflowName, taskID, job.Name, job.K8sJobName, namespace, len(pods))
+		}
 	}
-
 	kubeEvents := make([]*corev1.Event, 0)
 	for _, pod := range pods {
 		selector := fields.Set{"involvedObject.name": pod.Name, "involvedObject.kind": setting.Pod}.AsSelector()
@@ -2612,9 +2614,11 @@ func listRuntimeJobEventsFromKube(job *commonmodels.JobTask, logger *zap.Sugared
 			logger.Errorf("list events failed for pod %s/%s: %s", namespace, pod.Name, err)
 			continue
 		}
+		logger.Infof("listed runtime pod events, workflow:%s, taskID:%d, job:%s, namespace:%s, pod:%s, eventCount:%d", workflowName, taskID, job.Name, namespace, pod.Name, len(podEvents))
 		kubeEvents = append(kubeEvents, podEvents...)
 	}
 	if len(kubeEvents) == 0 {
+		logger.Infof("no runtime pod events found, workflow:%s, taskID:%d, job:%s, namespace:%s, podCount:%d", workflowName, taskID, job.Name, namespace, len(pods))
 		return nil
 	}
 
@@ -2659,7 +2663,7 @@ func listRuntimeJobEventsFromKube(job *commonmodels.JobTask, logger *zap.Sugared
 	return events
 }
 
-func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, now int64, projectName string, logger *zap.SugaredLogger) []*JobTaskPreview {
+func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, now int64, projectName, workflowName string, taskID int64, logger *zap.SugaredLogger) []*JobTaskPreview {
 	envMap := make(map[string]*commonmodels.Product)
 	resp := []*JobTaskPreview{}
 
@@ -2673,7 +2677,7 @@ func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, 
 		}
 		events := extractRuntimeJobEvents(job)
 		if job.Status == config.StatusPrepare {
-			if kubeEvents := listRuntimeJobEventsFromKube(job, logger); kubeEvents != nil {
+			if kubeEvents := listRuntimeJobEventsFromKube(job, workflowName, taskID, logger); kubeEvents != nil {
 				events = kubeEvents
 			}
 		}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -2552,7 +2552,7 @@ func extractRuntimeJobEvents(job *commonmodels.JobTask) *commonmodels.Events {
 	return nil
 }
 
-func listRuntimeJobEventsFromKube(job *commonmodels.JobTask, logger *zap.SugaredLogger) *commonmodels.Events {
+func ListRuntimeJobEventsFromKube(job *commonmodels.JobTask, logger *zap.SugaredLogger) *commonmodels.Events {
 	if job.K8sJobName == "" {
 		return nil
 	}
@@ -2682,7 +2682,7 @@ func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, 
 		}
 		events := extractRuntimeJobEvents(job)
 		if job.Status == config.StatusPrepare {
-			if kubeEvents := listRuntimeJobEventsFromKube(job, logger); kubeEvents != nil {
+			if kubeEvents := ListRuntimeJobEventsFromKube(job, logger); kubeEvents != nil {
 				events = kubeEvents
 			}
 		}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -140,7 +140,6 @@ type JobTaskPreview struct {
 	ErrorHandlerUserID   string                       `bson:"error_handler_user_id"  yaml:"error_handler_user_id" json:"error_handler_user_id"`
 	ErrorHandlerUserName string                       `bson:"error_handler_username"  yaml:"error_handler_username" json:"error_handler_username"`
 	RetryCount           int                          `bson:"retry_count"           yaml:"retry_count"               json:"retry_count"`
-	Events               *commonmodels.Events         `bson:" - "         json:"events"`
 	// JobInfo contains the fields that make up the job task name, for frontend display
 	JobInfo interface{} `bson:"job_info" json:"job_info"`
 }
@@ -2460,7 +2459,7 @@ func GetWorkflowTaskV4(workflowName string, taskID int64, logger *zap.SugaredLog
 			EndTime:    stage.EndTime,
 			Parallel:   stage.Parallel,
 			ManualExec: stage.ManualExec,
-			Jobs:       jobsToJobPreviews(stage.Jobs, task.GlobalContext, timeNow, task.ProjectName, logger),
+			Jobs:       jobsToJobPreviews(stage.Jobs, task.GlobalContext, timeNow, task.ProjectName),
 			Error:      stage.Error,
 		})
 	}
@@ -2531,23 +2530,6 @@ func HandleJobError(workflowName, jobName, userID, username string, taskID int64
 	if err := workflowtool.SetJobErrorHandlingDecision(workflowName, jobName, taskID, decision, userID, username); err != nil {
 		logger.Error(err)
 		return e.ErrApproveTask.AddErr(err)
-	}
-	return nil
-}
-
-// extractRuntimeJobEvents extracts the runtime job events from the job task spec.
-func extractRuntimeJobEvents(job *commonmodels.JobTask) *commonmodels.Events {
-	switch job.JobType {
-	case string(config.JobFreestyle), string(config.JobZadigBuild), string(config.JobZadigTesting), string(config.JobZadigScanning), string(config.JobZadigDistributeImage):
-		taskJobSpec := &commonmodels.JobTaskFreestyleSpec{}
-		if err := commonmodels.IToi(job.Spec, taskJobSpec); err == nil {
-			return taskJobSpec.Events
-		}
-	case string(config.JobPlugin):
-		taskJobSpec := &commonmodels.JobTaskPluginSpec{}
-		if err := commonmodels.IToi(job.Spec, taskJobSpec); err == nil {
-			return taskJobSpec.Events
-		}
 	}
 	return nil
 }
@@ -2683,7 +2665,7 @@ func GetWorkflowTaskV4JobEvents(workflowName, jobName string, taskID int64, logg
 	return nil, e.ErrGetTask.AddDesc(fmt.Sprintf("job %s not found", jobName))
 }
 
-func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, now int64, projectName string, logger *zap.SugaredLogger) []*JobTaskPreview {
+func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, now int64, projectName string) []*JobTaskPreview {
 	envMap := make(map[string]*commonmodels.Product)
 	resp := []*JobTaskPreview{}
 
@@ -2695,7 +2677,6 @@ func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, 
 				costSeconds = job.EndTime - job.StartTime
 			}
 		}
-		events := extractRuntimeJobEvents(job)
 		jobPreview := &JobTaskPreview{
 			Name:                 job.Name,
 			Key:                  job.Key,
@@ -2715,7 +2696,6 @@ func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, 
 			ErrorHandlerUserID:   job.ErrorHandlerUserID,
 			ErrorHandlerUserName: job.ErrorHandlerUserName,
 			RetryCount:           job.RetryCount,
-			Events:               events,
 		}
 		switch job.JobType {
 		case string(config.JobFreestyle):

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -2572,8 +2572,11 @@ func listRuntimeJobEventsFromKube(job *commonmodels.JobTask, logger *zap.Sugared
 			namespace = taskJobSpec.Properties.Namespace
 		}
 	}
-	if clusterID == "" || namespace == "" {
+	if namespace == "" {
 		return nil
+	}
+	if clusterID == "" {
+		clusterID = setting.LocalClusterID
 	}
 
 	kubeClient, err := clientmanager.NewKubeClientManager().GetControllerRuntimeClient(clusterID)

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -2460,7 +2460,7 @@ func GetWorkflowTaskV4(workflowName string, taskID int64, logger *zap.SugaredLog
 			EndTime:    stage.EndTime,
 			Parallel:   stage.Parallel,
 			ManualExec: stage.ManualExec,
-			Jobs:       jobsToJobPreviews(stage.Jobs, task.GlobalContext, timeNow, task.ProjectName, task.WorkflowName, task.TaskID, logger),
+			Jobs:       jobsToJobPreviews(stage.Jobs, task.GlobalContext, timeNow, task.ProjectName, logger),
 			Error:      stage.Error,
 		})
 	}
@@ -2552,7 +2552,14 @@ func extractRuntimeJobEvents(job *commonmodels.JobTask) *commonmodels.Events {
 	return nil
 }
 
-func listRuntimeJobEventsFromKube(job *commonmodels.JobTask, workflowName string, taskID int64, logger *zap.SugaredLogger) *commonmodels.Events {
+func listRuntimeJobEventsFromKube(job *commonmodels.JobTask, logger *zap.SugaredLogger) *commonmodels.Events {
+	if job.K8sJobName == "" {
+		return nil
+	}
+	if job.Infrastructure == setting.JobVMInfrastructure {
+		return nil
+	}
+
 	var clusterID, namespace string
 	switch job.JobType {
 	case string(config.JobFreestyle), string(config.JobZadigBuild), string(config.JobZadigTesting), string(config.JobZadigScanning), string(config.JobZadigDistributeImage):
@@ -2567,6 +2574,8 @@ func listRuntimeJobEventsFromKube(job *commonmodels.JobTask, workflowName string
 			clusterID = taskJobSpec.Properties.ClusterID
 			namespace = taskJobSpec.Properties.Namespace
 		}
+	default:
+		return nil
 	}
 	if clusterID == "" {
 		clusterID = setting.LocalClusterID
@@ -2577,37 +2586,31 @@ func listRuntimeJobEventsFromKube(job *commonmodels.JobTask, workflowName string
 		} else {
 			namespace = setting.AttachedClusterNamespace
 		}
-		logger.Infof("fallback runtime pod events namespace, workflow:%s, taskID:%d, job:%s, jobType:%s, k8sJobName:%s, clusterID:%s, namespace:%s", workflowName, taskID, job.Name, job.JobType, job.K8sJobName, clusterID, namespace)
 	}
-	logger.Infof("listing runtime pod events, workflow:%s, taskID:%d, job:%s, jobType:%s, k8sJobName:%s, clusterID:%s, namespace:%s", workflowName, taskID, job.Name, job.JobType, job.K8sJobName, clusterID, namespace)
-
-	kubeClient, err := clientmanager.NewKubeClientManager().GetControllerRuntimeClient(clusterID)
+	kubeManager := clientmanager.NewKubeClientManager()
+	kubeClient, err := kubeManager.GetControllerRuntimeClient(clusterID)
 	if err != nil {
 		logger.Errorf("get kube client failed for job %s, clusterID:%s, err:%v", job.Name, clusterID, err)
 		return nil
 	}
-	apiReader, err := clientmanager.NewKubeClientManager().GetControllerRuntimeAPIReader(clusterID)
+	apiReader, err := kubeManager.GetControllerRuntimeAPIReader(clusterID)
 	if err != nil {
 		logger.Errorf("get kube api reader failed for job %s, clusterID:%s, err:%v", job.Name, clusterID, err)
 		return nil
 	}
 
-	pods := make([]*corev1.Pod, 0)
-	if job.K8sJobName != "" {
-		podSelector := k8slabels.Set{setting.JobLabelNameKey: strings.Replace(job.K8sJobName, "_", "-", -1)}.AsSelector()
-		pods, err = getter.ListPods(namespace, podSelector, kubeClient)
+	k8sJobName := strings.Replace(job.K8sJobName, "_", "-", -1)
+	podSelector := k8slabels.Set{setting.JobLabelNameKey: k8sJobName}.AsSelector()
+	pods, err := getter.ListPods(namespace, podSelector, kubeClient)
+	if err != nil {
+		logger.Errorf("list pods failed for job %s/%s, namespace:%s, err:%v", job.Name, job.K8sJobName, namespace, err)
+		return nil
+	}
+	if len(pods) == 0 {
+		pods, err = getter.ListPods(namespace, k8slabels.Set{"job-name": k8sJobName}.AsSelector(), kubeClient)
 		if err != nil {
-			logger.Errorf("list pods failed for job %s/%s, namespace:%s, err:%v", job.Name, job.K8sJobName, namespace, err)
+			logger.Errorf("list pods by job-name failed for job %s/%s, namespace:%s, err:%v", job.Name, job.K8sJobName, namespace, err)
 			return nil
-		}
-		logger.Infof("listed runtime pods by s-name, workflow:%s, taskID:%d, job:%s, k8sJobName:%s, namespace:%s, podCount:%d", workflowName, taskID, job.Name, job.K8sJobName, namespace, len(pods))
-		if len(pods) == 0 {
-			pods, err = getter.ListPods(namespace, k8slabels.Set{"job-name": job.K8sJobName}.AsSelector(), kubeClient)
-			if err != nil {
-				logger.Errorf("list pods by job-name failed for job %s/%s, namespace:%s, err:%v", job.Name, job.K8sJobName, namespace, err)
-				return nil
-			}
-			logger.Infof("listed runtime pods by job-name, workflow:%s, taskID:%d, job:%s, k8sJobName:%s, namespace:%s, podCount:%d", workflowName, taskID, job.Name, job.K8sJobName, namespace, len(pods))
 		}
 	}
 	kubeEvents := make([]*corev1.Event, 0)
@@ -2618,11 +2621,9 @@ func listRuntimeJobEventsFromKube(job *commonmodels.JobTask, workflowName string
 			logger.Errorf("list events failed for pod %s/%s: %s", namespace, pod.Name, err)
 			continue
 		}
-		logger.Infof("listed runtime pod events, workflow:%s, taskID:%d, job:%s, namespace:%s, pod:%s, eventCount:%d", workflowName, taskID, job.Name, namespace, pod.Name, len(podEvents))
 		kubeEvents = append(kubeEvents, podEvents...)
 	}
 	if len(kubeEvents) == 0 {
-		logger.Infof("no runtime pod events found, workflow:%s, taskID:%d, job:%s, namespace:%s, podCount:%d", workflowName, taskID, job.Name, namespace, len(pods))
 		return nil
 	}
 
@@ -2667,7 +2668,7 @@ func listRuntimeJobEventsFromKube(job *commonmodels.JobTask, workflowName string
 	return events
 }
 
-func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, now int64, projectName, workflowName string, taskID int64, logger *zap.SugaredLogger) []*JobTaskPreview {
+func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, now int64, projectName string, logger *zap.SugaredLogger) []*JobTaskPreview {
 	envMap := make(map[string]*commonmodels.Product)
 	resp := []*JobTaskPreview{}
 
@@ -2681,7 +2682,7 @@ func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, 
 		}
 		events := extractRuntimeJobEvents(job)
 		if job.Status == config.StatusPrepare {
-			if kubeEvents := listRuntimeJobEventsFromKube(job, workflowName, taskID, logger); kubeEvents != nil {
+			if kubeEvents := listRuntimeJobEventsFromKube(job, logger); kubeEvents != nil {
 				events = kubeEvents
 			}
 		}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -2681,7 +2681,7 @@ func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, 
 			}
 		}
 		events := extractRuntimeJobEvents(job)
-		if job.Status == config.StatusPrepare || job.Status == config.StatusRunning {
+		if job.Status == config.StatusPrepare {
 			if kubeEvents := listRuntimeJobEventsFromKube(job, logger); kubeEvents != nil {
 				events = kubeEvents
 			}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -32,6 +33,9 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"gorm.io/gorm/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	controllerRuntimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -64,6 +68,7 @@ import (
 	"github.com/koderover/zadig/v2/pkg/tool/cache"
 	"github.com/koderover/zadig/v2/pkg/tool/clientmanager"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
+	"github.com/koderover/zadig/v2/pkg/tool/kube/getter"
 	larktool "github.com/koderover/zadig/v2/pkg/tool/lark"
 	"github.com/koderover/zadig/v2/pkg/tool/log"
 	"github.com/koderover/zadig/v2/pkg/tool/nacos"
@@ -2455,7 +2460,7 @@ func GetWorkflowTaskV4(workflowName string, taskID int64, logger *zap.SugaredLog
 			EndTime:    stage.EndTime,
 			Parallel:   stage.Parallel,
 			ManualExec: stage.ManualExec,
-			Jobs:       jobsToJobPreviews(stage.Jobs, task.GlobalContext, timeNow, task.ProjectName),
+			Jobs:       jobsToJobPreviews(stage.Jobs, task.GlobalContext, timeNow, task.ProjectName, logger),
 			Error:      stage.Error,
 		})
 	}
@@ -2547,7 +2552,106 @@ func extractRuntimeJobEvents(job *commonmodels.JobTask) *commonmodels.Events {
 	return nil
 }
 
-func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, now int64, projectName string) []*JobTaskPreview {
+func listRuntimeJobEventsFromKube(job *commonmodels.JobTask, logger *zap.SugaredLogger) *commonmodels.Events {
+	if job.K8sJobName == "" {
+		return nil
+	}
+
+	var clusterID, namespace string
+	switch job.JobType {
+	case string(config.JobFreestyle), string(config.JobZadigBuild), string(config.JobZadigTesting), string(config.JobZadigScanning), string(config.JobZadigDistributeImage):
+		taskJobSpec := &commonmodels.JobTaskFreestyleSpec{}
+		if err := commonmodels.IToi(job.Spec, taskJobSpec); err == nil {
+			clusterID = taskJobSpec.Properties.ClusterID
+			namespace = taskJobSpec.Properties.Namespace
+		}
+	case string(config.JobPlugin):
+		taskJobSpec := &commonmodels.JobTaskPluginSpec{}
+		if err := commonmodels.IToi(job.Spec, taskJobSpec); err == nil {
+			clusterID = taskJobSpec.Properties.ClusterID
+			namespace = taskJobSpec.Properties.Namespace
+		}
+	}
+	if clusterID == "" || namespace == "" {
+		return nil
+	}
+
+	kubeClient, err := clientmanager.NewKubeClientManager().GetControllerRuntimeClient(clusterID)
+	if err != nil {
+		logger.Errorf("get kube client failed for job %s, clusterID:%s, err:%v", job.Name, clusterID, err)
+		return nil
+	}
+
+	podSelector := k8slabels.Set{setting.JobLabelNameKey: strings.Replace(job.K8sJobName, "_", "-", -1)}.AsSelector()
+	pods, err := getter.ListPods(namespace, podSelector, kubeClient)
+	if err != nil {
+		logger.Errorf("list pods failed for job %s/%s, namespace:%s, err:%v", job.Name, job.K8sJobName, namespace, err)
+		return nil
+	}
+	if len(pods) == 0 {
+		pods, err = getter.ListPods(namespace, k8slabels.Set{"job-name": job.K8sJobName}.AsSelector(), kubeClient)
+		if err != nil {
+			logger.Errorf("list pods by job-name failed for job %s/%s, namespace:%s, err:%v", job.Name, job.K8sJobName, namespace, err)
+			return nil
+		}
+	}
+
+	kubeEvents := make([]*corev1.Event, 0)
+	for _, pod := range pods {
+		selector := fields.Set{"involvedObject.name": pod.Name, "involvedObject.kind": setting.Pod}.AsSelector()
+		podEvents, err := getter.ListEvents(namespace, selector, kubeClient)
+		if err != nil {
+			logger.Errorf("list events failed for pod %s/%s: %s", namespace, pod.Name, err)
+			continue
+		}
+		kubeEvents = append(kubeEvents, podEvents...)
+	}
+	if len(kubeEvents) == 0 {
+		return nil
+	}
+
+	sort.SliceStable(kubeEvents, func(i, j int) bool {
+		return kubeEvents[i].CreationTimestamp.Unix() < kubeEvents[j].CreationTimestamp.Unix()
+	})
+
+	reported := make(map[string]struct{})
+	events := &commonmodels.Events{}
+	for _, kubeEvent := range kubeEvents {
+		eventKey := fmt.Sprintf("%s|%s|%s|%s", kubeEvent.InvolvedObject.Name, kubeEvent.Type, kubeEvent.Reason, kubeEvent.Message)
+		if _, ok := reported[eventKey]; ok {
+			continue
+		}
+		reported[eventKey] = struct{}{}
+
+		eventType := "info"
+		if kubeEvent.Type == corev1.EventTypeWarning {
+			eventType = "error"
+		}
+
+		eventTime := kubeEvent.LastTimestamp.Time
+		if kubeEvent.LastTimestamp.IsZero() {
+			eventTime = kubeEvent.FirstTimestamp.Time
+		}
+		if eventTime.IsZero() && !kubeEvent.EventTime.IsZero() {
+			eventTime = kubeEvent.EventTime.Time
+		}
+		if eventTime.IsZero() {
+			eventTime = time.Now()
+		}
+
+		*events = append(*events, &commonmodels.Event{
+			EventType: eventType,
+			Time:      eventTime.Format("2006-01-02 15:04:05"),
+			Message:   fmt.Sprintf("Pod event [%s/%s]: %s", kubeEvent.Type, kubeEvent.Reason, kubeEvent.Message),
+		})
+	}
+	if len(*events) == 0 {
+		return nil
+	}
+	return events
+}
+
+func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, now int64, projectName string, logger *zap.SugaredLogger) []*JobTaskPreview {
 	envMap := make(map[string]*commonmodels.Product)
 	resp := []*JobTaskPreview{}
 
@@ -2557,6 +2661,12 @@ func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, 
 			costSeconds = now - job.StartTime
 			if job.EndTime != 0 {
 				costSeconds = job.EndTime - job.StartTime
+			}
+		}
+		events := extractRuntimeJobEvents(job)
+		if job.Status == config.StatusPrepare {
+			if kubeEvents := listRuntimeJobEventsFromKube(job, logger); kubeEvents != nil {
+				events = kubeEvents
 			}
 		}
 		jobPreview := &JobTaskPreview{
@@ -2578,7 +2688,7 @@ func jobsToJobPreviews(jobs []*commonmodels.JobTask, context map[string]string, 
 			ErrorHandlerUserID:   job.ErrorHandlerUserID,
 			ErrorHandlerUserName: job.ErrorHandlerUserName,
 			RetryCount:           job.RetryCount,
-			Events:               extractRuntimeJobEvents(job),
+			Events:               events,
 		}
 		switch job.JobType {
 		case string(config.JobFreestyle):

--- a/pkg/microservice/aslan/core/workflow/testing/handler/router.go
+++ b/pkg/microservice/aslan/core/workflow/testing/handler/router.go
@@ -75,6 +75,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		scanner.POST("/:id/task", FindScanningProjectNameFromID, CreateScanningTask)
 		scanner.GET("/:id/task", FindScanningProjectNameFromID, ListScanningTask)
 		scanner.GET("/:id/task/:scan_id", FindScanningProjectNameFromID, GetScanningTask)
+		scanner.GET("/:id/task/:scan_id/events", FindScanningProjectNameFromID, GetScanningTaskEvents)
 		scanner.DELETE("/:id/task/:scan_id", FindScanningProjectNameFromID, CancelScanningTask)
 		scanner.GET("/:id/task/:scan_id/sse", FindScanningProjectNameFromID, GetScanningTaskSSE)
 
@@ -102,6 +103,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		testTask.GET("", ListTestTask)
 		testTask.DELETE("", CancelTestTaskV3)
 		testTask.GET("/detail", GetTestTaskInfo)
+		testTask.GET("/events", GetTestTaskEvents)
 		testTask.GET("/report", GetTestTaskJUnitReportInfo)
 		testTask.POST("/restart", RestartTestTaskV2)
 		testTask.GET("/artifact", GetTestingTaskArtifact)

--- a/pkg/microservice/aslan/core/workflow/testing/handler/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/handler/scanning.go
@@ -479,6 +479,48 @@ func GetScanningTask(c *gin.Context) {
 	ctx.Resp, ctx.RespErr = service.GetScanningTaskInfo(scanningID, taskID, ctx.Logger)
 }
 
+func GetScanningTaskEvents(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	projectKey := c.GetString("projectKey")
+	scanningID := c.Param("id")
+
+	if !ctx.Resources.IsSystemAdmin {
+		if _, ok := ctx.Resources.ProjectAuthInfo[projectKey]; !ok {
+			ctx.UnAuthorized = true
+			return
+		}
+
+		if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin &&
+			!ctx.Resources.ProjectAuthInfo[projectKey].Scanning.View {
+			ctx.UnAuthorized = true
+			return
+		}
+	}
+
+	taskIDStr := c.Param("scan_id")
+	if taskIDStr == "" {
+		ctx.RespErr = fmt.Errorf("scan_id must be provided")
+		return
+	}
+
+	taskID, err := strconv.ParseInt(taskIDStr, 10, 64)
+	if err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc(fmt.Sprintf("invalid task id: %s", err))
+		return
+	}
+
+	ctx.Resp, ctx.RespErr = service.GetScanningTaskEvents(scanningID, taskID, ctx.Logger)
+}
+
 func CancelScanningTask(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()

--- a/pkg/microservice/aslan/core/workflow/testing/handler/test_task.go
+++ b/pkg/microservice/aslan/core/workflow/testing/handler/test_task.go
@@ -232,6 +232,42 @@ func GetTestTaskInfo(c *gin.Context) {
 	ctx.Resp, ctx.RespErr = service.GetTestTaskDetail(projectKey, testName, taskID, ctx.Logger)
 }
 
+func GetTestTaskEvents(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	projectKey := c.Query("projectName")
+	testName := c.Query("testName")
+	taskIDStr := c.Query("taskID")
+
+	if !ctx.Resources.IsSystemAdmin {
+		if _, ok := ctx.Resources.ProjectAuthInfo[projectKey]; !ok {
+			ctx.UnAuthorized = true
+			return
+		}
+
+		if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin &&
+			!ctx.Resources.ProjectAuthInfo[projectKey].Test.View {
+			ctx.UnAuthorized = true
+			return
+		}
+	}
+
+	taskID, err := strconv.ParseInt(taskIDStr, 10, 64)
+	if err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc(fmt.Sprintf("taskID args err :%s", err))
+		return
+	}
+
+	ctx.Resp, ctx.RespErr = service.GetTestTaskEvents(projectKey, testName, taskID, ctx.Logger)
+}
+
 func GetTestTaskJUnitReportInfo(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()

--- a/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
@@ -447,26 +447,46 @@ func GetScanningTaskInfo(scanningID string, taskID int64, log *zap.SugaredLogger
 	if errorMsg == "" {
 		errorMsg = workflowTask.Error
 	}
-	events := jobTaskSpec.Events
-	if workflowTask.Stages[0].Jobs[0].Status == config.StatusPrepare {
-		if kubeEvents := workflowservice.ListRuntimeJobEventsFromKube(workflowTask.Stages[0].Jobs[0], log); kubeEvents != nil {
-			events = kubeEvents
-		}
-	}
-
 	return &ScanningTaskDetail{
 		Creator:       workflowTask.TaskCreator,
 		Status:        string(status),
 		Error:         errorMsg,
 		CreateTime:    workflowTask.CreateTime,
 		EndTime:       workflowTask.EndTime,
-		Events:        events,
+		Events:        jobTaskSpec.Events,
 		RepoInfo:      repoInfo,
 		SonarMetrics:  sonarMetrics,
 		ResultLink:    resultAddr,
 		JobName:       jobName,
 		IsHasArtifact: isHasArtifact,
 	}, nil
+}
+
+func GetScanningTaskEvents(scanningID string, taskID int64, log *zap.SugaredLogger) (*commonmodels.Events, error) {
+	scanSvc := commonservice.NewScanningService()
+	scanningInfo, err := scanSvc.GetByID(scanningID)
+	if err != nil {
+		log.Errorf("failed to get scanning from mongodb, the error is: %s", err)
+		return nil, err
+	}
+
+	workflowName := commonutil.GenScanningWorkflowName(scanningInfo.ID.Hex())
+	workflowTask, err := commonrepo.NewworkflowTaskv4Coll().Find(workflowName, taskID)
+	if err != nil {
+		log.Errorf("failed to find workflow task %d for scanning: %s, error: %s", taskID, scanningID, err)
+		return nil, err
+	}
+
+	if len(workflowTask.Stages) != 1 || len(workflowTask.Stages[0].Jobs) != 1 {
+		errMsg := "invalid scan task!"
+		log.Errorf(errMsg)
+		return nil, errors.New(errMsg)
+	}
+
+	if events := workflowservice.ListRuntimeJobEventsFromKube(workflowTask.Stages[0].Jobs[0], log); events != nil {
+		return events, nil
+	}
+	return &commonmodels.Events{}, nil
 }
 
 func generateCustomWorkflowFromScanningModule(scanInfo *commonmodels.Scanning, args *CreateScanningTaskReq, notificationID string, log *zap.SugaredLogger) (*commonmodels.WorkflowV4, error) {

--- a/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
@@ -447,6 +447,12 @@ func GetScanningTaskInfo(scanningID string, taskID int64, log *zap.SugaredLogger
 	if errorMsg == "" {
 		errorMsg = workflowTask.Error
 	}
+	events := jobTaskSpec.Events
+	if workflowTask.Stages[0].Jobs[0].Status == config.StatusPrepare {
+		if kubeEvents := workflowservice.ListRuntimeJobEventsFromKube(workflowTask.Stages[0].Jobs[0], log); kubeEvents != nil {
+			events = kubeEvents
+		}
+	}
 
 	return &ScanningTaskDetail{
 		Creator:       workflowTask.TaskCreator,
@@ -454,7 +460,7 @@ func GetScanningTaskInfo(scanningID string, taskID int64, log *zap.SugaredLogger
 		Error:         errorMsg,
 		CreateTime:    workflowTask.CreateTime,
 		EndTime:       workflowTask.EndTime,
-		Events:        jobTaskSpec.Events,
+		Events:        events,
 		RepoInfo:      repoInfo,
 		SonarMetrics:  sonarMetrics,
 		ResultLink:    resultAddr,

--- a/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/scanning.go
@@ -453,7 +453,6 @@ func GetScanningTaskInfo(scanningID string, taskID int64, log *zap.SugaredLogger
 		Error:         errorMsg,
 		CreateTime:    workflowTask.CreateTime,
 		EndTime:       workflowTask.EndTime,
-		Events:        jobTaskSpec.Events,
 		RepoInfo:      repoInfo,
 		SonarMetrics:  sonarMetrics,
 		ResultLink:    resultAddr,

--- a/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
@@ -248,6 +248,12 @@ func GetTestTaskDetail(projectKey, testName string, taskID int64, log *zap.Sugar
 	if errorMsg == "" {
 		errorMsg = workflowTask.Error
 	}
+	events := jobSpec.Events
+	if workflowTask.Stages[0].Jobs[0].Status == config.StatusPrepare {
+		if kubeEvents := workflowservice.ListRuntimeJobEventsFromKube(workflowTask.Stages[0].Jobs[0], log); kubeEvents != nil {
+			events = kubeEvents
+		}
+	}
 
 	subTaskInfo[testName] = map[string]interface{}{
 		"start_time": workflowTask.Stages[0].Jobs[0].StartTime,
@@ -294,7 +300,7 @@ func GetTestTaskDetail(projectKey, testName string, taskID int64, log *zap.Sugar
 		Stages:              stages,
 		TestReports:         testResultMap,
 		IsRestart:           workflowTask.IsRestart,
-		Events:              jobSpec.Events,
+		Events:              events,
 	}, nil
 }
 

--- a/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
@@ -294,7 +294,6 @@ func GetTestTaskDetail(projectKey, testName string, taskID int64, log *zap.Sugar
 		Stages:              stages,
 		TestReports:         testResultMap,
 		IsRestart:           workflowTask.IsRestart,
-		Events:              jobSpec.Events,
 	}, nil
 }
 

--- a/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
@@ -248,12 +248,6 @@ func GetTestTaskDetail(projectKey, testName string, taskID int64, log *zap.Sugar
 	if errorMsg == "" {
 		errorMsg = workflowTask.Error
 	}
-	events := jobSpec.Events
-	if workflowTask.Stages[0].Jobs[0].Status == config.StatusPrepare {
-		if kubeEvents := workflowservice.ListRuntimeJobEventsFromKube(workflowTask.Stages[0].Jobs[0], log); kubeEvents != nil {
-			events = kubeEvents
-		}
-	}
 
 	subTaskInfo[testName] = map[string]interface{}{
 		"start_time": workflowTask.Stages[0].Jobs[0].StartTime,
@@ -300,8 +294,28 @@ func GetTestTaskDetail(projectKey, testName string, taskID int64, log *zap.Sugar
 		Stages:              stages,
 		TestReports:         testResultMap,
 		IsRestart:           workflowTask.IsRestart,
-		Events:              events,
+		Events:              jobSpec.Events,
 	}, nil
+}
+
+func GetTestTaskEvents(projectKey, testName string, taskID int64, log *zap.SugaredLogger) (*commonmodels.Events, error) {
+	workflowName := util.GenTestingWorkflowName(testName)
+	workflowTask, err := commonrepo.NewworkflowTaskv4Coll().Find(workflowName, taskID)
+	if err != nil {
+		log.Errorf("failed to find workflow task %d for test: %s, error: %s", taskID, testName, err)
+		return nil, err
+	}
+
+	if len(workflowTask.Stages) != 1 || len(workflowTask.Stages[0].Jobs) != 1 {
+		errMsg := "invalid test task!"
+		log.Errorf(errMsg)
+		return nil, errors.New(errMsg)
+	}
+
+	if events := workflowservice.ListRuntimeJobEventsFromKube(workflowTask.Stages[0].Jobs[0], log); events != nil {
+		return events, nil
+	}
+	return &commonmodels.Events{}, nil
 }
 
 func GetTestTaskReportDetail(projectKey, testName string, taskID int64, log *zap.SugaredLogger) ([]*commonmodels.TestSuite, error) {

--- a/pkg/microservice/aslan/core/workflow/testing/service/types.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/types.go
@@ -188,18 +188,17 @@ type ScanningTaskResp struct {
 }
 
 type ScanningTaskDetail struct {
-	Creator        string               `json:"creator"`
-	Status         string               `json:"status"`
-	Error          string               `json:"error,omitempty"`
-	CreateTime     int64                `json:"create_time"`
-	EndTime        int64                `json:"end_time"`
-	Events         *commonmodels.Events `json:"events,omitempty"`
-	RepoInfo       []*types.Repository  `json:"repo_info"`
-	SonarMetrics   *step.SonarMetrics   `json:"sonar_metrics"`
-	ResultLink     string               `json:"result_link,omitempty"`
-	IsHasArtifact  bool                 `json:"is_has_artifact"`
-	JobName        string               `json:"job_name"`
-	JobDisplayName string               `json:"job_display_name"`
+	Creator        string              `json:"creator"`
+	Status         string              `json:"status"`
+	Error          string              `json:"error,omitempty"`
+	CreateTime     int64               `json:"create_time"`
+	EndTime        int64               `json:"end_time"`
+	RepoInfo       []*types.Repository `json:"repo_info"`
+	SonarMetrics   *step.SonarMetrics  `json:"sonar_metrics"`
+	ResultLink     string              `json:"result_link,omitempty"`
+	IsHasArtifact  bool                `json:"is_has_artifact"`
+	JobName        string              `json:"job_name"`
+	JobDisplayName string              `json:"job_display_name"`
 }
 
 func ConvertToDBScanningModule(args *Scanning) *commonmodels.Scanning {


### PR DESCRIPTION
### What this PR does / Why we need it:

Fix workflow task detail API returning empty Pod events for jobs stuck in `prepare`.

Pod events are needed to troubleshoot scheduling, image pull, mount, quota, and other Kubernetes prepare-stage issues. Previously events were written to `jobTaskSpec.Events`, but this field is `bson:"-"`, so events were dropped after `ack()` persisted the task.

### What is changed and how it works?

When building workflow task detail, jobs in `prepare` now fetch Pod events directly from Kubernetes:

- Resolve `cluster_id`, `namespace`, and `k8s_job_name`
- Find related Pods
- Query Pod Events from Kubernetes
- Return them in the existing `events` response format

Events are no longer persisted in the workflow task document.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4819)
<!-- Reviewable:end -->
