### PR TITLE
fix: add service context to source detail error log

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/webhook/github.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github.go
@@ -591,6 +591,10 @@ func updateServiceTemplateHelmValuesByGithubPush(pushEvent *github.PushEvent, lo
 				continue
 			}
 
+			if createFrom.YamlData == nil || createFrom.YamlData.SourceDetail == nil {
+				continue
+			}
+
 			sourceRepo, err := createFrom.GetSourceDetail()
 			if err != nil {
 				log.Errorf(

--- a/pkg/microservice/aslan/core/workflow/service/webhook/github.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github.go
@@ -584,13 +584,19 @@ func updateServiceTemplateHelmValuesByGithubPush(pushEvent *github.PushEvent, lo
 
 			createFrom, err := service.GetHelmCreateFrom()
 			if err != nil {
-				log.Errorf("Failed to get helm create from, error: %v", err)
+				log.Errorf(
+					"Failed to get helm create from for service, project: %s, service: %s, production: %v, error: %v",
+					service.ProductName, service.ServiceName, production, err,
+				)
 				continue
 			}
 
 			sourceRepo, err := createFrom.GetSourceDetail()
 			if err != nil {
-				log.Errorf("Failed to get source detail, error: %v", err)
+				log.Errorf(
+					"Failed to get source detail for helm chart template service, project: %s, service: %s, template: %s, production: %v, error: %v",
+					service.ProductName, service.ServiceName, createFrom.TemplateName, production, err,
+				)
 				continue
 			}
 

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab.go
@@ -622,13 +622,19 @@ func updateServiceTemplateValuesByPushEvent(ref string, diffs []string, pathWith
 
 			createFrom, err := service.GetHelmCreateFrom()
 			if err != nil {
-				log.Errorf("Failed to get helm create from, error: %v", err)
+				log.Errorf(
+					"Failed to get helm create from for service, project: %s, service: %s, production: %v, error: %v",
+					service.ProductName, service.ServiceName, production, err,
+				)
 				continue
 			}
 
 			sourceRepo, err := createFrom.GetSourceDetail()
 			if err != nil {
-				log.Errorf("Failed to get source detail, error: %v", err)
+				log.Errorf(
+					"Failed to get source detail for helm chart template service, project: %s, service: %s, template: %s, production: %v, error: %v",
+					service.ProductName, service.ServiceName, createFrom.TemplateName, production, err,
+				)
 				continue
 			}
 

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab.go
@@ -629,6 +629,10 @@ func updateServiceTemplateValuesByPushEvent(ref string, diffs []string, pathWith
 				continue
 			}
 
+			if createFrom.YamlData == nil || createFrom.YamlData.SourceDetail == nil {
+				continue
+			}
+
 			sourceRepo, err := createFrom.GetSourceDetail()
 			if err != nil {
 				log.Errorf(


### PR DESCRIPTION
### What this PR does / Why we need it:

Improve Git webhook error logs for Helm services created from chart templates.

Previously, errors related to parsing `create_from` or retrieving `source_detail` lacked sufficient context, making it difficult to identify the affected project and service.

### What is changed and how it works?

- Add project name, service name, and production status to `GetHelmCreateFrom` error logs.
- Add Helm chart template name to `GetSourceDetail` error logs.
- Keep the existing webhook processing and error-handling behavior unchanged.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4832)
<!-- Reviewable:end -->
