### PR TITLE
fix: filter invalid service module names during sync

### DIFF
--- a/pkg/microservice/aslan/core/common/service/repository/service_module.go
+++ b/pkg/microservice/aslan/core/common/service/repository/service_module.go
@@ -193,7 +193,7 @@ func pickServiceModuleColl(production bool) *mongodb.ServiceModuleColl {
 func containersToAutoRecords(projectName, serviceName string, revision int64, containers []*models.Container) []*models.ServiceModule {
 	records := make([]*models.ServiceModule, 0, len(containers))
 	for _, c := range containers {
-		if c == nil || c.Name == "" {
+		if c == nil || c.Name == "" || c.Name == "<nil>" {
 			continue
 		}
 		records = append(records, &models.ServiceModule{


### PR DESCRIPTION
### What this PR does / Why we need it:

Prevents invalid service module names from causing duplicate-key errors during migration.

### What is changed and how it works?

Filters empty and `"<nil>"` module names before writing service module records.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4854)
<!-- Reviewable:end -->
