### PR TITLE
fix(workflow): continue APISIX tasks after individual failures

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_apisix.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_apisix.go
@@ -65,20 +65,27 @@ func (c *ApisixJobCtl) Run(ctx context.Context) {
 		return
 	}
 
+	failed := false
 	for _, task := range c.jobTaskSpec.Tasks {
 		task.Status = string(config.StatusRunning)
 		c.ack()
 
 		if err := c.executeTask(client, task); err != nil {
+			failed = true
 			task.Status = string(config.StatusFailed)
 			task.Error = err.Error()
 			logError(c.job, fmt.Sprintf("failed to execute APISIX task: %v", err), c.logger)
-			return
+			c.ack()
+			continue
 		}
 
 		c.writeTaskOutput(task)
 		task.Status = string(config.StatusPassed)
 		c.ack()
+	}
+
+	if failed {
+		return
 	}
 
 	c.job.Status = config.StatusPassed


### PR DESCRIPTION
### What this PR does / Why we need it:

Ensures all configuration changes in an APISIX job are executed, even if an individual change fails.

### What is changed and how it works?

- Records the failed configuration task and continues executing subsequent tasks.
- Marks the APISIX job as failed if any configuration task fails.
- Marks the job as passed only when all configuration tasks complete successfully.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4820)
<!-- Reviewable:end -->
