### PR TITLE
fix: include service names in resource conflict errors

### DIFF
--- a/pkg/microservice/aslan/core/common/service/kube/apply.go
+++ b/pkg/microservice/aslan/core/common/service/kube/apply.go
@@ -19,7 +19,6 @@ package kube
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -451,7 +450,7 @@ func checkResourcesAppliedByOtherEnvs(resources []*commonmodels.ServiceResource,
 		}
 	}
 
-	resourceOwners := make(map[string]sets.String)
+	resourceConflicts := sets.NewString()
 
 	for _, env := range envs {
 		for _, svc := range env.GetServiceMap() {
@@ -461,25 +460,17 @@ func checkResourcesAppliedByOtherEnvs(resources []*commonmodels.ServiceResource,
 			for _, res := range svc.Resources {
 				resourceKey := res.String()
 				if clusterResSet.Has(resourceKey) || env.Namespace == productInfo.Namespace && namespacedResSet.Has(resourceKey) {
-					if _, ok := resourceOwners[resourceKey]; !ok {
-						resourceOwners[resourceKey] = sets.NewString()
-					}
-					resourceOwners[resourceKey].Insert(fmt.Sprintf("%s/%s/%s", env.ProductName, env.EnvName, svc.ServiceName))
+					resourceConflicts.Insert(fmt.Sprintf("resource %q is already applied by service %q in environment %q of project %q", resourceKey, svc.ServiceName, env.EnvName, env.ProductName))
 				}
 			}
 		}
 	}
 
-	if len(resourceOwners) == 0 {
+	if resourceConflicts.Len() == 0 {
 		return nil
 	}
 
-	resourcesWithOwners := make([]string, 0, len(resourceOwners))
-	for resource, owners := range resourceOwners {
-		resourcesWithOwners = append(resourcesWithOwners, fmt.Sprintf("%s: %s", resource, strings.Join(owners.List(), ", ")))
-	}
-	sort.Strings(resourcesWithOwners)
-	return fmt.Errorf("resource is applied by other envs: %s", strings.Join(resourcesWithOwners, "; "))
+	return fmt.Errorf("resource ownership conflict: %s", strings.Join(resourceConflicts.List(), "; "))
 }
 
 func isClusterScopedK8sServiceResource(kind string) bool {

--- a/pkg/microservice/aslan/core/common/service/kube/apply.go
+++ b/pkg/microservice/aslan/core/common/service/kube/apply.go
@@ -19,6 +19,7 @@ package kube
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -450,7 +451,7 @@ func checkResourcesAppliedByOtherEnvs(resources []*commonmodels.ServiceResource,
 		}
 	}
 
-	sharedNSEnvList := make(map[string]*commonmodels.Product)
+	resourceOwners := make(map[string]sets.String)
 
 	for _, env := range envs {
 		for _, svc := range env.GetServiceMap() {
@@ -460,22 +461,25 @@ func checkResourcesAppliedByOtherEnvs(resources []*commonmodels.ServiceResource,
 			for _, res := range svc.Resources {
 				resourceKey := res.String()
 				if clusterResSet.Has(resourceKey) || env.Namespace == productInfo.Namespace && namespacedResSet.Has(resourceKey) {
-					sharedNSEnvList[res.String()] = env
-					break
+					if _, ok := resourceOwners[resourceKey]; !ok {
+						resourceOwners[resourceKey] = sets.NewString()
+					}
+					resourceOwners[resourceKey].Insert(fmt.Sprintf("%s/%s/%s", env.ProductName, env.EnvName, svc.ServiceName))
 				}
 			}
 		}
 	}
 
-	if len(sharedNSEnvList) == 0 {
+	if len(resourceOwners) == 0 {
 		return nil
 	}
 
-	usedEnvStr := make([]string, 0)
-	for resource, env := range sharedNSEnvList {
-		usedEnvStr = append(usedEnvStr, fmt.Sprintf("%s: %s/%s", resource, env.ProductName, env.EnvName))
+	resourcesWithOwners := make([]string, 0, len(resourceOwners))
+	for resource, owners := range resourceOwners {
+		resourcesWithOwners = append(resourcesWithOwners, fmt.Sprintf("%s: %s", resource, strings.Join(owners.List(), ", ")))
 	}
-	return fmt.Errorf("resource is applied by other envs: %v", strings.Join(usedEnvStr, ","))
+	sort.Strings(resourcesWithOwners)
+	return fmt.Errorf("resource is applied by other envs: %s", strings.Join(resourcesWithOwners, "; "))
 }
 
 func isClusterScopedK8sServiceResource(kind string) bool {


### PR DESCRIPTION
### What this PR does / Why we need it:

Improves resource conflict errors so users can quickly identify which services reference the same Kubernetes resource.

### What is changed and how it works?

- Includes the project, environment, and service name for each conflicting resource.
- Reports all conflicting services and resources instead of only one environment.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4872)
<!-- Reviewable:end -->
