### PR TITLE
fix: task-level notification issues across channels

### DIFF
--- a/pkg/microservice/aslan/core/common/service/instantmessage/lark.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/lark.go
@@ -247,10 +247,10 @@ func (w *Service) SendFeishuHookText(uri, content string) error {
 }
 
 func getColorTemplateWithStatus(status config.Status) string {
-	if status == config.StatusPassed || status == config.StatusCreated {
+	if status == config.StatusPassed || status == config.StatusCreated || status == config.StatusPrepare {
 		return feishuHeaderTemplateGreen
 	}
-	if status == config.StatusPause {
+	if status == config.StatusPause || status == config.StatusWaitingApprove {
 		return feishuHeaderTemplateOrange
 	}
 	return feishuHeaderTemplateRed

--- a/pkg/microservice/aslan/core/common/service/instantmessage/wechatwork.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/wechatwork.go
@@ -29,9 +29,10 @@ const (
 	WeChatTextTypeMarkdown     TextType = "markdown"
 	WeChatTextTypeTemplateCard TextType = "template_card"
 
-	textColorBlue  = "#3270e3"
-	textColorGreen = "#00a13e"
-	textColorRed   = "#eb0823"
+	textColorBlue   = "#3270e3"
+	textColorGreen  = "#00a13e"
+	textColorRed    = "#eb0823"
+	textColorOrange = "#ff8800"
 )
 
 type TextType string

--- a/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
@@ -358,7 +358,7 @@ func (w *Service) SendWorkflowTaskNotifications(task *models.WorkflowTask) error
 		}
 
 		statusSets := sets.NewString(notify.NotifyTypes...)
-		if statusSets.Has(string(task.Status)) || (statusChanged && statusSets.Has(string(config.StatusChanged))) {
+		if notifyStatusMatch(statusSets, task.Status) || (statusChanged && statusSets.Has(string(config.StatusChanged))) {
 			if shouldSkipFeishuPersonPauseNotification(task, notify) {
 				continue
 			}
@@ -741,10 +741,7 @@ func (w *Service) resolveManualExecStageMailUsers(task *models.WorkflowTask, sta
 			continue
 		}
 		if user.Type == setting.UserTypeStageExecutor {
-			if stage == nil || stage.ManualExec == nil {
-				continue
-			}
-			usersToExpand = append(usersToExpand, stage.ManualExec.ManualExecUsers...)
+			usersToExpand = append(usersToExpand, manualExecStageUsers(stage)...)
 			continue
 		}
 		usersToExpand = append(usersToExpand, user)
@@ -759,16 +756,34 @@ func (w *Service) resolveManualExecStageMailUsers(task *models.WorkflowTask, sta
 	return dynamicrecipient.UniqMailUsers(append(directUsers, users...)), nil
 }
 
+// manualExecStageUsers returns the stage executors for notifications: the user
+// who actually executed the stage once it has been executed, otherwise the
+// configured candidate executors.
+func manualExecStageUsers(stage *models.StageTask) []*models.User {
+	if stage == nil || stage.ManualExec == nil {
+		return nil
+	}
+	if stage.ManualExec.ManualExectorID != "" {
+		return []*models.User{{
+			Type:     setting.UserTypeUser,
+			UserID:   stage.ManualExec.ManualExectorID,
+			UserName: stage.ManualExec.ManualExectorName,
+		}}
+	}
+	return stage.ManualExec.ManualExecUsers
+}
+
 func resolveManualExecStageUsers(stage *models.StageTask, taskCreatorID string) ([]*models.User, map[string]*types.UserInfo) {
-	if stage == nil || stage.ManualExec == nil || len(stage.ManualExec.ManualExecUsers) == 0 {
+	stageUsers := manualExecStageUsers(stage)
+	if len(stageUsers) == 0 {
 		return nil, map[string]*types.UserInfo{}
 	}
 
 	if taskCreatorID != "" {
-		return commonutil.GeneFlatUsersWithCaller(stage.ManualExec.ManualExecUsers, taskCreatorID)
+		return commonutil.GeneFlatUsersWithCaller(stageUsers, taskCreatorID)
 	}
 
-	return commonutil.GeneFlatUsers(stage.ManualExec.ManualExecUsers)
+	return commonutil.GeneFlatUsers(stageUsers)
 }
 
 // ---------------------------------------------------------------------------
@@ -782,6 +797,9 @@ type TaskNotifyInput struct {
 	Task *models.WorkflowTask
 	// Job is the current job that triggered the notification.
 	Job *models.JobTask
+	// Jobs optionally holds all split JobTasks of the original workflow job so
+	// they are rendered in a single notification. When empty, only Job is used.
+	Jobs []*models.JobTask
 	// WorkflowName is the name of the workflow, used to fetch the task if Task is nil.
 	WorkflowName string
 	// TaskID is the ID of the workflow task, used to fetch the task if Task is nil.
@@ -819,12 +837,22 @@ func HasTaskNotifyCtls(notifyCtls []*models.NotifyCtl, status config.Status) boo
 		if status == config.StatusWaitingApprove && isTaskWaitingApproveNotifyType(statusSets) {
 			return true
 		}
-		if statusSets.Has(string(status)) {
+		if notifyStatusMatch(statusSets, status) {
 			return true
 		}
 	}
 
 	return false
+}
+
+// notifyStatusMatch reports whether a notify config subscribes to the given
+// status. A rejected approval is a failure outcome, so configs that subscribe
+// to failed also receive reject notifications.
+func notifyStatusMatch(statusSets sets.String, status config.Status) bool {
+	if statusSets.Has(string(status)) {
+		return true
+	}
+	return status == config.StatusReject && statusSets.Has(string(config.StatusFailed))
 }
 
 func isTaskWaitingApproveNotifyType(statusSets sets.String) bool {
@@ -875,17 +903,38 @@ func (w *Service) SendTaskNotifications(input *TaskNotifyInput) error {
 	stageForNotification := findTaskNotifyStage(task.Stages, input.Job)
 	taskCopy := *task
 	taskCopy.Status = input.Status
-	if input.Job != nil {
-		taskCopy.Stages = []*models.StageTask{
-			{
-				Name:      input.Job.DisplayName,
-				Status:    input.Job.Status,
-				StartTime: input.Job.StartTime,
-				EndTime:   input.Job.EndTime,
-				Error:     input.Job.Error,
-				Jobs:      []*models.JobTask{input.Job},
-			},
+	notifyJobs := input.Jobs
+	if len(notifyJobs) == 0 && input.Job != nil {
+		notifyJobs = []*models.JobTask{input.Job}
+	}
+	if len(notifyJobs) > 0 {
+		stageName := notifyJobs[0].DisplayName
+		if len(notifyJobs) > 1 && notifyJobs[0].OriginName != "" {
+			stageName = notifyJobs[0].OriginName
 		}
+		syntheticStage := &models.StageTask{
+			Name:      stageName,
+			Status:    notifyJobs[0].Status,
+			StartTime: notifyJobs[0].StartTime,
+			EndTime:   notifyJobs[0].EndTime,
+			Error:     notifyJobs[0].Error,
+			Jobs:      notifyJobs,
+		}
+		for _, job := range notifyJobs[1:] {
+			if job.StartTime != 0 && (syntheticStage.StartTime == 0 || job.StartTime < syntheticStage.StartTime) {
+				syntheticStage.StartTime = job.StartTime
+			}
+			if job.EndTime > syntheticStage.EndTime {
+				syntheticStage.EndTime = job.EndTime
+			}
+			if syntheticStage.Error == "" {
+				syntheticStage.Error = job.Error
+			}
+		}
+		if len(notifyJobs) > 1 {
+			syntheticStage.Status = input.Status
+		}
+		taskCopy.Stages = []*models.StageTask{syntheticStage}
 	}
 	task = &taskCopy
 
@@ -913,7 +962,7 @@ func (w *Service) SendTaskNotifications(input *TaskNotifyInput) error {
 			if !isTaskWaitingApproveNotifyType(statusSets) {
 				continue
 			}
-		} else if !statusSets.Has(string(input.Status)) {
+		} else if !notifyStatusMatch(statusSets, input.Status) {
 			continue
 		}
 
@@ -1538,6 +1587,8 @@ func getWorkflowTaskTplExec(tplcontent string, args *workflowTaskNotification) (
 		"getColor": func(status config.Status) string {
 			if status == config.StatusPassed || status == config.StatusCreated || status == config.StatusPrepare {
 				return textColorGreen
+			} else if status == config.StatusWaitingApprove || status == config.StatusPause {
+				return textColorOrange
 			} else {
 				return textColorRed
 			}
@@ -1556,7 +1607,7 @@ func getWorkflowTaskTplExec(tplcontent string, args *workflowTaskNotification) (
 				return getText("taskStatusRejected", language)
 			} else if status == config.StatusCreated || status == config.StatusPrepare {
 				return getText("taskStatusExecutionStarted", language)
-			} else if status == config.StatusManualApproval {
+			} else if status == config.StatusManualApproval || status == config.StatusWaitingApprove {
 				return getText("taskStatusManualApproval", language)
 			} else if status == config.StatusPause {
 				return getText("taskStatusPause", language)
@@ -1616,7 +1667,7 @@ func getJobTaskTplExec(tplcontent string, args *jobTaskNotification, language st
 				return getText("taskStatusRejected", language)
 			} else if status == config.StatusCreated || status == config.StatusPrepare {
 				return getText("taskStatusExecutionStarted", language)
-			} else if status == config.StatusManualApproval {
+			} else if status == config.StatusManualApproval || status == config.StatusWaitingApprove {
 				return getText("taskStatusManualApproval", language)
 			} else if status == config.StatusPause {
 				return getText("taskStatusPause", language)

--- a/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task_task_notify_test.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task_task_notify_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instantmessage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+)
+
+func TestNotifyStatusMatchRejectWithFailedSubscription(t *testing.T) {
+	failedOnly := sets.NewString(string(config.StatusFailed))
+	require.True(t, notifyStatusMatch(failedOnly, config.StatusReject))
+	require.True(t, notifyStatusMatch(failedOnly, config.StatusFailed))
+	require.False(t, notifyStatusMatch(failedOnly, config.StatusPassed))
+}
+
+func TestWaitingApproveNotificationPresentation(t *testing.T) {
+	content, err := getJobTaskTplExec(
+		`{{taskStatus .Job.Status}}`,
+		&jobTaskNotification{Job: &models.JobTask{Status: config.StatusWaitingApprove}},
+		string(config.SystemLanguageZhCN),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "待确认", content)
+	require.Equal(t, feishuHeaderTemplateOrange, getColorTemplateWithStatus(config.StatusWaitingApprove))
+}
+
+func TestManualExecStageUsersPreferActualExecutor(t *testing.T) {
+	candidates := []*models.User{{UserID: "candidate-1"}, {UserID: "candidate-2"}}
+	stage := &models.StageTask{ManualExec: &models.ManualExec{
+		ManualExecUsers:   candidates,
+		ManualExectorID:   "actual-user",
+		ManualExectorName: "Actual User",
+	}}
+
+	users := manualExecStageUsers(stage)
+	require.Len(t, users, 1)
+	require.Equal(t, "actual-user", users[0].UserID)
+	require.Equal(t, "Actual User", users[0].UserName)
+}
+
+func TestManualExecStageUsersFallBackToCandidates(t *testing.T) {
+	candidates := []*models.User{{UserID: "candidate-1"}, {UserID: "candidate-2"}}
+	stage := &models.StageTask{ManualExec: &models.ManualExec{ManualExecUsers: candidates}}
+
+	require.Equal(t, candidates, manualExecStageUsers(stage))
+}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job.go
@@ -198,7 +198,7 @@ func initJobCtl(job *commonmodels.JobTask, workflowCtx *commonmodels.WorkflowTas
 	return jobCtl
 }
 
-func runJob(ctx context.Context, job *commonmodels.JobTask, workflowCtx *commonmodels.WorkflowTaskCtx, logger *zap.SugaredLogger, ack func()) {
+func runJob(ctx context.Context, job *commonmodels.JobTask, workflowCtx *commonmodels.WorkflowTaskCtx, notifier *jobNotifier, logger *zap.SugaredLogger, ack func()) {
 	setJobStartTimeContext(job, workflowCtx)
 
 	// Keep the original execution timestamps when a completed job is skipped
@@ -222,7 +222,7 @@ func runJob(ctx context.Context, job *commonmodels.JobTask, workflowCtx *commonm
 		logger.Infof("finish job: %s,status: %s", job.Name, job.Status)
 		setJobFinalStatusContext(job, workflowCtx)
 		ack()
-		sendJobNotifications(workflowCtx, job, job.Status, logger)
+		notifier.jobFinished(job)
 		if workflowCtx.IsDebug {
 			logger.Infof("skip updating debug job info into db")
 			return
@@ -263,7 +263,7 @@ func runJob(ctx context.Context, job *commonmodels.JobTask, workflowCtx *commonm
 	job.K8sJobName = getJobName(workflowCtx.WorkflowName, workflowCtx.TaskID)
 	ack()
 
-	sendJobNotifications(workflowCtx, job, config.StatusPrepare, logger)
+	notifier.jobStarted(job)
 
 	logger.Infof("start job: %s,status: %s", job.Name, job.Status)
 
@@ -285,7 +285,15 @@ func runJob(ctx context.Context, job *commonmodels.JobTask, workflowCtx *commonm
 }
 
 func sendJobNotifications(workflowCtx *commonmodels.WorkflowTaskCtx, job *commonmodels.JobTask, status config.Status, logger *zap.SugaredLogger) {
-	if workflowCtx == nil || job == nil || !instantmessage.HasTaskNotifyCtls(job.NotifyCtls, status) {
+	sendJobGroupNotifications(workflowCtx, []*commonmodels.JobTask{job}, status, logger)
+}
+
+func sendJobGroupNotifications(workflowCtx *commonmodels.WorkflowTaskCtx, jobs []*commonmodels.JobTask, status config.Status, logger *zap.SugaredLogger) {
+	if workflowCtx == nil || len(jobs) == 0 {
+		return
+	}
+	primary := jobs[0]
+	if primary == nil || !instantmessage.HasTaskNotifyCtls(primary.NotifyCtls, status) {
 		return
 	}
 
@@ -297,14 +305,128 @@ func sendJobNotifications(workflowCtx *commonmodels.WorkflowTaskCtx, job *common
 	if err := sendTaskNotifications(&instantmessage.TaskNotifyInput{
 		WorkflowName:            workflowCtx.WorkflowName,
 		TaskID:                  workflowCtx.TaskID,
-		Job:                     job,
-		NotifyCtls:              job.NotifyCtls,
+		Job:                     primary,
+		Jobs:                    jobs,
+		NotifyCtls:              primary.NotifyCtls,
 		Status:                  status,
 		StatusTextKeyOverride:   statusTextKeyOverride,
 		RecipientRuntimeContext: workflowCtx.GlobalContextGetAll(),
 	}); err != nil {
-		logger.Warnf("send task notification failed, job: %s, status: %s, error: %v", job.Name, status, err)
+		logger.Warnf("send task notification failed, job: %s, status: %s, error: %v", primary.Name, status, err)
 	}
+}
+
+// jobNotifier groups the split JobTasks of one original workflow job (e.g. a
+// build job with one JobTask per service) so that each original job produces a
+// single start notification and a single aggregated final notification.
+type jobNotifier struct {
+	workflowCtx *commonmodels.WorkflowTaskCtx
+	logger      *zap.SugaredLogger
+
+	mu     sync.Mutex
+	groups map[string]*jobNotifyGroup
+}
+
+type jobNotifyGroup struct {
+	jobs     []*commonmodels.JobTask
+	prepared bool
+	finished int
+	notified bool
+}
+
+func newJobNotifier(jobs []*commonmodels.JobTask, workflowCtx *commonmodels.WorkflowTaskCtx, logger *zap.SugaredLogger) *jobNotifier {
+	notifier := &jobNotifier{
+		workflowCtx: workflowCtx,
+		logger:      logger,
+		groups:      map[string]*jobNotifyGroup{},
+	}
+	for _, job := range jobs {
+		key := jobNotifyGroupKey(job)
+		group, ok := notifier.groups[key]
+		if !ok {
+			group = &jobNotifyGroup{}
+			notifier.groups[key] = group
+		}
+		group.jobs = append(group.jobs, job)
+	}
+	return notifier
+}
+
+func jobNotifyGroupKey(job *commonmodels.JobTask) string {
+	if job.OriginName != "" {
+		return job.OriginName
+	}
+	return job.Name
+}
+
+func (n *jobNotifier) jobStarted(job *commonmodels.JobTask) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	group := n.groups[jobNotifyGroupKey(job)]
+	if group == nil || group.prepared {
+		return
+	}
+	group.prepared = true
+	sendJobGroupNotifications(n.workflowCtx, group.jobs, config.StatusPrepare, n.logger)
+}
+
+func (n *jobNotifier) jobFinished(job *commonmodels.JobTask) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	group := n.groups[jobNotifyGroupKey(job)]
+	if group == nil || group.notified {
+		return
+	}
+	group.finished++
+	if group.finished < len(group.jobs) {
+		return
+	}
+	group.notified = true
+	sendJobGroupNotifications(n.workflowCtx, group.jobs, aggregateJobNotifyStatus(group.jobs), n.logger)
+}
+
+// flush sends final notifications for groups whose remaining jobs will never
+// run, e.g. when a stage aborts after a failed job.
+func (n *jobNotifier) flush() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	for _, group := range n.groups {
+		if group.notified || group.finished == 0 {
+			continue
+		}
+		group.notified = true
+		sendJobGroupNotifications(n.workflowCtx, group.jobs, aggregateJobNotifyStatus(group.jobs), n.logger)
+	}
+}
+
+func aggregateJobNotifyStatus(jobs []*commonmodels.JobTask) config.Status {
+	statusPriority := map[config.Status]int{
+		config.StatusCancelled: 7,
+		config.StatusTimeout:   6,
+		config.StatusFailed:    5,
+		config.StatusPause:     4,
+		config.StatusReject:    3,
+		config.StatusPassed:    2,
+		config.StatusUnstable:  1,
+		config.StatusSkipped:   0,
+	}
+
+	aggregated := jobs[0].Status
+	aggregatedPriority := -1
+	for _, job := range jobs {
+		priority, ok := statusPriority[job.Status]
+		if !ok {
+			continue
+		}
+		if priority > aggregatedPriority {
+			aggregated = job.Status
+			aggregatedPriority = priority
+		}
+	}
+	return aggregated
 }
 
 func retryJob(ctx context.Context, workflowName string, taskID int64, job *commonmodels.JobTask, jobCtl JobCtl, ack func(), maxRetry int) {
@@ -376,16 +498,19 @@ func waitForManualErrorHandling(ctx context.Context, workflowCtx *commonmodels.W
 }
 
 func RunJobs(ctx context.Context, jobs []*commonmodels.JobTask, workflowCtx *commonmodels.WorkflowTaskCtx, concurrency int, logger *zap.SugaredLogger, ack func()) {
+	notifier := newJobNotifier(jobs, workflowCtx, logger)
+	defer notifier.flush()
+
 	if concurrency == 1 {
 		for _, job := range jobs {
-			runJob(ctx, job, workflowCtx, logger, ack)
+			runJob(ctx, job, workflowCtx, notifier, logger, ack)
 			if jobStatusFailed(job.Status) {
 				return
 			}
 		}
 		return
 	}
-	jobPool := NewPool(ctx, jobs, workflowCtx, concurrency, logger, ack)
+	jobPool := NewPool(ctx, jobs, workflowCtx, notifier, concurrency, logger, ack)
 	jobPool.Run()
 }
 
@@ -420,6 +545,7 @@ func CleanPendingBlueGreenReleaseJobs(ctx context.Context, workflowTask *commonm
 type Pool struct {
 	Jobs        []*commonmodels.JobTask
 	workflowCtx *commonmodels.WorkflowTaskCtx
+	notifier    *jobNotifier
 	concurrency int
 	jobsChan    chan *commonmodels.JobTask
 	logger      *zap.SugaredLogger
@@ -430,11 +556,12 @@ type Pool struct {
 
 // NewPool initializes a new pool with the given tasks and
 // at the given concurrency.
-func NewPool(ctx context.Context, jobs []*commonmodels.JobTask, workflowCtx *commonmodels.WorkflowTaskCtx, concurrency int, logger *zap.SugaredLogger, ack func()) *Pool {
+func NewPool(ctx context.Context, jobs []*commonmodels.JobTask, workflowCtx *commonmodels.WorkflowTaskCtx, notifier *jobNotifier, concurrency int, logger *zap.SugaredLogger, ack func()) *Pool {
 	return &Pool{
 		Jobs:        jobs,
 		concurrency: concurrency,
 		workflowCtx: workflowCtx,
+		notifier:    notifier,
 		jobsChan:    make(chan *commonmodels.JobTask),
 		logger:      logger,
 		ack:         ack,
@@ -463,7 +590,7 @@ func (p *Pool) Run() {
 // The work loop for any single goroutine.
 func (p *Pool) work() {
 	for job := range p.jobsChan {
-		runJob(p.ctx, job, p.workflowCtx, p.logger, p.ack)
+		runJob(p.ctx, job, p.workflowCtx, p.notifier, p.logger, p.ack)
 		p.wg.Done()
 	}
 }

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job.go
@@ -328,10 +328,11 @@ type jobNotifier struct {
 }
 
 type jobNotifyGroup struct {
-	jobs     []*commonmodels.JobTask
-	prepared bool
-	finished int
-	notified bool
+	jobs      []*commonmodels.JobTask
+	snapshots []*commonmodels.JobTask
+	prepared  bool
+	finished  int
+	notified  bool
 }
 
 func newJobNotifier(jobs []*commonmodels.JobTask, workflowCtx *commonmodels.WorkflowTaskCtx, logger *zap.SugaredLogger) *jobNotifier {
@@ -348,8 +349,30 @@ func newJobNotifier(jobs []*commonmodels.JobTask, workflowCtx *commonmodels.Work
 			notifier.groups[key] = group
 		}
 		group.jobs = append(group.jobs, job)
+		group.snapshots = append(group.snapshots, snapshotJobTask(job))
 	}
 	return notifier
+}
+
+func snapshotJobTask(job *commonmodels.JobTask) *commonmodels.JobTask {
+	if job == nil {
+		return nil
+	}
+	copied := *job
+	return &copied
+}
+
+func (g *jobNotifyGroup) updateSnapshot(job *commonmodels.JobTask) {
+	for i, original := range g.jobs {
+		if original == job {
+			g.snapshots[i] = snapshotJobTask(job)
+			return
+		}
+	}
+}
+
+func (g *jobNotifyGroup) jobSnapshots() []*commonmodels.JobTask {
+	return append([]*commonmodels.JobTask(nil), g.snapshots...)
 }
 
 func jobNotifyGroupKey(job *commonmodels.JobTask) string {
@@ -361,44 +384,62 @@ func jobNotifyGroupKey(job *commonmodels.JobTask) string {
 
 func (n *jobNotifier) jobStarted(job *commonmodels.JobTask) {
 	n.mu.Lock()
-	defer n.mu.Unlock()
-
 	group := n.groups[jobNotifyGroupKey(job)]
 	if group == nil || group.prepared {
+		n.mu.Unlock()
 		return
 	}
 	group.prepared = true
-	sendJobGroupNotifications(n.workflowCtx, group.jobs, config.StatusPrepare, n.logger)
+	group.updateSnapshot(job)
+	jobs := group.jobSnapshots()
+	n.mu.Unlock()
+
+	sendJobGroupNotifications(n.workflowCtx, jobs, config.StatusPrepare, n.logger)
 }
 
 func (n *jobNotifier) jobFinished(job *commonmodels.JobTask) {
 	n.mu.Lock()
-	defer n.mu.Unlock()
-
 	group := n.groups[jobNotifyGroupKey(job)]
 	if group == nil || group.notified {
+		n.mu.Unlock()
 		return
 	}
 	group.finished++
+	group.updateSnapshot(job)
 	if group.finished < len(group.jobs) {
+		n.mu.Unlock()
 		return
 	}
 	group.notified = true
-	sendJobGroupNotifications(n.workflowCtx, group.jobs, aggregateJobNotifyStatus(group.jobs), n.logger)
+	jobs := group.jobSnapshots()
+	status := aggregateJobNotifyStatus(jobs)
+	n.mu.Unlock()
+
+	sendJobGroupNotifications(n.workflowCtx, jobs, status, n.logger)
 }
 
 // flush sends final notifications for groups whose remaining jobs will never
 // run, e.g. when a stage aborts after a failed job.
 func (n *jobNotifier) flush() {
-	n.mu.Lock()
-	defer n.mu.Unlock()
+	type notification struct {
+		jobs   []*commonmodels.JobTask
+		status config.Status
+	}
 
+	n.mu.Lock()
+	pending := make([]notification, 0, len(n.groups))
 	for _, group := range n.groups {
 		if group.notified || group.finished == 0 {
 			continue
 		}
 		group.notified = true
-		sendJobGroupNotifications(n.workflowCtx, group.jobs, aggregateJobNotifyStatus(group.jobs), n.logger)
+		jobs := group.jobSnapshots()
+		pending = append(pending, notification{jobs: jobs, status: aggregateJobNotifyStatus(jobs)})
+	}
+	n.mu.Unlock()
+
+	for _, item := range pending {
+		sendJobGroupNotifications(n.workflowCtx, item.jobs, item.status, n.logger)
 	}
 }
 

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
@@ -377,7 +377,7 @@ func waitForLarkApprove(ctx context.Context, spec *commonmodels.JobTaskApprovalS
 					return config.StatusPassed, nil
 				}
 				if util.GetStringFromPointer(larkApprovalInstance.Status) == "REJECTED" {
-					return config.StatusFailed, nil
+					return config.StatusReject, nil
 				}
 				if util.GetStringFromPointer(larkApprovalInstance.Status) == "CANCELLED" {
 					return config.StatusCancelled, nil

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_notifier_test.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_notifier_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobcontroller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
+	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/instantmessage"
+)
+
+func newNotifyTestJob(name, origin string, status config.Status) *commonmodels.JobTask {
+	return &commonmodels.JobTask{
+		Name:       name,
+		OriginName: origin,
+		Status:     status,
+		NotifyCtls: []*commonmodels.NotifyCtl{
+			{
+				Enabled:                    true,
+				WebHookType:                "feishu",
+				LarkHookNotificationConfig: &commonmodels.LarkHookNotificationConfig{HookAddress: "https://example.com/hook"},
+				NotifyTypes: []string{
+					string(config.StatusPrepare),
+					string(config.StatusPassed),
+					string(config.StatusFailed),
+				},
+			},
+		},
+	}
+}
+
+func withSendTaskNotificationsStub(t *testing.T, stub func(input *instantmessage.TaskNotifyInput) error) {
+	t.Helper()
+	originalSend := sendTaskNotifications
+	sendTaskNotifications = stub
+	t.Cleanup(func() { sendTaskNotifications = originalSend })
+}
+
+func newNotifyTestWorkflowCtx() *commonmodels.WorkflowTaskCtx {
+	return &commonmodels.WorkflowTaskCtx{
+		WorkflowName: "wf",
+		TaskID:       1,
+		GlobalContextGetAll: func() map[string]string {
+			return map[string]string{}
+		},
+	}
+}
+
+func TestJobNotifierDoesNotHoldLockWhileSending(t *testing.T) {
+	job := newNotifyTestJob("job-a", "build-a", "")
+	notifier := newJobNotifier([]*commonmodels.JobTask{job}, newNotifyTestWorkflowCtx(), zap.NewNop().Sugar())
+
+	withSendTaskNotificationsStub(t, func(input *instantmessage.TaskNotifyInput) error {
+		require.True(t, notifier.mu.TryLock(), "notifier lock is held while sending a notification")
+		notifier.mu.Unlock()
+		return nil
+	})
+
+	notifier.jobStarted(job)
+	job.Status = config.StatusPassed
+	notifier.jobFinished(job)
+}
+
+func TestJobNotifierSendsJobSnapshots(t *testing.T) {
+	var got *instantmessage.TaskNotifyInput
+	withSendTaskNotificationsStub(t, func(input *instantmessage.TaskNotifyInput) error {
+		got = input
+		return nil
+	})
+
+	jobA := newNotifyTestJob("job-a", "build", config.StatusPrepare)
+	jobA.StartTime = 10
+	jobB := newNotifyTestJob("job-b", "build", "")
+	jobB.StartTime = 0
+	notifier := newJobNotifier([]*commonmodels.JobTask{jobA, jobB}, newNotifyTestWorkflowCtx(), zap.NewNop().Sugar())
+
+	notifier.jobStarted(jobA)
+
+	require.NotNil(t, got)
+	require.Len(t, got.Jobs, 2)
+	require.NotSame(t, jobA, got.Jobs[0])
+	require.NotSame(t, jobB, got.Jobs[1])
+	require.NotSame(t, jobA, got.Job)
+
+	jobA.Status = config.StatusFailed
+	jobA.StartTime = 99
+	jobB.Status = config.StatusPassed
+	jobB.StartTime = 100
+
+	require.Equal(t, config.StatusPrepare, got.Jobs[0].Status)
+	require.Equal(t, int64(10), got.Jobs[0].StartTime)
+	require.Empty(t, got.Jobs[1].Status)
+	require.Equal(t, int64(0), got.Jobs[1].StartTime)
+}
+
+func TestJobNotifierGroupsSplitJobTasks(t *testing.T) {
+	var sent []*instantmessage.TaskNotifyInput
+	withSendTaskNotificationsStub(t, func(input *instantmessage.TaskNotifyInput) error {
+		sent = append(sent, input)
+		return nil
+	})
+
+	jobA1 := newNotifyTestJob("job-a-1", "build", "")
+	jobA2 := newNotifyTestJob("job-a-2", "build", "")
+	jobB := newNotifyTestJob("job-b", "deploy", "")
+	notifier := newJobNotifier([]*commonmodels.JobTask{jobA1, jobA2, jobB}, newNotifyTestWorkflowCtx(), zap.NewNop().Sugar())
+
+	notifier.jobStarted(jobA1)
+	notifier.jobStarted(jobA2)
+	notifier.jobStarted(jobB)
+	require.Len(t, sent, 2)
+	require.Len(t, sent[0].Jobs, 2)
+	require.Equal(t, config.StatusPrepare, sent[0].Status)
+
+	sent = nil
+	jobA1.Status = config.StatusPassed
+	notifier.jobFinished(jobA1)
+	require.Empty(t, sent)
+
+	jobA2.Status = config.StatusFailed
+	notifier.jobFinished(jobA2)
+	require.Len(t, sent, 1)
+	require.Equal(t, config.StatusFailed, sent[0].Status)
+	require.Len(t, sent[0].Jobs, 2)
+}
+
+func TestJobNotifierFlushesStartedIncompleteGroup(t *testing.T) {
+	var sent []*instantmessage.TaskNotifyInput
+	withSendTaskNotificationsStub(t, func(input *instantmessage.TaskNotifyInput) error {
+		sent = append(sent, input)
+		return nil
+	})
+
+	jobA1 := newNotifyTestJob("job-a-1", "build", "")
+	jobA2 := newNotifyTestJob("job-a-2", "build", "")
+	jobB := newNotifyTestJob("job-b", "deploy", "")
+	notifier := newJobNotifier([]*commonmodels.JobTask{jobA1, jobA2, jobB}, newNotifyTestWorkflowCtx(), zap.NewNop().Sugar())
+
+	notifier.jobStarted(jobA1)
+	sent = nil
+	jobA1.Status = config.StatusFailed
+	notifier.jobFinished(jobA1)
+	notifier.flush()
+
+	require.Len(t, sent, 1)
+	require.Equal(t, config.StatusFailed, sent[0].Status)
+	require.Len(t, sent[0].Jobs, 2)
+}
+
+func TestAggregateJobNotifyStatus(t *testing.T) {
+	cases := []struct {
+		name     string
+		statuses []config.Status
+		want     config.Status
+	}{
+		{"all passed", []config.Status{config.StatusPassed, config.StatusPassed}, config.StatusPassed},
+		{"one failed", []config.Status{config.StatusPassed, config.StatusFailed}, config.StatusFailed},
+		{"reject beats passed", []config.Status{config.StatusPassed, config.StatusReject}, config.StatusReject},
+		{"timeout beats failed", []config.Status{config.StatusFailed, config.StatusTimeout}, config.StatusTimeout},
+		{"unstarted ignored", []config.Status{config.StatusPassed, ""}, config.StatusPassed},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			jobs := make([]*commonmodels.JobTask, 0, len(tc.statuses))
+			for _, status := range tc.statuses {
+				jobs = append(jobs, &commonmodels.JobTask{Status: status})
+			}
+			require.Equal(t, tc.want, aggregateJobNotifyStatus(jobs))
+		})
+	}
+}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
@@ -89,7 +89,7 @@ func NewWorkflowController(workflowTask *commonmodels.WorkflowTask, logger *zap.
 
 func SendWorkflowNotifyMessage(task *commonmodels.WorkflowTask, receiver string, status config.Status, log *zap.SugaredLogger) {
 	if status != config.StatusFailed && status != config.StatusPassed && status != config.StatusCancelled &&
-		status != config.StatusWaitingApprove && status != config.StatusTimeout {
+		status != config.StatusWaitingApprove && status != config.StatusTimeout && status != config.StatusReject {
 		return
 	}
 	ctx := &commonmodels.WorkflowTaskStatusCtx{

--- a/pkg/microservice/aslan/core/common/util/workflownotify/job_content.go
+++ b/pkg/microservice/aslan/core/common/util/workflownotify/job_content.go
@@ -174,7 +174,7 @@ func BuildWorkflowJobContents(args *BuildJobContentsArgs) ([]string, []*webhookn
 					image = args.Task.GlobalContext[imageContextKey]
 				}
 				if len(commitID) > 0 {
-					jobTplcontent += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextRepositoryInfo\"}}**：%s %s[%s](%s)  ", branchTag, prInfo, commitID, gitCommitURL)
+					jobTplcontent += fmt.Sprintf("{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextRepositoryInfo\"}}**：%s %s[%s](%s)  \n", branchTag, prInfo, commitID, gitCommitURL)
 					jobTplcontent += "{{if eq .WebHookType \"dingding\"}}##### {{end}}**{{getText \"notificationTextCommitMessage\"}}**："
 					mailJobTplcontent += fmt.Sprintf("{{getText \"notificationTextRepositoryInfo\"}}：%s %s[%s]( %s ) \n", branchTag, prInfo, commitID, gitCommitURL)
 					if len(commitMsgs) == 1 {


### PR DESCRIPTION
## Summary

Fix 6 task-level notification issues:

1. **Approval rejection shown as "failed"**: Lark approval `REJECTED` now returns `StatusReject` (aligned with DingTalk / WeCom / native approval), so notifications on all channels correctly show "Rejected"; notification configs subscribed to "failed" also match the reject status, so existing configs won't miss rejection notifications (`job_approval.go`, `workflow.go`, `workflow_task.go`)
2. **DingTalk renders `#####` literally**: append a newline after the repository-info segment so the `##### ` heading prefix starts at the beginning of a line (`workflownotify/job_content.go`)
3. **Build jobs split by service send one notification per service**: add a `jobNotifier` that groups split JobTasks by `OriginName`, so all JobTasks from one original job send only one start notification and one aggregated final notification; a flush on early abort covers unfinished groups (`job.go`, `workflow_task.go`)
4. **Feishu card header for "execution started" should be green**: `StatusPrepare` / `StatusCreated` now use the green header template (`lark.go`)
5. **Title shows "failed" while waiting for manual confirmation**: `StatusWaitingApprove` now shows "Waiting for confirmation" text with orange color (`workflow_task.go`, `lark.go`, `wechatwork.go`)
6. **Stage executor does not receive Feishu person / mail notifications**: resolve the actual executor who clicked run (`ManualExectorID`) first, falling back to the candidate executor list when no one has executed yet (`workflow_task.go`)

## Test plan

- [x] `go build ./pkg/microservice/aslan/...` passes
- [x] `go test` covers the jobcontroller / instantmessage / workflowcontroller / workflownotify packages, all passing
- [ ] Verify actual delivery on each channel (Feishu group / Feishu person / Feishu webhook / DingTalk / WeCom / mail / webhook)
- [ ] Verify only one start / final notification is sent when a build job is split into multiple services
- [ ] Verify text and color for approval rejection and failed-waiting-for-manual-confirmation scenarios

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4842)
<!-- Reviewable:end -->
