### PR TITLE
fix: align LLM transaction finalization

### DIFF
--- a/pkg/microservice/aslan/core/system/service/llm.go
+++ b/pkg/microservice/aslan/core/system/service/llm.go
@@ -145,18 +145,17 @@ func UpdateLLMIntegration(ctx context.Context, ID string, args *commonmodels.LLM
 }
 
 func runLLMIntegrationTransaction(ctx context.Context, fn func(context.Context, *commonrepo.LLMIntegrationColl) error) (err error) {
-	session, cleanup, err := mongotool.SessionWithTransaction(ctx)
+	session, finishTransaction, err := mongotool.SessionWithTransaction(ctx)
 	if err != nil {
-		session.EndSession(ctx)
 		return err
 	}
-	defer func() { cleanup(err) }()
+	defer finishTransaction(&err)
 
 	txCtx := mongotool.SessionContext(ctx, session)
 	if err = fn(txCtx, commonrepo.NewLLMIntegrationColl()); err != nil {
 		return err
 	}
-	return mongotool.CommitTransaction(session)
+	return nil
 }
 
 func DeleteLLMIntegration(ctx context.Context, ID string) error {


### PR DESCRIPTION
### Summary
- Align the LLM transaction caller with the finalizer contract introduced by #4689, restoring the main branch build.

### Main Changes
- Defer finalization with the named return error and remove duplicate session close and explicit commit.
- Low risk: commit, abort, panic handling, and cleanup remain owned by the shared finalizer.

### Test
- Targeted Mongo, System LLM, Sprint Management, and Release Plan tests pass with vet disabled.
- Normal System testing remains blocked by pre-existing non-constant fmt.Errorf vet findings in workwx.go.

### Contact
Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4829)
<!-- Reviewable:end -->
