### PR TITLE
feat: check image existence before service rollback

### DIFF
--- a/pkg/microservice/aslan/core/common/service/registry/service.go
+++ b/pkg/microservice/aslan/core/common/service/registry/service.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecr"
@@ -78,10 +79,18 @@ type GetRepoImageDetailOption struct {
 	Tag   string
 }
 
+type CheckImageExistOption struct {
+	Endpoint
+	Image  string
+	Tag    string
+	Digest string
+}
+
 type Service interface {
 	ValidateRegistry(ep Endpoint, log *zap.SugaredLogger) error
 	ListRepoImages(option ListRepoImagesOption, log *zap.SugaredLogger) (*ReposResp, error)
 	GetImageInfo(option GetRepoImageDetailOption, log *zap.SugaredLogger) (*commonmodels.DeliveryImage, error)
+	CheckImageExist(option CheckImageExistOption, log *zap.SugaredLogger) (bool, error)
 }
 
 func NewV2Service(provider string, tlsEnabled bool, tlsCert string) Service {
@@ -497,6 +506,41 @@ func (s *v2RegistryService) GetImageInfo(option GetRepoImageDetailOption, log *z
 	}, nil
 }
 
+func (s *v2RegistryService) CheckImageExist(option CheckImageExistOption, log *zap.SugaredLogger) (bool, error) {
+	cli, err := s.createClient(option.Endpoint, log)
+	if err != nil {
+		return false, err
+	}
+
+	repoName := strings.Trim(strings.Join([]string{option.Namespace, option.Image}, "/"), "/")
+	if option.Digest == "" {
+		tags, err := cli.listTags(repoName)
+		if err != nil {
+			return false, err
+		}
+		for _, tag := range tags {
+			if tag == option.Tag {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	dgst, err := digest.Parse(option.Digest)
+	if err != nil {
+		return false, err
+	}
+	repo, err := cli.getRepository(repoName)
+	if err != nil {
+		return false, err
+	}
+	manifestService, err := repo.Manifests(cli.ctx)
+	if err != nil {
+		return false, err
+	}
+	return manifestService.Exists(cli.ctx, dgst)
+}
+
 type ReverseStringSlice []string
 
 // Len is the number of elements in the collection.
@@ -674,6 +718,30 @@ func (s *swrService) GetImageInfo(option GetRepoImageDetailOption, log *zap.Suga
 	return &commonmodels.DeliveryImage{}, nil
 }
 
+func (s *swrService) CheckImageExist(option CheckImageExistOption, log *zap.SugaredLogger) (bool, error) {
+	swrCli := s.createClient(option.Endpoint)
+	request := &model.ListRepositoryTagsRequest{Namespace: option.Namespace, Repository: option.Image}
+	if option.Digest == "" {
+		request.Tag = &option.Tag
+	}
+	repoTags, err := swrCli.ListRepositoryTags(request)
+	if err != nil {
+		return false, err
+	}
+	if repoTags.Body == nil {
+		return false, nil
+	}
+	for _, repoTag := range *repoTags.Body {
+		if option.Digest != "" && repoTag.Digest == option.Digest {
+			return true, nil
+		}
+		if option.Digest == "" && repoTag.Tag == option.Tag {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 type ecrService struct {
 }
 
@@ -803,4 +871,28 @@ func (s *ecrService) GetImageInfo(option GetRepoImageDetailOption, log *zap.Suga
 		}, nil
 	}
 	return &commonmodels.DeliveryImage{}, nil
+}
+
+func (s *ecrService) CheckImageExist(option CheckImageExistOption, log *zap.SugaredLogger) (bool, error) {
+	svc, err := s.getECRService(option.Endpoint, log)
+	if err != nil {
+		return false, err
+	}
+	imageID := &ecr.ImageIdentifier{}
+	if option.Digest != "" {
+		imageID.ImageDigest = aws.String(option.Digest)
+	} else {
+		imageID.ImageTag = aws.String(option.Tag)
+	}
+	result, err := svc.DescribeImages(&ecr.DescribeImagesInput{
+		ImageIds:       []*ecr.ImageIdentifier{imageID},
+		RepositoryName: aws.String(option.Image),
+	})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == ecr.ErrCodeImageNotFoundException {
+			return false, nil
+		}
+		return false, err
+	}
+	return len(result.ImageDetails) > 0, nil
 }

--- a/pkg/microservice/aslan/core/common/service/registry/service.go
+++ b/pkg/microservice/aslan/core/common/service/registry/service.go
@@ -41,6 +41,8 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/schema2"
+	"github.com/docker/distribution/registry/api/errcode"
+	v2 "github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/client"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/auth/challenge"
@@ -231,6 +233,36 @@ func (c *authClient) listTags(repoName string) (tags []string, err error) {
 	}
 
 	return
+}
+
+func (c *authClient) tagExists(repoName, tag string) (bool, error) {
+	repo, err := c.getRepository(repoName)
+	if err != nil {
+		return false, err
+	}
+
+	_, err = repo.Tags(c.ctx).Get(c.ctx, tag)
+	if err == nil {
+		return true, nil
+	}
+	if isRegistryImageNotFound(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func isRegistryImageNotFound(err error) bool {
+	switch registryErr := err.(type) {
+	case errcode.Error:
+		return registryErr.Code == v2.ErrorCodeManifestUnknown || registryErr.Code == v2.ErrorCodeNameUnknown
+	case errcode.Errors:
+		for _, item := range registryErr {
+			if isRegistryImageNotFound(item) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 type containerInfo struct {
@@ -514,16 +546,7 @@ func (s *v2RegistryService) CheckImageExist(option CheckImageExistOption, log *z
 
 	repoName := strings.Trim(strings.Join([]string{option.Namespace, option.Image}, "/"), "/")
 	if option.Digest == "" {
-		tags, err := cli.listTags(repoName)
-		if err != nil {
-			return false, err
-		}
-		for _, tag := range tags {
-			if tag == option.Tag {
-				return true, nil
-			}
-		}
-		return false, nil
+		return cli.tagExists(repoName, option.Tag)
 	}
 
 	dgst, err := digest.Parse(option.Digest)

--- a/pkg/microservice/aslan/core/common/service/version.go
+++ b/pkg/microservice/aslan/core/common/service/version.go
@@ -19,7 +19,9 @@ package service
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/distribution/reference"
 	"github.com/koderover/zadig/v2/pkg/tool/clientmanager"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -34,6 +36,7 @@ import (
 	helmservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/helm"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/kube"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/notify"
+	registryservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/registry"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/repository"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller"
 	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
@@ -297,6 +300,120 @@ type RollbackEnvServiceVersionData struct {
 	HelmDeployStatusChan chan bool
 }
 
+func checkRollbackImagesExist(containers []*commonmodels.Container, log *zap.SugaredLogger) error {
+	registryInfos, err := ListRegistryNamespaces("", false, log)
+	if err != nil {
+		return fmt.Errorf("failed to list registries for rollback image check: %w", err)
+	}
+
+	type rollbackImageRegistry struct {
+		info *commonmodels.RegistryNamespace
+		host string
+	}
+
+	registries := make([]*rollbackImageRegistry, 0, len(registryInfos))
+	for _, registryInfo := range registryInfos {
+		registryAddress, err := registryInfo.GetRegistryAddress()
+		if err != nil {
+			log.Warnf("skip invalid registry %s during rollback image check: %v", registryInfo.ID.Hex(), err)
+			continue
+		}
+
+		registries = append(registries, &rollbackImageRegistry{
+			info: registryInfo,
+			host: strings.Split(registryAddress, "/")[0],
+		})
+	}
+
+	missingImages := make([]string, 0)
+	checkedImages := sets.NewString()
+	credentialRegistries := make(map[string]*commonmodels.RegistryNamespace)
+	for _, container := range containers {
+		if container == nil || container.Image == "" || checkedImages.Has(container.Image) {
+			continue
+		}
+		checkedImages.Insert(container.Image)
+
+		named, err := reference.ParseNormalizedNamed(container.Image)
+		if err != nil {
+			missingImages = append(missingImages, container.Image)
+			continue
+		}
+		imagePath := reference.Path(named)
+		var matchedRegistry *rollbackImageRegistry
+		for _, registry := range registries {
+			if !strings.EqualFold(reference.Domain(named), registry.host) {
+				continue
+			}
+			namespace := strings.Trim(registry.info.Namespace, "/")
+			if namespace != "" && imagePath != namespace && !strings.HasPrefix(imagePath, namespace+"/") {
+				continue
+			}
+			if matchedRegistry == nil || len(namespace) > len(strings.Trim(matchedRegistry.info.Namespace, "/")) {
+				matchedRegistry = registry
+			}
+		}
+		if matchedRegistry == nil {
+			return fmt.Errorf("无法检查回滚镜像 %s：未找到匹配的镜像仓库配置", container.Image)
+		}
+
+		registryID := matchedRegistry.info.ID.Hex()
+		registryInfo, ok := credentialRegistries[registryID]
+		if !ok {
+			registryInfo, err = FindRegistryById(registryID, true, log)
+			if err != nil {
+				return fmt.Errorf("获取镜像仓库 %s 的凭证失败: %w", matchedRegistry.host, err)
+			}
+			credentialRegistries[registryID] = registryInfo
+		}
+
+		repositoryName := imagePath
+		namespace := strings.Trim(registryInfo.Namespace, "/")
+		if namespace != "" {
+			repositoryName = strings.TrimPrefix(repositoryName, namespace+"/")
+		}
+
+		tag, imageDigest := "", ""
+		if digested, ok := named.(reference.Digested); ok {
+			imageDigest = digested.Digest().String()
+		} else if tagged, ok := named.(reference.Tagged); ok {
+			tag = tagged.Tag()
+		} else {
+			tag = reference.TagNameOnly(named).(reference.Tagged).Tag()
+		}
+
+		tlsEnabled, tlsCert := true, ""
+		if registryInfo.AdvancedSetting != nil {
+			tlsEnabled = registryInfo.AdvancedSetting.TLSEnabled
+			tlsCert = registryInfo.AdvancedSetting.TLSCert
+		}
+		registrySvc := registryservice.NewV2Service(registryInfo.RegProvider, tlsEnabled, tlsCert)
+		exists, err := registrySvc.CheckImageExist(registryservice.CheckImageExistOption{
+			Endpoint: registryservice.Endpoint{
+				Addr:      registryInfo.RegAddr,
+				Ak:        registryInfo.AccessKey,
+				Sk:        registryInfo.SecretKey,
+				Region:    registryInfo.Region,
+				Namespace: registryInfo.Namespace,
+			},
+			Image:  repositoryName,
+			Tag:    tag,
+			Digest: imageDigest,
+		}, log)
+		if err != nil {
+			return fmt.Errorf("无法检查回滚镜像 %s 是否存在: %w", container.Image, err)
+		}
+		if !exists {
+			missingImages = append(missingImages, container.Image)
+		}
+	}
+
+	if len(missingImages) > 0 {
+		return fmt.Errorf("回滚镜像不存在：%s，请确认镜像可用后重试", strings.Join(missingImages, "、"))
+	}
+	return nil
+}
+
 func RollbackEnvServiceVersion(ctx *internalhandler.Context, projectName, envName, serviceName string, revision int64, isHelmChart, isProduction, overrideResource bool, detail string, log *zap.SugaredLogger) (*RollbackEnvServiceVersionData, error) {
 	envSvcVersion, err := mongodb.NewEnvServiceVersionColl().Find(projectName, envName, serviceName, isHelmChart, isProduction, revision)
 	if err != nil {
@@ -327,6 +444,10 @@ func RollbackEnvServiceVersion(ctx *internalhandler.Context, projectName, envNam
 
 	if env.ServiceDeployStrategy[serviceName] != envSvcVersion.DeployStrategy {
 		return nil, e.ErrRollbackEnvServiceVersion.AddErr(fmt.Errorf("服务 %s 的部署策略发生变化，不能回滚", envSvcVersion.Service.ServiceName))
+	}
+
+	if err := checkRollbackImagesExist(envSvcVersion.Service.Containers, log); err != nil {
+		return nil, e.ErrRollbackEnvServiceVersion.AddErr(err)
 	}
 
 	session := mongotool.Session()

--- a/pkg/microservice/aslan/core/common/service/version.go
+++ b/pkg/microservice/aslan/core/common/service/version.go
@@ -301,14 +301,21 @@ type RollbackEnvServiceVersionData struct {
 }
 
 type CheckRollbackEnvServiceVersionResponse struct {
-	Available         bool     `json:"available"`
-	UnavailableImages []string `json:"unavailable_images"`
+	Available         bool                         `json:"available"`
+	UnavailableImages []string                     `json:"unavailable_images"`
+	Warnings          []*RollbackImageCheckWarning `json:"warnings"`
 }
 
-func checkRollbackImages(containers []*commonmodels.Container, log *zap.SugaredLogger) ([]string, error) {
+type RollbackImageCheckWarning struct {
+	Image   string `json:"image"`
+	Reason  string `json:"reason"`
+	Message string `json:"message"`
+}
+
+func checkRollbackImages(containers []*commonmodels.Container, log *zap.SugaredLogger) ([]string, []*RollbackImageCheckWarning, error) {
 	registryInfos, err := ListRegistryNamespaces("", false, log)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list registries for rollback image check: %w", err)
+		return nil, nil, fmt.Errorf("failed to list registries for rollback image check: %w", err)
 	}
 
 	type rollbackImageRegistry struct {
@@ -331,6 +338,7 @@ func checkRollbackImages(containers []*commonmodels.Container, log *zap.SugaredL
 	}
 
 	missingImages := make([]string, 0)
+	warnings := make([]*RollbackImageCheckWarning, 0)
 	checkedImages := sets.NewString()
 	credentialRegistries := make(map[string]*commonmodels.RegistryNamespace)
 	for _, container := range containers {
@@ -359,7 +367,12 @@ func checkRollbackImages(containers []*commonmodels.Container, log *zap.SugaredL
 			}
 		}
 		if matchedRegistry == nil {
-			return nil, fmt.Errorf("无法检查回滚镜像 %s：未找到匹配的镜像仓库配置", container.Image)
+			warnings = append(warnings, &RollbackImageCheckWarning{
+				Image:   container.Image,
+				Reason:  "registry_not_configured",
+				Message: "未找到匹配的镜像仓库配置，无法确认镜像是否存在",
+			})
+			continue
 		}
 
 		registryID := matchedRegistry.info.ID.Hex()
@@ -367,7 +380,13 @@ func checkRollbackImages(containers []*commonmodels.Container, log *zap.SugaredL
 		if !ok {
 			registryInfo, err = FindRegistryById(registryID, true, log)
 			if err != nil {
-				return nil, fmt.Errorf("获取镜像仓库 %s 的凭证失败: %w", matchedRegistry.host, err)
+				log.Warnf("failed to get credentials for rollback image %s from registry %s: %v", container.Image, matchedRegistry.host, err)
+				warnings = append(warnings, &RollbackImageCheckWarning{
+					Image:   container.Image,
+					Reason:  "registry_credentials_unavailable",
+					Message: "获取镜像仓库凭证失败，无法确认镜像是否存在",
+				})
+				continue
 			}
 			credentialRegistries[registryID] = registryInfo
 		}
@@ -406,14 +425,20 @@ func checkRollbackImages(containers []*commonmodels.Container, log *zap.SugaredL
 			Digest: imageDigest,
 		}, log)
 		if err != nil {
-			return nil, fmt.Errorf("无法检查回滚镜像 %s 是否存在: %w", container.Image, err)
+			log.Warnf("failed to check whether rollback image %s exists: %v", container.Image, err)
+			warnings = append(warnings, &RollbackImageCheckWarning{
+				Image:   container.Image,
+				Reason:  "image_check_failed",
+				Message: "镜像仓库查询失败，无法确认镜像是否存在",
+			})
+			continue
 		}
 		if !exists {
 			missingImages = append(missingImages, container.Image)
 		}
 	}
 
-	return missingImages, nil
+	return missingImages, warnings, nil
 }
 
 func CheckRollbackEnvServiceVersion(projectName, envName, serviceName string, revision int64, isHelmChart, isProduction bool, log *zap.SugaredLogger) (*CheckRollbackEnvServiceVersionResponse, error) {
@@ -425,13 +450,14 @@ func CheckRollbackEnvServiceVersion(projectName, envName, serviceName string, re
 		return nil, fmt.Errorf("failed to find %s/%s/%s service for revision %d, isProduction %v, error: %w", projectName, envName, serviceName, revision, isProduction, err)
 	}
 
-	unavailableImages, err := checkRollbackImages(envSvcVersion.Service.Containers, log)
+	unavailableImages, warnings, err := checkRollbackImages(envSvcVersion.Service.Containers, log)
 	if err != nil {
 		return nil, err
 	}
 	return &CheckRollbackEnvServiceVersionResponse{
 		Available:         len(unavailableImages) == 0,
 		UnavailableImages: unavailableImages,
+		Warnings:          warnings,
 	}, nil
 }
 

--- a/pkg/microservice/aslan/core/common/service/version.go
+++ b/pkg/microservice/aslan/core/common/service/version.go
@@ -300,10 +300,15 @@ type RollbackEnvServiceVersionData struct {
 	HelmDeployStatusChan chan bool
 }
 
-func checkRollbackImagesExist(containers []*commonmodels.Container, log *zap.SugaredLogger) error {
+type CheckRollbackEnvServiceVersionResponse struct {
+	Available         bool     `json:"available"`
+	UnavailableImages []string `json:"unavailable_images"`
+}
+
+func checkRollbackImages(containers []*commonmodels.Container, log *zap.SugaredLogger) ([]string, error) {
 	registryInfos, err := ListRegistryNamespaces("", false, log)
 	if err != nil {
-		return fmt.Errorf("failed to list registries for rollback image check: %w", err)
+		return nil, fmt.Errorf("failed to list registries for rollback image check: %w", err)
 	}
 
 	type rollbackImageRegistry struct {
@@ -354,7 +359,7 @@ func checkRollbackImagesExist(containers []*commonmodels.Container, log *zap.Sug
 			}
 		}
 		if matchedRegistry == nil {
-			return fmt.Errorf("无法检查回滚镜像 %s：未找到匹配的镜像仓库配置", container.Image)
+			return nil, fmt.Errorf("无法检查回滚镜像 %s：未找到匹配的镜像仓库配置", container.Image)
 		}
 
 		registryID := matchedRegistry.info.ID.Hex()
@@ -362,7 +367,7 @@ func checkRollbackImagesExist(containers []*commonmodels.Container, log *zap.Sug
 		if !ok {
 			registryInfo, err = FindRegistryById(registryID, true, log)
 			if err != nil {
-				return fmt.Errorf("获取镜像仓库 %s 的凭证失败: %w", matchedRegistry.host, err)
+				return nil, fmt.Errorf("获取镜像仓库 %s 的凭证失败: %w", matchedRegistry.host, err)
 			}
 			credentialRegistries[registryID] = registryInfo
 		}
@@ -401,17 +406,33 @@ func checkRollbackImagesExist(containers []*commonmodels.Container, log *zap.Sug
 			Digest: imageDigest,
 		}, log)
 		if err != nil {
-			return fmt.Errorf("无法检查回滚镜像 %s 是否存在: %w", container.Image, err)
+			return nil, fmt.Errorf("无法检查回滚镜像 %s 是否存在: %w", container.Image, err)
 		}
 		if !exists {
 			missingImages = append(missingImages, container.Image)
 		}
 	}
 
-	if len(missingImages) > 0 {
-		return fmt.Errorf("回滚镜像不存在：%s，请确认镜像可用后重试", strings.Join(missingImages, "、"))
+	return missingImages, nil
+}
+
+func CheckRollbackEnvServiceVersion(projectName, envName, serviceName string, revision int64, isHelmChart, isProduction bool, log *zap.SugaredLogger) (*CheckRollbackEnvServiceVersionResponse, error) {
+	envSvcVersion, err := mongodb.NewEnvServiceVersionColl().Find(projectName, envName, serviceName, isHelmChart, isProduction, revision)
+	if err != nil {
+		if mongodb.IsErrNoDocuments(err) {
+			return nil, fmt.Errorf("历史版本 %d 不存在", revision)
+		}
+		return nil, fmt.Errorf("failed to find %s/%s/%s service for revision %d, isProduction %v, error: %w", projectName, envName, serviceName, revision, isProduction, err)
 	}
-	return nil
+
+	unavailableImages, err := checkRollbackImages(envSvcVersion.Service.Containers, log)
+	if err != nil {
+		return nil, err
+	}
+	return &CheckRollbackEnvServiceVersionResponse{
+		Available:         len(unavailableImages) == 0,
+		UnavailableImages: unavailableImages,
+	}, nil
 }
 
 func RollbackEnvServiceVersion(ctx *internalhandler.Context, projectName, envName, serviceName string, revision int64, isHelmChart, isProduction, overrideResource bool, detail string, log *zap.SugaredLogger) (*RollbackEnvServiceVersionData, error) {
@@ -444,10 +465,6 @@ func RollbackEnvServiceVersion(ctx *internalhandler.Context, projectName, envNam
 
 	if env.ServiceDeployStrategy[serviceName] != envSvcVersion.DeployStrategy {
 		return nil, e.ErrRollbackEnvServiceVersion.AddErr(fmt.Errorf("服务 %s 的部署策略发生变化，不能回滚", envSvcVersion.Service.ServiceName))
-	}
-
-	if err := checkRollbackImagesExist(envSvcVersion.Service.Containers, log); err != nil {
-		return nil, e.ErrRollbackEnvServiceVersion.AddErr(err)
 	}
 
 	session := mongotool.Session()

--- a/pkg/microservice/aslan/core/common/service/version.go
+++ b/pkg/microservice/aslan/core/common/service/version.go
@@ -301,21 +301,14 @@ type RollbackEnvServiceVersionData struct {
 }
 
 type CheckRollbackEnvServiceVersionResponse struct {
-	Available         bool                         `json:"available"`
-	UnavailableImages []string                     `json:"unavailable_images"`
-	Warnings          []*RollbackImageCheckWarning `json:"warnings"`
+	Available         bool     `json:"available"`
+	UnavailableImages []string `json:"unavailable_images"`
 }
 
-type RollbackImageCheckWarning struct {
-	Image   string `json:"image"`
-	Reason  string `json:"reason"`
-	Message string `json:"message"`
-}
-
-func checkRollbackImages(containers []*commonmodels.Container, log *zap.SugaredLogger) ([]string, []*RollbackImageCheckWarning, error) {
+func checkRollbackImages(containers []*commonmodels.Container, log *zap.SugaredLogger) ([]string, error) {
 	registryInfos, err := ListRegistryNamespaces("", false, log)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to list registries for rollback image check: %w", err)
+		return nil, fmt.Errorf("failed to list registries for rollback image check: %w", err)
 	}
 
 	type rollbackImageRegistry struct {
@@ -338,7 +331,6 @@ func checkRollbackImages(containers []*commonmodels.Container, log *zap.SugaredL
 	}
 
 	missingImages := make([]string, 0)
-	warnings := make([]*RollbackImageCheckWarning, 0)
 	checkedImages := sets.NewString()
 	credentialRegistries := make(map[string]*commonmodels.RegistryNamespace)
 	for _, container := range containers {
@@ -367,11 +359,7 @@ func checkRollbackImages(containers []*commonmodels.Container, log *zap.SugaredL
 			}
 		}
 		if matchedRegistry == nil {
-			warnings = append(warnings, &RollbackImageCheckWarning{
-				Image:   container.Image,
-				Reason:  "registry_not_configured",
-				Message: "未找到匹配的镜像仓库配置，无法确认镜像是否存在",
-			})
+			log.Warnf("no matching registry configured for rollback image %s, skip image existence check", container.Image)
 			continue
 		}
 
@@ -381,11 +369,6 @@ func checkRollbackImages(containers []*commonmodels.Container, log *zap.SugaredL
 			registryInfo, err = FindRegistryById(registryID, true, log)
 			if err != nil {
 				log.Warnf("failed to get credentials for rollback image %s from registry %s: %v", container.Image, matchedRegistry.host, err)
-				warnings = append(warnings, &RollbackImageCheckWarning{
-					Image:   container.Image,
-					Reason:  "registry_credentials_unavailable",
-					Message: "获取镜像仓库凭证失败，无法确认镜像是否存在",
-				})
 				continue
 			}
 			credentialRegistries[registryID] = registryInfo
@@ -426,11 +409,6 @@ func checkRollbackImages(containers []*commonmodels.Container, log *zap.SugaredL
 		}, log)
 		if err != nil {
 			log.Warnf("failed to check whether rollback image %s exists: %v", container.Image, err)
-			warnings = append(warnings, &RollbackImageCheckWarning{
-				Image:   container.Image,
-				Reason:  "image_check_failed",
-				Message: "镜像仓库查询失败，无法确认镜像是否存在",
-			})
 			continue
 		}
 		if !exists {
@@ -438,7 +416,7 @@ func checkRollbackImages(containers []*commonmodels.Container, log *zap.SugaredL
 		}
 	}
 
-	return missingImages, warnings, nil
+	return missingImages, nil
 }
 
 func CheckRollbackEnvServiceVersion(projectName, envName, serviceName string, revision int64, isHelmChart, isProduction bool, log *zap.SugaredLogger) (*CheckRollbackEnvServiceVersionResponse, error) {
@@ -450,14 +428,13 @@ func CheckRollbackEnvServiceVersion(projectName, envName, serviceName string, re
 		return nil, fmt.Errorf("failed to find %s/%s/%s service for revision %d, isProduction %v, error: %w", projectName, envName, serviceName, revision, isProduction, err)
 	}
 
-	unavailableImages, warnings, err := checkRollbackImages(envSvcVersion.Service.Containers, log)
+	unavailableImages, err := checkRollbackImages(envSvcVersion.Service.Containers, log)
 	if err != nil {
 		return nil, err
 	}
 	return &CheckRollbackEnvServiceVersionResponse{
 		Available:         len(unavailableImages) == 0,
 		UnavailableImages: unavailableImages,
-		Warnings:          warnings,
 	}, nil
 }
 

--- a/pkg/microservice/aslan/core/common/service/version.go
+++ b/pkg/microservice/aslan/core/common/service/version.go
@@ -344,14 +344,20 @@ func checkRollbackImages(containers []*commonmodels.Container, log *zap.SugaredL
 			missingImages = append(missingImages, container.Image)
 			continue
 		}
-		imagePath := reference.Path(named)
+		imageRegistry, err := ExtractImageRegistry(container.Image)
+		if err != nil {
+			missingImages = append(missingImages, container.Image)
+			continue
+		}
+		imageRegistry = strings.Split(strings.Trim(imageRegistry, "/"), "/")[0]
+		imageNamespace := strings.Trim(ExtractRegistryNamespace(container.Image), "/")
 		var matchedRegistry *rollbackImageRegistry
 		for _, registry := range registries {
-			if !strings.EqualFold(reference.Domain(named), registry.host) {
+			if !strings.EqualFold(imageRegistry, registry.host) {
 				continue
 			}
 			namespace := strings.Trim(registry.info.Namespace, "/")
-			if namespace != "" && imagePath != namespace && !strings.HasPrefix(imagePath, namespace+"/") {
+			if namespace != "" && imageNamespace != namespace && !strings.HasPrefix(imageNamespace, namespace+"/") {
 				continue
 			}
 			if matchedRegistry == nil || len(namespace) > len(strings.Trim(matchedRegistry.info.Namespace, "/")) {
@@ -374,19 +380,15 @@ func checkRollbackImages(containers []*commonmodels.Container, log *zap.SugaredL
 			credentialRegistries[registryID] = registryInfo
 		}
 
-		repositoryName := imagePath
+		repositoryName := reference.Path(named)
 		namespace := strings.Trim(registryInfo.Namespace, "/")
 		if namespace != "" {
 			repositoryName = strings.TrimPrefix(repositoryName, namespace+"/")
 		}
 
-		tag, imageDigest := "", ""
-		if digested, ok := named.(reference.Digested); ok {
-			imageDigest = digested.Digest().String()
-		} else if tagged, ok := named.(reference.Tagged); ok {
-			tag = tagged.Tag()
-		} else {
-			tag = reference.TagNameOnly(named).(reference.Tagged).Tag()
+		tag := ExtractImageTag(container.Image)
+		if tag == "" {
+			tag = "latest"
 		}
 
 		tlsEnabled, tlsCert := true, ""
@@ -403,9 +405,8 @@ func checkRollbackImages(containers []*commonmodels.Container, log *zap.SugaredL
 				Region:    registryInfo.Region,
 				Namespace: registryInfo.Namespace,
 			},
-			Image:  repositoryName,
-			Tag:    tag,
-			Digest: imageDigest,
+			Image: repositoryName,
+			Tag:   tag,
 		}, log)
 		if err != nil {
 			log.Warnf("failed to check whether rollback image %s exists: %v", container.Image, err)

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -221,6 +221,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		environments.GET("/:name/version/:serviceName", ListEnvServiceVersions)
 		environments.GET("/:name/version/:serviceName/revision/:revision", GetEnvServiceVersionYaml)
 		environments.GET("/:name/version/:serviceName/diff", DiffEnvServiceVersions)
+		environments.GET("/:name/version/:serviceName/rollback/check", CheckRollbackEnvServiceVersion)
 		environments.POST("/:name/version/:serviceName/rollback", RollbackEnvServiceVersion)
 
 		environments.GET("sae", ListSAEEnvs)

--- a/pkg/microservice/aslan/core/environment/handler/version.go
+++ b/pkg/microservice/aslan/core/environment/handler/version.go
@@ -291,6 +291,93 @@ type RollbackEnvServiceVersionRequest struct {
 	Detail string `json:"detail"`
 }
 
+// @Summary Check Environment Service Version Before Rollback
+// @Description Check whether images in an environment service version are available before rollback
+// @Tags 	environment
+// @Accept 	json
+// @Produce json
+// @Param 	name			path		string							true	"env name"
+// @Param 	serviceName		path		string							true	"service name or release name when isHelmChart is true"
+// @Param 	projectName		query		string							true	"project name"
+// @Param 	revision	 	query		int								true	"revision"
+// @Param 	isHelmChart		query		bool							true	"is helm chart type"
+// @Param 	production		query		bool							false	"is production environment"
+// @Success 200 			{object}  	service.CheckRollbackEnvServiceVersionResponse
+// @Router /api/aslan/environment/environments/{name}/version/{serviceName}/rollback/check [get]
+func CheckRollbackEnvServiceVersion(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	projectKey := c.Query("projectName")
+	envName := c.Param("name")
+	serviceName := c.Param("serviceName")
+	if projectKey == "" {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("empty projectName")
+		return
+	}
+	if envName == "" {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("empty name")
+		return
+	}
+	if serviceName == "" {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("empty serviceName")
+		return
+	}
+	production := c.Query("production") == "true"
+
+	if !ctx.Resources.IsSystemAdmin {
+		if _, ok := ctx.Resources.ProjectAuthInfo[projectKey]; !ok {
+			ctx.UnAuthorized = true
+			return
+		}
+
+		if production {
+			if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin &&
+				!ctx.Resources.ProjectAuthInfo[projectKey].ProductionEnv.Rollback {
+				permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, projectKey, types.ResourceTypeEnvironment, envName, types.ProductionEnvActionRollback)
+				if err != nil || !permitted {
+					ctx.UnAuthorized = true
+					return
+				}
+			}
+		} else {
+			if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin &&
+				!ctx.Resources.ProjectAuthInfo[projectKey].Env.Rollback {
+				permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, projectKey, types.ResourceTypeEnvironment, envName, types.EnvActionRollback)
+				if err != nil || !permitted {
+					ctx.UnAuthorized = true
+					return
+				}
+			}
+		}
+	}
+
+	revision, err := strconv.ParseInt(c.Query("revision"), 10, 64)
+	if err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddErr(fmt.Errorf("invalid revision: %s", err))
+		return
+	}
+	isHelmChart, err := strconv.ParseBool(c.Query("isHelmChart"))
+	if err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddErr(fmt.Errorf("invalid isHelmChart: %s", err))
+		return
+	}
+	if err := commonutil.CheckZadigProfessionalLicense(); err != nil {
+		ctx.RespErr = err
+		return
+	}
+
+	ctx.Resp, ctx.RespErr = commonservice.CheckRollbackEnvServiceVersion(
+		projectKey, envName, serviceName, revision, isHelmChart, production, ctx.Logger,
+	)
+}
+
 // @Summary Rollback Environment Service Version
 // @Description Rollback Environment Service Version
 // @Tags 	environment

--- a/pkg/microservice/aslan/core/environment/handler/version.go
+++ b/pkg/microservice/aslan/core/environment/handler/version.go
@@ -302,6 +302,7 @@ type RollbackEnvServiceVersionRequest struct {
 // @Param 	revision	 	query		int								true	"revision"
 // @Param 	isHelmChart		query		bool							true	"is helm chart type"
 // @Param 	production		query		bool							false	"is production environment"
+// @Param 	workflowName	query		string							false	"workflow name; when provided, check workflow rollback permission instead of environment rollback permission"
 // @Success 200 			{object}  	service.CheckRollbackEnvServiceVersionResponse
 // @Router /api/aslan/environment/environments/{name}/version/{serviceName}/rollback/check [get]
 func CheckRollbackEnvServiceVersion(c *gin.Context) {
@@ -330,25 +331,33 @@ func CheckRollbackEnvServiceVersion(c *gin.Context) {
 		return
 	}
 	production := c.Query("production") == "true"
+	workflowName := c.Query("workflowName")
 
 	if !ctx.Resources.IsSystemAdmin {
-		if _, ok := ctx.Resources.ProjectAuthInfo[projectKey]; !ok {
+		projectAuth, ok := ctx.Resources.ProjectAuthInfo[projectKey]
+		if !ok {
 			ctx.UnAuthorized = true
 			return
 		}
 
-		if production {
-			if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin &&
-				!ctx.Resources.ProjectAuthInfo[projectKey].ProductionEnv.Rollback {
-				permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, projectKey, types.ResourceTypeEnvironment, envName, types.ProductionEnvActionRollback)
-				if err != nil || !permitted {
-					ctx.UnAuthorized = true
-					return
+		if !projectAuth.IsProjectAdmin {
+			if workflowName != "" {
+				if !projectAuth.Workflow.Rollback {
+					permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, projectKey, types.ResourceTypeWorkflow, workflowName, types.WorkflowActionRollback)
+					if err != nil || !permitted {
+						ctx.UnAuthorized = true
+						return
+					}
 				}
-			}
-		} else {
-			if !ctx.Resources.ProjectAuthInfo[projectKey].IsProjectAdmin &&
-				!ctx.Resources.ProjectAuthInfo[projectKey].Env.Rollback {
+			} else if production {
+				if !projectAuth.ProductionEnv.Rollback {
+					permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, projectKey, types.ResourceTypeEnvironment, envName, types.ProductionEnvActionRollback)
+					if err != nil || !permitted {
+						ctx.UnAuthorized = true
+						return
+					}
+				}
+			} else if !projectAuth.Env.Rollback {
 				permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, projectKey, types.ResourceTypeEnvironment, envName, types.EnvActionRollback)
 				if err != nil || !permitted {
 					ctx.UnAuthorized = true


### PR DESCRIPTION
### What this PR does / Why we need it:

Checks whether historical images exist before rollback to prevent deployment failures caused by missing images.

### What is changed and how it works?

Matches rollback images with configured registries and verifies their availability before updating environment resources. The rollback is blocked with an error if an image is missing or cannot be checked.


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4828)
<!-- Reviewable:end -->
