### PR TITLE
feat: add Helm Values auto-sync status

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/template/product.go
+++ b/pkg/microservice/aslan/core/common/repository/models/template/product.go
@@ -130,6 +130,7 @@ type CustomYaml struct {
 	RenderVariableKVs []*commontypes.RenderVariableKV `bson:"render_variable_kvs"               json:"render_variable_kvs"`
 	Source            string                          `bson:"source"                            json:"source"`
 	AutoSync          bool                            `bson:"auto_sync"                         json:"auto_sync"`
+	AutoSyncStatus    string                          `bson:"auto_sync_status,omitempty"        json:"auto_sync_status,omitempty"`
 	AutoSyncYaml      string                          `bson:"auto_sync_yaml"                    json:"auto_sync_yaml"`
 	SourceDetail      interface{}                     `bson:"source_detail"                     json:"source_detail"`
 	SourceID          string                          `bson:"source_id"                         json:"source_id"`

--- a/pkg/microservice/aslan/core/common/repository/mongodb/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/product.go
@@ -545,6 +545,9 @@ func (c *ProductColl) UpdateServiceAutoSyncStatus(productName, envName string, p
 	query, serviceFilter := buildServiceValuesSourceQuery(productName, envName, production, isHelmChartDeploy, identifier)
 	valuesPath := "services.$[].$[svc].render.override_yaml.auto_sync_status"
 	change := bson.M{"$set": bson.M{valuesPath: status}}
+	if status == "" {
+		change = bson.M{"$unset": bson.M{valuesPath: ""}}
+	}
 	arrayFilters := options.ArrayFilters{Filters: []interface{}{serviceFilter}}
 	updateOptions := options.UpdateOptions{ArrayFilters: &arrayFilters}
 

--- a/pkg/microservice/aslan/core/common/repository/mongodb/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/product.go
@@ -541,14 +541,53 @@ func (c *ProductColl) UpdateServiceValuesSource(productName, envName string, pro
 	return nil
 }
 
-func (c *ProductColl) UpdateServiceAutoSyncStatus(productName, envName string, production, isHelmChartDeploy bool, identifier, status string) error {
-	query, serviceFilter := buildServiceValuesSourceQuery(productName, envName, production, isHelmChartDeploy, identifier)
+func (c *ProductColl) UpdateServicesAutoSyncStatus(productName, envName string, production bool, serviceNames, releaseNames []string, status string) error {
+	if len(serviceNames) == 0 && len(releaseNames) == 0 {
+		return nil
+	}
+
+	matchServices := make([]bson.M, 0, 2)
+	serviceFilters := make([]bson.M, 0, 2)
+	if len(serviceNames) > 0 {
+		matchServices = append(matchServices, bson.M{
+			"service_name": bson.M{"$in": serviceNames},
+			"type":         bson.M{"$ne": setting.HelmChartDeployType},
+		})
+		serviceFilters = append(serviceFilters, bson.M{
+			"svc.service_name": bson.M{"$in": serviceNames},
+			"svc.type":         bson.M{"$ne": setting.HelmChartDeployType},
+		})
+	}
+	if len(releaseNames) > 0 {
+		matchServices = append(matchServices, bson.M{
+			"release_name": bson.M{"$in": releaseNames},
+			"type":         setting.HelmChartDeployType,
+		})
+		serviceFilters = append(serviceFilters, bson.M{
+			"svc.release_name": bson.M{"$in": releaseNames},
+			"svc.type":         setting.HelmChartDeployType,
+		})
+	}
+
+	query := bson.M{
+		"env_name":     envName,
+		"product_name": productName,
+		"services": bson.M{"$elemMatch": bson.M{"$elemMatch": bson.M{
+			"$or": matchServices,
+		}}},
+	}
+	if production {
+		query["production"] = true
+	} else {
+		query["$or"] = []bson.M{{"production": bson.M{"$eq": false}}, {"production": bson.M{"$exists": false}}}
+	}
+
 	valuesPath := "services.$[].$[svc].render.override_yaml.auto_sync_status"
 	change := bson.M{"$set": bson.M{valuesPath: status}}
 	if status == "" {
 		change = bson.M{"$unset": bson.M{valuesPath: ""}}
 	}
-	arrayFilters := options.ArrayFilters{Filters: []interface{}{serviceFilter}}
+	arrayFilters := options.ArrayFilters{Filters: []interface{}{bson.M{"$or": serviceFilters}}}
 	updateOptions := options.UpdateOptions{ArrayFilters: &arrayFilters}
 
 	result, err := c.UpdateOne(mongotool.SessionContext(context.TODO(), c.Session), query, change, &updateOptions)
@@ -556,7 +595,7 @@ func (c *ProductColl) UpdateServiceAutoSyncStatus(productName, envName string, p
 		return err
 	}
 	if result.MatchedCount == 0 {
-		return fmt.Errorf("no matching service found to update auto sync status: %s", identifier)
+		return fmt.Errorf("no matching services found to update auto sync status")
 	}
 	return nil
 }

--- a/pkg/microservice/aslan/core/common/repository/mongodb/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/product.go
@@ -541,6 +541,23 @@ func (c *ProductColl) UpdateServiceValuesSource(productName, envName string, pro
 	return nil
 }
 
+func (c *ProductColl) UpdateServiceAutoSyncStatus(productName, envName string, production, isHelmChartDeploy bool, identifier, status string) error {
+	query, serviceFilter := buildServiceValuesSourceQuery(productName, envName, production, isHelmChartDeploy, identifier)
+	valuesPath := "services.$[].$[svc].render.override_yaml.auto_sync_status"
+	change := bson.M{"$set": bson.M{valuesPath: status}}
+	arrayFilters := options.ArrayFilters{Filters: []interface{}{serviceFilter}}
+	updateOptions := options.UpdateOptions{ArrayFilters: &arrayFilters}
+
+	result, err := c.UpdateOne(mongotool.SessionContext(context.TODO(), c.Session), query, change, &updateOptions)
+	if err != nil {
+		return err
+	}
+	if result.MatchedCount == 0 {
+		return fmt.Errorf("no matching service found to update auto sync status: %s", identifier)
+	}
+	return nil
+}
+
 func buildServiceValuesSourceQuery(productName, envName string, production, isHelmChartDeploy bool, identifier string) (bson.M, bson.M) {
 	identifierField := "service_name"
 	typeFilter := interface{}(bson.M{"$ne": setting.HelmChartDeployType})

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2084,6 +2084,23 @@ func populateHelmValuesSourceCommits(chartValues []*commonservice.HelmSvcRenderA
 	}
 }
 
+func updateHelmAutoSyncStatuses(product *commonmodels.Product, renders []*templatemodels.ServiceRender, status string) error {
+	for _, render := range renders {
+		if render == nil || render.OverrideYaml == nil || !render.OverrideYaml.AutoSync {
+			continue
+		}
+		identifier := render.ServiceName
+		if render.IsHelmChartDeploy {
+			identifier = render.ReleaseName
+		}
+		if err := commonrepo.NewProductColl().UpdateServiceAutoSyncStatus(product.ProductName, product.EnvName, product.Production, render.IsHelmChartDeploy, identifier, status); err != nil {
+			return err
+		}
+		render.OverrideYaml.AutoSyncStatus = status
+	}
+	return nil
+}
+
 func SyncHelmProductEnvironment(productName, envName, requestID string, log *zap.SugaredLogger) error {
 	syncLock := cache.NewRedisLockWithExpiry(fmt.Sprintf("%s:%s:%s", SyncHelmEnvVariablesLockKey, productName, envName), time.Second*1800)
 	err := syncLock.TryLock()
@@ -2133,9 +2150,21 @@ func SyncHelmProductEnvironment(productName, envName, requestID string, log *zap
 		util.Go(func() {
 			defer wg.Done()
 
+			if err := updateHelmAutoSyncStatuses(product, []*templatemodels.ServiceRender{chartInfo}, setting.HelmAutoSyncStatusPending); err != nil {
+				log.Errorf("failed to update Helm Values auto sync status to pending, serviceName: %s, err: %s", chartInfo.ServiceName, err)
+			}
 			changed, values, err := commonservice.SyncYamlFromSource(chartInfo.OverrideYaml, chartInfo.OverrideYaml.YamlContent, chartInfo.OverrideYaml.AutoSyncYaml)
 			if err != nil {
+				if statusErr := updateHelmAutoSyncStatuses(product, []*templatemodels.ServiceRender{chartInfo}, setting.HelmAutoSyncStatusFailed); statusErr != nil {
+					log.Errorf("failed to update Helm Values auto sync status to failed, serviceName: %s, err: %s", chartInfo.ServiceName, statusErr)
+				}
 				log.Errorf("failed to sync yaml from source, serviceName: %s, err: %s", chartInfo.ServiceName, err)
+				return
+			}
+			if !changed {
+				if statusErr := updateHelmAutoSyncStatuses(product, []*templatemodels.ServiceRender{chartInfo}, setting.HelmAutoSyncStatusSynced); statusErr != nil {
+					log.Errorf("failed to update Helm Values auto sync status to synced, serviceName: %s, err: %s", chartInfo.ServiceName, statusErr)
+				}
 				return
 			}
 
@@ -2289,12 +2318,24 @@ func updateHelmProductVariable(productResp *commonmodels.Product, userName, requ
 			}
 		}()
 
+		if syncLock != nil {
+			if statusErr := updateHelmAutoSyncStatuses(productResp, productResp.ServiceRenders, setting.HelmAutoSyncStatusSyncing); statusErr != nil {
+				log.Errorf("failed to update Helm Values auto sync status to syncing: %v", statusErr)
+			}
+		}
 		err := kube.DeployMultiHelmRelease(productResp, helmClient, nil, userName, log)
+		autoSyncStatus := setting.HelmAutoSyncStatusSynced
 		if err != nil {
+			autoSyncStatus = setting.HelmAutoSyncStatusFailed
 			log.Errorf("error occurred when upgrading services in env: %s/%s, err: %s ", productName, envName, err)
 			// 发送更新产品失败消息给用户
 			title := fmt.Sprintf("更新 [%s] 的 [%s] 环境失败", productName, envName)
 			notify.SendErrorMessage(userName, title, requestID, err, log)
+		}
+		if syncLock != nil {
+			if statusErr := updateHelmAutoSyncStatuses(productResp, productResp.ServiceRenders, autoSyncStatus); statusErr != nil {
+				log.Errorf("failed to update Helm Values auto sync result: %v", statusErr)
+			}
 		}
 		productResp.Status = setting.ProductStatusSuccess
 		if err = commonrepo.NewProductColl().UpdateStatusAndError(envName, productName, productResp.Status, ""); err != nil {

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2085,16 +2085,24 @@ func populateHelmValuesSourceCommits(chartValues []*commonservice.HelmSvcRenderA
 }
 
 func updateHelmAutoSyncStatuses(product *commonmodels.Product, renders []*templatemodels.ServiceRender, status string) error {
+	serviceNames := make([]string, 0)
+	releaseNames := make([]string, 0)
 	for _, render := range renders {
 		if render == nil || render.OverrideYaml == nil {
 			continue
 		}
-		identifier := render.ServiceName
 		if render.IsHelmChartDeploy {
-			identifier = render.ReleaseName
+			releaseNames = append(releaseNames, render.ReleaseName)
+		} else {
+			serviceNames = append(serviceNames, render.ServiceName)
 		}
-		if err := commonrepo.NewProductColl().UpdateServiceAutoSyncStatus(product.ProductName, product.EnvName, product.Production, render.IsHelmChartDeploy, identifier, status); err != nil {
-			return err
+	}
+	if err := commonrepo.NewProductColl().UpdateServicesAutoSyncStatus(product.ProductName, product.EnvName, product.Production, serviceNames, releaseNames, status); err != nil {
+		return err
+	}
+	for _, render := range renders {
+		if render == nil || render.OverrideYaml == nil {
+			continue
 		}
 		render.OverrideYaml.AutoSyncStatus = status
 	}

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -2086,7 +2086,7 @@ func populateHelmValuesSourceCommits(chartValues []*commonservice.HelmSvcRenderA
 
 func updateHelmAutoSyncStatuses(product *commonmodels.Product, renders []*templatemodels.ServiceRender, status string) error {
 	for _, render := range renders {
-		if render == nil || render.OverrideYaml == nil || !render.OverrideYaml.AutoSync {
+		if render == nil || render.OverrideYaml == nil {
 			continue
 		}
 		identifier := render.ServiceName
@@ -2150,21 +2150,9 @@ func SyncHelmProductEnvironment(productName, envName, requestID string, log *zap
 		util.Go(func() {
 			defer wg.Done()
 
-			if err := updateHelmAutoSyncStatuses(product, []*templatemodels.ServiceRender{chartInfo}, setting.HelmAutoSyncStatusPending); err != nil {
-				log.Errorf("failed to update Helm Values auto sync status to pending, serviceName: %s, err: %s", chartInfo.ServiceName, err)
-			}
 			changed, values, err := commonservice.SyncYamlFromSource(chartInfo.OverrideYaml, chartInfo.OverrideYaml.YamlContent, chartInfo.OverrideYaml.AutoSyncYaml)
 			if err != nil {
-				if statusErr := updateHelmAutoSyncStatuses(product, []*templatemodels.ServiceRender{chartInfo}, setting.HelmAutoSyncStatusFailed); statusErr != nil {
-					log.Errorf("failed to update Helm Values auto sync status to failed, serviceName: %s, err: %s", chartInfo.ServiceName, statusErr)
-				}
 				log.Errorf("failed to sync yaml from source, serviceName: %s, err: %s", chartInfo.ServiceName, err)
-				return
-			}
-			if !changed {
-				if statusErr := updateHelmAutoSyncStatuses(product, []*templatemodels.ServiceRender{chartInfo}, setting.HelmAutoSyncStatusSynced); statusErr != nil {
-					log.Errorf("failed to update Helm Values auto sync status to synced, serviceName: %s, err: %s", chartInfo.ServiceName, statusErr)
-				}
 				return
 			}
 
@@ -2307,6 +2295,11 @@ func updateHelmProductVariable(productResp *commonmodels.Product, userName, requ
 		}
 		return e.ErrUpdateEnv.AddDesc(e.UpdateEnvStatusErrMsg)
 	}
+	if syncLock != nil {
+		if err := updateHelmAutoSyncStatuses(productResp, productResp.ServiceRenders, setting.HelmAutoSyncStatusSyncing); err != nil {
+			log.Errorf("failed to update Helm Values auto sync status to syncing: %v", err)
+		}
+	}
 
 	go func() {
 		defer func() {
@@ -2314,28 +2307,19 @@ func updateHelmProductVariable(productResp *commonmodels.Product, userName, requ
 				log.Errorf("panic in updateHelmProductVariable async function, project: %s, env: %s, panic: %v", productName, envName, r)
 			}
 			if syncLock != nil {
+				if err := updateHelmAutoSyncStatuses(productResp, productResp.ServiceRenders, ""); err != nil {
+					log.Errorf("failed to clear Helm Values auto sync status: %v", err)
+				}
 				syncLock.Unlock()
 			}
 		}()
 
-		if syncLock != nil {
-			if statusErr := updateHelmAutoSyncStatuses(productResp, productResp.ServiceRenders, setting.HelmAutoSyncStatusSyncing); statusErr != nil {
-				log.Errorf("failed to update Helm Values auto sync status to syncing: %v", statusErr)
-			}
-		}
 		err := kube.DeployMultiHelmRelease(productResp, helmClient, nil, userName, log)
-		autoSyncStatus := setting.HelmAutoSyncStatusSynced
 		if err != nil {
-			autoSyncStatus = setting.HelmAutoSyncStatusFailed
 			log.Errorf("error occurred when upgrading services in env: %s/%s, err: %s ", productName, envName, err)
 			// 发送更新产品失败消息给用户
 			title := fmt.Sprintf("更新 [%s] 的 [%s] 环境失败", productName, envName)
 			notify.SendErrorMessage(userName, title, requestID, err, log)
-		}
-		if syncLock != nil {
-			if statusErr := updateHelmAutoSyncStatuses(productResp, productResp.ServiceRenders, autoSyncStatus); statusErr != nil {
-				log.Errorf("failed to update Helm Values auto sync result: %v", statusErr)
-			}
 		}
 		productResp.Status = setting.ProductStatusSuccess
 		if err = commonrepo.NewProductColl().UpdateStatusAndError(envName, productName, productResp.Status, ""); err != nil {

--- a/pkg/microservice/aslan/core/environment/service/helm.go
+++ b/pkg/microservice/aslan/core/environment/service/helm.go
@@ -77,6 +77,7 @@ type HelmReleaseResp struct {
 	IsHelmChartDeploy bool                          `json:"isHelmChartDeploy"`
 	DeployStrategy    setting.ServiceDeployStrategy `json:"deployStrategy"`
 	Error             string                        `json:"error"`
+	AutoSyncStatus    string                        `json:"autoSyncStatus"`
 }
 
 type HelmServiceDiffSummary struct {
@@ -562,6 +563,7 @@ func ListReleases(args *HelmReleaseQueryArgs, envName string, production bool, l
 			Updatable:      updatable,
 			DeployStrategy: prod.ServiceDeployStrategy[svcDataSet.ProdSvc.ServiceName],
 			Error:          svcDataSet.ProdSvc.Error,
+			AutoSyncStatus: svcDataSet.ProdSvc.GetServiceRender().OverrideYaml.AutoSyncStatus,
 		}
 		respObj.Updatable = updatable
 

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -393,6 +393,14 @@ const (
 	ProductStatusUnstable = "Unstable"
 )
 
+// Helm Values auto sync status.
+const (
+	HelmAutoSyncStatusPending = "pending"
+	HelmAutoSyncStatusSyncing = "syncing"
+	HelmAutoSyncStatusSynced  = "synced"
+	HelmAutoSyncStatusFailed  = "failed"
+)
+
 // DeliveryVersion status
 
 type DeliveryVersionStatus string

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -393,13 +393,7 @@ const (
 	ProductStatusUnstable = "Unstable"
 )
 
-// Helm Values auto sync status.
-const (
-	HelmAutoSyncStatusPending = "pending"
-	HelmAutoSyncStatusSyncing = "syncing"
-	HelmAutoSyncStatusSynced  = "synced"
-	HelmAutoSyncStatusFailed  = "failed"
-)
+const HelmAutoSyncStatusSyncing = "syncing"
 
 // DeliveryVersion status
 


### PR DESCRIPTION
### What this PR does / Why we need it:

Adds visibility into Helm Git Values auto-sync progress so users can see when Values are being fetched or deployed.

### What is changed and how it works?

- Adds `autoSyncStatus` to the Helm releases API.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4869)
<!-- Reviewable:end -->
