### PR TITLE
fix: restrict CLI metadata to system administrators

### DIFF
--- a/pkg/microservice/aslan/core/system/handler/cli_context.go
+++ b/pkg/microservice/aslan/core/system/handler/cli_context.go
@@ -25,9 +25,9 @@ import (
 	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
 )
 
-// OpenAPIGetCLIContext returns the authenticated user and Zadig edition metadata.
+// OpenAPIGetCLIContext returns the authenticated user and administrator-only Zadig metadata.
 // @Summary Get Zadig CLI context
-// @Description Returns the authenticated user, edition, licensed features, server version, and request ID.
+// @Description Returns the authenticated user and request ID. System administrators also receive edition, licensed features, and server version.
 // @Tags system
 // @Produce json
 // @Success 200 {object} service.CLIContextResponse
@@ -43,5 +43,5 @@ func OpenAPIGetCLIContext(c *gin.Context) {
 		return
 	}
 
-	ctx.Resp, ctx.RespErr = service.GetCLIContext(ctx.GenUserBriefInfo(), ctx.RequestID)
+	ctx.Resp, ctx.RespErr = service.GetCLIContext(ctx.GenUserBriefInfo(), ctx.RequestID, ctx.Resources.IsSystemAdmin)
 }

--- a/pkg/microservice/aslan/core/system/service/cli_context.go
+++ b/pkg/microservice/aslan/core/system/service/cli_context.go
@@ -26,10 +26,10 @@ import (
 
 type CLIContextResponse struct {
 	User          CLIUser  `json:"user"`
-	Edition       string   `json:"edition"`
-	LicenseStatus string   `json:"license_status"`
-	Features      []string `json:"features"`
-	ServerVersion string   `json:"server_version"`
+	Edition       string   `json:"edition,omitempty"`
+	LicenseStatus string   `json:"license_status,omitempty"`
+	Features      []string `json:"features,omitempty"`
+	ServerVersion string   `json:"server_version,omitempty"`
 	RequestID     string   `json:"request_id"`
 }
 
@@ -40,7 +40,20 @@ type CLIUser struct {
 	IdentityType string `json:"identity_type"`
 }
 
-func GetCLIContext(user types.UserBriefInfo, requestID string) (*CLIContextResponse, error) {
+func GetCLIContext(user types.UserBriefInfo, requestID string, isSystemAdmin bool) (*CLIContextResponse, error) {
+	response := &CLIContextResponse{
+		User: CLIUser{
+			UID:          user.UID,
+			Name:         user.Name,
+			Account:      user.Account,
+			IdentityType: user.IdentityType,
+		},
+		RequestID: requestID,
+	}
+	if !isSystemAdmin {
+		return response, nil
+	}
+
 	licenseStatus, err := plutusenterprise.New().CheckZadigXLicenseStatus()
 	if err != nil {
 		return nil, fmt.Errorf("check zadig license status: %w", err)
@@ -49,17 +62,9 @@ func GetCLIContext(user types.UserBriefInfo, requestID string) (*CLIContextRespo
 		return nil, errors.New("check zadig license status: empty response")
 	}
 
-	return &CLIContextResponse{
-		User: CLIUser{
-			UID:          user.UID,
-			Name:         user.Name,
-			Account:      user.Account,
-			IdentityType: user.IdentityType,
-		},
-		Edition:       licenseStatus.Type,
-		LicenseStatus: licenseStatus.Status,
-		Features:      append([]string{}, licenseStatus.Features...),
-		ServerVersion: licenseStatus.CurrentVersion,
-		RequestID:     requestID,
-	}, nil
+	response.Edition = licenseStatus.Type
+	response.LicenseStatus = licenseStatus.Status
+	response.Features = append([]string{}, licenseStatus.Features...)
+	response.ServerVersion = licenseStatus.CurrentVersion
+	return response, nil
 }


### PR DESCRIPTION
### Summary
- Return CLI edition, license, feature, and server version metadata only to system administrators.

### Why
- Prevent regular authenticated users from receiving administrator-level system metadata.

### Risk / Compatibility
- Regular users still receive `user` and `request_id`; admin responses remain compatible.
- License status is no longer queried for regular users.

### Test
- `go test -vet=off ./pkg/microservice/aslan/core/system/handler ./pkg/microservice/aslan/core/system/service`

### Contact
Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4843)
<!-- Reviewable:end -->
