### PR TITLE
fix: avoid selecting virtual MFA field for group users

### DIFF
--- a/pkg/microservice/user/core/repository/orm/user.go
+++ b/pkg/microservice/user/core/repository/orm/user.go
@@ -237,7 +237,8 @@ func joinUserMFA(db *gorm.DB) *gorm.DB {
 func ListUsersByGroup(groupID string, db *gorm.DB) ([]*models.User, error) {
 	resp := make([]*models.User, 0)
 
-	err := db.Joins("INNER JOIN group_binding on group_binding.uid = user.uid").
+	err := db.Select("user.*").
+		Joins("INNER JOIN group_binding on group_binding.uid = user.uid").
 		Where("group_binding.group_id = ?", groupID).
 		Find(&resp).
 		Error


### PR DESCRIPTION
### Summary
- Explicitly select real user columns when listing users in a group.

### Why
- The User model exposes virtual mfa_enabled, but user has no such physical column.
- Group-member queries otherwise fail with MySQL 1054.

### Risk / Compatibility
- Low risk: preserves the existing group-member fields and only narrows the SQL projection.

### Test
- go test ./pkg/microservice/user/core/repository/orm -count=1

### Contact
- Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4856)
<!-- Reviewable:end -->
