### PR TITLE
feat: expand custom workflow OpenAPI

### DIFF
--- a/pkg/microservice/aslan/core/workflow/handler/openapi.go
+++ b/pkg/microservice/aslan/core/workflow/handler/openapi.go
@@ -323,6 +323,89 @@ func OpenAPIRetryCustomWorkflowTaskV4(c *gin.Context) {
 	ctx.RespErr = workflowservice.OpenAPIRetryCustomWorkflowTaskV4(name, c.Query("projectKey"), taskID, ctx.Logger)
 }
 
+func OpenAPIGetManualExecWorkflowTaskV4Context(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	workflowName, taskID, err := generalRequestValidate(c)
+	if err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+	projectKey := c.Query("projectKey")
+	if projectKey == "" {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("projectKey is required")
+		return
+	}
+	if !authorizeOpenAPIWorkflowExecution(ctx, projectKey, workflowName) {
+		ctx.UnAuthorized = true
+		return
+	}
+
+	ctx.Resp, ctx.RespErr = workflowservice.GetOpenAPIManualExecWorkflowTaskV4Context(workflowName, projectKey, taskID, ctx.UserID, ctx.Resources.IsSystemAdmin, ctx.Logger)
+}
+
+func OpenAPIManualExecWorkflowTaskV4(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	workflowName, taskID, err := generalRequestValidate(c)
+	if err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+	projectKey := c.Query("projectKey")
+	if projectKey == "" {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("projectKey is required")
+		return
+	}
+
+	args := new(workflowservice.OpenAPIManualExecWorkflowTaskV4Request)
+	data := getBody(c)
+	if err := json.Unmarshal([]byte(data), args); err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+	if args.StageName == "" {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("stage_name is required")
+		return
+	}
+	if !authorizeOpenAPIWorkflowExecution(ctx, projectKey, workflowName) {
+		ctx.UnAuthorized = true
+		return
+	}
+
+	internalhandler.InsertOperationLog(c, ctx.UserName, projectKey, "OpenAPI手动执行", "工作流任务", workflowName, workflowName, data, types.RequestBodyTypeJSON, ctx.Logger)
+	ctx.RespErr = workflowservice.OpenAPIManualExecWorkflowTaskV4(workflowName, projectKey, taskID, args.StageName, ctx.UserID, ctx.UserName, ctx.Resources.IsSystemAdmin, ctx.Logger)
+}
+
+func authorizeOpenAPIWorkflowExecution(ctx *internalhandler.Context, projectKey, workflowName string) bool {
+	if ctx.Resources.IsSystemAdmin {
+		return true
+	}
+	projectAuth, ok := ctx.Resources.ProjectAuthInfo[projectKey]
+	if !ok {
+		return false
+	}
+	if projectAuth.IsProjectAdmin || projectAuth.Workflow.Execute {
+		return true
+	}
+	permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, projectKey, types.ResourceTypeWorkflow, workflowName, types.WorkflowActionRun)
+	return err == nil && permitted
+}
+
 func OpenAPIUpdateWorkflowV4TaskRemark(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()

--- a/pkg/microservice/aslan/core/workflow/handler/router.go
+++ b/pkg/microservice/aslan/core/workflow/handler/router.go
@@ -183,11 +183,13 @@ func (*OpenAPIRouter) Inject(router *gin.RouterGroup) {
 	// custom workflow apis
 	custom := router.Group("custom")
 	{
+		custom.POST("", CreateWorkflowV4)
 		custom.POST("/task", CreateCustomWorkflowTask)
 		custom.GET("/task", OpenAPIGetWorkflowTaskV4)
 		custom.DELETE("/task", OpenAPICancelWorkflowTaskV4)
 		custom.POST("/task/approve", OpenAPIApproveStage)
 		custom.DELETE("", OpenAPIDeleteCustomWorkflowV4)
+		custom.PUT("/:name", UpdateWorkflowV4)
 		custom.GET("/:name/detail", OpenAPIGetCustomWorkflowV4)
 		custom.POST("/:name/task/:taskID", OpenAPIRetryCustomWorkflowTaskV4)
 		custom.PUT("/:name/task/:taskID", OpenAPIUpdateWorkflowV4TaskRemark)

--- a/pkg/microservice/aslan/core/workflow/handler/router.go
+++ b/pkg/microservice/aslan/core/workflow/handler/router.go
@@ -193,6 +193,8 @@ func (*OpenAPIRouter) Inject(router *gin.RouterGroup) {
 		custom.GET("/:name/detail", OpenAPIGetCustomWorkflowV4)
 		custom.POST("/:name/task/:taskID", OpenAPIRetryCustomWorkflowTaskV4)
 		custom.PUT("/:name/task/:taskID", OpenAPIUpdateWorkflowV4TaskRemark)
+		custom.GET("/:name/task/:taskID/manual-exec", OpenAPIGetManualExecWorkflowTaskV4Context)
+		custom.POST("/:name/task/:taskID/manual-exec", OpenAPIManualExecWorkflowTaskV4)
 		custom.GET("/:name/tasks", OpenAPIGetCustomWorkflowTaskV4)
 
 	}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_manual_exec_openapi.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_manual_exec_openapi.go
@@ -42,7 +42,7 @@ type OpenAPIManualExecExecutor struct {
 	GroupName string `json:"group_name,omitempty"`
 }
 
-type OpenAPIManualExecWorkflowTaskV4Context struct {
+type OpenAPIManualExecWorkflowTaskV4Response struct {
 	ProjectKey  string                       `json:"project_key"`
 	WorkflowKey string                       `json:"workflow_key"`
 	TaskID      int64                        `json:"task_id"`
@@ -52,7 +52,7 @@ type OpenAPIManualExecWorkflowTaskV4Context struct {
 	Executors   []*OpenAPIManualExecExecutor `json:"executors"`
 }
 
-func GetOpenAPIManualExecWorkflowTaskV4Context(workflowName, projectKey string, taskID int64, executorID string, isSystemAdmin bool, logger *zap.SugaredLogger) (*OpenAPIManualExecWorkflowTaskV4Context, error) {
+func GetOpenAPIManualExecWorkflowTaskV4Context(workflowName, projectKey string, taskID int64, executorID string, isSystemAdmin bool, logger *zap.SugaredLogger) (*OpenAPIManualExecWorkflowTaskV4Response, error) {
 	task, err := commonrepo.NewworkflowTaskv4Coll().Find(workflowName, taskID)
 	if err != nil {
 		logger.Errorf("find workflowTaskV4 error: %s", err)
@@ -90,7 +90,7 @@ func OpenAPIManualExecWorkflowTaskV4(workflowName, projectKey string, taskID int
 	return ManualExecWorkflowTaskV4(workflowName, taskID, stageName, stage.Jobs, executorID, "", executorName, isSystemAdmin, logger)
 }
 
-func buildManualExecContext(task *commonmodels.WorkflowTask, executorID string, isSystemAdmin bool) (*OpenAPIManualExecWorkflowTaskV4Context, error) {
+func buildManualExecContext(task *commonmodels.WorkflowTask, executorID string, isSystemAdmin bool) (*OpenAPIManualExecWorkflowTaskV4Response, error) {
 	if task == nil {
 		return nil, errors.New("workflow task is required")
 	}
@@ -106,7 +106,7 @@ func buildManualExecContext(task *commonmodels.WorkflowTask, executorID string, 
 		return nil, errors.New("workflow task has no stage waiting for manual execution")
 	}
 
-	return &OpenAPIManualExecWorkflowTaskV4Context{
+	return &OpenAPIManualExecWorkflowTaskV4Response{
 		ProjectKey:  task.ProjectName,
 		WorkflowKey: task.WorkflowName,
 		TaskID:      task.TaskID,

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_manual_exec_openapi.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_manual_exec_openapi.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
+	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
+	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
+	"github.com/koderover/zadig/v2/pkg/setting"
+	e "github.com/koderover/zadig/v2/pkg/tool/errors"
+)
+
+type OpenAPIManualExecWorkflowTaskV4Request struct {
+	StageName string `json:"stage_name"`
+}
+
+type OpenAPIManualExecExecutor struct {
+	Type      string `json:"type"`
+	UserID    string `json:"user_id,omitempty"`
+	UserName  string `json:"user_name,omitempty"`
+	GroupID   string `json:"group_id,omitempty"`
+	GroupName string `json:"group_name,omitempty"`
+}
+
+type OpenAPIManualExecWorkflowTaskV4Context struct {
+	ProjectKey  string                       `json:"project_key"`
+	WorkflowKey string                       `json:"workflow_key"`
+	TaskID      int64                        `json:"task_id"`
+	Status      config.Status                `json:"status"`
+	StageName   string                       `json:"stage_name"`
+	CanExecute  bool                         `json:"can_execute"`
+	Executors   []*OpenAPIManualExecExecutor `json:"executors"`
+}
+
+func GetOpenAPIManualExecWorkflowTaskV4Context(workflowName, projectKey string, taskID int64, executorID string, isSystemAdmin bool, logger *zap.SugaredLogger) (*OpenAPIManualExecWorkflowTaskV4Context, error) {
+	task, err := commonrepo.NewworkflowTaskv4Coll().Find(workflowName, taskID)
+	if err != nil {
+		logger.Errorf("find workflowTaskV4 error: %s", err)
+		return nil, e.ErrGetTask.AddErr(err)
+	}
+	if task.ProjectName != projectKey {
+		return nil, errors.Errorf("workflow task project %s does not match projectKey %s", task.ProjectName, projectKey)
+	}
+
+	return buildManualExecContext(task, executorID, isSystemAdmin)
+}
+
+func OpenAPIManualExecWorkflowTaskV4(workflowName, projectKey string, taskID int64, stageName, executorID, executorName string, isSystemAdmin bool, logger *zap.SugaredLogger) error {
+	if stageName == "" {
+		return errors.New("stage_name is required")
+	}
+
+	task, err := commonrepo.NewworkflowTaskv4Coll().Find(workflowName, taskID)
+	if err != nil {
+		logger.Errorf("find workflowTaskV4 error: %s", err)
+		return e.ErrGetTask.AddErr(err)
+	}
+	if task.ProjectName != projectKey {
+		return errors.Errorf("workflow task project %s does not match projectKey %s", task.ProjectName, projectKey)
+	}
+	workflow, err := GetManualExecWorkflowTaskV4Info(workflowName, taskID, logger)
+	if err != nil {
+		return err
+	}
+	stage := findWorkflowStage(workflow.Stages, stageName)
+	if stage == nil {
+		return fmt.Errorf("stage %s not found in workflow %s", stageName, workflowName)
+	}
+
+	return ManualExecWorkflowTaskV4(workflowName, taskID, stageName, stage.Jobs, executorID, "", executorName, isSystemAdmin, logger)
+}
+
+func buildManualExecContext(task *commonmodels.WorkflowTask, executorID string, isSystemAdmin bool) (*OpenAPIManualExecWorkflowTaskV4Context, error) {
+	if task == nil {
+		return nil, errors.New("workflow task is required")
+	}
+	if task.Status != config.StatusPause {
+		return nil, errors.New("工作流任务状态无法手动执行")
+	}
+	if task.OriginWorkflowArgs == nil || task.OriginWorkflowArgs.Stages == nil {
+		return nil, errors.New("工作流任务数据异常, 无法手动执行")
+	}
+
+	stage := findPendingManualExecStage(task.Stages)
+	if stage == nil {
+		return nil, errors.New("workflow task has no stage waiting for manual execution")
+	}
+
+	return &OpenAPIManualExecWorkflowTaskV4Context{
+		ProjectKey:  task.ProjectName,
+		WorkflowKey: task.WorkflowName,
+		TaskID:      task.TaskID,
+		Status:      task.Status,
+		StageName:   stage.Name,
+		CanExecute:  canExecuteManualStage(stage.ManualExec.ManualExecUsers, task.TaskCreatorID, executorID, isSystemAdmin),
+		Executors:   manualExecExecutors(stage.ManualExec.ManualExecUsers, task),
+	}, nil
+}
+
+func validateManualExecRequest(task *commonmodels.WorkflowTask, stageName, executorID string, isSystemAdmin bool) error {
+	context, err := buildManualExecContext(task, executorID, isSystemAdmin)
+	if err != nil {
+		return err
+	}
+	if context.StageName != stageName {
+		return errors.Errorf("stage %s is not waiting for manual execution", stageName)
+	}
+	if !context.CanExecute {
+		return errors.Errorf("user %s is not allowed to manually execute stage %s", executorID, stageName)
+	}
+	return nil
+}
+
+func findPendingManualExecStage(stages []*commonmodels.StageTask) *commonmodels.StageTask {
+	for _, stage := range stages {
+		if stage != nil && stage.Status == config.StatusPause && stage.ManualExec != nil && stage.ManualExec.Enabled && !stage.ManualExec.Excuted {
+			return stage
+		}
+	}
+	return nil
+}
+
+func findWorkflowStage(stages []*commonmodels.WorkflowStage, stageName string) *commonmodels.WorkflowStage {
+	for _, stage := range stages {
+		if stage != nil && stage.Name == stageName {
+			return stage
+		}
+	}
+	return nil
+}
+
+func canExecuteManualStage(users []*commonmodels.User, taskCreatorID, executorID string, isSystemAdmin bool) bool {
+	if isSystemAdmin {
+		return true
+	}
+	groups := make([]*commonmodels.User, 0)
+	for _, user := range users {
+		if user == nil {
+			continue
+		}
+		switch user.Type {
+		case setting.UserTypeTaskCreator:
+			if executorID == taskCreatorID {
+				return true
+			}
+		case setting.UserTypeUser, "":
+			if executorID == user.UserID {
+				return true
+			}
+		case setting.UserTypeGroup:
+			groups = append(groups, user)
+		}
+	}
+	flatUsers, _ := commonutil.GeneFlatUsers(groups)
+	for _, user := range flatUsers {
+		if user != nil && user.UserID == executorID {
+			return true
+		}
+	}
+	return false
+}
+
+func manualExecExecutors(users []*commonmodels.User, task *commonmodels.WorkflowTask) []*OpenAPIManualExecExecutor {
+	executors := make([]*OpenAPIManualExecExecutor, 0, len(users))
+	for _, user := range users {
+		if user == nil {
+			continue
+		}
+		executor := &OpenAPIManualExecExecutor{
+			Type:      user.Type,
+			UserID:    user.UserID,
+			UserName:  user.UserName,
+			GroupID:   user.GroupID,
+			GroupName: user.GroupName,
+		}
+		if user.Type == "" {
+			executor.Type = setting.UserTypeUser
+		}
+		if user.Type == setting.UserTypeTaskCreator {
+			executor.UserID = task.TaskCreatorID
+			executor.UserName = task.TaskCreator
+		}
+		executors = append(executors, executor)
+	}
+	return executors
+}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -1079,15 +1079,13 @@ func ManualExecWorkflowTaskV4(workflowName string, taskID int64, stageName strin
 		logger.Errorf("find workflowTaskV4 error: %s", err)
 		return e.ErrGetTask.AddErr(err)
 	}
-	switch task.Status {
-	case config.StatusPause:
-	default:
-		return errors.New("工作流任务状态无法手动执行")
+	if err := validateManualExecRequest(task, stageName, executorID, isSystemAdmin); err != nil {
+		return err
 	}
+	return manualExecWorkflowTaskV4(task, workflowName, taskID, stageName, jobs, executorID, executorName, logger)
+}
 
-	if task.OriginWorkflowArgs == nil || task.OriginWorkflowArgs.Stages == nil {
-		return errors.New("工作流任务数据异常, 无法手动执行")
-	}
+func manualExecWorkflowTaskV4(task *commonmodels.WorkflowTask, workflowName string, taskID int64, stageName string, jobs []*commonmodels.Job, executorID, executorName string, logger *zap.SugaredLogger) error {
 
 	originJobs := []*commonmodels.Job{}
 	if err := commonmodels.IToi(&jobs, &originJobs); err != nil {
@@ -1269,37 +1267,7 @@ func ManualExecWorkflowTaskV4(workflowName string, taskID int64, stageName strin
 				return errors.Errorf("previous stage %s status is not passed or skipped", preStage.Name)
 			}
 
-			if stage.ManualExec == nil || !stage.ManualExec.Enabled {
-				return errors.Errorf("stage %s is not enabled for manual execution", stage.Name)
-			}
 			stage.ManualExec.Excuted = true
-
-			approval := false
-			if isSystemAdmin {
-				approval = true
-			}
-
-			for _, user := range stage.ManualExec.ManualExecUsers {
-				if user.Type == setting.UserTypeTaskCreator {
-					if executorID == task.TaskCreatorID {
-						approval = true
-						break
-					}
-				}
-			}
-			if !approval {
-				users, _ := util.GeneFlatUsers(stage.ManualExec.ManualExecUsers)
-				for _, user := range users {
-					if user.UserID == executorID {
-						approval = true
-						break
-					}
-				}
-			}
-
-			if !approval {
-				return errors.Errorf("user %s is not allowed to manually execute stage %s", executorID, stage.Name)
-			}
 
 			found = true
 			stage.ManualExec.ManualExectorID = executorID


### PR DESCRIPTION
### Summary
- Expose workflow definition writes and manual stage execution through OpenAPI.

### Why
- Let supported clients manage workflows and handle manual gates without private APIs.

### Main Changes
- Register workflow create and update routes.
- Add manual-exec context and execution routes.
- Return current stage, executors, and current-user eligibility.
- Resolve Jobs server-side and reuse the existing manual execution entry.

### Risk / Compatibility
- Existing UI manual execution keeps the same endpoint and final backend authorization.
- New routes are additive; direct configured users are matched by UID before group expansion.

### Test
- go test -vet=off ./pkg/microservice/aslan/core/workflow/handler ./pkg/microservice/aslan/core/workflow/service/workflow

### Contact
Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4822)
<!-- Reviewable:end -->
