### PR TITLE
fix: skip missing service image only deploy

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_deploy.go
@@ -141,6 +141,12 @@ func (c *DeployJobCtl) run(ctx context.Context) error {
 		logError(c.job, msg, c.logger)
 		return errors.New(msg)
 	}
+	if len(c.jobTaskSpec.DeployContents) == 1 && slices.Contains(c.jobTaskSpec.DeployContents, config.DeployImage) &&
+		env.GetServiceMap()[c.jobTaskSpec.ServiceName] == nil {
+		msg := fmt.Sprintf("service %s not found in env %s/%s", c.jobTaskSpec.ServiceName, env.ProductName, env.EnvName)
+		logError(c.job, msg, c.logger)
+		return errors.New(msg)
+	}
 
 	c.namespace = env.Namespace
 	c.jobTaskSpec.ClusterID = env.ClusterID

--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_deploy.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_deploy.go
@@ -462,15 +462,8 @@ func (j DeployJobController) ToTask(taskID int64) ([]*commonmodels.JobTask, erro
 			}
 		}
 
-		services := make([]*commonmodels.DeployServiceInfo, 0, len(j.jobSpec.Services))
 		for _, service := range j.jobSpec.Services {
 			moduleList := make([]*commonmodels.DeployModuleInfo, 0)
-
-			if len(j.jobSpec.DeployContents) == 1 && slices.Contains(j.jobSpec.DeployContents, config.DeployImage) {
-				if _, ok := productServiceMap[service.ServiceName]; !ok {
-					continue
-				}
-			}
 
 			deployService, ok := deployServiceMap[service.ServiceName]
 			if !ok {
@@ -484,9 +477,7 @@ func (j DeployJobController) ToTask(taskID int64) ([]*commonmodels.JobTask, erro
 				}
 			}
 			service.Modules = moduleList
-			services = append(services, service)
 		}
-		j.jobSpec.Services = services
 	}
 
 	serviceMap := map[string]*commonmodels.DeployServiceInfo{}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_deploy.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_deploy.go
@@ -462,8 +462,15 @@ func (j DeployJobController) ToTask(taskID int64) ([]*commonmodels.JobTask, erro
 			}
 		}
 
+		services := make([]*commonmodels.DeployServiceInfo, 0, len(j.jobSpec.Services))
 		for _, service := range j.jobSpec.Services {
 			moduleList := make([]*commonmodels.DeployModuleInfo, 0)
+
+			if len(j.jobSpec.DeployContents) == 1 && slices.Contains(j.jobSpec.DeployContents, config.DeployImage) {
+				if _, ok := productServiceMap[service.ServiceName]; !ok {
+					continue
+				}
+			}
 
 			deployService, ok := deployServiceMap[service.ServiceName]
 			if !ok {
@@ -477,7 +484,9 @@ func (j DeployJobController) ToTask(taskID int64) ([]*commonmodels.JobTask, erro
 				}
 			}
 			service.Modules = moduleList
+			services = append(services, service)
 		}
+		j.jobSpec.Services = services
 	}
 
 	serviceMap := map[string]*commonmodels.DeployServiceInfo{}


### PR DESCRIPTION
### What this PR does / Why we need it:

Prevents missing services from being deployed during image-only deployments.

### What is changed and how it works?

The missing service job now fails during execution without affecting other service jobs.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4865)
<!-- Reviewable:end -->
