### PR TITLE
fix: support test task runtime inputs in OpenAPI

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/types.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/types.go
@@ -340,6 +340,10 @@ func OpenAPIKVInputToKeyValList(originalKvs commonmodels.RuntimeKeyValList, kvIn
 				if kvInput.Value != "" {
 					kv.ChoiceValue = strings.Split(kvInput.Value, ",")
 				}
+			} else if kv.Type == commonmodels.FileType {
+				kv.FileID = kvInput.FileID
+				kv.FileName = kvInput.FileName
+				kv.FilePath = kvInput.FilePath
 			}
 		}
 	}
@@ -384,7 +388,7 @@ func OpenAPIRepoInputToRepository(originalRepos []*types.Repository, repoInpus [
 			}
 
 			if repoInfo.Type != "perforce" {
-				if repo.RepoNamespace == inputRepo.RepoNamespace && repo.RepoName == inputRepo.RepoName {
+				if repo.GetRepoNamespace() == inputRepo.RepoNamespace && repo.RepoName == inputRepo.RepoName {
 					repo.Branch = inputRepo.Branch
 					repo.PR = inputRepo.PR
 					repo.PRs = inputRepo.PRs

--- a/pkg/microservice/aslan/core/workflow/testing/handler/openapi.go
+++ b/pkg/microservice/aslan/core/workflow/testing/handler/openapi.go
@@ -184,15 +184,15 @@ func OpenAPICreateTestTask(c *gin.Context) {
 	ctx.RespErr = err
 }
 
-// @summary Get test run information
+// @summary Get test information
 // @description Get the safe runtime input metadata for a configured test
 // @tags OpenAPI
 // @produce json
 // @Param projectKey query string true "Project key"
 // @Param testName path string true "Test name"
-// @success 200 {object} testingservice.OpenAPITestRunInfo
+// @success 200 {object} testingservice.OpenAPITestInfo
 // @router /openapi/quality/testing/{testName} [get]
-func OpenAPIGetTestRunInfo(c *gin.Context) {
+func OpenAPIGetTestInfo(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
@@ -217,7 +217,7 @@ func OpenAPIGetTestRunInfo(c *gin.Context) {
 		}
 	}
 
-	ctx.Resp, ctx.RespErr = testingservice.OpenAPIGetTestRunInfo(projectKey, testName, ctx.Logger)
+	ctx.Resp, ctx.RespErr = testingservice.OpenAPIGetTestInfo(projectKey, testName, ctx.Logger)
 }
 
 func OpenAPIGetTestTaskResult(c *gin.Context) {

--- a/pkg/microservice/aslan/core/workflow/testing/handler/openapi.go
+++ b/pkg/microservice/aslan/core/workflow/testing/handler/openapi.go
@@ -184,15 +184,15 @@ func OpenAPICreateTestTask(c *gin.Context) {
 	ctx.RespErr = err
 }
 
-// @summary Get test run configuration
+// @summary Get test run information
 // @description Get the safe runtime input metadata for a configured test
 // @tags OpenAPI
 // @produce json
 // @Param projectKey query string true "Project key"
 // @Param testName path string true "Test name"
-// @success 200 {object} testingservice.OpenAPITestRunConfig
-// @router /openapi/quality/testing/{testName}/config [get]
-func OpenAPIGetTestRunConfig(c *gin.Context) {
+// @success 200 {object} testingservice.OpenAPITestRunInfo
+// @router /openapi/quality/testing/{testName} [get]
+func OpenAPIGetTestRunInfo(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
@@ -217,7 +217,7 @@ func OpenAPIGetTestRunConfig(c *gin.Context) {
 		}
 	}
 
-	ctx.Resp, ctx.RespErr = testingservice.OpenAPIGetTestRunConfig(projectKey, testName, ctx.Logger)
+	ctx.Resp, ctx.RespErr = testingservice.OpenAPIGetTestRunInfo(projectKey, testName, ctx.Logger)
 }
 
 func OpenAPIGetTestTaskResult(c *gin.Context) {

--- a/pkg/microservice/aslan/core/workflow/testing/handler/openapi.go
+++ b/pkg/microservice/aslan/core/workflow/testing/handler/openapi.go
@@ -184,6 +184,42 @@ func OpenAPICreateTestTask(c *gin.Context) {
 	ctx.RespErr = err
 }
 
+// @summary Get test run configuration
+// @description Get the safe runtime input metadata for a configured test
+// @tags OpenAPI
+// @produce json
+// @Param projectKey query string true "Project key"
+// @Param testName path string true "Test name"
+// @success 200 {object} testingservice.OpenAPITestRunConfig
+// @router /openapi/quality/testing/{testName}/config [get]
+func OpenAPIGetTestRunConfig(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	projectKey := c.Query("projectKey")
+	testName := c.Param("testName")
+	if projectKey == "" || testName == "" {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("invalid params")
+		return
+	}
+
+	if !ctx.Resources.IsSystemAdmin {
+		projectAuth, ok := ctx.Resources.ProjectAuthInfo[projectKey]
+		if !ok || (!projectAuth.IsProjectAdmin && !projectAuth.Test.Execute) {
+			ctx.UnAuthorized = true
+			return
+		}
+	}
+
+	ctx.Resp, ctx.RespErr = testingservice.OpenAPIGetTestRunConfig(projectKey, testName, ctx.Logger)
+}
+
 func OpenAPIGetTestTaskResult(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()

--- a/pkg/microservice/aslan/core/workflow/testing/handler/router.go
+++ b/pkg/microservice/aslan/core/workflow/testing/handler/router.go
@@ -150,6 +150,7 @@ func (*QualityRouter) Inject(router *gin.RouterGroup) {
 	test := router.Group("testing")
 	{
 		test.POST("/task", OpenAPICreateTestTask)
+		test.GET("/:testName/config", OpenAPIGetTestRunConfig)
 		test.GET("/:testName/task/:taskID", OpenAPIGetTestTaskResult)
 	}
 }

--- a/pkg/microservice/aslan/core/workflow/testing/handler/router.go
+++ b/pkg/microservice/aslan/core/workflow/testing/handler/router.go
@@ -150,7 +150,7 @@ func (*QualityRouter) Inject(router *gin.RouterGroup) {
 	test := router.Group("testing")
 	{
 		test.POST("/task", OpenAPICreateTestTask)
-		test.GET("/:testName/config", OpenAPIGetTestRunConfig)
+		test.GET("/:testName", OpenAPIGetTestRunInfo)
 		test.GET("/:testName/task/:taskID", OpenAPIGetTestTaskResult)
 	}
 }

--- a/pkg/microservice/aslan/core/workflow/testing/handler/router.go
+++ b/pkg/microservice/aslan/core/workflow/testing/handler/router.go
@@ -150,7 +150,7 @@ func (*QualityRouter) Inject(router *gin.RouterGroup) {
 	test := router.Group("testing")
 	{
 		test.POST("/task", OpenAPICreateTestTask)
-		test.GET("/:testName", OpenAPIGetTestRunInfo)
+		test.GET("/:testName", OpenAPIGetTestInfo)
 		test.GET("/:testName/task/:taskID", OpenAPIGetTestTaskResult)
 	}
 }

--- a/pkg/microservice/aslan/core/workflow/testing/service/openapi.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/openapi.go
@@ -142,14 +142,13 @@ func OpenAPICreateTestTask(userName, account, userID string, args *OpenAPICreate
 		return 0, fmt.Errorf("find test[%s] error: %v", args.TestName, err)
 	}
 
-	repos := testInfo.Repos
+	var repoOverrides []*types.Repository
 	if len(args.RepoInfo) > 0 {
-		if err := util.DeepCopy(&repos, testInfo.Repos); err != nil {
+		var configuredRepos []*types.Repository
+		if err := util.DeepCopy(&configuredRepos, testInfo.Repos); err != nil {
 			return 0, fmt.Errorf("copy test repositories error: %v", err)
 		}
-		// The converter updates matching Git repository objects in place. Applying it to
-		// the copied slice preserves repositories omitted from the runtime override.
-		overrides, err := workflowservice.OpenAPIRepoInputToRepository(repos, args.RepoInfo)
+		overrides, err := workflowservice.OpenAPIRepoInputToRepository(configuredRepos, args.RepoInfo)
 		if err != nil {
 			return 0, err
 		}
@@ -161,13 +160,14 @@ func OpenAPICreateTestTask(userName, account, userID string, args *OpenAPICreate
 				return 0, fmt.Errorf("perforce repository overrides are not supported")
 			}
 		}
+		repoOverrides = overrides
 	}
 
 	task := &commonmodels.TestTaskArgs{
 		TestName:        args.TestName,
 		ProductName:     args.ProjectName,
 		TestTaskCreator: userName,
-		Repos:           repos,
+		Repos:           repoOverrides,
 	}
 	if len(args.Inputs) > 0 {
 		keyVals := make(commonmodels.RuntimeKeyValList, 0)
@@ -194,6 +194,47 @@ func OpenAPICreateTestTask(userName, account, userID string, args *OpenAPICreate
 		return 0, err
 	}
 	return result.TaskID, nil
+}
+
+func OpenAPIGetTestRunConfig(projectKey, testName string, logger *zap.SugaredLogger) (*OpenAPITestRunConfig, error) {
+	testInfo, err := GetRaw(testName, projectKey, logger)
+	if err != nil {
+		return nil, err
+	}
+	return buildOpenAPITestRunConfig(testInfo), nil
+}
+
+func buildOpenAPITestRunConfig(testInfo *commonmodels.Testing) *OpenAPITestRunConfig {
+	resp := &OpenAPITestRunConfig{
+		ProjectKey: testInfo.ProductName,
+		TestName:   testInfo.Name,
+		Inputs:     make([]*OpenAPITestRunConfigInput, 0),
+	}
+	if testInfo.PreTest == nil {
+		return resp
+	}
+
+	for _, input := range testInfo.PreTest.Envs {
+		if input == nil {
+			continue
+		}
+		value := input.GetValue()
+		hasValue := strings.TrimSpace(value) != "" || strings.TrimSpace(input.FileID) != ""
+		if input.IsCredential {
+			value = ""
+		}
+		resp.Inputs = append(resp.Inputs, &OpenAPITestRunConfigInput{
+			Key:          input.Key,
+			Value:        value,
+			Type:         string(input.Type),
+			ChoiceOption: append([]string(nil), input.ChoiceOption...),
+			Required:     input.Required,
+			IsCredential: input.IsCredential,
+			HasValue:     hasValue,
+			Description:  input.Description,
+		})
+	}
+	return resp
 }
 
 func OpenAPIGetTestTaskResult(taskID int64, productName, testName string, logger *zap.SugaredLogger) (*OpenAPITestTaskDetail, error) {

--- a/pkg/microservice/aslan/core/workflow/testing/service/openapi.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/openapi.go
@@ -189,7 +189,7 @@ func OpenAPICreateTestTask(userName, account, userID string, args *OpenAPICreate
 	if err != nil {
 		return 0, err
 	}
-	result, err := createTestTaskV2WithResolvedConfig(testInfo, task, testKeyVals, resolvedRepos, userName, account, userID, logger)
+	result, err := createTestTaskV2WithTestInfo(testInfo, task, testKeyVals, resolvedRepos, userName, account, userID, logger)
 	if err != nil {
 		logger.Errorf("OpenAPI: failed to create test task, project:%s, test name:%s, err: %s", args.ProjectName, args.TestName, err)
 		return 0, err
@@ -197,19 +197,19 @@ func OpenAPICreateTestTask(userName, account, userID string, args *OpenAPICreate
 	return result.TaskID, nil
 }
 
-func OpenAPIGetTestRunConfig(projectKey, testName string, logger *zap.SugaredLogger) (*OpenAPITestRunConfig, error) {
+func OpenAPIGetTestRunInfo(projectKey, testName string, logger *zap.SugaredLogger) (*OpenAPITestRunInfo, error) {
 	testInfo, err := GetRaw(testName, projectKey, logger)
 	if err != nil {
 		return nil, err
 	}
-	return buildOpenAPITestRunConfig(testInfo), nil
+	return buildOpenAPITestRunInfo(testInfo), nil
 }
 
-func buildOpenAPITestRunConfig(testInfo *commonmodels.Testing) *OpenAPITestRunConfig {
-	resp := &OpenAPITestRunConfig{
+func buildOpenAPITestRunInfo(testInfo *commonmodels.Testing) *OpenAPITestRunInfo {
+	resp := &OpenAPITestRunInfo{
 		ProjectKey: testInfo.ProductName,
 		TestName:   testInfo.Name,
-		Inputs:     make([]*OpenAPITestRunConfigInput, 0),
+		Inputs:     make([]*OpenAPITestRunInput, 0),
 	}
 	if testInfo.PreTest == nil {
 		return resp
@@ -224,7 +224,7 @@ func buildOpenAPITestRunConfig(testInfo *commonmodels.Testing) *OpenAPITestRunCo
 		if input.IsCredential {
 			value = ""
 		}
-		resp.Inputs = append(resp.Inputs, &OpenAPITestRunConfigInput{
+		resp.Inputs = append(resp.Inputs, &OpenAPITestRunInput{
 			Key:          input.Key,
 			Value:        value,
 			Type:         string(input.Type),

--- a/pkg/microservice/aslan/core/workflow/testing/service/openapi.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/openapi.go
@@ -28,6 +28,7 @@ import (
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
+	workflowservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/workflow/service/workflow"
 	openapitool "github.com/koderover/zadig/v2/pkg/tool/openapi"
 	"github.com/koderover/zadig/v2/pkg/types"
 )
@@ -135,10 +136,29 @@ func generateScanningModuleFromOpenAPIInput(req *OpenAPICreateScanningReq, log *
 }
 
 func OpenAPICreateTestTask(userName, account, userID string, args *OpenAPICreateTestTaskReq, logger *zap.SugaredLogger) (int64, error) {
+	testInfo, err := commonrepo.NewTestingColl().Find(args.TestName, args.ProjectName)
+	if err != nil {
+		return 0, fmt.Errorf("find test[%s] error: %v", args.TestName, err)
+	}
+	repos, err := workflowservice.OpenAPIRepoInputToRepository(testInfo.Repos, args.RepoInfo)
+	if err != nil {
+		return 0, err
+	}
+	if len(args.RepoInfo) > 0 && len(repos) != len(args.RepoInfo) {
+		return 0, fmt.Errorf("one or more repositories do not match the test configuration")
+	}
+	keyVals := make(commonmodels.RuntimeKeyValList, 0)
+	if testInfo.PreTest != nil {
+		keyVals = testInfo.PreTest.Envs.ToRuntimeList()
+	}
+	keyVals = workflowservice.OpenAPIKVInputToKeyValList(keyVals, args.Inputs)
+	taskKeyVals := keyVals.ToKVList()
 	task := &commonmodels.TestTaskArgs{
 		TestName:        args.TestName,
 		ProductName:     args.ProjectName,
 		TestTaskCreator: userName,
+		Repos:           repos,
+		KeyVals:         &taskKeyVals,
 	}
 	result, err := CreateTestTaskV2(task, userName, account, userID, logger)
 	if err != nil {

--- a/pkg/microservice/aslan/core/workflow/testing/service/openapi.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/openapi.go
@@ -152,13 +152,13 @@ func OpenAPICreateTestTask(userName, account, userID string, args *OpenAPICreate
 		if err != nil {
 			return 0, err
 		}
-		if len(overrides) != len(args.RepoInfo) {
-			return 0, fmt.Errorf("one or more repositories do not match the test configuration")
-		}
 		for _, override := range overrides {
 			if override.Source == "perforce" {
 				return 0, fmt.Errorf("perforce repository overrides are not supported")
 			}
+		}
+		if len(overrides) != len(args.RepoInfo) {
+			return 0, fmt.Errorf("one or more repositories do not match the test configuration")
 		}
 		repoOverrides = overrides
 	}
@@ -188,7 +188,7 @@ func OpenAPICreateTestTask(userName, account, userID string, args *OpenAPICreate
 		task.KeyVals = &taskKeyVals
 	}
 
-	result, err := CreateTestTaskV2(task, userName, account, userID, logger)
+	result, err := createTestTaskV2WithTestInfo(testInfo, task, userName, account, userID, logger)
 	if err != nil {
 		logger.Errorf("OpenAPI: failed to create test task, project:%s, test name:%s, err: %s", args.ProjectName, args.TestName, err)
 		return 0, err

--- a/pkg/microservice/aslan/core/workflow/testing/service/openapi.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/openapi.go
@@ -31,6 +31,7 @@ import (
 	workflowservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/workflow/service/workflow"
 	openapitool "github.com/koderover/zadig/v2/pkg/tool/openapi"
 	"github.com/koderover/zadig/v2/pkg/types"
+	"github.com/koderover/zadig/v2/pkg/util"
 )
 
 func OpenAPICreateScanningModule(username string, args *OpenAPICreateScanningReq, log *zap.SugaredLogger) error {
@@ -140,26 +141,53 @@ func OpenAPICreateTestTask(userName, account, userID string, args *OpenAPICreate
 	if err != nil {
 		return 0, fmt.Errorf("find test[%s] error: %v", args.TestName, err)
 	}
-	repos, err := workflowservice.OpenAPIRepoInputToRepository(testInfo.Repos, args.RepoInfo)
-	if err != nil {
-		return 0, err
+
+	repos := testInfo.Repos
+	if len(args.RepoInfo) > 0 {
+		if err := util.DeepCopy(&repos, testInfo.Repos); err != nil {
+			return 0, fmt.Errorf("copy test repositories error: %v", err)
+		}
+		// The converter updates matching Git repository objects in place. Applying it to
+		// the copied slice preserves repositories omitted from the runtime override.
+		overrides, err := workflowservice.OpenAPIRepoInputToRepository(repos, args.RepoInfo)
+		if err != nil {
+			return 0, err
+		}
+		if len(overrides) != len(args.RepoInfo) {
+			return 0, fmt.Errorf("one or more repositories do not match the test configuration")
+		}
+		for _, override := range overrides {
+			if override.Source == "perforce" {
+				return 0, fmt.Errorf("perforce repository overrides are not supported")
+			}
+		}
 	}
-	if len(args.RepoInfo) > 0 && len(repos) != len(args.RepoInfo) {
-		return 0, fmt.Errorf("one or more repositories do not match the test configuration")
-	}
-	keyVals := make(commonmodels.RuntimeKeyValList, 0)
-	if testInfo.PreTest != nil {
-		keyVals = testInfo.PreTest.Envs.ToRuntimeList()
-	}
-	keyVals = workflowservice.OpenAPIKVInputToKeyValList(keyVals, args.Inputs)
-	taskKeyVals := keyVals.ToKVList()
+
 	task := &commonmodels.TestTaskArgs{
 		TestName:        args.TestName,
 		ProductName:     args.ProjectName,
 		TestTaskCreator: userName,
 		Repos:           repos,
-		KeyVals:         &taskKeyVals,
 	}
+	if len(args.Inputs) > 0 {
+		keyVals := make(commonmodels.RuntimeKeyValList, 0)
+		if testInfo.PreTest != nil {
+			keyVals = testInfo.PreTest.Envs.ToRuntimeList()
+		}
+		configuredInputs := make(map[string]struct{}, len(keyVals))
+		for _, keyVal := range keyVals {
+			configuredInputs[keyVal.Key] = struct{}{}
+		}
+		for _, input := range args.Inputs {
+			if _, ok := configuredInputs[input.Key]; !ok {
+				return 0, fmt.Errorf("input %q does not exist in the test configuration", input.Key)
+			}
+		}
+		keyVals = workflowservice.OpenAPIKVInputToKeyValList(keyVals, args.Inputs)
+		taskKeyVals := keyVals.ToKVList()
+		task.KeyVals = &taskKeyVals
+	}
+
 	result, err := CreateTestTaskV2(task, userName, account, userID, logger)
 	if err != nil {
 		logger.Errorf("OpenAPI: failed to create test task, project:%s, test name:%s, err: %s", args.ProjectName, args.TestName, err)

--- a/pkg/microservice/aslan/core/workflow/testing/service/openapi.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/openapi.go
@@ -142,13 +142,12 @@ func OpenAPICreateTestTask(userName, account, userID string, args *OpenAPICreate
 		return 0, fmt.Errorf("find test[%s] error: %v", args.TestName, err)
 	}
 
-	var repoOverrides []*types.Repository
+	var resolvedRepos []*types.Repository
+	if err := util.DeepCopy(&resolvedRepos, testInfo.Repos); err != nil {
+		return 0, fmt.Errorf("copy test repositories error: %v", err)
+	}
 	if len(args.RepoInfo) > 0 {
-		var configuredRepos []*types.Repository
-		if err := util.DeepCopy(&configuredRepos, testInfo.Repos); err != nil {
-			return 0, fmt.Errorf("copy test repositories error: %v", err)
-		}
-		overrides, err := workflowservice.OpenAPIRepoInputToRepository(configuredRepos, args.RepoInfo)
+		overrides, err := workflowservice.OpenAPIRepoInputToRepository(resolvedRepos, args.RepoInfo)
 		if err != nil {
 			return 0, err
 		}
@@ -160,14 +159,12 @@ func OpenAPICreateTestTask(userName, account, userID string, args *OpenAPICreate
 		if len(overrides) != len(args.RepoInfo) {
 			return 0, fmt.Errorf("one or more repositories do not match the test configuration")
 		}
-		repoOverrides = overrides
 	}
 
 	task := &commonmodels.TestTaskArgs{
 		TestName:        args.TestName,
 		ProductName:     args.ProjectName,
 		TestTaskCreator: userName,
-		Repos:           repoOverrides,
 	}
 	if len(args.Inputs) > 0 {
 		keyVals := make(commonmodels.RuntimeKeyValList, 0)
@@ -188,7 +185,11 @@ func OpenAPICreateTestTask(userName, account, userID string, args *OpenAPICreate
 		task.KeyVals = &taskKeyVals
 	}
 
-	result, err := createTestTaskV2WithTestInfo(testInfo, task, userName, account, userID, logger)
+	testKeyVals, err := resolveTestTaskKeyVals(testInfo, task)
+	if err != nil {
+		return 0, err
+	}
+	result, err := createTestTaskV2WithResolvedConfig(testInfo, task, testKeyVals, resolvedRepos, userName, account, userID, logger)
 	if err != nil {
 		logger.Errorf("OpenAPI: failed to create test task, project:%s, test name:%s, err: %s", args.ProjectName, args.TestName, err)
 		return 0, err

--- a/pkg/microservice/aslan/core/workflow/testing/service/openapi.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/openapi.go
@@ -197,19 +197,19 @@ func OpenAPICreateTestTask(userName, account, userID string, args *OpenAPICreate
 	return result.TaskID, nil
 }
 
-func OpenAPIGetTestRunInfo(projectKey, testName string, logger *zap.SugaredLogger) (*OpenAPITestRunInfo, error) {
+func OpenAPIGetTestInfo(projectKey, testName string, logger *zap.SugaredLogger) (*OpenAPITestInfo, error) {
 	testInfo, err := GetRaw(testName, projectKey, logger)
 	if err != nil {
 		return nil, err
 	}
-	return buildOpenAPITestRunInfo(testInfo), nil
+	return buildOpenAPITestInfo(testInfo), nil
 }
 
-func buildOpenAPITestRunInfo(testInfo *commonmodels.Testing) *OpenAPITestRunInfo {
-	resp := &OpenAPITestRunInfo{
+func buildOpenAPITestInfo(testInfo *commonmodels.Testing) *OpenAPITestInfo {
+	resp := &OpenAPITestInfo{
 		ProjectKey: testInfo.ProductName,
 		TestName:   testInfo.Name,
-		Inputs:     make([]*OpenAPITestRunInput, 0),
+		Inputs:     make([]*OpenAPITestInput, 0),
 	}
 	if testInfo.PreTest == nil {
 		return resp
@@ -224,7 +224,7 @@ func buildOpenAPITestRunInfo(testInfo *commonmodels.Testing) *OpenAPITestRunInfo
 		if input.IsCredential {
 			value = ""
 		}
-		resp.Inputs = append(resp.Inputs, &OpenAPITestRunInput{
+		resp.Inputs = append(resp.Inputs, &OpenAPITestInput{
 			Key:          input.Key,
 			Value:        value,
 			Type:         string(input.Type),

--- a/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
@@ -59,7 +59,7 @@ func CreateTestTaskV2(args *commonmodels.TestTaskArgs, username, account, userID
 		return nil, err
 	}
 
-	return createTestTaskV2WithResolvedConfig(testInfo, args, testKeyVals, resolvedRepos, username, account, userID, log)
+	return createTestTaskV2WithTestInfo(testInfo, args, testKeyVals, resolvedRepos, username, account, userID, log)
 }
 
 func resolveTestTaskKeyVals(testInfo *commonmodels.Testing, args *commonmodels.TestTaskArgs) (commonmodels.RuntimeKeyValList, error) {
@@ -78,7 +78,7 @@ func resolveTestTaskKeyVals(testInfo *commonmodels.Testing, args *commonmodels.T
 	return testKeyVals, nil
 }
 
-func createTestTaskV2WithResolvedConfig(testInfo *commonmodels.Testing, args *commonmodels.TestTaskArgs, testKeyVals commonmodels.RuntimeKeyValList, resolvedRepos []*types.Repository, username, account, userID string, log *zap.SugaredLogger) (*CreateTaskResp, error) {
+func createTestTaskV2WithTestInfo(testInfo *commonmodels.Testing, args *commonmodels.TestTaskArgs, testKeyVals commonmodels.RuntimeKeyValList, resolvedRepos []*types.Repository, username, account, userID string, log *zap.SugaredLogger) (*CreateTaskResp, error) {
 	testWorkflow, err := generateCustomWorkflowFromTestingModule(testInfo, args, testKeyVals, resolvedRepos)
 	if err != nil {
 		return nil, err

--- a/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
@@ -371,21 +371,9 @@ func generateCustomWorkflowFromTestingModule(testInfo *commonmodels.Testing, arg
 		NotificationID:   args.NotificationID,
 	}
 
-	// set pr and branch
-	for i, build := range testInfo.Repos {
-		// check same repo and source
-		if build.Source == args.Repos[i].Source && build.RepoOwner == args.Repos[i].RepoOwner && build.RepoName == args.Repos[i].RepoName {
-			pr := args.Repos[i].PRs
-			if len(pr) != 0 {
-				testInfo.Repos[i].PRs = pr
-			}
-			if args.Repos[i].Branch != "" {
-				testInfo.Repos[i].Branch = args.Repos[i].Branch
-			}
-			if args.Repos[i].Tag != "" {
-				testInfo.Repos[i].Tag = args.Repos[i].Tag
-			}
-		}
+	repos := testInfo.Repos
+	if len(args.Repos) > 0 {
+		repos = args.Repos
 	}
 
 	stage := make([]*commonmodels.WorkflowStage, 0)
@@ -406,7 +394,7 @@ func generateCustomWorkflowFromTestingModule(testInfo *commonmodels.Testing, arg
 					Name:        testInfo.Name,
 					ProjectName: testInfo.ProductName,
 					KeyVals:     keyVals,
-					Repos:       testInfo.Repos,
+					Repos:       repos,
 				},
 			},
 			ServiceAndTests: nil,

--- a/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
@@ -30,6 +30,7 @@ import (
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	workflowservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/workflow/service/workflow"
 	jobctrl "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/workflow/service/workflow/controller/job"
+	rootutil "github.com/koderover/zadig/v2/pkg/util"
 )
 
 type CreateTaskResp struct {
@@ -62,7 +63,12 @@ func CreateTestTaskV2(args *commonmodels.TestTaskArgs, username, account, userID
 		return nil, err
 	}
 
-	testWorkflow, err := generateCustomWorkflowFromTestingModule(testInfo, args, testKeyVals)
+	resolvedRepos, err := resolveTestTaskRepos(testInfo.Repos, args.Repos)
+	if err != nil {
+		return nil, err
+	}
+
+	testWorkflow, err := generateCustomWorkflowFromTestingModule(testInfo, args, testKeyVals, resolvedRepos)
 	if err != nil {
 		return nil, err
 	}
@@ -82,6 +88,53 @@ func CreateTestTaskV2(args *commonmodels.TestTaskArgs, username, account, userID
 	}
 
 	return nil, err
+}
+
+func resolveTestTaskRepos(configuredRepos, overrides []*types.Repository) ([]*types.Repository, error) {
+	var repos []*types.Repository
+	if err := rootutil.DeepCopy(&repos, configuredRepos); err != nil {
+		return nil, fmt.Errorf("copy test repositories error: %w", err)
+	}
+	if len(overrides) == 0 {
+		return repos, nil
+	}
+
+	repoKey := func(repo *types.Repository) string {
+		return fmt.Sprintf("%d/%s/%s", repo.CodehostID, repo.GetRepoNamespace(), repo.RepoName)
+	}
+	configuredByKey := make(map[string]*types.Repository, len(repos))
+	for _, repo := range repos {
+		if repo == nil {
+			continue
+		}
+		configuredByKey[repoKey(repo)] = repo
+	}
+
+	seen := make(map[string]struct{}, len(overrides))
+	for i, override := range overrides {
+		if override == nil {
+			return nil, fmt.Errorf("test repository override %d cannot be empty", i)
+		}
+		key := repoKey(override)
+		if _, ok := seen[key]; ok {
+			return nil, fmt.Errorf("test repository %s is duplicated", key)
+		}
+		seen[key] = struct{}{}
+
+		repo, ok := configuredByKey[key]
+		if !ok {
+			return nil, fmt.Errorf("test repository %s is not configured", key)
+		}
+		repo.Branch = override.Branch
+		repo.MergeBranches = append([]string(nil), override.MergeBranches...)
+		repo.PR = override.PR
+		repo.PRs = append([]int(nil), override.PRs...)
+		repo.Tag = override.Tag
+		repo.EnableCommit = override.EnableCommit
+		repo.CommitID = override.CommitID
+	}
+
+	return repos, nil
 }
 
 type TestTaskList struct {
@@ -343,7 +396,7 @@ func GetTestTaskReportDetail(projectKey, testName string, taskID int64, log *zap
 	return testResults, nil
 }
 
-func generateCustomWorkflowFromTestingModule(testInfo *commonmodels.Testing, args *commonmodels.TestTaskArgs, keyVals commonmodels.RuntimeKeyValList) (*commonmodels.WorkflowV4, error) {
+func generateCustomWorkflowFromTestingModule(testInfo *commonmodels.Testing, args *commonmodels.TestTaskArgs, keyVals commonmodels.RuntimeKeyValList, repos []*types.Repository) (*commonmodels.WorkflowV4, error) {
 	concurrencyLimit := 1
 	if testInfo.PreTest != nil {
 		concurrencyLimit = testInfo.PreTest.ConcurrencyLimit
@@ -369,11 +422,6 @@ func generateCustomWorkflowFromTestingModule(testInfo *commonmodels.Testing, arg
 		ConcurrencyLimit: concurrencyLimit,
 		NotifyCtls:       testInfo.NotifyCtls,
 		NotificationID:   args.NotificationID,
-	}
-
-	repos := testInfo.Repos
-	if len(args.Repos) > 0 {
-		repos = args.Repos
 	}
 
 	stage := make([]*commonmodels.WorkflowStage, 0)

--- a/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
@@ -49,10 +49,20 @@ func CreateTestTaskV2(args *commonmodels.TestTaskArgs, username, account, userID
 		log.Errorf("find test[%s] error: %v", args.TestName, err)
 		return nil, fmt.Errorf("find test[%s] error: %v", args.TestName, err)
 	}
-	return createTestTaskV2WithTestInfo(testInfo, args, username, account, userID, log)
+
+	testKeyVals, err := resolveTestTaskKeyVals(testInfo, args)
+	if err != nil {
+		return nil, err
+	}
+	resolvedRepos, err := resolveTestTaskRepos(testInfo.Repos, args.Repos)
+	if err != nil {
+		return nil, err
+	}
+
+	return createTestTaskV2WithResolvedConfig(testInfo, args, testKeyVals, resolvedRepos, username, account, userID, log)
 }
 
-func createTestTaskV2WithTestInfo(testInfo *commonmodels.Testing, args *commonmodels.TestTaskArgs, username, account, userID string, log *zap.SugaredLogger) (*CreateTaskResp, error) {
+func resolveTestTaskKeyVals(testInfo *commonmodels.Testing, args *commonmodels.TestTaskArgs) (commonmodels.RuntimeKeyValList, error) {
 	testKeyVals := make(commonmodels.RuntimeKeyValList, 0)
 	if testInfo.PreTest != nil {
 		testKeyVals = testInfo.PreTest.Envs.ToRuntimeList()
@@ -65,12 +75,10 @@ func createTestTaskV2WithTestInfo(testInfo *commonmodels.Testing, args *commonmo
 	if err := jobctrl.ValidateRequiredRuntimeKeyVals(testKeyVals, fmt.Sprintf("test %s", args.TestName)); err != nil {
 		return nil, err
 	}
+	return testKeyVals, nil
+}
 
-	resolvedRepos, err := resolveTestTaskRepos(testInfo.Repos, args.Repos)
-	if err != nil {
-		return nil, err
-	}
-
+func createTestTaskV2WithResolvedConfig(testInfo *commonmodels.Testing, args *commonmodels.TestTaskArgs, testKeyVals commonmodels.RuntimeKeyValList, resolvedRepos []*types.Repository, username, account, userID string, log *zap.SugaredLogger) (*CreateTaskResp, error) {
 	testWorkflow, err := generateCustomWorkflowFromTestingModule(testInfo, args, testKeyVals, resolvedRepos)
 	if err != nil {
 		return nil, err

--- a/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/test_task.go
@@ -49,7 +49,10 @@ func CreateTestTaskV2(args *commonmodels.TestTaskArgs, username, account, userID
 		log.Errorf("find test[%s] error: %v", args.TestName, err)
 		return nil, fmt.Errorf("find test[%s] error: %v", args.TestName, err)
 	}
+	return createTestTaskV2WithTestInfo(testInfo, args, username, account, userID, log)
+}
 
+func createTestTaskV2WithTestInfo(testInfo *commonmodels.Testing, args *commonmodels.TestTaskArgs, username, account, userID string, log *zap.SugaredLogger) (*CreateTaskResp, error) {
 	testKeyVals := make(commonmodels.RuntimeKeyValList, 0)
 	if testInfo.PreTest != nil {
 		testKeyVals = testInfo.PreTest.Envs.ToRuntimeList()
@@ -59,7 +62,7 @@ func CreateTestTaskV2(args *commonmodels.TestTaskArgs, username, account, userID
 		testKeyVals = args.KeyVals.ToRuntimeList()
 	}
 	// validate required key vals
-	if err = jobctrl.ValidateRequiredRuntimeKeyVals(testKeyVals, fmt.Sprintf("test %s", args.TestName)); err != nil {
+	if err := jobctrl.ValidateRequiredRuntimeKeyVals(testKeyVals, fmt.Sprintf("test %s", args.TestName)); err != nil {
 		return nil, err
 	}
 

--- a/pkg/microservice/aslan/core/workflow/testing/service/types.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/types.go
@@ -299,8 +299,10 @@ func ConvertDBScanningModule(scanning *commonmodels.Scanning) *Scanning {
 }
 
 type OpenAPICreateTestTaskReq struct {
-	ProjectName string `json:"project_key"`
-	TestName    string `json:"test_name"`
+	ProjectName string                    `json:"project_key"`
+	TestName    string                    `json:"test_name"`
+	RepoInfo    []*types.OpenAPIRepoInput `json:"repo_info,omitempty"`
+	Inputs      []*types.KV               `json:"inputs,omitempty"`
 }
 
 func (t *OpenAPICreateTestTaskReq) Validate() (bool, error) {
@@ -309,6 +311,19 @@ func (t *OpenAPICreateTestTaskReq) Validate() (bool, error) {
 	}
 	if t.TestName == "" {
 		return false, fmt.Errorf("test name cannot be empty")
+	}
+	for i, repo := range t.RepoInfo {
+		if repo == nil {
+			return false, fmt.Errorf("repo_info[%d] cannot be empty", i)
+		}
+		if strings.TrimSpace(repo.CodeHostName) == "" || strings.TrimSpace(repo.RepoNamespace) == "" || strings.TrimSpace(repo.RepoName) == "" || strings.TrimSpace(repo.Branch) == "" {
+			return false, fmt.Errorf("repo_info[%d] codehost_name, repo_namespace, repo_name and branch cannot be empty", i)
+		}
+	}
+	for i, input := range t.Inputs {
+		if input == nil || strings.TrimSpace(input.Key) == "" {
+			return false, fmt.Errorf("inputs[%d] key cannot be empty", i)
+		}
 	}
 
 	return true, nil

--- a/pkg/microservice/aslan/core/workflow/testing/service/types.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/types.go
@@ -312,6 +312,7 @@ func (t *OpenAPICreateTestTaskReq) Validate() (bool, error) {
 	if t.TestName == "" {
 		return false, fmt.Errorf("test name cannot be empty")
 	}
+	repositories := make(map[string]struct{}, len(t.RepoInfo))
 	for i, repo := range t.RepoInfo {
 		if repo == nil {
 			return false, fmt.Errorf("repo_info[%d] cannot be empty", i)
@@ -319,11 +320,22 @@ func (t *OpenAPICreateTestTaskReq) Validate() (bool, error) {
 		if strings.TrimSpace(repo.CodeHostName) == "" || strings.TrimSpace(repo.RepoNamespace) == "" || strings.TrimSpace(repo.RepoName) == "" || strings.TrimSpace(repo.Branch) == "" {
 			return false, fmt.Errorf("repo_info[%d] codehost_name, repo_namespace, repo_name and branch cannot be empty", i)
 		}
+		repository := strings.TrimSpace(repo.CodeHostName) + "\n" + strings.TrimSpace(repo.RepoNamespace) + "\n" + strings.TrimSpace(repo.RepoName)
+		if _, ok := repositories[repository]; ok {
+			return false, fmt.Errorf("repo_info[%d] duplicates repository %s/%s", i, repo.RepoNamespace, repo.RepoName)
+		}
+		repositories[repository] = struct{}{}
 	}
+	inputs := make(map[string]struct{}, len(t.Inputs))
 	for i, input := range t.Inputs {
 		if input == nil || strings.TrimSpace(input.Key) == "" {
 			return false, fmt.Errorf("inputs[%d] key cannot be empty", i)
 		}
+		key := strings.TrimSpace(input.Key)
+		if _, ok := inputs[key]; ok {
+			return false, fmt.Errorf("inputs[%d] duplicates key %q", i, input.Key)
+		}
+		inputs[key] = struct{}{}
 	}
 
 	return true, nil

--- a/pkg/microservice/aslan/core/workflow/testing/service/types.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/types.go
@@ -317,8 +317,15 @@ func (t *OpenAPICreateTestTaskReq) Validate() (bool, error) {
 		if repo == nil {
 			return false, fmt.Errorf("repo_info[%d] cannot be empty", i)
 		}
-		if strings.TrimSpace(repo.CodeHostName) == "" || strings.TrimSpace(repo.RepoNamespace) == "" || strings.TrimSpace(repo.RepoName) == "" || strings.TrimSpace(repo.Branch) == "" {
-			return false, fmt.Errorf("repo_info[%d] codehost_name, repo_namespace, repo_name and branch cannot be empty", i)
+		if strings.TrimSpace(repo.CodeHostName) == "" || strings.TrimSpace(repo.RepoNamespace) == "" || strings.TrimSpace(repo.RepoName) == "" {
+			return false, fmt.Errorf("repo_info[%d] codehost_name, repo_namespace and repo_name cannot be empty", i)
+		}
+		if repo.EnableCommit {
+			if strings.TrimSpace(repo.CommitID) == "" {
+				return false, fmt.Errorf("repo_info[%d] commit_id cannot be empty when enable_commit is true", i)
+			}
+		} else if strings.TrimSpace(repo.Branch) == "" {
+			return false, fmt.Errorf("repo_info[%d] branch cannot be empty when enable_commit is false", i)
 		}
 		repository := strings.TrimSpace(repo.CodeHostName) + "\n" + strings.TrimSpace(repo.RepoNamespace) + "\n" + strings.TrimSpace(repo.RepoName)
 		if _, ok := repositories[repository]; ok {
@@ -345,13 +352,13 @@ type OpenAPICreateTestTaskResp struct {
 	TaskID int64 `json:"task_id"`
 }
 
-type OpenAPITestRunInfo struct {
-	ProjectKey string                 `json:"project_key"`
-	TestName   string                 `json:"test_name"`
-	Inputs     []*OpenAPITestRunInput `json:"inputs"`
+type OpenAPITestInfo struct {
+	ProjectKey string              `json:"project_key"`
+	TestName   string              `json:"test_name"`
+	Inputs     []*OpenAPITestInput `json:"inputs"`
 }
 
-type OpenAPITestRunInput struct {
+type OpenAPITestInput struct {
 	Key          string   `json:"key"`
 	Value        string   `json:"value,omitempty"`
 	Type         string   `json:"type,omitempty"`

--- a/pkg/microservice/aslan/core/workflow/testing/service/types.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/types.go
@@ -345,6 +345,23 @@ type OpenAPICreateTestTaskResp struct {
 	TaskID int64 `json:"task_id"`
 }
 
+type OpenAPITestRunConfig struct {
+	ProjectKey string                       `json:"project_key"`
+	TestName   string                       `json:"test_name"`
+	Inputs     []*OpenAPITestRunConfigInput `json:"inputs"`
+}
+
+type OpenAPITestRunConfigInput struct {
+	Key          string   `json:"key"`
+	Value        string   `json:"value,omitempty"`
+	Type         string   `json:"type,omitempty"`
+	ChoiceOption []string `json:"choice_option,omitempty"`
+	Required     bool     `json:"required"`
+	IsCredential bool     `json:"is_credential"`
+	HasValue     bool     `json:"has_value"`
+	Description  string   `json:"description,omitempty"`
+}
+
 type OpenAPIScanTaskDetail struct {
 	ScanName   string                  `json:"scan_name"`
 	Creator    string                  `json:"creator"`

--- a/pkg/microservice/aslan/core/workflow/testing/service/types.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/types.go
@@ -345,13 +345,13 @@ type OpenAPICreateTestTaskResp struct {
 	TaskID int64 `json:"task_id"`
 }
 
-type OpenAPITestRunConfig struct {
-	ProjectKey string                       `json:"project_key"`
-	TestName   string                       `json:"test_name"`
-	Inputs     []*OpenAPITestRunConfigInput `json:"inputs"`
+type OpenAPITestRunInfo struct {
+	ProjectKey string                 `json:"project_key"`
+	TestName   string                 `json:"test_name"`
+	Inputs     []*OpenAPITestRunInput `json:"inputs"`
 }
 
-type OpenAPITestRunConfigInput struct {
+type OpenAPITestRunInput struct {
 	Key          string   `json:"key"`
 	Value        string   `json:"value,omitempty"`
 	Type         string   `json:"type,omitempty"`

--- a/pkg/microservice/aslan/core/workflow/testing/service/types_test.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/types_test.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/koderover/zadig/v2/pkg/types"
+)
+
+func TestOpenAPICreateTestTaskReqValidateRepositoryRef(t *testing.T) {
+	tests := []struct {
+		name      string
+		repo      *types.OpenAPIRepoInput
+		wantValid bool
+		wantError string
+	}{
+		{
+			name: "branch ref",
+			repo: &types.OpenAPIRepoInput{
+				CodeHostName:  "github",
+				RepoNamespace: "koderover",
+				RepoName:      "zadig",
+				Branch:        "main",
+			},
+			wantValid: true,
+		},
+		{
+			name: "commit ref without branch",
+			repo: &types.OpenAPIRepoInput{
+				CodeHostName:  "github",
+				RepoNamespace: "koderover",
+				RepoName:      "zadig",
+				EnableCommit:  true,
+				CommitID:      "abc123",
+			},
+			wantValid: true,
+		},
+		{
+			name: "commit ref without commit id",
+			repo: &types.OpenAPIRepoInput{
+				CodeHostName:  "github",
+				RepoNamespace: "koderover",
+				RepoName:      "zadig",
+				Branch:        "main",
+				EnableCommit:  true,
+			},
+			wantError: "repo_info[0] commit_id cannot be empty when enable_commit is true",
+		},
+		{
+			name: "branch ref without branch",
+			repo: &types.OpenAPIRepoInput{
+				CodeHostName:  "github",
+				RepoNamespace: "koderover",
+				RepoName:      "zadig",
+			},
+			wantError: "repo_info[0] branch cannot be empty when enable_commit is false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &OpenAPICreateTestTaskReq{
+				ProjectName: "project",
+				TestName:    "test",
+				RepoInfo:    []*types.OpenAPIRepoInput{tt.repo},
+			}
+
+			valid, err := req.Validate()
+			assert.Equal(t, tt.wantValid, valid)
+			if tt.wantError == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.EqualError(t, err, tt.wantError)
+		})
+	}
+}

--- a/pkg/types/openapi.go
+++ b/pkg/types/openapi.go
@@ -139,6 +139,12 @@ type KV struct {
 	Type string `json:"type,omitempty"`
 	// 是否为敏感信息
 	IsCredential bool `json:"is_credential,omitempty"`
+	// 文件 ID
+	FileID string `json:"file_id,omitempty"`
+	// 文件名称
+	FileName string `json:"file_name,omitempty"`
+	// 文件路径
+	FilePath string `json:"file_path,omitempty"`
 }
 
 type OpenAPIUserBriefInfo struct {


### PR DESCRIPTION
### Summary
- Support test task runtime overrides and preflight discovery.
### Main Changes
- Preserve configured repositories and runtime defaults.
- Add `GET /openapi/quality/testing/:testName/config`.
- Return safe input metadata under `test.execute` permission.
### Risk / Compatibility
- Existing requests keep configured defaults; the endpoint is additive and read-only.
### Test
- `go test ./pkg/microservice/aslan/core/workflow/testing/...`
- `go vet ./pkg/microservice/aslan/core/workflow/testing/...`
Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4864)
<!-- Reviewable:end -->
