### PR TITLE
fix: skip missing services for image-only deploy from job

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_deploy.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_deploy.go
@@ -461,8 +461,15 @@ func (j DeployJobController) ToTask(taskID int64) ([]*commonmodels.JobTask, erro
 			}
 		}
 
+		services := make([]*commonmodels.DeployServiceInfo, 0, len(j.jobSpec.Services))
 		for _, service := range j.jobSpec.Services {
 			moduleList := make([]*commonmodels.DeployModuleInfo, 0)
+
+			if len(j.jobSpec.DeployContents) == 1 && slices.Contains(j.jobSpec.DeployContents, config.DeployImage) {
+				if _, ok := productServiceMap[service.ServiceName]; !ok {
+					continue
+				}
+			}
 
 			deployService, ok := deployServiceMap[service.ServiceName]
 			if !ok {
@@ -476,7 +483,9 @@ func (j DeployJobController) ToTask(taskID int64) ([]*commonmodels.JobTask, erro
 				}
 			}
 			service.Modules = moduleList
+			services = append(services, service)
 		}
+		j.jobSpec.Services = services
 	}
 
 	serviceMap := map[string]*commonmodels.DeployServiceInfo{}


### PR DESCRIPTION
### What this PR does / Why we need it:

Fixes an issue where an image-only deploy job that sources services from a previous deploy job could deploy a service that does not exist in the target environment. In this case, deploying from dev to prod could incorrectly create a prod service when the expected behavior is to skip it.

### What is changed and how it works?

When a deploy job uses `SourceFromJob` and its deploy contents are image-only, the job now filters inherited services against the target environment’s existing service map before generating deploy subtasks.

Services that are not present in the target environment are removed from `j.jobSpec.Services`, so no deploy task is created for them. Other deploy modes are unchanged.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4826)
<!-- Reviewable:end -->
