### PR TITLE
fix: restore vm job cache to the configured cache dir without nesting

### DIFF
--- a/pkg/cli/zadig-agent/internal/agent/job/cache.go
+++ b/pkg/cli/zadig-agent/internal/agent/job/cache.go
@@ -62,7 +62,7 @@ func (l *cacheLock) Unlock(key string) {
 	delete(l.cm, key)
 }
 
-func ReadCache(job types.ZadigJobTask, dest, cacheDir string, logger *zap.SugaredLogger) {
+func ReadCache(job types.ZadigJobTask, dest, cacheDir string, copyContents bool, logger *zap.SugaredLogger) {
 	// lock the cache path to avoid other job write or read this path at the same time
 	key := fmt.Sprintf("%s-%s-%s", job.ProjectName, job.WorkflowName, job.JobName)
 	cache.Lock(key)
@@ -76,14 +76,14 @@ func ReadCache(job types.ZadigJobTask, dest, cacheDir string, logger *zap.Sugare
 		}
 		return
 	} else {
-		err = copyCmd(cachePath, dest, logger)
+		err = copyCmd(cachePath, dest, copyContents, logger)
 		if err != nil {
 			log.Errorf("failed to copy cache directory %s to %s, error: %v", cachePath, dest, err)
 		}
 	}
 }
 
-func WriteCache(job types.ZadigJobTask, src string, cachePath string, logger *zap.SugaredLogger) {
+func WriteCache(job types.ZadigJobTask, src string, cachePath string, copyContents bool, logger *zap.SugaredLogger) {
 	// lock the cache path to avoid other job write or read this path at the same time
 	key := fmt.Sprintf("%s-%s-%s", job.ProjectName, job.WorkflowName, job.JobName)
 	cache.Lock(key)
@@ -96,14 +96,19 @@ func WriteCache(job types.ZadigJobTask, src string, cachePath string, logger *za
 		}
 	}
 
-	err := copyCmd(src, cachePath, logger)
+	err := copyCmd(src, cachePath, copyContents, logger)
 	if err != nil {
 		log.Errorf("failed to copy cache directory %s to %s, error: %v", src, cachePath, err)
 	}
 }
 
