### PR TITLE
fix: populate image name for Job workloads

### DIFF
--- a/pkg/shared/kube/wrapper/job.go
+++ b/pkg/shared/kube/wrapper/job.go
@@ -114,7 +114,11 @@ func (job *job) WorkloadResource(pods []*corev1.Pod) *resource.Workload {
 	}
 
 	for _, c := range job.Spec.Template.Spec.Containers {
-		wl.Images = append(wl.Images, resource.ContainerImage{Name: c.Name, Image: c.Image})
+		wl.Images = append(wl.Images, resource.ContainerImage{
+			Name:      c.Name,
+			Image:     c.Image,
+			ImageName: util.ExtractImageName(c.Image),
+		})
 	}
 
 	for _, p := range pods {


### PR DESCRIPTION
### What this PR does / Why we need it:

Fixes an issue where Job-type services could not list images because `image_name` was empty in the service detail response.

### What is changed and how it works?

Populate `ImageName` when converting Job container information into workload image data. The image name is extracted from the full container image using `util.ExtractImageName`, keeping Job behavior consistent with Deployment, StatefulSet, and DaemonSet workloads.


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4852)
<!-- Reviewable:end -->
