### PR TITLE
feat: support updating Job container images

### DIFF
--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -993,7 +993,7 @@ func FindServiceFromIstioGateway(gwObjs *v1alpha3.GatewayList, serviceName strin
 }
 
 // GetHelmServiceName get service name from annotations of resources deployed by helm
-// resType currently only support Deployment, StatefulSet and CronJob
+// resType currently only support Deployment, StatefulSet, Job and CronJob.
 // this function needs to be optimized
 func GetHelmServiceName(prod *models.Product, resType, resName string, kubeClient client.Client, version *version.Info) (string, error) {
 	res := &unstructured.Unstructured{}
@@ -1009,6 +1009,8 @@ func GetHelmServiceName(prod *models.Product, resType, resName string, kubeClien
 		res.SetGroupVersionKind(getter.DeploymentGVK)
 	case setting.StatefulSet:
 		res.SetGroupVersionKind(getter.StatefulSetGVK)
+	case setting.Job:
+		res.SetGroupVersionKind(getter.JobGVK)
 	case setting.CronJob:
 		if !kubeclient.VersionLessThan121(version) {
 			res.SetGroupVersionKind(getter.CronJobGVK)

--- a/pkg/microservice/aslan/core/environment/handler/image.go
+++ b/pkg/microservice/aslan/core/environment/handler/image.go
@@ -304,6 +304,84 @@ func UpdateDaemonSetContainerImage(c *gin.Context) {
 	ctx.RespErr = service.UpdateContainerImage(ctx.RequestID, ctx.UserName, args, ctx.Logger)
 }
 
+func UpdateJobContainerImage(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	args := new(service.UpdateContainerImageArgs)
+	args.Type = setting.Job
+	production := c.Query("production") == "true"
+	args.Production = production
+
+	data, err := c.GetRawData()
+	if err != nil {
+		log.Errorf("UpdateJobContainerImage c.GetRawData() err : %v", err)
+		return
+	}
+	if err = json.Unmarshal(data, args); err != nil {
+		log.Errorf("UpdateJobContainerImage json.Unmarshal err : %v", err)
+		return
+	}
+
+	detail := fmt.Sprintf("环境名称:%s,服务名称:%s,Job:%s", args.EnvName, args.ServiceName, args.Name)
+	detailEn := fmt.Sprintf("Environment Name: %s, Service Name: %s, Job: %s", args.EnvName, args.ServiceName, args.Name)
+	internalhandler.InsertDetailedOperationLog(
+		c, ctx.UserName, args.ProductName, setting.OperationSceneEnv,
+		"更新", "环境-服务镜像",
+		detail,
+		detailEn,
+		string(data), types.RequestBodyTypeJSON, ctx.Logger, args.EnvName)
+
+	// authorization checks
+	if !ctx.Resources.IsSystemAdmin {
+		if _, ok := ctx.Resources.ProjectAuthInfo[args.ProductName]; !ok {
+			ctx.UnAuthorized = true
+			return
+		}
+
+		if production {
+			if !ctx.Resources.ProjectAuthInfo[args.ProductName].IsProjectAdmin &&
+				!ctx.Resources.ProjectAuthInfo[args.ProductName].ProductionEnv.EditConfig {
+				permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, args.ProductName, types.ResourceTypeEnvironment, args.EnvName, types.ProductionEnvActionEditConfig)
+				if err != nil || !permitted {
+					ctx.UnAuthorized = true
+					return
+				}
+			}
+
+			err = commonutil.CheckZadigProfessionalLicense()
+			if err != nil {
+				ctx.RespErr = err
+				return
+			}
+		} else {
+			if !ctx.Resources.ProjectAuthInfo[args.ProductName].IsProjectAdmin &&
+				!ctx.Resources.ProjectAuthInfo[args.ProductName].Env.EditConfig {
+				permitted, err := internalhandler.GetCollaborationModePermission(ctx.UserID, args.ProductName, types.ResourceTypeEnvironment, args.EnvName, types.EnvActionEditConfig)
+				if err != nil || !permitted {
+					ctx.UnAuthorized = true
+					return
+				}
+			}
+		}
+	}
+
+	c.Request.Body = io.NopCloser(bytes.NewBuffer(data))
+
+	if err := c.BindJSON(args); err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+
+	ctx.RespErr = service.UpdateContainerImage(ctx.RequestID, ctx.UserName, args, ctx.Logger)
+}
+
 func UpdateCronJobContainerImage(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
@@ -388,6 +466,74 @@ type OpenAPIUpdateContainerImageArgs struct {
 	Name          string `json:"name"`
 	ContainerName string `json:"container_name"`
 	Image         string `json:"image"`
+}
+
+func OpenAPIUpdateJobContainerImage(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	args := new(OpenAPIUpdateContainerImageArgs)
+	args.Type = setting.Job
+
+	data, err := c.GetRawData()
+	if err != nil {
+		log.Errorf("OpenAPIUpdateJobContainerImage c.GetRawData() err : %v", err)
+		return
+	}
+	if err = json.Unmarshal(data, args); err != nil {
+		log.Errorf("OpenAPIUpdateJobContainerImage json.Unmarshal err : %v", err)
+		return
+	}
+
+	detail := fmt.Sprintf("环境名称:%s,服务名称:%s,Job:%s", args.EnvName, args.ServiceName, args.Name)
+	detailEn := fmt.Sprintf("Environment Name: %s, Service Name: %s, Job: %s", args.EnvName, args.ServiceName, args.Name)
+	internalhandler.InsertDetailedOperationLog(
+		c, ctx.UserName, args.ProductName, setting.OperationSceneEnv,
+		"更新", "OpenAPI-环境-服务镜像",
+		detail,
+		detailEn,
+		string(data), types.RequestBodyTypeJSON, ctx.Logger, args.EnvName)
+
+	permitted := ctx.Resources.IsSystemAdmin
+	if !permitted {
+		if projectAuthInfo, ok := ctx.Resources.ProjectAuthInfo[args.ProductName]; ok {
+			permitted = projectAuthInfo.IsProjectAdmin || projectAuthInfo.Env.EditConfig
+
+			if !permitted {
+				collabPermitted, permissionErr := internalhandler.GetCollaborationModePermission(
+					ctx.UserID, args.ProductName, types.ResourceTypeEnvironment, args.EnvName, types.EnvActionEditConfig,
+				)
+				permitted = permissionErr == nil && collabPermitted
+			}
+		}
+	}
+
+	if !permitted {
+		ctx.UnAuthorized = true
+		return
+	}
+
+	c.Request.Body = io.NopCloser(bytes.NewBuffer(data))
+	if err := c.BindJSON(args); err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc(err.Error())
+		return
+	}
+
+	ctx.RespErr = service.UpdateContainerImage(ctx.RequestID, ctx.UserName, &service.UpdateContainerImageArgs{
+		Type:          args.Type,
+		ProductName:   args.ProductName,
+		EnvName:       args.EnvName,
+		ServiceName:   args.ServiceName,
+		Name:          args.Name,
+		ContainerName: args.ContainerName,
+		Image:         args.Image,
+	}, ctx.Logger)
 }
 
 func OpenAPIUpdateDeploymentContainerImage(c *gin.Context) {

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -86,6 +86,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		image.POST("/deployment/:envName", UpdateDeploymentContainerImage)
 		image.POST("/daemonset/:envName", UpdateDaemonSetContainerImage)
 		image.POST("/statefulset/:envName", UpdateStatefulSetContainerImage)
+		image.POST("/job/:envName", UpdateJobContainerImage)
 		image.POST("/cronjob/:envName", UpdateCronJobContainerImage)
 	}
 
@@ -282,6 +283,7 @@ func (*OpenAPIRouter) Inject(router *gin.RouterGroup) {
 	{
 		image.POST("/deployment/:envName", OpenAPIUpdateDeploymentContainerImage)
 		image.POST("/statefulset/:envName", OpenAPIUpdateStatefulSetContainerImage)
+		image.POST("/job/:envName", OpenAPIUpdateJobContainerImage)
 		image.POST("/cronjob/:envName", OpenAPIUpdateCronJobContainerImage)
 	}
 

--- a/pkg/microservice/aslan/core/environment/service/image.go
+++ b/pkg/microservice/aslan/core/environment/service/image.go
@@ -156,6 +156,11 @@ func UpdateContainerImage(requestID, username string, args *UpdateContainerImage
 				log.Errorf("[%s] UpdateStatefulsetImageByName error: %s", namespace, err.Error())
 				return e.ErrUpdateConainterImage.AddDesc("更新 StatefulSet 容器镜像失败")
 			}
+		case setting.Job:
+			if err := updater.UpdateJobImageV2(context.TODO(), product.ClusterID, namespace, args.Name, args.ContainerName, args.Image); err != nil {
+				log.Errorf("[%s] UpdateJobImageByName error: %s", namespace, err.Error())
+				return e.ErrUpdateConainterImage.AddDesc("更新 Job 容器镜像失败")
+			}
 		case setting.CronJob:
 			if err := updater.UpdateCronJobImageV2(context.TODO(), product.ClusterID, namespace, args.Name, args.ContainerName, args.Image); err != nil {
 				log.Errorf("[%s] UpdateCronJobImageByName error: %s", namespace, err.Error())

--- a/pkg/tool/kube/updater/job_v2.go
+++ b/pkg/tool/kube/updater/job_v2.go
@@ -78,6 +78,87 @@ func CreateJobV2(ctx context.Context, clusterID string, job *batchv1.Job) error 
 	return nil
 }
 
+// UpdateJobImageV2 updates a Job image by recreating the Job because its pod
+// template is immutable after creation. If creating the updated Job fails, it
+// makes a best-effort attempt to restore the original Job.
+func UpdateJobImageV2(ctx context.Context, clusterID, namespace, name, containerName, newImage string) error {
+	cl, err := clientmanager.NewKubeClientManager().GetControllerRuntimeClient(clusterID)
+	if err != nil {
+		return fmt.Errorf("failed to get kube client: %w", err)
+	}
+
+	job := &batchv1.Job{}
+	if err := cl.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, job); err != nil {
+		return fmt.Errorf("failed to get job %s/%s: %w", namespace, name, err)
+	}
+
+	originalJob := job.DeepCopy()
+	originalJob.ResourceVersion = ""
+	originalJob.UID = ""
+	originalJob.Generation = 0
+	originalJob.CreationTimestamp = metav1.Time{}
+	originalJob.DeletionTimestamp = nil
+	originalJob.DeletionGracePeriodSeconds = nil
+	originalJob.ManagedFields = nil
+	originalJob.Status = batchv1.JobStatus{}
+
+	if originalJob.Spec.ManualSelector == nil || !*originalJob.Spec.ManualSelector {
+		originalJob.Spec.Selector = nil
+		for _, label := range []string{
+			"batch.kubernetes.io/controller-uid",
+			"batch.kubernetes.io/job-name",
+			"controller-uid",
+			"job-name",
+		} {
+			delete(originalJob.Spec.Template.Labels, label)
+		}
+	}
+
+	updatedJob := originalJob.DeepCopy()
+	containerFound := false
+	for i := range updatedJob.Spec.Template.Spec.Containers {
+		if updatedJob.Spec.Template.Spec.Containers[i].Name == containerName {
+			updatedJob.Spec.Template.Spec.Containers[i].Image = newImage
+			containerFound = true
+			break
+		}
+	}
+	if !containerFound {
+		return fmt.Errorf("failed to update image for job %s/%s: container %q not found", namespace, name, containerName)
+	}
+	if err := util.CreateApplyAnnotation(updatedJob); err != nil {
+		return fmt.Errorf("failed to create apply annotation for updated job %s/%s: %w", namespace, name, err)
+	}
+
+	propagationPolicy := metav1.DeletePropagationForeground
+	if err := cl.Delete(ctx, job, &client.DeleteOptions{PropagationPolicy: &propagationPolicy}); err != nil {
+		return fmt.Errorf("failed to delete job %s/%s before image update: %w", namespace, name, err)
+	}
+
+	if err := wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(c context.Context) (bool, error) {
+		fetched := &batchv1.Job{}
+		err := cl.Get(c, client.ObjectKey{Namespace: namespace, Name: name}, fetched)
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return false, nil
+	}); err != nil {
+		return fmt.Errorf("failed waiting for job %s/%s to be deleted before image update: %w", namespace, name, err)
+	}
+
+	if err := cl.Create(ctx, updatedJob); err != nil {
+		if restoreErr := cl.Create(ctx, originalJob); restoreErr != nil {
+			return fmt.Errorf("failed to recreate job %s/%s with updated image: %w; failed to restore original job: %v", namespace, name, err, restoreErr)
+		}
+		return fmt.Errorf("failed to recreate job %s/%s with updated image: %w; original job restored", namespace, name, err)
+	}
+
+	return nil
+}
+
 func DeleteJobV2(ctx context.Context, clusterID, namespace, name string) error {
 	cl, err := clientmanager.NewKubeClientManager().GetControllerRuntimeClient(clusterID)
 	if err != nil {


### PR DESCRIPTION
### What this PR does / Why we need it:

Adds support for updating Kubernetes Job container images.

### What is changed and how it works?

- Adds Job image update APIs.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4857)
<!-- Reviewable:end -->
