### PR TITLE
fix: preserve helm service modules when updating release naming

### DIFF
--- a/pkg/microservice/aslan/core/common/service/repository/service_module.go
+++ b/pkg/microservice/aslan/core/common/service/repository/service_module.go
@@ -118,6 +118,34 @@ func ListAutoServiceModules(ctx context.Context, projectName, serviceName string
 	return pickServiceModuleColl(production).ListAutoByRevision(ctx, projectName, serviceName, revision)
 }
 
+// CloneAutoServiceModulesForRevision carries visible auto-discovered modules
+// forward for a metadata-only service revision. Manual modules are not copied
+// because they are revision-independent.
+func CloneAutoServiceModulesForRevision(ctx context.Context, projectName, serviceName string, production bool, sourceRevision, targetRevision int64) error {
+	if projectName == "" || serviceName == "" || sourceRevision == 0 || targetRevision == 0 || sourceRevision == targetRevision {
+		return nil
+	}
+	records, err := ListAutoServiceModules(ctx, projectName, serviceName, production, sourceRevision)
+	if err != nil {
+		return err
+	}
+	clones := make([]*models.ServiceModule, 0, len(records))
+	for _, record := range records {
+		if record == nil {
+			continue
+		}
+		clones = append(clones, &models.ServiceModule{
+			Name:       record.Name,
+			Type:       record.Type,
+			Image:      record.Image,
+			ImageName:  record.ImageName,
+			ImagePath:  record.ImagePath,
+			CreateTime: record.CreateTime,
+		})
+	}
+	return pickServiceModuleColl(production).ReplaceAutoForRevision(ctx, projectName, serviceName, targetRevision, clones)
+}
+
 // DeleteAutoServiceModulesForRevision drops every auto record for one
 // (service, revision). Used by Delete in this package when a specific
 // revision is reaped. Manual records are untouched.

--- a/pkg/microservice/aslan/core/service/service/service.go
+++ b/pkg/microservice/aslan/core/service/service/service.go
@@ -1016,6 +1016,7 @@ func UpdateReleaseNamingRule(userName, requestID, projectName string, args *Rele
 		return err
 	}
 
+	sourceRevision := serviceTemplate.Revision
 	serviceTemplate.ReleaseNaming = args.NamingRule
 	rev, err := getNextServiceRevision(projectName, args.ServiceName, production)
 	if err != nil {
@@ -1052,6 +1053,16 @@ func UpdateReleaseNamingRule(userName, requestID, projectName string, args *Rele
 	err = repository.Create(serviceTemplate, production)
 	if err != nil {
 		return fmt.Errorf("failed to update relase naming for service: %s, err: %s", args.ServiceName, err)
+	}
+	if err = repository.CloneAutoServiceModulesForRevision(
+		context.Background(),
+		serviceTemplate.ProductName,
+		serviceTemplate.ServiceName,
+		production,
+		sourceRevision,
+		rev,
+	); err != nil {
+		return fmt.Errorf("failed to copy service modules for service %s from revision %d to %d: %s", args.ServiceName, sourceRevision, rev, err)
 	}
 
 	return nil


### PR DESCRIPTION
### What this PR does / Why we need it:

Fixes an issue where updating the Helm release naming rule created a new service revision without its auto-discovered service modules. This caused environment updates to clear service modules and generate versions with empty image information.

### What is changed and how it works?

- Records the current service revision before creating the new revision.
- Clones auto-discovered modules directly in `service_module` from the old revision to the new revision.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4848)
<!-- Reviewable:end -->
