### PR TITLE
fix: make OpenAPI checkout path optional

### DIFF
--- a/pkg/types/openapi.go
+++ b/pkg/types/openapi.go
@@ -42,7 +42,7 @@ type OpenAPIRepoInput struct {
 	// 远程名称
 	RemoteName string `json:"remote_name" binding:"required"`
 	// 检出路径
-	CheckoutPath string `json:"checkout_path" binding:"required"`
+	CheckoutPath string `json:"checkout_path"`
 	// 是否使用子模块
 	SubModules bool `json:"submodules"`
 


### PR DESCRIPTION
### Summary
- Allow OpenAPI repository inputs to omit `checkout_path`.

### Why
- Build execution already defaults an empty checkout path to the repository name.

### Risk / Compatibility
- Low risk; existing non-empty values are unchanged.

### Test
- `go test ./pkg/types`
- `go vet ./pkg/types`
- Empty checkout path binding regression verified locally.

### Contact
Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4867)
<!-- Reviewable:end -->
