### PR TITLE
fix: sync release plan job status on workflow retry

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/release_plan.go
@@ -128,6 +128,39 @@ func (c *ReleasePlanColl) UpdateByID(ctx context.Context, idString string, args 
 	return err
 }
 
+// ResetWorkflowJobForRetry resets a release plan workflow job after its workflow task is retried directly.
+// The workflow name and task ID together identify the release job to avoid updating an unrelated task.
+func (c *ReleasePlanColl) ResetWorkflowJobForRetry(ctx context.Context, idString, workflowName string, taskID int64) error {
+	id, err := primitive.ObjectIDFromHex(idString)
+	if err != nil {
+		return fmt.Errorf("invalid release plan id")
+	}
+
+	query := bson.M{
+		"_id": id,
+		"jobs": bson.M{"$elemMatch": bson.M{
+			"type":               config.JobWorkflow,
+			"spec.workflow.name": workflowName,
+			"spec.task_id":       taskID,
+		}},
+	}
+	change := bson.M{"$set": bson.M{
+		"jobs.$.status":      config.ReleasePlanJobStatusRunning,
+		"jobs.$.spec.status": config.StatusPrepare,
+		"status":             config.ReleasePlanStatusExecuting,
+		"success_time":       int64(0),
+	}}
+
+	result, err := c.UpdateOne(ctx, query, change)
+	if err != nil {
+		return err
+	}
+	if result.MatchedCount == 0 {
+		return fmt.Errorf("release plan workflow job not found, workflow: %s, task ID: %d", workflowName, taskID)
+	}
+	return nil
+}
+
 func (c *ReleasePlanColl) DeleteByID(ctx context.Context, idString string) error {
 	id, err := primitive.ObjectIDFromHex(idString)
 	if err != nil {

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -1185,6 +1185,16 @@ func RetryWorkflowTaskV4(workflowName string, taskID int64, logger *zap.SugaredL
 		log.Errorf("retry workflow task error: %v", err)
 		return e.ErrCreateTask.AddDesc(fmt.Sprintf("重试工作流任务失败: %s", err.Error()))
 	}
+	if task.ReleasePlan != nil {
+		if err := commonrepo.NewReleasePlanColl().ResetWorkflowJobForRetry(
+			context.Background(), task.ReleasePlan.ID, task.WorkflowName, task.TaskID,
+		); err != nil {
+			logger.Errorf(
+				"failed to reset release plan workflow job after retry, release plan: %s, workflow: %s, task ID: %d, error: %v",
+				task.ReleasePlan.ID, task.WorkflowName, task.TaskID, err,
+			)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
### What this PR does / Why we need it:

Fixes release plan job status not being updated when a release-plan-triggered workflow is retried directly from the workflow page.

### What is changed and how it works?

After a workflow retry starts successfully, the workflow’s release plan reference, workflow name, and task ID are used to locate the corresponding release job. The release job is reset to `running`, and the release plan is reset to `executing`, allowing the existing watcher to update the job when the retry completes.


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4871)
<!-- Reviewable:end -->
