### PR TITLE
feat(environment): add Helm release version and values diff status

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/product.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+	templatemodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models/template"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/types"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	mongotool "github.com/koderover/zadig/v2/pkg/tool/mongo"
@@ -507,6 +508,62 @@ func (c *ProductColl) UpdateOneService(productName, envName string, groupIndex, 
 	}
 
 	return nil
+}
+
+// UpdateServiceValuesSource updates only the external Values source metadata of a service.
+// It intentionally leaves yaml_content and override_values unchanged so saving a source
+// configuration does not trigger or emulate an import.
+func (c *ProductColl) UpdateServiceValuesSource(productName, envName string, production, isHelmChartDeploy bool, identifier string, sourceData *templatemodels.CustomYaml, updateBy string) error {
+	if sourceData == nil {
+		return errors.New("nil values source data")
+	}
+	query, serviceFilter := buildServiceValuesSourceQuery(productName, envName, production, isHelmChartDeploy, identifier)
+	valuesPath := "services.$[].$[svc].render.override_yaml"
+	change := bson.M{"$set": bson.M{
+		"update_time":                  time.Now().Unix(),
+		"update_by":                    updateBy,
+		valuesPath + ".source":         sourceData.Source,
+		valuesPath + ".source_id":      sourceData.SourceID,
+		valuesPath + ".source_detail":  sourceData.SourceDetail,
+		valuesPath + ".auto_sync":      sourceData.AutoSync,
+		valuesPath + ".auto_sync_yaml": sourceData.AutoSyncYaml,
+	}}
+	arrayFilters := options.ArrayFilters{Filters: []interface{}{serviceFilter}}
+	updateOptions := options.UpdateOptions{ArrayFilters: &arrayFilters}
+
+	result, err := c.UpdateOne(mongotool.SessionContext(context.TODO(), c.Session), query, change, &updateOptions)
+	if err != nil {
+		return err
+	}
+	if result.MatchedCount == 0 {
+		return fmt.Errorf("no matching service found to update values source: %s", identifier)
+	}
+	return nil
+}
+
+func buildServiceValuesSourceQuery(productName, envName string, production, isHelmChartDeploy bool, identifier string) (bson.M, bson.M) {
+	identifierField := "service_name"
+	typeFilter := interface{}(bson.M{"$ne": setting.HelmChartDeployType})
+	if isHelmChartDeploy {
+		identifierField = "release_name"
+		typeFilter = setting.HelmChartDeployType
+	}
+	matchService := bson.M{identifierField: identifier, "type": typeFilter}
+	query := bson.M{
+		"env_name":     envName,
+		"product_name": productName,
+		"services":     bson.M{"$elemMatch": bson.M{"$elemMatch": matchService}},
+	}
+	if production {
+		query["production"] = true
+	} else {
+		query["$or"] = []bson.M{{"production": bson.M{"$eq": false}}, {"production": bson.M{"$exists": false}}}
+	}
+	serviceFilter := bson.M{
+		fmt.Sprintf("svc.%s", identifierField): identifier,
+		"svc.type":                             typeFilter,
+	}
+	return query, serviceFilter
 }
 
 // Note: Only use for add a service

