### PR TITLE
fix(workflow): expose pull request source branch

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitee_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitee_workflowv4_task.go
@@ -281,7 +281,7 @@ func TriggerWorkflowV4ByGiteeEvent(event interface{}, rawPayload, baseURI, reque
 					Owner:          eventRepo.RepoOwner,
 					Repo:           eventRepo.RepoName,
 					CodehostID:     item.MainRepo.CodehostID,
-					Branch:         ev.PullRequest.Head.Ref,
+					Branch:         ev.SourceBranch,
 					TargetBranch:   eventRepo.TargetBranch,
 					IsPr:           true,
 					MergeRequestID: mergeRequestID,

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitee_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitee_workflowv4_task.go
@@ -281,7 +281,7 @@ func TriggerWorkflowV4ByGiteeEvent(event interface{}, rawPayload, baseURI, reque
 					Owner:          eventRepo.RepoOwner,
 					Repo:           eventRepo.RepoName,
 					CodehostID:     item.MainRepo.CodehostID,
-					Branch:         eventRepo.Branch,
+					Branch:         ev.PullRequest.Head.Ref,
 					TargetBranch:   eventRepo.TargetBranch,
 					IsPr:           true,
 					MergeRequestID: mergeRequestID,

--- a/pkg/microservice/aslan/core/workflow/service/webhook/github_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github_workflowv4_task.go
@@ -276,7 +276,7 @@ func TriggerWorkflowV4ByGithubEvent(event interface{}, rawPayload, baseURI, deli
 				hookPayload = &commonmodels.HookPayload{
 					Owner:          *ev.Repo.Owner.Login,
 					Repo:           *ev.Repo.Name,
-					Branch:         *ev.PullRequest.Base.Ref,
+					Branch:         *ev.PullRequest.Head.Ref,
 					TargetBranch:   *ev.PullRequest.Base.Ref,
 					Ref:            *ev.PullRequest.Head.SHA,
 					IsPr:           true,

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflowv4_task.go
@@ -373,7 +373,7 @@ func TriggerWorkflowV4ByGitlabEvent(event interface{}, rawPayload, baseURI, requ
 				hookPayload = &commonmodels.HookPayload{
 					Owner:          eventRepo.RepoOwner,
 					Repo:           eventRepo.RepoName,
-					Branch:         eventRepo.Branch,
+					Branch:         ev.ObjectAttributes.SourceBranch,
 					TargetBranch:   eventRepo.TargetBranch,
 					IsPr:           true,
 					MergeRequestID: mergeRequestID,


### PR DESCRIPTION
### Summary
- Make `workflow.trigger.branch` return the source branch for GitHub/GitLab/Gitee PR or MR events.
- Keep `workflow.trigger.target_branch` and repository checkout behavior unchanged.

### Risk
- PR/MR scripts using `workflow.trigger.branch` will now receive the source branch.

### Test
- `go test -vet=off ./pkg/microservice/aslan/core/workflow/service/webhook ./pkg/microservice/aslan/core/common/util`

### Contact
- Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4830)
<!-- Reviewable:end -->
