### PR TITLE
feat: support Anthropic-compatible LLM integrations

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/llm_integration.go
+++ b/pkg/microservice/aslan/core/common/repository/models/llm_integration.go
@@ -24,7 +24,9 @@ import (
 
 type LLMIntegration struct {
 	ID           primitive.ObjectID `bson:"_id,omitempty"  json:"id"`
+	Name         string             `bson:"name"           json:"name"`
 	ProviderName llm.Provider       `bson:"provider_name"  json:"provider_name"`
+	Protocol     llm.Protocol       `bson:"protocol"       json:"protocol"`
 	Token        string             `bson:"token"          json:"token"`
 	BaseURL      string             `bson:"base_url"       json:"base_url"`
 	Model        string             `bson:"model"          json:"model"`

--- a/pkg/microservice/aslan/core/common/repository/mongodb/llm_integration.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/llm_integration.go
@@ -24,6 +24,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
@@ -45,7 +46,22 @@ func NewLLMIntegrationColl() *LLMIntegrationColl {
 }
 
 func (c *LLMIntegrationColl) EnsureIndex(ctx context.Context) error {
-	return nil
+	indexes := []mongo.IndexModel{
+		{
+			Keys: bson.D{{Key: "name", Value: 1}},
+			Options: options.Index().
+				SetUnique(true).
+				SetPartialFilterExpression(bson.M{"name": bson.M{"$type": "string"}}),
+		},
+		{
+			Keys: bson.D{{Key: "is_default", Value: 1}},
+			Options: options.Index().
+				SetUnique(true).
+				SetPartialFilterExpression(bson.M{"is_default": true}),
+		},
+	}
+	_, err := c.Indexes().CreateMany(ctx, indexes)
+	return err
 }
 
 func (c *LLMIntegrationColl) GetCollectionName() string {
@@ -95,6 +111,28 @@ func (c *LLMIntegrationColl) Update(ctx context.Context, id string, args *models
 	return err
 }
 
+func (c *LLMIntegrationColl) SetDefault(ctx context.Context, id string) error {
+	oid, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return err
+	}
+	if err := c.FindOne(ctx, bson.M{"_id": oid}).Err(); err != nil {
+		return err
+	}
+
+	if _, err := c.UpdateMany(ctx, bson.M{}, bson.M{"$set": bson.M{"is_default": false}}); err != nil {
+		return err
+	}
+	result, err := c.UpdateOne(ctx, bson.M{"_id": oid}, bson.M{"$set": bson.M{"is_default": true}})
+	if err != nil {
+		return err
+	}
+	if result.MatchedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}
+
 func (c *LLMIntegrationColl) Delete(ctx context.Context, id string) error {
 	oid, err := primitive.ObjectIDFromHex(id)
 	if err != nil {
@@ -111,6 +149,9 @@ func (c *LLMIntegrationColl) Create(ctx context.Context, args *models.LLMIntegra
 		return errors.New("nil llm provider args")
 	}
 
+	if args.ID.IsZero() {
+		args.ID = primitive.NewObjectID()
+	}
 	args.UpdateTime = time.Now().Unix()
 	_, err := c.InsertOne(ctx, args)
 	return err

--- a/pkg/microservice/aslan/core/common/service/llm.go
+++ b/pkg/microservice/aslan/core/common/service/llm.go
@@ -30,6 +30,8 @@ func GetDefaultLLMClient(ctx context.Context) (llm.ILLM, error) {
 
 func NewLLMClient(llmIntegration *models.LLMIntegration) (llm.ILLM, error) {
 	llmConfig := llm.LLMConfig{
+		Name:         llmIntegration.Name,
+		Protocol:     llmIntegration.Protocol,
 		ProviderName: llmIntegration.ProviderName,
 		Token:        llmIntegration.Token,
 		BaseURL:      llmIntegration.BaseURL,
@@ -39,14 +41,14 @@ func NewLLMClient(llmIntegration *models.LLMIntegration) (llm.ILLM, error) {
 		llmConfig.Proxy = config.ProxyHTTPSAddr()
 	}
 
-	llmClient, err := llm.NewClient(llmConfig.ProviderName)
+	llmClient, err := llm.NewClientByProtocol(llmConfig.Protocol)
 	if err != nil {
-		return nil, fmt.Errorf("Could not create the llm client for %s: %w", llmConfig.ProviderName, err)
+		return nil, fmt.Errorf("could not create the llm client for protocol %s: %w", llmConfig.Protocol, err)
 	}
 
 	err = llmClient.Configure(llmConfig)
 	if err != nil {
-		return nil, fmt.Errorf("Could not configure the llm client for %s: %w", llmConfig.ProviderName, err)
+		return nil, fmt.Errorf("could not configure the llm client for %s: %w", llmConfig.ProviderName, err)
 	}
 
 	return llmClient, nil

--- a/pkg/microservice/aslan/core/system/handler/llm.go
+++ b/pkg/microservice/aslan/core/system/handler/llm.go
@@ -29,11 +29,14 @@ import (
 )
 
 type CreateLLMIntegrationRequest struct {
+	Name         string       `json:"name"`
 	ProviderName llm.Provider `json:"provider_name"`
+	Protocol     llm.Protocol `json:"protocol"`
 	Token        string       `json:"token"`
 	BaseURL      string       `json:"base_url"`
 	Model        string       `json:"model"`
 	EnableProxy  bool         `json:"enable_proxy"`
+	IsDefault    bool         `json:"is_default"`
 }
 
 // @Summary Create a llm integration
@@ -196,11 +199,13 @@ func DeleteLLMIntegration(c *gin.Context) {
 
 func convertLLMArgToModel(args *CreateLLMIntegrationRequest) *commonmodels.LLMIntegration {
 	return &commonmodels.LLMIntegration{
+		Name:         args.Name,
 		ProviderName: args.ProviderName,
+		Protocol:     args.Protocol,
 		Token:        args.Token,
 		BaseURL:      args.BaseURL,
 		EnableProxy:  args.EnableProxy,
 		Model:        args.Model,
-		IsDefault:    true,
+		IsDefault:    args.IsDefault,
 	}
 }

--- a/pkg/microservice/aslan/core/system/service/llm.go
+++ b/pkg/microservice/aslan/core/system/service/llm.go
@@ -77,7 +77,7 @@ func CreateLLMIntegration(ctx context.Context, args *commonmodels.LLMIntegration
 			return fmt.Errorf("count llm integration: %w", err)
 		}
 
-		setDefault := shouldSetDefault(count, args.IsDefault)
+		setDefault := count == 0 || args.IsDefault
 		args.IsDefault = false
 		if err := repo.Create(txCtx, args); err != nil {
 			return fmt.Errorf("create llm integration: %w", err)
@@ -169,8 +169,8 @@ func DeleteLLMIntegration(ctx context.Context, ID string) error {
 	if err != nil {
 		return e.ErrDeleteLLMIntegration.AddErr(fmt.Errorf("count llm integrations: %w", err))
 	}
-	if err := validateLLMIntegrationDeletion(integration, count); err != nil {
-		return e.ErrDeleteLLMIntegration.AddErr(err)
+	if integration.IsDefault && count > 1 {
+		return e.ErrDeleteLLMIntegration.AddErr(fmt.Errorf("set another model as default before deleting the current default model"))
 	}
 	if err := repo.Delete(ctx, ID); err != nil {
 		fmtErr := fmt.Errorf("DeleteLLMIntegration err: %w", err)

--- a/pkg/microservice/aslan/core/system/service/llm.go
+++ b/pkg/microservice/aslan/core/system/service/llm.go
@@ -25,6 +25,7 @@ import (
 	commonservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
 	"github.com/koderover/zadig/v2/pkg/tool/log"
+	mongotool "github.com/koderover/zadig/v2/pkg/tool/mongo"
 )
 
 func CheckLLMIntegration(ctx context.Context) (bool, error) {
@@ -65,25 +66,41 @@ func ListLLMIntegration(ctx context.Context) ([]*commonmodels.LLMIntegration, er
 }
 
 func CreateLLMIntegration(ctx context.Context, args *commonmodels.LLMIntegration) error {
-	count, err := commonrepo.NewLLMIntegrationColl().Count(ctx)
-	if err != nil {
-		fmtErr := fmt.Errorf("count llm intergration err: %w", err)
-		log.Error(fmtErr)
-		return e.ErrCreateLLMIntegration.AddErr(fmtErr)
-	}
-	if count > 0 {
-		return e.ErrCreateLLMIntegration.AddDesc("llm integration already exists")
+	normalizeLLMIntegration(args)
+	if err := validateLLMIntegration(args); err != nil {
+		return e.ErrCreateLLMIntegration.AddErr(err)
 	}
 
-	if err := commonrepo.NewLLMIntegrationColl().Create(ctx, args); err != nil {
-		fmtErr := fmt.Errorf("CreateLLMIntegration err: %w", err)
-		log.Error(fmtErr)
-		return e.ErrCreateLLMIntegration.AddErr(fmtErr)
+	err := runLLMIntegrationTransaction(ctx, func(txCtx context.Context, repo *commonrepo.LLMIntegrationColl) error {
+		count, err := repo.Count(txCtx)
+		if err != nil {
+			return fmt.Errorf("count llm integration: %w", err)
+		}
+
+		setDefault := shouldSetDefault(count, args.IsDefault)
+		args.IsDefault = false
+		if err := repo.Create(txCtx, args); err != nil {
+			return fmt.Errorf("create llm integration: %w", err)
+		}
+		if setDefault {
+			if err := repo.SetDefault(txCtx, args.ID.Hex()); err != nil {
+				return fmt.Errorf("set default llm integration: %w", err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		log.Errorf("create llm integration: %v", err)
+		return e.ErrCreateLLMIntegration.AddErr(err)
 	}
 	return nil
 }
 
 func ValidateLLMIntegration(ctx context.Context, args *commonmodels.LLMIntegration) error {
+	normalizeLLMIntegration(args)
+	if err := validateLLMIntegration(args); err != nil {
+		return fmt.Errorf("验证 LLM 集成失败: %s", err)
+	}
 	llmClient, err := commonservice.NewLLMClient(args)
 	if err != nil {
 		return fmt.Errorf("验证 LLM 集成失败: %s", err)
@@ -98,19 +115,67 @@ func ValidateLLMIntegration(ctx context.Context, args *commonmodels.LLMIntegrati
 }
 
 func UpdateLLMIntegration(ctx context.Context, ID string, args *commonmodels.LLMIntegration) error {
-	if err := commonrepo.NewLLMIntegrationColl().Update(ctx, ID, args); err != nil {
-		fmtErr := fmt.Errorf("UpdateLLMIntegration err: %w", err)
-		log.Error(fmtErr)
-		return e.ErrUpdateLLMIntegration.AddErr(fmtErr)
+	normalizeLLMIntegration(args)
+	if err := validateLLMIntegration(args); err != nil {
+		return e.ErrUpdateLLMIntegration.AddErr(err)
+	}
+
+	err := runLLMIntegrationTransaction(ctx, func(txCtx context.Context, repo *commonrepo.LLMIntegrationColl) error {
+		current, err := repo.FindByID(txCtx, ID)
+		if err != nil {
+			return fmt.Errorf("find llm integration: %w", err)
+		}
+		setDefault := args.IsDefault || current.IsDefault
+		args.IsDefault = false
+		if err := repo.Update(txCtx, ID, args); err != nil {
+			return fmt.Errorf("update llm integration: %w", err)
+		}
+		if setDefault {
+			if err := repo.SetDefault(txCtx, ID); err != nil {
+				return fmt.Errorf("set default llm integration: %w", err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		log.Errorf("update llm integration: %v", err)
+		return e.ErrUpdateLLMIntegration.AddErr(err)
 	}
 	return nil
 }
 
+func runLLMIntegrationTransaction(ctx context.Context, fn func(context.Context, *commonrepo.LLMIntegrationColl) error) (err error) {
+	session, cleanup, err := mongotool.SessionWithTransaction(ctx)
+	if err != nil {
+		session.EndSession(ctx)
+		return err
+	}
+	defer func() { cleanup(err) }()
+
+	txCtx := mongotool.SessionContext(ctx, session)
+	if err = fn(txCtx, commonrepo.NewLLMIntegrationColl()); err != nil {
+		return err
+	}
+	return mongotool.CommitTransaction(session)
+}
+
 func DeleteLLMIntegration(ctx context.Context, ID string) error {
-	if err := commonrepo.NewLLMIntegrationColl().Delete(ctx, ID); err != nil {
+	repo := commonrepo.NewLLMIntegrationColl()
+	integration, err := repo.FindByID(ctx, ID)
+	if err != nil {
+		return e.ErrDeleteLLMIntegration.AddErr(fmt.Errorf("find llm integration: %w", err))
+	}
+	count, err := repo.Count(ctx)
+	if err != nil {
+		return e.ErrDeleteLLMIntegration.AddErr(fmt.Errorf("count llm integrations: %w", err))
+	}
+	if err := validateLLMIntegrationDeletion(integration, count); err != nil {
+		return e.ErrDeleteLLMIntegration.AddErr(err)
+	}
+	if err := repo.Delete(ctx, ID); err != nil {
 		fmtErr := fmt.Errorf("DeleteLLMIntegration err: %w", err)
 		log.Error(fmtErr)
-		return e.ErrDeleteCICDTools.AddErr(fmtErr)
+		return e.ErrDeleteLLMIntegration.AddErr(fmtErr)
 	}
 	return nil
 }

--- a/pkg/microservice/aslan/core/system/service/llm_validation.go
+++ b/pkg/microservice/aslan/core/system/service/llm_validation.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/v2/pkg/tool/llm"
+)
+
+func normalizeLLMIntegration(args *commonmodels.LLMIntegration) {
+	if args == nil {
+		return
+	}
+	args.Name = strings.TrimSpace(args.Name)
+	args.Model = strings.TrimSpace(args.Model)
+	args.BaseURL = strings.TrimSpace(args.BaseURL)
+	if args.Protocol == "" {
+		args.Protocol = llm.ProtocolOpenAI
+	}
+	if args.Name == "" {
+		args.Name = args.Model
+		if args.Name == "" {
+			args.Name = string(args.ProviderName)
+		}
+	}
+}
+
+func validateLLMIntegration(args *commonmodels.LLMIntegration) error {
+	if args == nil {
+		return fmt.Errorf("llm integration is required")
+	}
+	if args.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if !supportedLLMProvider(args.ProviderName) {
+		return fmt.Errorf("provider %s is not supported", args.ProviderName)
+	}
+	if args.Protocol != llm.ProtocolOpenAI && args.Protocol != llm.ProtocolAnthropic {
+		return fmt.Errorf("protocol %s is not supported", args.Protocol)
+	}
+	if args.Protocol == llm.ProtocolAnthropic && args.Model == "" {
+		return fmt.Errorf("model is required for anthropic protocol")
+	}
+	if args.Token == "" {
+		return fmt.Errorf("token is required")
+	}
+	if args.BaseURL != "" {
+		parsedURL, err := url.ParseRequestURI(args.BaseURL)
+		if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+			return fmt.Errorf("base_url is invalid")
+		}
+	}
+	return nil
+}
+
+func supportedLLMProvider(provider llm.Provider) bool {
+	switch provider {
+	case llm.ProviderOpenAI,
+		llm.ProviderDeepSeek,
+		llm.ProviderDeepSeekSiliconCloud,
+		llm.ProviderAzure,
+		llm.ProviderAzureAD,
+		llm.ProviderAliyunBailian,
+		llm.ProviderVolcengineArk,
+		llm.ProviderHuaweiMaas,
+		llm.ProviderOther:
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldSetDefault(existingCount int64, requested bool) bool {
+	return existingCount == 0 || requested
+}
+
+func validateLLMIntegrationDeletion(integration *commonmodels.LLMIntegration, count int64) error {
+	if integration.IsDefault && count > 1 {
+		return fmt.Errorf("set another model as default before deleting the current default model")
+	}
+	return nil
+}

--- a/pkg/microservice/aslan/core/system/service/llm_validation.go
+++ b/pkg/microservice/aslan/core/system/service/llm_validation.go
@@ -87,14 +87,3 @@ func supportedLLMProvider(provider llm.Provider) bool {
 		return false
 	}
 }
-
-func shouldSetDefault(existingCount int64, requested bool) bool {
-	return existingCount == 0 || requested
-}
-
-func validateLLMIntegrationDeletion(integration *commonmodels.LLMIntegration, count int64) error {
-	if integration.IsDefault && count > 1 {
-		return fmt.Errorf("set another model as default before deleting the current default model")
-	}
-	return nil
-}

--- a/pkg/tool/llm/anthropic.go
+++ b/pkg/tool/llm/anthropic.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/koderover/zadig/v2/pkg/tool/cache"
+	"github.com/koderover/zadig/v2/pkg/tool/log"
+)
+
+const (
+	defaultAnthropicBaseURL   = "https://api.anthropic.com"
+	defaultAnthropicMaxTokens = 4096
+	anthropicAPIVersion       = "2023-06-01"
+)
+
+type AnthropicClient struct {
+	name            string
+	integrationName string
+	model           string
+	token           string
+	baseURL         string
+	httpClient      *http.Client
+}
+
+type anthropicMessageRequest struct {
+	Model         string             `json:"model"`
+	MaxTokens     int                `json:"max_tokens"`
+	Messages      []anthropicMessage `json:"messages"`
+	Temperature   *float32           `json:"temperature,omitempty"`
+	StopSequences []string           `json:"stop_sequences,omitempty"`
+}
+
+type anthropicMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type anthropicMessageResponse struct {
+	Content []anthropicContent `json:"content"`
+}
+
+type anthropicContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func (c *AnthropicClient) Configure(config LLMConfig) error {
+	baseURL := strings.TrimRight(config.GetBaseURL(), "/")
+	if baseURL == "" {
+		baseURL = defaultAnthropicBaseURL
+	}
+	parsedBaseURL, err := url.Parse(baseURL)
+	if err != nil || parsedBaseURL.Scheme == "" || parsedBaseURL.Host == "" {
+		return fmt.Errorf("invalid anthropic base url %q", baseURL)
+	}
+
+	httpClient := &http.Client{Timeout: 5 * time.Minute}
+	if config.GetProxy() != "" {
+		proxyURL, err := url.Parse(config.GetProxy())
+		if err != nil {
+			return fmt.Errorf("invalid proxy url %s", config.GetProxy())
+		}
+		httpClient.Transport = &http.Transport{Proxy: http.ProxyURL(proxyURL)}
+	}
+
+	c.name = string(config.GetProviderName())
+	c.integrationName = config.GetIntegrationName()
+	c.model = config.GetModel()
+	c.token = config.GetToken()
+	c.baseURL = baseURL
+	c.httpClient = httpClient
+	return nil
+}
+
+func (c *AnthropicClient) GetCompletion(ctx context.Context, prompt string, options ...ParamOption) (string, error) {
+	opts := ParamOptions{}
+	for _, opt := range options {
+		opt(&opts)
+	}
+	opts = ValidOptions(opts)
+
+	model := opts.Model
+	if model == "" {
+		model = c.model
+	}
+	if model == "" {
+		return "", errors.New("anthropic model is required")
+	}
+	maxTokens := opts.MaxTokens
+	if maxTokens == 0 {
+		maxTokens = defaultAnthropicMaxTokens
+	}
+
+	request := &anthropicMessageRequest{
+		Model:         model,
+		MaxTokens:     maxTokens,
+		Messages:      []anthropicMessage{{Role: "user", Content: prompt}},
+		StopSequences: opts.StopWords,
+	}
+	if opts.hasTemperature() {
+		request.Temperature = &opts.Temperature
+	}
+	requestBody, err := json.Marshal(request)
+	if err != nil {
+		return "", fmt.Errorf("marshal anthropic request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.messagesURL(), bytes.NewReader(requestBody))
+	if err != nil {
+		return "", fmt.Errorf("create anthropic request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", c.token)
+	req.Header.Set("anthropic-version", anthropicAPIVersion)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("create anthropic message failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		if readErr != nil {
+			return "", fmt.Errorf("anthropic request failed with status %d", resp.StatusCode)
+		}
+		return "", fmt.Errorf("anthropic request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	response := new(anthropicMessageResponse)
+	if err := json.NewDecoder(resp.Body).Decode(response); err != nil {
+		return "", fmt.Errorf("decode anthropic response: %w", err)
+	}
+	var result strings.Builder
+	for _, content := range response.Content {
+		if content.Type == "text" {
+			result.WriteString(content.Text)
+		}
+	}
+	if result.Len() == 0 {
+		return "", errors.New("anthropic response contains no text content")
+	}
+	return result.String(), nil
+}
+
+func (c *AnthropicClient) Parse(ctx context.Context, prompt string, cache cache.ICache, options ...ParamOption) (string, error) {
+	cacheKey := GetCacheKeyWithModel(cacheNamespace(ProtocolAnthropic, c.integrationName, Provider(c.GetName())), c.GetModel(), prompt)
+	if !cache.IsCacheDisabled() && cache.Exists(cacheKey) {
+		response, err := cache.Load(cacheKey)
+		if err != nil {
+			return "", err
+		}
+		if response != "" {
+			output, err := base64.StdEncoding.DecodeString(response)
+			if err != nil {
+				return "", fmt.Errorf("decode cached anthropic response: %w", err)
+			}
+			return string(output), nil
+		}
+	}
+
+	response, err := c.GetCompletion(ctx, prompt, options...)
+	if err != nil {
+		return "", err
+	}
+	if !cache.IsCacheDisabled() {
+		if err := cache.Store(cacheKey, base64.StdEncoding.EncodeToString([]byte(response))); err != nil {
+			log.Errorf("error storing anthropic response: %v", err)
+		}
+	}
+	return response, nil
+}
+
+func (c *AnthropicClient) GetName() string {
+	if c.name == "" {
+		return string(ProviderOther)
+	}
+	return c.name
+}
+
+func (c *AnthropicClient) GetModel() string {
+	return c.model
+}
+
+func (c *AnthropicClient) messagesURL() string {
+	switch {
+	case strings.HasSuffix(c.baseURL, "/v1/messages"):
+		return c.baseURL
+	case strings.HasSuffix(c.baseURL, "/v1"):
+		return c.baseURL + "/messages"
+	default:
+		return c.baseURL + "/v1/messages"
+	}
+}

--- a/pkg/tool/llm/anthropic.go
+++ b/pkg/tool/llm/anthropic.go
@@ -170,7 +170,15 @@ func (c *AnthropicClient) GetCompletion(ctx context.Context, prompt string, opti
 }
 
 func (c *AnthropicClient) Parse(ctx context.Context, prompt string, cache cache.ICache, options ...ParamOption) (string, error) {
-	cacheKey := GetCacheKeyWithModel(cacheNamespace(ProtocolAnthropic, c.integrationName, Provider(c.GetName())), c.GetModel(), prompt)
+	model := c.GetModel()
+	opts := ParamOptions{}
+	for _, opt := range options {
+		opt(&opts)
+	}
+	if opts.Model != "" {
+		model = opts.Model
+	}
+	cacheKey := GetCacheKeyWithModel(cacheNamespace(ProtocolAnthropic, c.integrationName, Provider(c.GetName())), model, prompt)
 	if !cache.IsCacheDisabled() && cache.Exists(cacheKey) {
 		response, err := cache.Load(cacheKey)
 		if err != nil {

--- a/pkg/tool/llm/illm.go
+++ b/pkg/tool/llm/illm.go
@@ -54,24 +54,6 @@ type ILLM interface {
 	GetModel() string
 }
 
-// NewClient keeps the legacy OpenAI-protocol constructor for compatibility.
-func NewClient(provider Provider) (ILLM, error) {
-	switch provider {
-	case ProviderOpenAI,
-		ProviderDeepSeek,
-		ProviderDeepSeekSiliconCloud,
-		ProviderAzure,
-		ProviderAzureAD,
-		ProviderAliyunBailian,
-		ProviderVolcengineArk,
-		ProviderHuaweiMaas,
-		ProviderOther:
-		return &OpenAIClient{}, nil
-	default:
-		return nil, fmt.Errorf("provider %s not supported", provider)
-	}
-}
-
 func NewClientByProtocol(protocol Protocol) (ILLM, error) {
 	switch protocol {
 	case "", ProtocolOpenAI:
@@ -97,10 +79,6 @@ func (p *LLMConfig) GetIntegrationName() string {
 	return p.Name
 }
 
-func (p *LLMConfig) GetProtocol() Protocol {
-	return p.Protocol
-}
-
 func (p *LLMConfig) GetProviderName() Provider {
 	return p.ProviderName
 }
@@ -119,12 +97,6 @@ func (p *LLMConfig) GetModel() string {
 
 func (p *LLMConfig) GetProxy() string {
 	return p.Proxy
-}
-
-func GetCacheKey(provider, sEnc string) string {
-	data := fmt.Sprintf("%s-%s", provider, sEnc)
-	hash := sha256.Sum256([]byte(data))
-	return hex.EncodeToString(hash[:])
 }
 
 func GetCacheKeyWithModel(provider, model, sEnc string) string {

--- a/pkg/tool/llm/illm.go
+++ b/pkg/tool/llm/illm.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/koderover/zadig/v2/pkg/tool/cache"
 )
@@ -35,19 +36,14 @@ const (
 	ProviderAliyunBailian        Provider = "bailian"
 	ProviderVolcengineArk        Provider = "ark"
 	ProviderHuaweiMaas           Provider = "maas"
+	ProviderOther                Provider = "other"
 )
 
-var (
-	clients = map[Provider]ILLM{
-		ProviderOpenAI:               &OpenAIClient{},
-		ProviderDeepSeek:             &OpenAIClient{},
-		ProviderDeepSeekSiliconCloud: &OpenAIClient{},
-		ProviderAzure:                &OpenAIClient{},
-		ProviderAzureAD:              &OpenAIClient{},
-		ProviderAliyunBailian:        &OpenAIClient{},
-		ProviderVolcengineArk:        &OpenAIClient{},
-		ProviderHuaweiMaas:           &OpenAIClient{},
-	}
+type Protocol string
+
+const (
+	ProtocolOpenAI    Protocol = "openai"
+	ProtocolAnthropic Protocol = "anthropic"
 )
 
 type ILLM interface {
@@ -58,20 +54,51 @@ type ILLM interface {
 	GetModel() string
 }
 
+// NewClient keeps the legacy OpenAI-protocol constructor for compatibility.
 func NewClient(provider Provider) (ILLM, error) {
-	if c, ok := clients[provider]; !ok {
+	switch provider {
+	case ProviderOpenAI,
+		ProviderDeepSeek,
+		ProviderDeepSeekSiliconCloud,
+		ProviderAzure,
+		ProviderAzureAD,
+		ProviderAliyunBailian,
+		ProviderVolcengineArk,
+		ProviderHuaweiMaas,
+		ProviderOther:
+		return &OpenAIClient{}, nil
+	default:
 		return nil, fmt.Errorf("provider %s not supported", provider)
-	} else {
-		return c, nil
+	}
+}
+
+func NewClientByProtocol(protocol Protocol) (ILLM, error) {
+	switch protocol {
+	case "", ProtocolOpenAI:
+		return &OpenAIClient{}, nil
+	case ProtocolAnthropic:
+		return &AnthropicClient{}, nil
+	default:
+		return nil, fmt.Errorf("protocol %s is not supported", protocol)
 	}
 }
 
 type LLMConfig struct {
+	Name         string
+	Protocol     Protocol
 	ProviderName Provider
 	Model        string
 	Token        string
 	BaseURL      string
 	Proxy        string
+}
+
+func (p *LLMConfig) GetIntegrationName() string {
+	return p.Name
+}
+
+func (p *LLMConfig) GetProtocol() Protocol {
+	return p.Protocol
 }
 
 func (p *LLMConfig) GetProviderName() Provider {
@@ -94,10 +121,23 @@ func (p *LLMConfig) GetProxy() string {
 	return p.Proxy
 }
 
-func GetCacheKey(provider string, sEnc string) string {
+func GetCacheKey(provider, sEnc string) string {
 	data := fmt.Sprintf("%s-%s", provider, sEnc)
+	hash := sha256.Sum256([]byte(data))
+	return hex.EncodeToString(hash[:])
+}
+
+func GetCacheKeyWithModel(provider, model, sEnc string) string {
+	data := strings.Join([]string{provider, model, sEnc}, "\x00")
 
 	hash := sha256.Sum256([]byte(data))
 
 	return hex.EncodeToString(hash[:])
+}
+
+func cacheNamespace(protocol Protocol, integrationName string, provider Provider) string {
+	if integrationName == "" {
+		integrationName = string(provider)
+	}
+	return string(protocol) + ":" + integrationName
 }

--- a/pkg/tool/llm/openai.go
+++ b/pkg/tool/llm/openai.go
@@ -57,20 +57,10 @@ func (c *OpenAIClient) Configure(config LLMConfig) error {
 			c.apiType = string(openai.APITypeAzureAD)
 			defaultConfig.APIType = openai.APITypeAzureAD
 		}
-	} else if strings.HasPrefix(string(config.GetProviderName()), string(ProviderDeepSeek)) {
-		c.apiType = string(openai.APITypeOpenAI)
-		defaultConfig = openai.DefaultConfig(token)
-		defaultConfig.BaseURL = config.GetBaseURL()
-	} else if strings.HasPrefix(string(config.GetProviderName()), string(ProviderAliyunBailian)) ||
-		strings.HasPrefix(string(config.GetProviderName()), string(ProviderVolcengineArk)) ||
-		strings.HasPrefix(string(config.GetProviderName()), string(ProviderHuaweiMaas)) {
-		c.apiType = string(openai.APITypeOpenAI)
-		defaultConfig = openai.DefaultConfig(token)
-		defaultConfig.BaseURL = config.GetBaseURL()
 	} else {
 		c.apiType = string(openai.APITypeOpenAI)
 		defaultConfig = openai.DefaultConfig(token)
-		if config.GetProviderName() == ProviderOther && config.GetBaseURL() != "" {
+		if config.GetBaseURL() != "" {
 			defaultConfig.BaseURL = config.GetBaseURL()
 		}
 	}

--- a/pkg/tool/llm/openai.go
+++ b/pkg/tool/llm/openai.go
@@ -38,10 +38,11 @@ const (
 )
 
 type OpenAIClient struct {
-	name    string
-	model   string
-	client  *openai.Client
-	apiType string
+	name            string
+	integrationName string
+	model           string
+	client          *openai.Client
+	apiType         string
 }
 
 func (c *OpenAIClient) Configure(config LLMConfig) error {
@@ -56,21 +57,12 @@ func (c *OpenAIClient) Configure(config LLMConfig) error {
 			c.apiType = string(openai.APITypeAzureAD)
 			defaultConfig.APIType = openai.APITypeAzureAD
 		}
-	} else if strings.HasPrefix(string(config.GetProviderName()), string(ProviderDeepSeek)) {
-		c.apiType = string(openai.APITypeOpenAI)
-		defaultConfig = openai.DefaultConfig(token)
-		baseURL := config.GetBaseURL()
-		defaultConfig.BaseURL = baseURL
-	} else if strings.HasPrefix(string(config.GetProviderName()), string(ProviderAliyunBailian)) ||
-		strings.HasPrefix(string(config.GetProviderName()), string(ProviderVolcengineArk)) ||
-		strings.HasPrefix(string(config.GetProviderName()), string(ProviderHuaweiMaas)) {
-		c.apiType = string(openai.APITypeOpenAI)
-		defaultConfig = openai.DefaultConfig(token)
-		baseURL := config.GetBaseURL()
-		defaultConfig.BaseURL = baseURL
 	} else {
 		c.apiType = string(openai.APITypeOpenAI)
 		defaultConfig = openai.DefaultConfig(token)
+		if config.GetBaseURL() != "" {
+			defaultConfig.BaseURL = config.GetBaseURL()
+		}
 	}
 
 	httpClient := &http.Client{
@@ -95,6 +87,7 @@ func (c *OpenAIClient) Configure(config LLMConfig) error {
 
 	c.client = client
 	c.name = string(config.GetProviderName())
+	c.integrationName = config.GetIntegrationName()
 	c.model = config.GetModel()
 	return nil
 }
@@ -175,7 +168,7 @@ func (c *OpenAIClient) GetCompletion(ctx context.Context, prompt string, options
 
 func (a *OpenAIClient) Parse(ctx context.Context, prompt string, cache cache.ICache, options ...ParamOption) (string, error) {
 	// Check for cached data
-	cacheKey := GetCacheKey(a.GetName(), prompt)
+	cacheKey := GetCacheKeyWithModel(cacheNamespace(ProtocolOpenAI, a.integrationName, Provider(a.GetName())), a.GetModel(), prompt)
 
 	if !cache.IsCacheDisabled() && cache.Exists(cacheKey) {
 		response, err := cache.Load(cacheKey)

--- a/pkg/tool/llm/openai.go
+++ b/pkg/tool/llm/openai.go
@@ -57,10 +57,20 @@ func (c *OpenAIClient) Configure(config LLMConfig) error {
 			c.apiType = string(openai.APITypeAzureAD)
 			defaultConfig.APIType = openai.APITypeAzureAD
 		}
+	} else if strings.HasPrefix(string(config.GetProviderName()), string(ProviderDeepSeek)) {
+		c.apiType = string(openai.APITypeOpenAI)
+		defaultConfig = openai.DefaultConfig(token)
+		defaultConfig.BaseURL = config.GetBaseURL()
+	} else if strings.HasPrefix(string(config.GetProviderName()), string(ProviderAliyunBailian)) ||
+		strings.HasPrefix(string(config.GetProviderName()), string(ProviderVolcengineArk)) ||
+		strings.HasPrefix(string(config.GetProviderName()), string(ProviderHuaweiMaas)) {
+		c.apiType = string(openai.APITypeOpenAI)
+		defaultConfig = openai.DefaultConfig(token)
+		defaultConfig.BaseURL = config.GetBaseURL()
 	} else {
 		c.apiType = string(openai.APITypeOpenAI)
 		defaultConfig = openai.DefaultConfig(token)
-		if config.GetBaseURL() != "" {
+		if config.GetProviderName() == ProviderOther && config.GetBaseURL() != "" {
 			defaultConfig.BaseURL = config.GetBaseURL()
 		}
 	}
@@ -168,7 +178,15 @@ func (c *OpenAIClient) GetCompletion(ctx context.Context, prompt string, options
 
 func (a *OpenAIClient) Parse(ctx context.Context, prompt string, cache cache.ICache, options ...ParamOption) (string, error) {
 	// Check for cached data
-	cacheKey := GetCacheKeyWithModel(cacheNamespace(ProtocolOpenAI, a.integrationName, Provider(a.GetName())), a.GetModel(), prompt)
+	model := a.GetModel()
+	opts := ParamOptions{}
+	for _, opt := range options {
+		opt(&opts)
+	}
+	if opts.Model != "" {
+		model = opts.Model
+	}
+	cacheKey := GetCacheKeyWithModel(cacheNamespace(ProtocolOpenAI, a.integrationName, Provider(a.GetName())), model, prompt)
 
 	if !cache.IsCacheDisabled() && cache.Exists(cacheKey) {
 		response, err := cache.Load(cacheKey)

--- a/pkg/tool/llm/options.go
+++ b/pkg/tool/llm/options.go
@@ -14,6 +14,8 @@ type ParamOptions struct {
 	// StopWords is a list of words to stop on.
 	StopWords []string       `json:"stop_words"`
 	LogitBias map[string]int `json:"logit_bias"`
+
+	temperatureSet bool
 }
 
 func WithModel(model string) ParamOption {
@@ -31,6 +33,7 @@ func WithMaxTokens(maxTokens int) ParamOption {
 func WithTemperature(temperature float32) ParamOption {
 	return func(o *ParamOptions) {
 		o.Temperature = temperature
+		o.temperatureSet = true
 	}
 }
 
@@ -57,4 +60,8 @@ func ValidOptions(options ParamOptions) ParamOptions {
 		options.StopWords = nil
 	}
 	return options
+}
+
+func (o ParamOptions) hasTemperature() bool {
+	return o.temperatureSet || o.Temperature != 0
 }


### PR DESCRIPTION
### Summary
- Add configurable OpenAI and Anthropic protocol support for LLM integrations.

### Main Changes
- Support the Anthropic Messages API with custom endpoints and models.
- Support named multi-model configurations and one selectable default model.
- Keep legacy OpenAI clients compatible; missing protocol still defaults to OpenAI.
- Make default-model changes transactional and preserve explicit temperature zero.

### Test
- go test -vet=off on the affected LLM and Aslan packages.
- go build ./cmd/aslan

Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4825)
<!-- Reviewable:end -->
