### PR TITLE
fix: populate environment metadata when previewing Helm manifests

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -1593,9 +1593,12 @@ func GenEstimatedValues(projectName, envName, namespace, serviceOrReleaseName st
 
 	switch scene {
 	case EstimateValuesSceneCreateEnv:
-		prod = &commonmodels.Product{}
-		prod.DefaultValues = arg.DefaultValues
-		prod.Namespace = namespace
+		prod = &commonmodels.Product{
+			ProductName:   projectName,
+			EnvName:       envName,
+			Namespace:     namespace,
+			DefaultValues: arg.DefaultValues,
+		}
 		prodSvc, latestTmplSvc, err = prepareEstimateDataForEnvCreation(projectName, serviceOrReleaseName, arg.Production, isHelmChartDeploy, log)
 		if err != nil {
 			return nil, fmt.Errorf("failed to prepare estimate data for env creation, err: %s", err)


### PR DESCRIPTION
### What this PR does / Why we need it:

Fixes Helm manifest preview failures when creating an environment for services using custom release naming rules such as `$Service$-$EnvName$` or `$Service$-$Product$`.

Previously, the temporary product object used by the `estimated-values` API did not contain the project name or environment name. This could generate an invalid Helm release name such as `zadig-`.

### What is changed and how it works?

Populate `ProductName` and `EnvName`, along with the existing `Namespace` and `DefaultValues`, when constructing the temporary product object for the `create_env` scene.

This ensures all supported placeholders have the required values when generating the Helm release name:

- `$Product$`
- `$EnvName$`
- `$Namespace$`
- `$Service$`

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4839)
<!-- Reviewable:end -->
