### PR TITLE
fix: report notification errors without interrupting jobs

### DIFF
--- a/pkg/microservice/aslan/core/common/service/imnotify/dingTalk.go
+++ b/pkg/microservice/aslan/core/common/service/imnotify/dingTalk.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package imnotify
 
+import "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/instantmessage"
+
 type DingDingMessage struct {
 	MsgType  string            `json:"msgtype"`
 	MarkDown *DingDingMarkDown `json:"markdown"`
@@ -45,6 +47,9 @@ func (w *IMNotifyService) SendDingDingMessage(uri, title, content string, atMobi
 		IsAtAll:   isAtAll,
 	}
 
-	_, err := w.SendMessageRequest(uri, message)
-	return err
+	response, err := w.SendMessageRequest(uri, message)
+	if err != nil {
+		return err
+	}
+	return instantmessage.ValidateDingDingResponse(response)
 }

--- a/pkg/microservice/aslan/core/common/service/instantmessage/dingTalk.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/dingTalk.go
@@ -17,6 +17,7 @@ limitations under the License.
 package instantmessage
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
@@ -55,6 +56,26 @@ type DingDingAt struct {
 	IsAtAll   bool     `json:"isAtAll"`
 }
 
+// ValidateDingDingResponse checks the business result returned by a DingTalk
+// custom bot. DingTalk may return HTTP 200 for a rejected message, so the
+// response body must be checked separately from the transport error.
+func ValidateDingDingResponse(body []byte) error {
+	var response struct {
+		ErrCode *int   `json:"errcode"`
+		ErrMsg  string `json:"errmsg"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return fmt.Errorf("failed to parse DingTalk response: %w", err)
+	}
+	if response.ErrCode == nil {
+		return fmt.Errorf("DingTalk response is missing errcode")
+	}
+	if *response.ErrCode != 0 {
+		return fmt.Errorf("DingTalk response error: errcode=%d, errmsg=%s", *response.ErrCode, response.ErrMsg)
+	}
+	return nil
+}
+
 const (
 	DingDingMsgType         = "actionCard"
 	DingDingMarkdownMsgType = "markdown"
@@ -63,8 +84,11 @@ const (
 
 func (w *Service) sendDingDingMessage(uri, title, content, actionURL string, atMobiles []string, isAtAll bool) error {
 	message := BuildDingDingMessage(title, content, actionURL, atMobiles, isAtAll)
-	_, err := w.SendMessageRequest(uri, message)
-	return err
+	response, err := w.SendMessageRequest(uri, message)
+	if err != nil {
+		return err
+	}
+	return ValidateDingDingResponse(response)
 }
 
 func BuildDingDingMessage(title, content, actionURL string, atMobiles []string, isAtAll bool) *DingDingMessage {

--- a/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
+++ b/pkg/microservice/aslan/core/common/service/instantmessage/workflow_task.go
@@ -241,6 +241,7 @@ func (w *Service) SendWorkflowTaskApproveNotifications(workflowName string, task
 		}
 	}
 
+	respErr := new(multierror.Error)
 	for _, sourceNotify := range resp.NotifyCtls {
 		notify, err := models.CloneNotifyCtl(sourceNotify)
 		if err != nil {
@@ -296,10 +297,10 @@ func (w *Service) SendWorkflowTaskApproveNotifications(workflowName string, task
 		}
 
 		if err := w.sendNotification(title, content, notify, larkCard, webhookNotify, task.Status); err != nil {
-			log.Errorf("failed to send notification, err: %s", err)
+			respErr = multierror.Append(respErr, fmt.Errorf("failed to send notification: %w", err))
 		}
 	}
-	return nil
+	return respErr.ErrorOrNil()
 }
 
 // TODO: manual error handling is not supported in the SendWorkflowTaskNotifications function, mainly because the error handling is done in the lifetime of a job, where the
@@ -324,6 +325,7 @@ func (w *Service) SendWorkflowTaskNotifications(task *models.WorkflowTask) error
 	if task.Status == config.StatusCreated {
 		statusChanged = false
 	}
+	respErr := new(multierror.Error)
 	for _, sourceNotify := range task.OriginWorkflowArgs.NotifyCtls {
 		notify, err := models.CloneNotifyCtl(sourceNotify)
 		if err != nil {
@@ -379,11 +381,11 @@ func (w *Service) SendWorkflowTaskNotifications(task *models.WorkflowTask) error
 			}
 
 			if err := w.sendNotification(title, content, notify, larkCard, webhookNotify, task.Status); err != nil {
-				log.Errorf("failed to send notification, err: %s", err)
+				respErr = multierror.Append(respErr, fmt.Errorf("failed to send notification: %w", err))
 			}
 		}
 	}
-	return nil
+	return respErr.ErrorOrNil()
 }
 
 func shouldSkipFeishuPersonPauseNotification(task *models.WorkflowTask, notify *models.NotifyCtl) bool {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job.go
@@ -312,7 +312,7 @@ func sendJobGroupNotifications(workflowCtx *commonmodels.WorkflowTaskCtx, jobs [
 		StatusTextKeyOverride:   statusTextKeyOverride,
 		RecipientRuntimeContext: workflowCtx.GlobalContextGetAll(),
 	}); err != nil {
-		logger.Warnf("send task notification failed, job: %s, status: %s, error: %v", primary.Name, status, err)
+		logger.Errorf("send task notification failed, job: %s, status: %s, error: %v", primary.Name, status, err)
 	}
 }
 

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_notification.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_notification.go
@@ -393,11 +393,9 @@ func sendDingDingMessage(productName, workflowName, workflowDisplayName string, 
 	resp, err := c.Post(uri, httpclient.SetBody(messageReq))
 	if err != nil {
 		return err
-	} else {
-		fmt.Println(string(resp.Body()))
 	}
 
-	return nil
+	return instantmessage.ValidateDingDingResponse(resp.Body())
 }
 
 func sendWorkWxMessage(productName, workflowName, workflowDisplayName string, taskID int64, uri, title, message string, idList []string, isAtAll bool) error {


### PR DESCRIPTION
### Summary
- Report notification failures without interrupting business tasks.
### Main Changes
- Aggregate errors from workflow, approval, and job-level dynamic-recipient resolution and delivery.
- Validate `errcode` in DingTalk HTTP 200 responses.
- Keep business Job status and subsequent execution unaffected by notification failures.
### Risk / Compatibility
- Successful notification behavior is unchanged; failures are now returned and logged.
### Test
- Targeted compile checks passed for `instantmessage`, `imnotify`, and `jobcontroller`.
### Contact
Contact: huanghongbo@koderover.com
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4858)
<!-- Reviewable:end -->