-func copyCmd(src, dest string, logger *zap.SugaredLogger) error {
-	cmd := exec.Command("cp", "-f", "-r", src, dest)
+func copyCmd(src, dest string, copyContents bool, logger *zap.SugaredLogger) error {
+	copySource := src
+	if copyContents {
+		copySource = filepath.Join(src, ".")
+	}
+
+	cmd := exec.Command("cp", "-f", "-R", copySource, dest)
 	var wg sync.WaitGroup
 
 	cmdStdoutReader, err := cmd.StdoutPipe()

--- a/pkg/cli/zadig-agent/internal/agent/job/job_executor.go
+++ b/pkg/cli/zadig-agent/internal/agent/job/job_executor.go
@@ -320,7 +320,8 @@ func (e *JobExecutor) AfterExecute() error {
 	if e.JobCtx.Cache != nil && e.JobCtx.Cache.CacheEnable {
 		src := e.Dirs.Workspace
 		if e.JobCtx.Cache.CacheDirType == common.CacheDirUserDefineType && e.JobCtx.Cache.CacheUserDir != "" {
-			src = e.JobCtx.Cache.CacheUserDir
+			src = strings.ReplaceAll(e.JobCtx.Cache.CacheUserDir, "$WORKSPACE", e.Dirs.Workspace)
+			src = strings.ReplaceAll(src, "${WORKSPACE}", e.Dirs.Workspace)
 			if !filepath.IsAbs(src) {
 				src = filepath.Join(e.Dirs.Workspace, src)
 			}

--- a/pkg/cli/zadig-agent/internal/agent/job/job_executor.go
+++ b/pkg/cli/zadig-agent/internal/agent/job/job_executor.go
@@ -158,7 +158,9 @@ func (e *JobExecutor) InitWorkDirectory() error {
 	// check the job whether job use cache and init workspace by cache
 	if e.JobCtx.Cache != nil && e.JobCtx.Cache.CacheEnable {
 		cacheDest := filepath.Dir(e.Dirs.Workspace)
+		copyContents := false
 		if e.JobCtx.Cache.CacheDirType == common.CacheDirUserDefineType && e.JobCtx.Cache.CacheUserDir != "" {
+			copyContents = true
 			cacheDest = strings.ReplaceAll(e.JobCtx.Cache.CacheUserDir, "$WORKSPACE", e.Dirs.Workspace)
 			cacheDest = strings.ReplaceAll(cacheDest, "${WORKSPACE}", e.Dirs.Workspace)
 			if !filepath.IsAbs(cacheDest) {
@@ -168,7 +170,7 @@ func (e *JobExecutor) InitWorkDirectory() error {
 		if err := os.MkdirAll(cacheDest, os.ModePerm); err != nil {
 			return fmt.Errorf("failed to create cache restore directory %s, error: %v", cacheDest, err)
 		}
-		ReadCache(*e.Job, cacheDest, e.Dirs.CacheDir, log.GetSimpleLogger())
+		ReadCache(*e.Job, cacheDest, e.Dirs.CacheDir, copyContents, log.GetSimpleLogger())
 	}
 
 	// ------------------------------------------- init agent job log tmp dir -------------------------------------------
@@ -330,7 +332,9 @@ func (e *JobExecutor) AfterExecute() error {
 	// -------------------------------------------------- save job cache ------------------------------------------------
 	if e.JobCtx.Cache != nil && e.JobCtx.Cache.CacheEnable {
 		src := e.Dirs.Workspace
+		copyContents := false
 		if e.JobCtx.Cache.CacheDirType == common.CacheDirUserDefineType && e.JobCtx.Cache.CacheUserDir != "" {
+			copyContents = true
 			src = strings.ReplaceAll(e.JobCtx.Cache.CacheUserDir, "$WORKSPACE", e.Dirs.Workspace)
 			src = strings.ReplaceAll(src, "${WORKSPACE}", e.Dirs.Workspace)
 			if !filepath.IsAbs(src) {
@@ -349,7 +353,7 @@ func (e *JobExecutor) AfterExecute() error {
 		} else {
 			cachePath = filepath.Join(e.Dirs.CacheDir, e.Job.ProjectName, e.Job.WorkflowName)
 		}
-		WriteCache(*e.Job, src, cachePath, log.GetSimpleLogger())
+		WriteCache(*e.Job, src, cachePath, copyContents, log.GetSimpleLogger())
 	}
 
 	// ------------------------------------------------ report all job log ----------------------------------------------

--- a/pkg/cli/zadig-agent/internal/agent/job/job_executor.go
+++ b/pkg/cli/zadig-agent/internal/agent/job/job_executor.go
@@ -157,7 +157,18 @@ func (e *JobExecutor) InitWorkDirectory() error {
 
 	// check the job whether job use cache and init workspace by cache
 	if e.JobCtx.Cache != nil && e.JobCtx.Cache.CacheEnable {
-		ReadCache(*e.Job, filepath.Dir(e.Dirs.Workspace), e.Dirs.CacheDir, log.GetSimpleLogger())
+		cacheDest := filepath.Dir(e.Dirs.Workspace)
+		if e.JobCtx.Cache.CacheDirType == common.CacheDirUserDefineType && e.JobCtx.Cache.CacheUserDir != "" {
+			cacheDest = strings.ReplaceAll(e.JobCtx.Cache.CacheUserDir, "$WORKSPACE", e.Dirs.Workspace)
+			cacheDest = strings.ReplaceAll(cacheDest, "${WORKSPACE}", e.Dirs.Workspace)
+			if !filepath.IsAbs(cacheDest) {
+				cacheDest = filepath.Join(e.Dirs.Workspace, cacheDest)
+			}
+		}
+		if err := os.MkdirAll(cacheDest, os.ModePerm); err != nil {
+			return fmt.Errorf("failed to create cache restore directory %s, error: %v", cacheDest, err)
+		}
+		ReadCache(*e.Job, cacheDest, e.Dirs.CacheDir, log.GetSimpleLogger())
 	}
 
 	// ------------------------------------------- init agent job log tmp dir -------------------------------------------


### PR DESCRIPTION
## Summary

Fixes two P0/P1 cache issues found by QA on env-500 for VM/agent jobs, follow-ups to #4670:

1. **PVC cache is never read for user-defined cache dirs**: on restore, `ReadCache` always copied the cache into the workspace parent directory, ignoring the configured user-defined cache dir, so builds never saw the cached content.
2. **Whole workspace copied / nested directories**: `cp -f -r src dest` nests `src` inside `dest` on repeated runs, and the user-defined cache dir was used verbatim without expanding `$WORKSPACE`, falling back to copying the entire workspace.

## Why

QA build log shows a successful build with cache enabled where git clone/tooling still start from scratch (`没有读取 PVC 缓存`), and cache writeback duplicates the workspace content per run.

Root causes in the agent:

- `job_executor.go` restore path hardcoded `filepath.Dir(e.Dirs.Workspace)` as the destination.
- `CacheUserDir` was not expanded (`$WORKSPACE` / `${WORKSPACE}`) on save, and not honored at all on restore.
- `copyCmd` used `cp -f -r src dest`, which creates `dest/src` nesting instead of syncing contents.

## Main Changes

- `pkg/cli/zadig-agent/internal/agent/job/job_executor.go`:
  - restore cache into the user-defined cache dir (with `$WORKSPACE`/`${WORKSPACE}` expansion and absolute-path support), creating it first;
  - apply the same expansion on the save path.
- `pkg/cli/zadig-agent/internal/agent/job/cache.go`: `ReadCache`/`WriteCache`/`copyCmd` gain a `copyContents` flag; for user-defined dirs copy `src/.` with `cp -f -R` so contents are synced without nesting.

## Risk & Compatibility

- Default (workspace) cache behavior is unchanged: `copyContents=false` keeps the previous copy semantics.
- Only affects the zadig-agent VM job cache path; no server-side or API changes.

## Test

- `go build ./pkg/cli/zadig-agent/...` passes.
- Commits were previously verified locally against a VM agent with user-defined cache dir: restore lands in the configured dir and repeated save/restore no longer nests directories.

## Contact

@huanghongbo-hhb

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4851)
<!-- Reviewable:end -->
