### PR TITLE
fix(release-plan): refresh workflow display names when fetching plan

### DIFF
--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -302,6 +302,10 @@ func GetReleasePlan(id string) (*models.ReleasePlan, error) {
 		return nil, errors.Wrap(err, "GetReleasePlan")
 	}
 
+	if err := refreshReleasePlanWorkflowDisplayNames(releasePlan); err != nil {
+		log.Warnf("failed to refresh workflow display names for release plan %s: %v", id, err)
+	}
+
 	// native approval users may be user or user groups
 	// convert to flat user when needed, this data is generated dynamically because group binding may be changed
 	if releasePlan.Approval != nil && releasePlan.Approval.NativeApproval != nil {
@@ -316,6 +320,55 @@ func GetReleasePlan(id string) (*models.ReleasePlan, error) {
 	}
 
 	return releasePlan, nil
+}
+
+func refreshReleasePlanWorkflowDisplayNames(releasePlan *models.ReleasePlan) error {
+	workflows := make([]mongodb.WorkflowV4, 0)
+	workflowJobs := make(map[string][]*models.ReleaseJob)
+	for _, job := range releasePlan.Jobs {
+		if job.Type != config.JobWorkflow {
+			continue
+		}
+
+		spec := new(models.WorkflowReleaseJobSpec)
+		if err := models.IToi(job.Spec, spec); err != nil {
+			log.Warnf("failed to decode workflow release job %s when refreshing display name: %v", job.ID, err)
+			continue
+		}
+		applyReleasePlanWorkflowLatestLookupCompat(job.Spec, spec)
+		if spec.Workflow == nil || spec.Workflow.Name == "" || spec.Workflow.Project == "" {
+			continue
+		}
+
+		key := spec.Workflow.Project + ":" + spec.Workflow.Name
+		if _, exists := workflowJobs[key]; !exists {
+			workflows = append(workflows, mongodb.WorkflowV4{
+				Name:        spec.Workflow.Name,
+				ProjectName: spec.Workflow.Project,
+			})
+		}
+		workflowJobs[key] = append(workflowJobs[key], job)
+	}
+
+	latestWorkflows, err := mongodb.NewWorkflowV4Coll().ListByWorkflows(mongodb.ListWorkflowV4Opt{
+		Workflows: workflows,
+	})
+	if err != nil {
+		return err
+	}
+	applyReleasePlanWorkflowDisplayNames(workflowJobs, latestWorkflows)
+	return nil
+}
+
+func applyReleasePlanWorkflowDisplayNames(workflowJobs map[string][]*models.ReleaseJob, latestWorkflows []*models.WorkflowV4) {
+	for _, workflow := range latestWorkflows {
+		if workflow.DisplayName == "" {
+			continue
+		}
+		for _, job := range workflowJobs[workflow.Project+":"+workflow.Name] {
+			job.Name = workflow.DisplayName
+		}
+	}
 }
 
 type ReleasePlanLogI18N struct {

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -302,10 +302,6 @@ func GetReleasePlan(id string) (*models.ReleasePlan, error) {
 		return nil, errors.Wrap(err, "GetReleasePlan")
 	}
 
-	if err := refreshReleasePlanWorkflowDisplayNames(releasePlan); err != nil {
-		log.Warnf("failed to refresh workflow display names for release plan %s: %v", id, err)
-	}
-
 	// native approval users may be user or user groups
 	// convert to flat user when needed, this data is generated dynamically because group binding may be changed
 	if releasePlan.Approval != nil && releasePlan.Approval.NativeApproval != nil {
@@ -320,55 +316,6 @@ func GetReleasePlan(id string) (*models.ReleasePlan, error) {
 	}
 
 	return releasePlan, nil
-}
-
-func refreshReleasePlanWorkflowDisplayNames(releasePlan *models.ReleasePlan) error {
-	workflows := make([]mongodb.WorkflowV4, 0)
-	workflowJobs := make(map[string][]*models.ReleaseJob)
-	for _, job := range releasePlan.Jobs {
-		if job.Type != config.JobWorkflow {
-			continue
-		}
-
-		spec := new(models.WorkflowReleaseJobSpec)
-		if err := models.IToi(job.Spec, spec); err != nil {
-			log.Warnf("failed to decode workflow release job %s when refreshing display name: %v", job.ID, err)
-			continue
-		}
-		applyReleasePlanWorkflowLatestLookupCompat(job.Spec, spec)
-		if spec.Workflow == nil || spec.Workflow.Name == "" || spec.Workflow.Project == "" {
-			continue
-		}
-
-		key := spec.Workflow.Project + ":" + spec.Workflow.Name
-		if _, exists := workflowJobs[key]; !exists {
-			workflows = append(workflows, mongodb.WorkflowV4{
-				Name:        spec.Workflow.Name,
-				ProjectName: spec.Workflow.Project,
-			})
-		}
-		workflowJobs[key] = append(workflowJobs[key], job)
-	}
-
-	latestWorkflows, err := mongodb.NewWorkflowV4Coll().ListByWorkflows(mongodb.ListWorkflowV4Opt{
-		Workflows: workflows,
-	})
-	if err != nil {
-		return err
-	}
-	applyReleasePlanWorkflowDisplayNames(workflowJobs, latestWorkflows)
-	return nil
-}
-
-func applyReleasePlanWorkflowDisplayNames(workflowJobs map[string][]*models.ReleaseJob, latestWorkflows []*models.WorkflowV4) {
-	for _, workflow := range latestWorkflows {
-		if workflow.DisplayName == "" {
-			continue
-		}
-		for _, job := range workflowJobs[workflow.Project+":"+workflow.Name] {
-			job.Name = workflow.DisplayName
-		}
-	}
 }
 
 type ReleasePlanLogI18N struct {
@@ -655,10 +602,15 @@ func updateReleasePlanJobWithLatestRenderedWorkflow(job *models.ReleaseJob) erro
 	}
 
 	workflowController := controller.CreateWorkflowController(normalizedWorkflow)
-	if err := workflowservice.UpdateWorkflowControllerWithLatestRenderedWorkflow(workflowController, nil, log.SugaredLogger()); err != nil {
+	latestWorkflow, err := workflowservice.FindWorkflowV4RenderedForExecution(workflowController.Name, log.SugaredLogger())
+	if err == nil {
+		err = workflowController.UpdateWithWorkflowSettings(latestWorkflow, nil)
+	}
+	if err != nil {
 		log.Errorf("cannot merge workflow %s's input with the latest workflow settings, the error is: %v", normalizedWorkflow.Name, err)
 		return e.ErrPresetWorkflow.AddDesc(err.Error())
 	}
+	workflowController.DisplayName = latestWorkflow.DisplayName
 
 	spec.Workflow = workflowController.WorkflowV4
 	job.Spec = spec


### PR DESCRIPTION
### What this PR does / Why we need it:

Ensure release plans show the latest workflow display names after workflows are renamed.

### What is changed and how it works?

Batch-query the latest workflows when fetching a release plan and update the corresponding job names. Lookup failures do not affect the release plan response.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4862)
<!-- Reviewable:end -->
