### PR TITLE
fix: workflow notification aborted by executor resolution failure and mail nil-pointer panic

### DIFF
--- a/pkg/microservice/aslan/core/common/service/instantmessage/mail.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/mail.go
@@ -18,6 +18,7 @@ package instantmessage
 
 import (
 	_ "embed"
+	"fmt"
 
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
@@ -35,11 +36,13 @@ func (w *Service) sendMailMessage(title, content string, users []*models.User) e
 	email, err := systemconfig.New().GetEmailHost()
 	if err != nil {
 		log.Errorf("sendMailMessage GetEmailHost error, error msg:%s", err)
+		return fmt.Errorf("failed to get email host config: %w", err)
 	}
 
 	emailSvc, err := systemconfig.New().GetEmailService()
 	if err != nil {
 		log.Errorf("sendMailMessage GetEmailService error, error msg:%s", err)
+		return fmt.Errorf("failed to get email service config: %w", err)
 	}
 
 	sentEmails := make(map[string]struct{})

--- a/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
@@ -292,23 +292,7 @@ func (w *Service) SendWorkflowTaskApproveNotifications(workflowName string, task
 		}
 
 		if notify.WebHookType == setting.NotifyWebHookTypeFeishuPerson {
-			for _, target := range notify.LarkPersonNotificationConfig.TargetUsers {
-				if target.IsExecutor {
-					client, err := larkservice.GetLarkClientByIMAppID(notify.LarkPersonNotificationConfig.AppID)
-					if err != nil {
-						return fmt.Errorf("failed to get notify target info: create feishu client error: %s", err)
-					}
-					resolvedTarget, err := w.resolveWorkflowTaskExecutorLarkTarget(client, task)
-					if err != nil {
-						log.Errorf("failed to resolve workflow executor lark target: %v", err)
-						return err
-					}
-					target.ID = resolvedTarget.ID
-					target.Name = resolvedTarget.Name
-					target.Avatar = resolvedTarget.Avatar
-					target.IDType = resolvedTarget.IDType
-				}
-			}
+			w.resolveFeishuPersonExecutorTargets(notify, task)
 		}
 
 		if err := w.sendNotification(title, content, notify, larkCard, webhookNotify, task.Status); err != nil {
@@ -391,24 +375,7 @@ func (w *Service) SendWorkflowTaskNotifications(task *models.WorkflowTask) error
 			}
 
 			if notify.WebHookType == setting.NotifyWebHookTypeFeishuPerson {
-
-				for _, target := range notify.LarkPersonNotificationConfig.TargetUsers {
-					if target.IsExecutor {
-						client, err := larkservice.GetLarkClientByIMAppID(notify.LarkPersonNotificationConfig.AppID)
-						if err != nil {
-							return fmt.Errorf("failed to get notify target info: create feishu client error: %s", err)
-						}
-						resolvedTarget, err := w.resolveWorkflowTaskExecutorLarkTarget(client, task)
-						if err != nil {
-							log.Errorf("failed to resolve workflow executor lark target: %v", err)
-							return err
-						}
-						target.ID = resolvedTarget.ID
-						target.Name = resolvedTarget.Name
-						target.Avatar = resolvedTarget.Avatar
-						target.IDType = resolvedTarget.IDType
-					}
-				}
+				w.resolveFeishuPersonExecutorTargets(notify, task)
 			}
 
 			if err := w.sendNotification(title, content, notify, larkCard, webhookNotify, task.Status); err != nil {
@@ -489,6 +456,40 @@ func (w *Service) resolveWorkflowTaskExecutorLarkTarget(client *lark.Client, tas
 	}
 
 	return resolvedTarget, nil
+}
+
+// resolveFeishuPersonExecutorTargets resolves executor targets in place and drops the ones that
+// cannot be resolved (e.g. webhook/trigger-created tasks have no executor), so that the remaining
+// targets and other notification channels are still delivered.
+func (w *Service) resolveFeishuPersonExecutorTargets(notify *models.NotifyCtl, task *models.WorkflowTask) {
+	if notify.LarkPersonNotificationConfig == nil {
+		return
+	}
+
+	targets := make([]*lark.UserInfo, 0, len(notify.LarkPersonNotificationConfig.TargetUsers))
+	for _, target := range notify.LarkPersonNotificationConfig.TargetUsers {
+		if target == nil {
+			continue
+		}
+		if target.IsExecutor {
+			client, err := larkservice.GetLarkClientByIMAppID(notify.LarkPersonNotificationConfig.AppID)
+			if err != nil {
+				log.Warnf("skip workflow executor notify target: create feishu client error: %s", err)
+				continue
+			}
+			resolvedTarget, err := w.resolveWorkflowTaskExecutorLarkTarget(client, task)
+			if err != nil {
+				log.Warnf("skip workflow executor notify target: %v", err)
+				continue
+			}
+			target.ID = resolvedTarget.ID
+			target.Name = resolvedTarget.Name
+			target.Avatar = resolvedTarget.Avatar
+			target.IDType = resolvedTarget.IDType
+		}
+		targets = append(targets, target)
+	}
+	notify.LarkPersonNotificationConfig.TargetUsers = targets
 }
 
 func (w *Service) SendManualExecStageNotifications(workflowCtx *models.WorkflowTaskCtx, stage *models.StageTask) error {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
@@ -583,6 +583,11 @@ func (c *workflowCtl) updateWorkflowTask() {
 	isFirstComplete := c.workflowTask.Finished() && taskInColl.EndTime == 0 && c.workflowTask.EndTime > 0
 	shouldSendCompleteHook := isFirstComplete
 	shouldUpdateJiraIssue := isFirstComplete || (c.workflowTask.Status == config.StatusReject && taskInColl.Status != config.StatusReject)
+	// cancelled ACKs are let through above so job status can be persisted, and pause ACKs
+	// repeat while a stage stays paused; notify only on the first completion (finished
+	// statuses) or on the actual status transition (reject/pause have no EndTime).
+	isNewRejectOrPause := (c.workflowTask.Status == config.StatusReject || c.workflowTask.Status == config.StatusPause) && c.workflowTask.Status != taskInColl.Status
+	shouldSendStatusNotification := isFirstComplete || isNewRejectOrPause
 
 	c.workflowTaskMutex.Lock()
 	if err := commonrepo.NewworkflowTaskv4Coll().Update(c.workflowTask.ID.Hex(), c.workflowTask); err != nil {
@@ -594,16 +599,6 @@ func (c *workflowCtl) updateWorkflowTask() {
 
 	if c.workflowTask.Status == config.StatusPassed || c.workflowTask.Status == config.StatusFailed || c.workflowTask.Status == config.StatusTimeout || c.workflowTask.Status == config.StatusCancelled || c.workflowTask.Status == config.StatusReject || c.workflowTask.Status == config.StatusPause {
 		c.logger.Infof("%s:%d:%v task done", c.workflowTask.WorkflowName, c.workflowTask.TaskID, c.workflowTask.Status)
-		// cancelled ACKs are let through above so job status can be persisted, and
-		// pause ACKs repeat while a stage stays paused; without this guard every
-		// such ACK would re-send the same terminal notification.
-		shouldSendStatusNotification := false
-		switch c.workflowTask.Status {
-		case config.StatusPassed, config.StatusFailed, config.StatusTimeout, config.StatusCancelled:
-			shouldSendStatusNotification = isFirstComplete
-		case config.StatusReject, config.StatusPause:
-			shouldSendStatusNotification = c.workflowTask.Status != taskInColl.Status
-		}
 		if shouldSendStatusNotification {
 			if err := instantmessage.NewWeChatClient().SendWorkflowTaskNotifications(c.workflowTask); err != nil {
 				c.logger.Errorf("send workflow task notification failed, error: %v", err)

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/workflow.go
@@ -594,8 +594,20 @@ func (c *workflowCtl) updateWorkflowTask() {
 
 	if c.workflowTask.Status == config.StatusPassed || c.workflowTask.Status == config.StatusFailed || c.workflowTask.Status == config.StatusTimeout || c.workflowTask.Status == config.StatusCancelled || c.workflowTask.Status == config.StatusReject || c.workflowTask.Status == config.StatusPause {
 		c.logger.Infof("%s:%d:%v task done", c.workflowTask.WorkflowName, c.workflowTask.TaskID, c.workflowTask.Status)
-		if err := instantmessage.NewWeChatClient().SendWorkflowTaskNotifications(c.workflowTask); err != nil {
-			c.logger.Errorf("send workflow task notification failed, error: %v", err)
+		// cancelled ACKs are let through above so job status can be persisted, and
+		// pause ACKs repeat while a stage stays paused; without this guard every
+		// such ACK would re-send the same terminal notification.
+		shouldSendStatusNotification := false
+		switch c.workflowTask.Status {
+		case config.StatusPassed, config.StatusFailed, config.StatusTimeout, config.StatusCancelled:
+			shouldSendStatusNotification = isFirstComplete
+		case config.StatusReject, config.StatusPause:
+			shouldSendStatusNotification = c.workflowTask.Status != taskInColl.Status
+		}
+		if shouldSendStatusNotification {
+			if err := instantmessage.NewWeChatClient().SendWorkflowTaskNotifications(c.workflowTask); err != nil {
+				c.logger.Errorf("send workflow task notification failed, error: %v", err)
+			}
 		}
 		if shouldSendCompleteHook {
 			if err := SendSystemWorkflowHook(c.workflowTask, commonmodels.WorkflowHookEventCompleteExecute); err != nil {


### PR DESCRIPTION
## Summary
Fixes two P0 notification issues found by QA on env-500:
1. Webhook/trigger-created tasks have an empty `TaskCreatorID`, so resolving the feishu "executor" target failed and `return err` aborted the whole notification — all other targets and channels were dropped.
2. With the mail channel enabled but no email service configured, `sendMailMessage` dereferenced nil config (`mail.go:55`) and crashed the aslan process.

## Main Changes
- `instantmessage/workflow_task.go`: extract `resolveFeishuPersonExecutorTargets` shared by the approve/task paths; unresolvable executor targets are skipped with a warning, remaining targets and channels are still delivered.
- `instantmessage/mail.go`: return an error when email host/service config cannot be loaded instead of continuing with nil pointers.

## Risk & Compatibility
Only failure paths change: previously the notification was aborted (or aslan crashed). Manually executed tasks with a valid creator ID are unaffected. No API or data model changes.

## Test
`go build` / `go vet` pass. Root cause verified on env-500: task chufaqi #7 is trigger-created, aslan logs show the repeated `executor id is empty` abort at `workflow_task.go:403`.

## Contact
@huanghongbo-hhb

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4850)
<!-- Reviewable:end -->