--- a/pkg/microservice/aslan/core/common/service/helm_values.go
+++ b/pkg/microservice/aslan/core/common/service/helm_values.go
@@ -16,6 +16,10 @@ limitations under the License.
 package service
 
 import (
+	"go.uber.org/zap"
+
+	codeservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/code/service"
+	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	templatemodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models/template"
 	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	fsservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/fs"
@@ -23,6 +27,65 @@ import (
 	"github.com/koderover/zadig/v2/pkg/tool/log"
 	yamlutil "github.com/koderover/zadig/v2/pkg/util/yaml"
 )
+
+func GetLatestValuesSourceCommit(repoConfig *RepoConfig, log *zap.SugaredLogger) (*commonmodels.Commit, error) {
+	if repoConfig == nil || repoConfig.CodehostID == 0 || repoConfig.Repo == "" || repoConfig.Branch == "" {
+		return nil, nil
+	}
+	namespace := repoConfig.Namespace
+	if namespace == "" {
+		namespace = repoConfig.Owner
+	}
+	commits, err := codeservice.CodeHostListCommits(repoConfig.CodehostID, repoConfig.Repo, namespace, repoConfig.Branch, 1, 1, log)
+	if err != nil {
+		return nil, err
+	}
+	if len(commits) == 0 {
+		return nil, nil
+	}
+	return &commonmodels.Commit{
+		SHA:     commits[0].ID,
+		Message: commits[0].Message,
+	}, nil
+}
+
+func PopulateValuesSourceCommit(valuesData *ValuesDataArgs, log *zap.SugaredLogger) error {
+	if valuesData == nil || valuesData.GitRepoConfig == nil || valuesData.Commit != nil {
+		return nil
+	}
+	commit, err := GetLatestValuesSourceCommit(valuesData.GitRepoConfig, log)
+	if err != nil {
+		return err
+	}
+	valuesData.Commit = commit
+	return nil
+}
+
+func RefreshYamlSourceCommit(yamlData *templatemodels.CustomYaml, log *zap.SugaredLogger) error {
+	if yamlData == nil || !fromGitRepo(yamlData.Source) || yamlData.SourceDetail == nil {
+		return nil
+	}
+	sourceDetail, err := UnMarshalSourceDetail(yamlData.SourceDetail)
+	if err != nil {
+		return err
+	}
+	if sourceDetail.GitRepoConfig == nil {
+		return nil
+	}
+	commit, err := GetLatestValuesSourceCommit(&RepoConfig{
+		CodehostID: sourceDetail.GitRepoConfig.CodehostID,
+		Owner:      sourceDetail.GitRepoConfig.Owner,
+		Namespace:  sourceDetail.GitRepoConfig.Namespace,
+		Repo:       sourceDetail.GitRepoConfig.Repo,
+		Branch:     sourceDetail.GitRepoConfig.Branch,
+	}, log)
+	if err != nil {
+		return err
+	}
+	sourceDetail.Commit = commit
+	yamlData.SourceDetail = sourceDetail
+	return nil
+}
 
 func SyncYamlFromSource(yamlData *templatemodels.CustomYaml, curValue string, originValue string) (bool, string, error) {
 	if yamlData == nil || !yamlData.AutoSync {

--- a/pkg/microservice/aslan/core/common/service/helm_values.go
+++ b/pkg/microservice/aslan/core/common/service/helm_values.go
@@ -34,6 +34,49 @@ func SyncYamlFromSource(yamlData *templatemodels.CustomYaml, curValue string, or
 	return syncYamlFromGit(yamlData, curValue, originValue)
 }
 
+func LoadYamlFromSource(yamlData *templatemodels.CustomYaml) (string, bool, error) {
+	if yamlData == nil {
+		return "", false, nil
+	}
+	if yamlData.Source == setting.SourceFromVariableSet {
+		if yamlData.SourceID == "" {
+			return "", false, nil
+		}
+		variableSet, err := commonrepo.NewVariableSetColl().Find(&commonrepo.VariableSetFindOption{
+			ID: yamlData.SourceID,
+		})
+		if err != nil {
+			return "", false, err
+		}
+		return variableSet.VariableYaml, true, nil
+	}
+	if !fromGitRepo(yamlData.Source) || yamlData.SourceDetail == nil {
+		return "", false, nil
+	}
+	sourceDetail, err := UnMarshalSourceDetail(yamlData.SourceDetail)
+	if err != nil {
+		return "", false, err
+	}
+	if sourceDetail.GitRepoConfig == nil {
+		log.Warnf("git repo config is nil")
+		return "", false, nil
+	}
+	repoConfig := sourceDetail.GitRepoConfig
+
+	valuesYAML, err := fsservice.DownloadFileFromSource(&fsservice.DownloadFromSourceArgs{
+		CodehostID: repoConfig.CodehostID,
+		Namespace:  repoConfig.Namespace,
+		Owner:      repoConfig.Owner,
+		Repo:       repoConfig.Repo,
+		Path:       sourceDetail.LoadPath,
+		Branch:     repoConfig.Branch,
+	})
+	if err != nil {
+		return "", false, err
+	}
+	return string(valuesYAML), true, nil
+}
+
 func syncYamlFromVariableSet(yamlData *templatemodels.CustomYaml, curValue string) (bool, string, error) {
 	if yamlData.Source != setting.SourceFromVariableSet {
 		return false, "", nil

--- a/pkg/microservice/aslan/core/common/service/render.go
+++ b/pkg/microservice/aslan/core/common/service/render.go
@@ -43,11 +43,12 @@ type KVPair struct {
 }
 
 type ValuesDataArgs struct {
-	YamlSource    string      `json:"yamlSource"`
-	SourceID      string      `json:"source_id"`
-	AutoSync      bool        `json:"autoSync"`
-	AutoSyncYaml  string      `json:"autoSyncYaml"`
-	GitRepoConfig *RepoConfig `json:"gitRepoConfig"`
+	YamlSource    string         `json:"yamlSource"`
+	SourceID      string         `json:"source_id"`
+	AutoSync      bool           `json:"autoSync"`
+	AutoSyncYaml  string         `json:"autoSyncYaml"`
+	GitRepoConfig *RepoConfig    `json:"gitRepoConfig"`
+	Commit        *models.Commit `json:"-"`
 }
 
 type HelmSvcRenderArg struct {
@@ -127,6 +128,7 @@ func (args *HelmSvcRenderArg) toCustomValuesYaml() *templatemodels.CustomYaml {
 					Repo:       args.ValuesData.GitRepoConfig.Repo,
 					Branch:     args.ValuesData.GitRepoConfig.Branch,
 				},
+				Commit: args.ValuesData.Commit,
 			}
 			if len(args.ValuesData.GitRepoConfig.ValuesPaths) > 0 {
 				repoData.LoadPath = args.ValuesData.GitRepoConfig.ValuesPaths[0]

--- a/pkg/microservice/aslan/core/environment/handler/helm.go
+++ b/pkg/microservice/aslan/core/environment/handler/helm.go
@@ -17,6 +17,7 @@ limitations under the License.
 package handler
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/gin-gonic/gin"
@@ -25,6 +26,7 @@ import (
 	commonservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service"
 	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/environment/service"
+	"github.com/koderover/zadig/v2/pkg/setting"
 	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
 )
 
@@ -146,6 +148,78 @@ func GetHelmReleaseDiff(c *gin.Context) {
 	}
 
 	ctx.Resp, ctx.RespErr = service.GetHelmReleaseDiff(projectKey, envName, serviceOrReleaseName, production, isHelmChartDeploy, ctx.Logger)
+}
+
+func UpdateHelmValuesSource(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	envName := c.Param("name")
+	serviceOrReleaseName := c.Param("serviceOrReleaseName")
+	projectKey := c.Query("projectName")
+	production := c.Query("production") == "true"
+	isHelmChartDeployParam := c.Query("isHelmChartDeploy")
+	if projectKey == "" {
+		ctx.RespErr = fmt.Errorf("projectName can't be empty")
+		return
+	}
+	if serviceOrReleaseName == "" {
+		ctx.RespErr = fmt.Errorf("serviceOrReleaseName can't be empty")
+		return
+	}
+	if isHelmChartDeployParam != "true" && isHelmChartDeployParam != "false" {
+		ctx.RespErr = fmt.Errorf("isHelmChartDeploy must be true or false")
+		return
+	}
+	isHelmChartDeploy := isHelmChartDeployParam == "true"
+
+	if !ctx.Resources.IsSystemAdmin {
+		if _, ok := ctx.Resources.ProjectAuthInfo[projectKey]; !ok {
+			ctx.UnAuthorized = true
+			return
+		}
+		if production {
+			if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin &&
+				!ctx.Resources.ProjectAuthInfo[projectKey].ProductionEnv.EditConfig {
+				permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, projectKey, types.ResourceTypeEnvironment, envName, types.ProductionEnvActionEditConfig)
+				if err != nil || !permitted {
+					ctx.UnAuthorized = true
+					return
+				}
+			}
+			if err := commonutil.CheckZadigProfessionalLicense(); err != nil {
+				ctx.RespErr = err
+				return
+			}
+		} else if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin &&
+			!ctx.Resources.ProjectAuthInfo[projectKey].Env.EditConfig {
+			permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, projectKey, types.ResourceTypeEnvironment, envName, types.EnvActionEditConfig)
+			if err != nil || !permitted {
+				ctx.UnAuthorized = true
+				return
+			}
+		}
+	}
+
+	args := new(service.UpdateHelmValuesSourceArgs)
+	if err := c.ShouldBindJSON(args); err != nil {
+		ctx.RespErr = err
+		return
+	}
+	// The source snapshot is updated only by a successful import or sync, not by saving configuration.
+	if args.ValuesData != nil {
+		args.ValuesData.AutoSyncYaml = ""
+	}
+	data, _ := json.Marshal(args)
+	detail := fmt.Sprintf("%s:%s", envName, serviceOrReleaseName)
+	internalhandler.InsertDetailedOperationLog(c, ctx.UserName, projectKey, setting.OperationSceneEnv, "更新", "Helm Values 来源配置", detail, detail, string(data), types.RequestBodyTypeJSON, ctx.Logger, envName)
+
+	ctx.RespErr = service.UpdateHelmValuesSource(projectKey, envName, serviceOrReleaseName, ctx.UserName, production, isHelmChartDeploy, args)
 }
 
 // @Summary 获取Helm服务Chart Values

--- a/pkg/microservice/aslan/core/environment/handler/helm.go
+++ b/pkg/microservice/aslan/core/environment/handler/helm.go
@@ -84,6 +84,70 @@ func ListReleases(c *gin.Context) {
 	ctx.Resp, ctx.RespErr = service.ListReleases(args, envName, production, ctx.Logger)
 }
 
+func GetHelmReleaseDiff(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	envName := c.Param("name")
+	serviceOrReleaseName := c.Param("serviceOrReleaseName")
+	projectKey := c.Query("projectName")
+	production := c.Query("production") == "true"
+	isHelmChartDeployParam := c.Query("isHelmChartDeploy")
+	if projectKey == "" {
+		ctx.RespErr = fmt.Errorf("projectName can't be empty")
+		return
+	}
+	if serviceOrReleaseName == "" {
+		ctx.RespErr = fmt.Errorf("serviceOrReleaseName can't be empty")
+		return
+	}
+	if isHelmChartDeployParam != "true" && isHelmChartDeployParam != "false" {
+		ctx.RespErr = fmt.Errorf("isHelmChartDeploy must be true or false")
+		return
+	}
+	isHelmChartDeploy := isHelmChartDeployParam == "true"
+
+	if !ctx.Resources.IsSystemAdmin {
+		if _, ok := ctx.Resources.ProjectAuthInfo[projectKey]; !ok {
+			ctx.UnAuthorized = true
+			return
+		}
+
+		if production {
+			if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin &&
+				!ctx.Resources.ProjectAuthInfo[projectKey].ProductionEnv.View {
+				permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, projectKey, types.ResourceTypeEnvironment, envName, types.ProductionEnvActionView)
+				if err != nil || !permitted {
+					ctx.UnAuthorized = true
+					return
+				}
+			}
+
+			if err := commonutil.CheckZadigProfessionalLicense(); err != nil {
+				ctx.RespErr = err
+				return
+			}
+		} else {
+			if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin &&
+				!ctx.Resources.ProjectAuthInfo[projectKey].Env.View &&
+				!ctx.Resources.ProjectAuthInfo[projectKey].Version.Create {
+				permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, projectKey, types.ResourceTypeEnvironment, envName, types.EnvActionView)
+				if err != nil || !permitted {
+					ctx.UnAuthorized = true
+					return
+				}
+			}
+		}
+	}
+
+	ctx.Resp, ctx.RespErr = service.GetHelmReleaseDiff(projectKey, envName, serviceOrReleaseName, production, isHelmChartDeploy, ctx.Logger)
+}
+
 // @Summary 获取Helm服务Chart Values
 // @Description 获取Helm服务Chart Values
 // @Tags 	environment

--- a/pkg/microservice/aslan/core/environment/handler/helm.go
+++ b/pkg/microservice/aslan/core/environment/handler/helm.go
@@ -86,6 +86,59 @@ func ListReleases(c *gin.Context) {
 	ctx.Resp, ctx.RespErr = service.ListReleases(args, envName, production, ctx.Logger)
 }
 
+func ListHelmReleaseDiffSummaries(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	envName := c.Param("name")
+	projectKey := c.Query("projectName")
+	production := c.Query("production") == "true"
+	if projectKey == "" {
+		ctx.RespErr = fmt.Errorf("projectName can't be empty")
+		return
+	}
+
+	if !ctx.Resources.IsSystemAdmin {
+		if _, ok := ctx.Resources.ProjectAuthInfo[projectKey]; !ok {
+			ctx.UnAuthorized = true
+			return
+		}
+
+		if production {
+			if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin &&
+				!ctx.Resources.ProjectAuthInfo[projectKey].ProductionEnv.View {
+				permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, projectKey, types.ResourceTypeEnvironment, envName, types.ProductionEnvActionView)
+				if err != nil || !permitted {
+					ctx.UnAuthorized = true
+					return
+				}
+			}
+
+			if err := commonutil.CheckZadigProfessionalLicense(); err != nil {
+				ctx.RespErr = err
+				return
+			}
+		} else {
+			if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin &&
+				!ctx.Resources.ProjectAuthInfo[projectKey].Env.View &&
+				!ctx.Resources.ProjectAuthInfo[projectKey].Version.Create {
+				permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, projectKey, types.ResourceTypeEnvironment, envName, types.EnvActionView)
+				if err != nil || !permitted {
+					ctx.UnAuthorized = true
+					return
+				}
+			}
+		}
+	}
+
+	ctx.Resp, ctx.RespErr = service.ListHelmReleaseDiffSummaries(projectKey, envName, production, ctx.Logger)
+}
+
 func GetHelmReleaseDiff(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -165,6 +165,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 
 		environments.GET("/:name/helm/releases", ListReleases)
 		environments.GET("/:name/helm/releases/:serviceOrReleaseName/diff", GetHelmReleaseDiff)
+		environments.PUT("/:name/helm/releases/:serviceOrReleaseName/values-source", UpdateHelmValuesSource)
 		environments.DELETE("/:name/helm/releases", DeleteHelmReleases)
 		environments.GET("/:name/helm/values", GetChartValues)
 		environments.GET("/:name/helm/charts", GetChartInfos)

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -164,6 +164,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		environments.GET("/:name/workloads", ListWorkloadsInEnv)
 
 		environments.GET("/:name/helm/releases", ListReleases)
+		environments.GET("/:name/helm/releases/:serviceOrReleaseName/diff", GetHelmReleaseDiff)
 		environments.DELETE("/:name/helm/releases", DeleteHelmReleases)
 		environments.GET("/:name/helm/values", GetChartValues)
 		environments.GET("/:name/helm/charts", GetChartInfos)

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -164,6 +164,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		environments.GET("/:name/workloads", ListWorkloadsInEnv)
 
 		environments.GET("/:name/helm/releases", ListReleases)
+		environments.GET("/:name/helm/releases/diffs", ListHelmReleaseDiffSummaries)
 		environments.GET("/:name/helm/releases/:serviceOrReleaseName/diff", GetHelmReleaseDiff)
 		environments.PUT("/:name/helm/releases/:serviceOrReleaseName/values-source", UpdateHelmValuesSource)
 		environments.DELETE("/:name/helm/releases", DeleteHelmReleases)

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -1949,6 +1949,7 @@ func UpdateHelmProductCharts(productName, envName, userName, requestID string, p
 	if len(args.ChartValues) == 0 {
 		return nil
 	}
+	populateHelmValuesSourceCommits(args.ChartValues, log)
 
 	product, err := commonrepo.NewProductColl().Find(&commonrepo.ProductFindOptions{
 		Name:       productName,
@@ -2058,6 +2059,17 @@ func geneYamlData(args *commonservice.ValuesDataArgs) *templatemodels.CustomYaml
 	return ret
 }
 
+func populateHelmValuesSourceCommits(chartValues []*commonservice.HelmSvcRenderArg, log *zap.SugaredLogger) {
+	for _, chartValue := range chartValues {
+		if chartValue == nil {
+			continue
+		}
+		if err := commonservice.PopulateValuesSourceCommit(chartValue.ValuesData, log); err != nil {
+			log.Warnf("failed to get current Helm Values source commit, service: %s, release: %s, err: %s", chartValue.ServiceName, chartValue.ReleaseName, err)
+		}
+	}
+}
+
 func SyncHelmProductEnvironment(productName, envName, requestID string, log *zap.SugaredLogger) error {
 	syncLock := cache.NewRedisLockWithExpiry(fmt.Sprintf("%s:%s:%s", SyncHelmEnvVariablesLockKey, productName, envName), time.Second*1800)
 	err := syncLock.TryLock()
@@ -2114,6 +2126,9 @@ func SyncHelmProductEnvironment(productName, envName, requestID string, log *zap
 			}
 
 			if changed {
+				if err := commonservice.RefreshYamlSourceCommit(chartInfo.OverrideYaml, log); err != nil {
+					log.Warnf("failed to refresh Helm Values source commit, serviceName: %s, err: %s", chartInfo.ServiceName, err)
+				}
 				updatedRcMapLock.Lock()
 				chartInfo.OverrideYaml.YamlContent = values
 				chartInfo.OverrideYaml.AutoSyncYaml = values
@@ -2277,6 +2292,7 @@ func updateHelmProductVariable(productResp *commonmodels.Product, userName, requ
 }
 
 func UpdateMultipleHelmEnv(requestID, userName string, args *UpdateMultiHelmProductArg, production bool, log *zap.SugaredLogger) ([]*EnvStatus, error) {
+	populateHelmValuesSourceCommits(args.ChartValues, log)
 	mutexAutoUpdate := cache.NewRedisLock(updateMultipleProductLockKey(args.ProductName))
 	err := mutexAutoUpdate.Lock()
 	if err != nil {
@@ -2354,6 +2370,7 @@ func UpdateMultipleHelmEnv(requestID, userName string, args *UpdateMultiHelmProd
 }
 
 func UpdateMultipleHelmChartEnv(requestID, userName string, args *UpdateMultiHelmProductArg, production bool, log *zap.SugaredLogger) ([]*EnvStatus, error) {
+	populateHelmValuesSourceCommits(args.ChartValues, log)
 	mutexUpdateMultiHelm := cache.NewRedisLock(updateMultipleProductLockKey(args.ProductName))
 
 	err := mutexUpdateMultiHelm.Lock()

--- a/pkg/microservice/aslan/core/environment/service/environment_creation.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_creation.go
@@ -52,6 +52,13 @@ func prepareHelmProductCreation(templateProduct *templatemodels.Product, product
 	serviceDeployStrategy := make(map[string]setting.ServiceDeployStrategy)
 
 	// user custom chart values
+	chartValues := make([]*commonservice.HelmSvcRenderArg, 0, len(arg.ChartValues))
+	for _, chartValue := range arg.ChartValues {
+		if chartValue != nil {
+			chartValues = append(chartValues, chartValue.HelmSvcRenderArg)
+		}
+	}
+	populateHelmValuesSourceCommits(chartValues, log)
 	cvMap := make(map[string]*templatemodels.ServiceRender)
 	for _, singleCV := range arg.ChartValues {
 		tc, ok := templateChartInfoMap[singleCV.ServiceName]

--- a/pkg/microservice/aslan/core/environment/service/helm.go
+++ b/pkg/microservice/aslan/core/environment/service/helm.go
@@ -694,6 +694,9 @@ func GetHelmReleaseDiff(productName, envName, serviceOrReleaseName string, produ
 	if !diff.HasDiff {
 		return resp, nil
 	}
+	if !diff.ValuesChanged {
+		return resp, nil
+	}
 
 	render := prodSvc.GetServiceRender()
 	overrideYaml := render.GetOverrideYaml()

--- a/pkg/microservice/aslan/core/environment/service/helm.go
+++ b/pkg/microservice/aslan/core/environment/service/helm.go
@@ -112,6 +112,10 @@ type HelmServiceDiffResp struct {
 	ValuesDiff  *HelmServiceValuesDiff  `json:"valuesDiff,omitempty"`
 }
 
+type UpdateHelmValuesSourceArgs struct {
+	ValuesData *commonservice.ValuesDataArgs `json:"valuesData"`
+}
+
 type ChartInfo struct {
 	ServiceName string `json:"serviceName"`
 	Revision    int64  `json:"revision"`
@@ -257,6 +261,93 @@ func findHelmProductService(prod *models.Product, serviceOrReleaseName string, i
 		return prod.GetChartServiceMap()[serviceOrReleaseName]
 	}
 	return prod.GetServiceMap()[serviceOrReleaseName]
+}
+
+func buildHelmValuesSource(valuesData *commonservice.ValuesDataArgs) (*template.CustomYaml, error) {
+	sourceData := &template.CustomYaml{}
+	if valuesData == nil {
+		return sourceData, nil
+	}
+	repoConfig := valuesData.GitRepoConfig
+	if repoConfig == nil {
+		return nil, fmt.Errorf("gitRepoConfig can't be empty")
+	}
+	if repoConfig.CodehostID == 0 {
+		return nil, fmt.Errorf("codehostID can't be empty")
+	}
+	if repoConfig.Owner == "" && repoConfig.Namespace == "" {
+		return nil, fmt.Errorf("owner or namespace can't be empty")
+	}
+	if repoConfig.Repo == "" {
+		return nil, fmt.Errorf("repo can't be empty")
+	}
+	if repoConfig.Branch == "" {
+		return nil, fmt.Errorf("branch can't be empty")
+	}
+	if len(repoConfig.ValuesPaths) == 0 || repoConfig.ValuesPaths[0] == "" {
+		return nil, fmt.Errorf("values path can't be empty")
+	}
+
+	sourceData.Source = setting.SourceFromGitRepo
+	sourceData.AutoSync = valuesData.AutoSync
+	sourceData.SourceDetail = &models.CreateFromRepo{
+		GitRepoConfig: &template.GitRepoConfig{
+			CodehostID: repoConfig.CodehostID,
+			Owner:      repoConfig.Owner,
+			Namespace:  repoConfig.Namespace,
+			Repo:       repoConfig.Repo,
+			Branch:     repoConfig.Branch,
+		},
+		LoadPath: repoConfig.ValuesPaths[0],
+	}
+	return sourceData, nil
+}
+
+func sameHelmValuesSource(current, target *template.CustomYaml) bool {
+	if current == nil || target == nil || helmValuesSourceType(current) != helmValuesSourceType(target) || current.SourceID != target.SourceID {
+		return false
+	}
+	if helmValuesSourceType(target) == "" {
+		return current.SourceDetail == nil && target.SourceDetail == nil
+	}
+	currentDetail, err := commonservice.UnMarshalSourceDetail(current.SourceDetail)
+	if err != nil || currentDetail == nil || currentDetail.GitRepoConfig == nil {
+		return false
+	}
+	targetDetail, err := commonservice.UnMarshalSourceDetail(target.SourceDetail)
+	if err != nil || targetDetail == nil || targetDetail.GitRepoConfig == nil {
+		return false
+	}
+	currentRepo, targetRepo := currentDetail.GitRepoConfig, targetDetail.GitRepoConfig
+	return currentRepo.CodehostID == targetRepo.CodehostID &&
+		currentRepo.Owner == targetRepo.Owner &&
+		currentRepo.Namespace == targetRepo.Namespace &&
+		currentRepo.Repo == targetRepo.Repo &&
+		currentRepo.Branch == targetRepo.Branch &&
+		currentDetail.LoadPath == targetDetail.LoadPath
+}
+
+func helmValuesSourceType(source *template.CustomYaml) string {
+	if source == nil || source.Source != "" {
+		if source == nil {
+			return ""
+		}
+		return source.Source
+	}
+	detail, err := commonservice.UnMarshalSourceDetail(source.SourceDetail)
+	if err == nil && detail != nil && detail.GitRepoConfig != nil {
+		return setting.SourceFromGitRepo
+	}
+	return ""
+}
+
+func prepareHelmValuesSourceForSave(current, target *template.CustomYaml) {
+	if target == nil || target.Source == "" {
+		return
+	}
+	if sameHelmValuesSource(current, target) {
+		target.AutoSyncYaml = current.AutoSyncYaml
+	}
 }
 
 type ImageData struct {
@@ -573,6 +664,43 @@ func GetHelmReleaseDiff(productName, envName, serviceOrReleaseName string, produ
 	}
 
 	return resp, nil
+}
+
+func UpdateHelmValuesSource(productName, envName, serviceOrReleaseName, userName string, production, isHelmChartDeploy bool, args *UpdateHelmValuesSourceArgs) error {
+	if args == nil {
+		return fmt.Errorf("request body can't be empty")
+	}
+	sourceData, err := buildHelmValuesSource(args.ValuesData)
+	if err != nil {
+		return err
+	}
+
+	prod, err := commonrepo.NewProductColl().Find(&commonrepo.ProductFindOptions{
+		Name:       productName,
+		EnvName:    envName,
+		Production: &production,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to find project: %s, err: %s", productName, err)
+	}
+	prodSvc := findHelmProductService(prod, serviceOrReleaseName, isHelmChartDeploy)
+	if prodSvc == nil {
+		if isHelmChartDeploy {
+			return fmt.Errorf("failed to find release %s in env %s", serviceOrReleaseName, envName)
+		}
+		return fmt.Errorf("failed to find service %s in env %s", serviceOrReleaseName, envName)
+	}
+
+	prepareHelmValuesSourceForSave(prodSvc.GetServiceRender().OverrideYaml, sourceData)
+	return commonrepo.NewProductColl().UpdateServiceValuesSource(
+		productName,
+		envName,
+		production,
+		isHelmChartDeploy,
+		serviceOrReleaseName,
+		sourceData,
+		userName,
+	)
 }
 
 func loadChartFilesInfo(productName, serviceName string, revision int64, dir string) ([]*types.FileInfo, error) {

--- a/pkg/microservice/aslan/core/environment/service/helm.go
+++ b/pkg/microservice/aslan/core/environment/service/helm.go
@@ -715,6 +715,9 @@ func GetHelmReleaseDiff(productName, envName, serviceOrReleaseName string, produ
 	if err != nil {
 		return nil, err
 	}
+	diff.ValuesChanged = !equal
+	diff.HasDiff = diff.VersionChanged || diff.ValuesChanged
+	resp.HasDiff = diff.HasDiff
 	if !equal {
 		resp.ValuesDiff = &HelmServiceValuesDiff{
 			Current: valuesResp.Current,

--- a/pkg/microservice/aslan/core/environment/service/helm.go
+++ b/pkg/microservice/aslan/core/environment/service/helm.go
@@ -77,7 +77,6 @@ type HelmReleaseResp struct {
 	IsHelmChartDeploy bool                          `json:"isHelmChartDeploy"`
 	DeployStrategy    setting.ServiceDeployStrategy `json:"deployStrategy"`
 	Error             string                        `json:"error"`
-	Diff              *HelmServiceDiffSummary       `json:"diff,omitempty"`
 }
 
 type HelmServiceDiffSummary struct {
@@ -106,6 +105,13 @@ type HelmServiceDiffResp struct {
 	Diff        *HelmServiceDiffSummary `json:"diff"`
 	VersionDiff *HelmServiceVersionDiff `json:"versionDiff,omitempty"`
 	ValuesDiff  *HelmServiceValuesDiff  `json:"valuesDiff,omitempty"`
+}
+
+type HelmReleaseDiffSummaryResp struct {
+	ServiceName       string                  `json:"serviceName"`
+	ReleaseName       string                  `json:"releaseName"`
+	IsHelmChartDeploy bool                    `json:"isHelmChartDeploy"`
+	Diff              *HelmServiceDiffSummary `json:"diff"`
 }
 
 type UpdateHelmValuesSourceArgs struct {
@@ -138,11 +144,6 @@ const (
 
 	helmServiceDiffSummaryConcurrency = 5
 )
-
-type helmServiceDiffResult struct {
-	diff *HelmServiceDiffSummary
-	err  error
-}
 
 func listReleaseInNamespace(helmClient *helmtool.HelmClient, filter *ReleaseFilter) ([]*release.Release, error) {
 	listClient := action.NewList(helmClient.ActionConfig)
@@ -442,29 +443,9 @@ func ListReleases(args *HelmReleaseQueryArgs, envName string, production bool, l
 	}
 
 	ret := make([]*HelmReleaseResp, 0)
-	diffResults := make([]helmServiceDiffResult, len(svcDataList))
-	diffSemaphore := make(chan struct{}, helmServiceDiffSummaryConcurrency)
-	var diffWaitGroup sync.WaitGroup
-	for index, svcDataSet := range svcDataList {
-		if !filterFunc(svcDataSet) {
-			continue
-		}
-		index, svcDataSet := index, svcDataSet
-		diffWaitGroup.Add(1)
-		util.Go(func() {
-			defer diffWaitGroup.Done()
-			diffSemaphore <- struct{}{}
-			defer func() { <-diffSemaphore }()
-
-			diff, _, _, err := getHelmServiceDiffSummary(svcDataSet.ProdSvc, svcDataSet.TmplSvc)
-			diffResults[index] = helmServiceDiffResult{diff: diff, err: err}
-		})
-	}
-	diffWaitGroup.Wait()
-
 	chartInfoMap := prod.GetChartRenderMap()
 	chartDeployInfoMap := prod.GetChartDeployRenderMap()
-	for index, svcDataSet := range svcDataList {
+	for _, svcDataSet := range svcDataList {
 		if !filterFunc(svcDataSet) {
 			continue
 		}
@@ -523,20 +504,83 @@ func ListReleases(args *HelmReleaseQueryArgs, envName string, production bool, l
 			respObj.Status = HelmReleaseStatusFailed
 		}
 
-		diff, err := diffResults[index].diff, diffResults[index].err
-		if err != nil {
-			log.Warnf("failed to get helm service diff summary, project: %s, env: %s, service: %s, err: %s", projectName, envName, svcDataSet.ProdSvc.ServiceName, err)
-			if diff == nil {
-				diff = &HelmServiceDiffSummary{}
-			}
-			diff.Error = err.Error()
-		}
-		respObj.Diff = diff
-
 		ret = append(ret, respObj)
 	}
 
 	return ret, nil
+}
+
+func ListHelmReleaseDiffSummaries(productName, envName string, production bool, log *zap.SugaredLogger) ([]*HelmReleaseDiffSummaryResp, error) {
+	prod, err := commonrepo.NewProductColl().Find(&commonrepo.ProductFindOptions{
+		Name:       productName,
+		EnvName:    envName,
+		Production: &production,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to find project: %s, err: %s", productName, err)
+	}
+
+	serviceTmpls, err := repository.ListMaxRevisionsServices(productName, production, false)
+	if err != nil {
+		return nil, errors.Errorf("failed to list service templates for project: %s", productName)
+	}
+	serviceTmplMap := make(map[string]*models.Service)
+	for _, tmplSvc := range serviceTmpls {
+		serviceTmplMap[tmplSvc.ServiceName] = tmplSvc
+	}
+
+	serviceToReleaseName, err := commonutil.GetServiceNameToReleaseNameMap(prod)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build release-service map: %s", err)
+	}
+
+	prodSvcs := make([]*models.ProductService, 0)
+	for _, prodSvc := range prod.GetServiceMap() {
+		prodSvcs = append(prodSvcs, prodSvc)
+	}
+	for _, prodSvc := range prod.GetChartServiceMap() {
+		prodSvcs = append(prodSvcs, prodSvc)
+	}
+
+	resp := make([]*HelmReleaseDiffSummaryResp, len(prodSvcs))
+	diffSemaphore := make(chan struct{}, helmServiceDiffSummaryConcurrency)
+	var diffWaitGroup sync.WaitGroup
+	for index, prodSvc := range prodSvcs {
+		index, prodSvc := index, prodSvc
+		diffWaitGroup.Add(1)
+		util.Go(func() {
+			defer diffWaitGroup.Done()
+			diffSemaphore <- struct{}{}
+			defer func() { <-diffSemaphore }()
+
+			isHelmChartDeploy := !prodSvc.FromZadig()
+			releaseName := serviceToReleaseName[prodSvc.ServiceName]
+			var latestTmplSvc *models.Service
+			if isHelmChartDeploy {
+				releaseName = prodSvc.ReleaseName
+			} else {
+				latestTmplSvc = serviceTmplMap[prodSvc.ServiceName]
+			}
+
+			diff, _, _, diffErr := getHelmServiceDiffSummary(prodSvc, latestTmplSvc)
+			if diffErr != nil {
+				log.Warnf("failed to get helm service diff summary, project: %s, env: %s, service: %s, err: %s", productName, envName, prodSvc.ServiceName, diffErr)
+				if diff == nil {
+					diff = &HelmServiceDiffSummary{}
+				}
+				diff.Error = diffErr.Error()
+			}
+			resp[index] = &HelmReleaseDiffSummaryResp{
+				ServiceName:       prodSvc.ServiceName,
+				ReleaseName:       releaseName,
+				IsHelmChartDeploy: isHelmChartDeploy,
+				Diff:              diff,
+			}
+		})
+	}
+	diffWaitGroup.Wait()
+
+	return resp, nil
 }
 
 func GetHelmReleaseDiff(productName, envName, serviceOrReleaseName string, production, isHelmChartDeploy bool, log *zap.SugaredLogger) (*HelmServiceDiffResp, error) {

--- a/pkg/microservice/aslan/core/environment/service/helm.go
+++ b/pkg/microservice/aslan/core/environment/service/helm.go
@@ -204,16 +204,20 @@ func getHelmServiceDiffSummary(prodSvc *models.ProductService, latestTmplSvc *mo
 	}
 	summary.HasDiff = summary.VersionChanged
 
-	sourceValues, hasSource, err := commonservice.LoadYamlFromSource(render.OverrideYaml)
-	if err != nil {
-		return summary, "", false, err
-	}
-	if hasSource {
-		equal, err := yamlutil.Equal(sourceValues, render.GetOverrideYaml())
+	sourceValues, hasSource := "", false
+	if hasConfiguredHelmValuesSource(render.OverrideYaml) {
+		var err error
+		sourceValues, hasSource, err = commonservice.LoadYamlFromSource(render.OverrideYaml)
 		if err != nil {
 			return summary, "", false, err
 		}
-		summary.ValuesChanged = !equal
+		if hasSource {
+			equal, err := yamlutil.Equal(sourceValues, render.GetOverrideYaml())
+			if err != nil {
+				return summary, "", false, err
+			}
+			summary.ValuesChanged = !equal
+		}
 	}
 
 	summary.HasDiff = summary.VersionChanged || summary.ValuesChanged
@@ -318,6 +322,13 @@ func helmValuesSourceType(source *template.CustomYaml) string {
 		return setting.SourceFromGitRepo
 	}
 	return ""
+}
+
+func hasConfiguredHelmValuesSource(source *template.CustomYaml) bool {
+	if source == nil {
+		return false
+	}
+	return source.Source == setting.SourceFromGitRepo || source.Source == setting.SourceFromVariableSet
 }
 
 func prepareHelmValuesSourceForSave(current, target *template.CustomYaml) {

--- a/pkg/microservice/aslan/core/environment/service/helm.go
+++ b/pkg/microservice/aslan/core/environment/service/helm.go
@@ -81,21 +81,17 @@ type HelmReleaseResp struct {
 }
 
 type HelmServiceDiffSummary struct {
-	HasDiff             bool   `json:"hasDiff"`
-	VersionChanged      bool   `json:"versionChanged"`
-	ValuesChanged       bool   `json:"valuesChanged"`
-	CurrentRevision     int64  `json:"currentRevision"`
-	LatestRevision      int64  `json:"latestRevision"`
-	CurrentChartVersion string `json:"currentChartVersion"`
-	LatestChartVersion  string `json:"latestChartVersion"`
-	Error               string `json:"error,omitempty"`
+	HasDiff         bool   `json:"hasDiff"`
+	VersionChanged  bool   `json:"versionChanged"`
+	ValuesChanged   bool   `json:"valuesChanged"`
+	CurrentRevision int64  `json:"currentRevision"`
+	LatestRevision  int64  `json:"latestRevision"`
+	Error           string `json:"error,omitempty"`
 }
 
 type HelmServiceVersionDiff struct {
-	CurrentRevision     int64  `json:"currentRevision"`
-	LatestRevision      int64  `json:"latestRevision"`
-	CurrentChartVersion string `json:"currentChartVersion"`
-	LatestChartVersion  string `json:"latestChartVersion"`
+	CurrentRevision int64 `json:"currentRevision"`
+	LatestRevision  int64 `json:"latestRevision"`
 }
 
 type HelmServiceValuesDiff struct {
@@ -179,19 +175,7 @@ func getReleaseStatus(re *release.Release) ReleaseStatus {
 	}
 }
 
-func getCurrentTemplateService(productName string, prodSvc *models.ProductService, production bool) (*models.Service, error) {
-	if prodSvc == nil || !prodSvc.FromZadig() {
-		return nil, nil
-	}
-	return repository.QueryTemplateService(&commonrepo.ServiceFindOption{
-		ServiceName: prodSvc.ServiceName,
-		ProductName: productName,
-		Type:        setting.HelmDeployType,
-		Revision:    prodSvc.Revision,
-	}, production)
-}
-
-func getHelmServiceDiffSummary(productName string, prodSvc *models.ProductService, latestTmplSvc *models.Service, production bool) (*HelmServiceDiffSummary, string, bool, error) {
+func getHelmServiceDiffSummary(prodSvc *models.ProductService, latestTmplSvc *models.Service) (*HelmServiceDiffSummary, string, bool, error) {
 	summary := &HelmServiceDiffSummary{}
 	if prodSvc == nil {
 		return summary, "", false, nil
@@ -201,27 +185,10 @@ func getHelmServiceDiffSummary(productName string, prodSvc *models.ProductServic
 	summary.LatestRevision = prodSvc.Revision
 
 	render := prodSvc.GetServiceRender()
-	summary.CurrentChartVersion = render.ChartVersion
-	summary.LatestChartVersion = render.ChartVersion
 
 	if prodSvc.FromZadig() && latestTmplSvc != nil {
 		summary.LatestRevision = latestTmplSvc.Revision
-		if latestTmplSvc.HelmChart != nil {
-			summary.LatestChartVersion = latestTmplSvc.HelmChart.Version
-		}
 		summary.VersionChanged = prodSvc.Revision != latestTmplSvc.Revision
-
-		if !summary.VersionChanged {
-			summary.CurrentChartVersion = summary.LatestChartVersion
-		} else {
-			currentTmplSvc, err := getCurrentTemplateService(productName, prodSvc, production)
-			if err != nil {
-				return summary, "", false, err
-			}
-			if currentTmplSvc != nil && currentTmplSvc.HelmChart != nil {
-				summary.CurrentChartVersion = currentTmplSvc.HelmChart.Version
-			}
-		}
 	}
 	summary.HasDiff = summary.VersionChanged
 
@@ -489,7 +456,7 @@ func ListReleases(args *HelmReleaseQueryArgs, envName string, production bool, l
 			diffSemaphore <- struct{}{}
 			defer func() { <-diffSemaphore }()
 
-			diff, _, _, err := getHelmServiceDiffSummary(projectName, svcDataSet.ProdSvc, svcDataSet.TmplSvc, production)
+			diff, _, _, err := getHelmServiceDiffSummary(svcDataSet.ProdSvc, svcDataSet.TmplSvc)
 			diffResults[index] = helmServiceDiffResult{diff: diff, err: err}
 		})
 	}
@@ -602,7 +569,7 @@ func GetHelmReleaseDiff(productName, envName, serviceOrReleaseName string, produ
 		}
 	}
 
-	diff, sourceValues, hasSource, err := getHelmServiceDiffSummary(productName, prodSvc, latestTmplSvc, production)
+	diff, sourceValues, hasSource, err := getHelmServiceDiffSummary(prodSvc, latestTmplSvc)
 	if err != nil {
 		return nil, err
 	}
@@ -615,10 +582,8 @@ func GetHelmReleaseDiff(productName, envName, serviceOrReleaseName string, produ
 	}
 	if diff.VersionChanged {
 		resp.VersionDiff = &HelmServiceVersionDiff{
-			CurrentRevision:     diff.CurrentRevision,
-			LatestRevision:      diff.LatestRevision,
-			CurrentChartVersion: diff.CurrentChartVersion,
-			LatestChartVersion:  diff.LatestChartVersion,
+			CurrentRevision: diff.CurrentRevision,
+			LatestRevision:  diff.LatestRevision,
 		}
 	}
 	if !diff.HasDiff {

--- a/pkg/microservice/aslan/core/environment/service/helm.go
+++ b/pkg/microservice/aslan/core/environment/service/helm.go
@@ -49,6 +49,7 @@ import (
 	"github.com/koderover/zadig/v2/pkg/util"
 	"github.com/koderover/zadig/v2/pkg/util/converter"
 	jsonutil "github.com/koderover/zadig/v2/pkg/util/json"
+	yamlutil "github.com/koderover/zadig/v2/pkg/util/yaml"
 )
 
 type HelmReleaseQueryArgs struct {
@@ -76,6 +77,39 @@ type HelmReleaseResp struct {
 	IsHelmChartDeploy bool                          `json:"isHelmChartDeploy"`
 	DeployStrategy    setting.ServiceDeployStrategy `json:"deployStrategy"`
 	Error             string                        `json:"error"`
+	Diff              *HelmServiceDiffSummary       `json:"diff,omitempty"`
+}
+
+type HelmServiceDiffSummary struct {
+	HasDiff             bool   `json:"hasDiff"`
+	VersionChanged      bool   `json:"versionChanged"`
+	ValuesChanged       bool   `json:"valuesChanged"`
+	CurrentRevision     int64  `json:"currentRevision"`
+	LatestRevision      int64  `json:"latestRevision"`
+	CurrentChartVersion string `json:"currentChartVersion"`
+	LatestChartVersion  string `json:"latestChartVersion"`
+	Error               string `json:"error,omitempty"`
+}
+
+type HelmServiceVersionDiff struct {
+	CurrentRevision     int64  `json:"currentRevision"`
+	LatestRevision      int64  `json:"latestRevision"`
+	CurrentChartVersion string `json:"currentChartVersion"`
+	LatestChartVersion  string `json:"latestChartVersion"`
+}
+
+type HelmServiceValuesDiff struct {
+	Current string `json:"current"`
+	Latest  string `json:"latest"`
+}
+
+type HelmServiceDiffResp struct {
+	ServiceName string                  `json:"serviceName"`
+	ReleaseName string                  `json:"releaseName"`
+	HasDiff     bool                    `json:"hasDiff"`
+	Diff        *HelmServiceDiffSummary `json:"diff"`
+	VersionDiff *HelmServiceVersionDiff `json:"versionDiff,omitempty"`
+	ValuesDiff  *HelmServiceValuesDiff  `json:"valuesDiff,omitempty"`
 }
 
 type ChartInfo struct {
@@ -101,7 +135,14 @@ const (
 	HelmReleaseStatusDeployed    ReleaseStatus = "deployed"
 	HelmReleaseStatusFailed      ReleaseStatus = "failed"
 	HelmReleaseStatusNotDeployed ReleaseStatus = "notDeployed"
+
+	helmServiceDiffSummaryConcurrency = 5
 )
+
+type helmServiceDiffResult struct {
+	diff *HelmServiceDiffSummary
+	err  error
+}
 
 func listReleaseInNamespace(helmClient *helmtool.HelmClient, filter *ReleaseFilter) ([]*release.Release, error) {
 	listClient := action.NewList(helmClient.ActionConfig)
@@ -132,6 +173,90 @@ func getReleaseStatus(re *release.Release) ReleaseStatus {
 	default:
 		return HelmReleaseStatusFailed
 	}
+}
+
+func getCurrentTemplateService(productName string, prodSvc *models.ProductService, production bool) (*models.Service, error) {
+	if prodSvc == nil || !prodSvc.FromZadig() {
+		return nil, nil
+	}
+	return repository.QueryTemplateService(&commonrepo.ServiceFindOption{
+		ServiceName: prodSvc.ServiceName,
+		ProductName: productName,
+		Type:        setting.HelmDeployType,
+		Revision:    prodSvc.Revision,
+	}, production)
+}
+
+func getHelmServiceDiffSummary(productName string, prodSvc *models.ProductService, latestTmplSvc *models.Service, production bool) (*HelmServiceDiffSummary, string, bool, error) {
+	summary := &HelmServiceDiffSummary{}
+	if prodSvc == nil {
+		return summary, "", false, nil
+	}
+
+	summary.CurrentRevision = prodSvc.Revision
+	summary.LatestRevision = prodSvc.Revision
+
+	render := prodSvc.GetServiceRender()
+	summary.CurrentChartVersion = render.ChartVersion
+	summary.LatestChartVersion = render.ChartVersion
+
+	if prodSvc.FromZadig() && latestTmplSvc != nil {
+		summary.LatestRevision = latestTmplSvc.Revision
+		if latestTmplSvc.HelmChart != nil {
+			summary.LatestChartVersion = latestTmplSvc.HelmChart.Version
+		}
+		summary.VersionChanged = prodSvc.Revision != latestTmplSvc.Revision
+
+		if !summary.VersionChanged {
+			summary.CurrentChartVersion = summary.LatestChartVersion
+		} else {
+			currentTmplSvc, err := getCurrentTemplateService(productName, prodSvc, production)
+			if err != nil {
+				return summary, "", false, err
+			}
+			if currentTmplSvc != nil && currentTmplSvc.HelmChart != nil {
+				summary.CurrentChartVersion = currentTmplSvc.HelmChart.Version
+			}
+		}
+	}
+	summary.HasDiff = summary.VersionChanged
+
+	sourceValues, hasSource, err := commonservice.LoadYamlFromSource(render.OverrideYaml)
+	if err != nil {
+		return summary, "", false, err
+	}
+	if hasSource {
+		equal, err := yamlutil.Equal(sourceValues, render.GetOverrideYaml())
+		if err != nil {
+			return summary, "", false, err
+		}
+		summary.ValuesChanged = !equal
+	}
+
+	summary.HasDiff = summary.VersionChanged || summary.ValuesChanged
+	return summary, sourceValues, hasSource, nil
+}
+
+func parseOverrideValues(valueStr string) ([]*commonservice.KVPair, error) {
+	if valueStr == "" {
+		return nil, nil
+	}
+
+	ret := make([]*commonservice.KVPair, 0)
+	if err := json.Unmarshal([]byte(valueStr), &ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func findHelmProductService(prod *models.Product, serviceOrReleaseName string, isHelmChartDeploy bool) *models.ProductService {
+	if prod == nil {
+		return nil
+	}
+	if isHelmChartDeploy {
+		return prod.GetChartServiceMap()[serviceOrReleaseName]
+	}
+	return prod.GetServiceMap()[serviceOrReleaseName]
 }
 
 type ImageData struct {
@@ -259,10 +384,29 @@ func ListReleases(args *HelmReleaseQueryArgs, envName string, production bool, l
 	}
 
 	ret := make([]*HelmReleaseResp, 0)
+	diffResults := make([]helmServiceDiffResult, len(svcDataList))
+	diffSemaphore := make(chan struct{}, helmServiceDiffSummaryConcurrency)
+	var diffWaitGroup sync.WaitGroup
+	for index, svcDataSet := range svcDataList {
+		if !filterFunc(svcDataSet) {
+			continue
+		}
+		index, svcDataSet := index, svcDataSet
+		diffWaitGroup.Add(1)
+		util.Go(func() {
+			defer diffWaitGroup.Done()
+			diffSemaphore <- struct{}{}
+			defer func() { <-diffSemaphore }()
+
+			diff, _, _, err := getHelmServiceDiffSummary(projectName, svcDataSet.ProdSvc, svcDataSet.TmplSvc, production)
+			diffResults[index] = helmServiceDiffResult{diff: diff, err: err}
+		})
+	}
+	diffWaitGroup.Wait()
 
 	chartInfoMap := prod.GetChartRenderMap()
 	chartDeployInfoMap := prod.GetChartDeployRenderMap()
-	for _, svcDataSet := range svcDataList {
+	for index, svcDataSet := range svcDataList {
 		if !filterFunc(svcDataSet) {
 			continue
 		}
@@ -321,10 +465,114 @@ func ListReleases(args *HelmReleaseQueryArgs, envName string, production bool, l
 			respObj.Status = HelmReleaseStatusFailed
 		}
 
+		diff, err := diffResults[index].diff, diffResults[index].err
+		if err != nil {
+			log.Warnf("failed to get helm service diff summary, project: %s, env: %s, service: %s, err: %s", projectName, envName, svcDataSet.ProdSvc.ServiceName, err)
+			if diff == nil {
+				diff = &HelmServiceDiffSummary{}
+			}
+			diff.Error = err.Error()
+		}
+		respObj.Diff = diff
+
 		ret = append(ret, respObj)
 	}
 
 	return ret, nil
+}
+
+func GetHelmReleaseDiff(productName, envName, serviceOrReleaseName string, production, isHelmChartDeploy bool, log *zap.SugaredLogger) (*HelmServiceDiffResp, error) {
+	prod, err := commonrepo.NewProductColl().Find(&commonrepo.ProductFindOptions{
+		Name:       productName,
+		EnvName:    envName,
+		Production: &production,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to find project: %s, err: %s", productName, err)
+	}
+
+	prodSvc := findHelmProductService(prod, serviceOrReleaseName, isHelmChartDeploy)
+	if prodSvc == nil {
+		if isHelmChartDeploy {
+			return nil, fmt.Errorf("failed to find release %s in env %s", serviceOrReleaseName, envName)
+		}
+		return nil, fmt.Errorf("failed to find service %s in env %s", serviceOrReleaseName, envName)
+	}
+
+	var latestTmplSvc *models.Service
+	if !isHelmChartDeploy {
+		latestTmplSvc, err = repository.QueryTemplateService(&commonrepo.ServiceFindOption{
+			ServiceName: prodSvc.ServiceName,
+			ProductName: productName,
+			Type:        setting.HelmDeployType,
+		}, production)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query latest template service, serviceName: %s, err: %s", prodSvc.ServiceName, err)
+		}
+	}
+
+	diff, sourceValues, hasSource, err := getHelmServiceDiffSummary(productName, prodSvc, latestTmplSvc, production)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &HelmServiceDiffResp{
+		ServiceName: prodSvc.ServiceName,
+		ReleaseName: prodSvc.ReleaseName,
+		HasDiff:     diff.HasDiff,
+		Diff:        diff,
+	}
+	if diff.VersionChanged {
+		resp.VersionDiff = &HelmServiceVersionDiff{
+			CurrentRevision:     diff.CurrentRevision,
+			LatestRevision:      diff.LatestRevision,
+			CurrentChartVersion: diff.CurrentChartVersion,
+			LatestChartVersion:  diff.LatestChartVersion,
+		}
+	}
+	if !diff.HasDiff {
+		return resp, nil
+	}
+
+	render := prodSvc.GetServiceRender()
+	overrideYaml := render.GetOverrideYaml()
+	if hasSource {
+		overrideYaml = sourceValues
+	}
+	overrideValues, err := parseOverrideValues(render.OverrideValues)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse override values for service %s, err: %s", prodSvc.ServiceName, err)
+	}
+
+	arg := &EstimateValuesArg{
+		OverrideYaml:   overrideYaml,
+		OverrideValues: overrideValues,
+		Production:     production,
+	}
+	estimateServiceOrReleaseName := prodSvc.ServiceName
+	if isHelmChartDeploy {
+		estimateServiceOrReleaseName = prodSvc.ReleaseName
+		arg.ChartRepo = render.ChartRepo
+		arg.ChartName = render.ChartName
+		arg.ChartVersion = render.ChartVersion
+	}
+	valuesResp, err := GenEstimatedValues(productName, envName, prod.Namespace, estimateServiceOrReleaseName, EstimateValuesSceneUpdateService, EstimateContentTypeValues, EstimateValuesResponseFormatYaml, arg, diff.VersionChanged, production, isHelmChartDeploy, "", log)
+	if err != nil {
+		return nil, err
+	}
+
+	equal, err := yamlutil.Equal(valuesResp.Current, valuesResp.Latest)
+	if err != nil {
+		return nil, err
+	}
+	if !equal {
+		resp.ValuesDiff = &HelmServiceValuesDiff{
+			Current: valuesResp.Current,
+			Latest:  valuesResp.Latest,
+		}
+	}
+
+	return resp, nil
 }
 
 func loadChartFilesInfo(productName, serviceName string, revision int64, dir string) ([]*types.FileInfo, error) {

--- a/pkg/microservice/aslan/core/environment/service/helm.go
+++ b/pkg/microservice/aslan/core/environment/service/helm.go
@@ -98,13 +98,24 @@ type HelmServiceValuesDiff struct {
 	Latest  string `json:"latest"`
 }
 
+type HelmValuesSourceCommit struct {
+	ID      string `json:"id"`
+	Message string `json:"message"`
+}
+
+type HelmValuesSourceDiff struct {
+	CurrentCommit *HelmValuesSourceCommit `json:"currentCommit,omitempty"`
+	LatestCommit  *HelmValuesSourceCommit `json:"latestCommit,omitempty"`
+}
+
 type HelmServiceDiffResp struct {
-	ServiceName string                  `json:"serviceName"`
-	ReleaseName string                  `json:"releaseName"`
-	HasDiff     bool                    `json:"hasDiff"`
-	Diff        *HelmServiceDiffSummary `json:"diff"`
-	VersionDiff *HelmServiceVersionDiff `json:"versionDiff,omitempty"`
-	ValuesDiff  *HelmServiceValuesDiff  `json:"valuesDiff,omitempty"`
+	ServiceName      string                  `json:"serviceName"`
+	ReleaseName      string                  `json:"releaseName"`
+	HasDiff          bool                    `json:"hasDiff"`
+	Diff             *HelmServiceDiffSummary `json:"diff"`
+	VersionDiff      *HelmServiceVersionDiff `json:"versionDiff,omitempty"`
+	ValuesDiff       *HelmServiceValuesDiff  `json:"valuesDiff,omitempty"`
+	ValuesSourceDiff *HelmValuesSourceDiff   `json:"valuesSourceDiff,omitempty"`
 }
 
 type HelmReleaseDiffSummaryResp struct {
@@ -315,6 +326,44 @@ func prepareHelmValuesSourceForSave(current, target *template.CustomYaml) {
 	}
 	if sameHelmValuesSource(current, target) {
 		target.AutoSyncYaml = current.AutoSyncYaml
+		currentDetail, currentErr := commonservice.UnMarshalSourceDetail(current.SourceDetail)
+		targetDetail, targetErr := commonservice.UnMarshalSourceDetail(target.SourceDetail)
+		if currentErr == nil && targetErr == nil && currentDetail != nil && targetDetail != nil {
+			targetDetail.Commit = currentDetail.Commit
+			target.SourceDetail = targetDetail
+		}
+	}
+}
+
+func toHelmValuesSourceCommit(commit *models.Commit) *HelmValuesSourceCommit {
+	if commit == nil {
+		return nil
+	}
+	return &HelmValuesSourceCommit{ID: commit.SHA, Message: commit.Message}
+}
+
+func getHelmValuesSourceDiff(yamlData *template.CustomYaml, log *zap.SugaredLogger) *HelmValuesSourceDiff {
+	if yamlData == nil || helmValuesSourceType(yamlData) != setting.SourceFromGitRepo || yamlData.SourceDetail == nil {
+		return nil
+	}
+	sourceDetail, err := commonservice.UnMarshalSourceDetail(yamlData.SourceDetail)
+	if err != nil || sourceDetail == nil || sourceDetail.GitRepoConfig == nil {
+		return nil
+	}
+	repoConfig := sourceDetail.GitRepoConfig
+	latestCommit, err := commonservice.GetLatestValuesSourceCommit(&commonservice.RepoConfig{
+		CodehostID: repoConfig.CodehostID,
+		Owner:      repoConfig.Owner,
+		Namespace:  repoConfig.Namespace,
+		Repo:       repoConfig.Repo,
+		Branch:     repoConfig.Branch,
+	}, log)
+	if err != nil {
+		log.Warnf("failed to get latest Helm Values source commit, repo: %s, branch: %s, err: %s", repoConfig.Repo, repoConfig.Branch, err)
+	}
+	return &HelmValuesSourceDiff{
+		CurrentCommit: toHelmValuesSourceCommit(sourceDetail.Commit),
+		LatestCommit:  toHelmValuesSourceCommit(latestCommit),
 	}
 }
 
@@ -619,10 +668,11 @@ func GetHelmReleaseDiff(productName, envName, serviceOrReleaseName string, produ
 	}
 
 	resp := &HelmServiceDiffResp{
-		ServiceName: prodSvc.ServiceName,
-		ReleaseName: prodSvc.ReleaseName,
-		HasDiff:     diff.HasDiff,
-		Diff:        diff,
+		ServiceName:      prodSvc.ServiceName,
+		ReleaseName:      prodSvc.ReleaseName,
+		HasDiff:          diff.HasDiff,
+		Diff:             diff,
+		ValuesSourceDiff: getHelmValuesSourceDiff(prodSvc.GetServiceRender().OverrideYaml, log),
 	}
 	if diff.VersionChanged {
 		resp.VersionDiff = &HelmServiceVersionDiff{


### PR DESCRIPTION
### What this PR does / Why we need it:

Adds Helm release diff status so users can identify service template, Chart version, and Values changes before updating an environment.

### What is changed and how it works?

- Adds version and Values diff summaries to the Helm release list.
- Adds an API to retrieve detailed merged Values differences.
- Supports Values loaded from Git and variable sets.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4824)
<!-- Reviewable:end -->
