### PR TITLE
fix: unify operation log usernames

### DIFF
--- a/pkg/microservice/aslan/core/collaboration/handler/collaboration_mode.go
+++ b/pkg/microservice/aslan/core/collaboration/handler/collaboration_mode.go
@@ -74,7 +74,7 @@ func CreateCollaborationMode(c *gin.Context) {
 		return
 	}
 
-	internalhandler.InsertOperationLog(c, ctx.Account, args.ProjectName, "新增", "协作模式", detail, detail, string(data), types.RequestBodyTypeJSON, ctx.Logger)
+	internalhandler.InsertOperationLog(c, ctx.UserName, args.ProjectName, "新增", "协作模式", detail, detail, string(data), types.RequestBodyTypeJSON, ctx.Logger)
 
 	// authorization checks
 	if !ctx.Resources.IsSystemAdmin {
@@ -119,7 +119,7 @@ func UpdateCollaborationMode(c *gin.Context) {
 		return
 	}
 
-	internalhandler.InsertOperationLog(c, ctx.Account, args.ProjectName, "更新", "协作模式", detail, detail, string(data), types.RequestBodyTypeJSON, ctx.Logger)
+	internalhandler.InsertOperationLog(c, ctx.UserName, args.ProjectName, "更新", "协作模式", detail, detail, string(data), types.RequestBodyTypeJSON, ctx.Logger)
 
 	// authorization checks
 	if !ctx.Resources.IsSystemAdmin {
@@ -151,7 +151,7 @@ func DeleteCollaborationMode(c *gin.Context) {
 		return
 	}
 	name := c.Param("name")
-	internalhandler.InsertOperationLog(c, ctx.Account, projectName, "删除", "协作模式", name, name, "", types.RequestBodyTypeJSON, ctx.Logger)
+	internalhandler.InsertOperationLog(c, ctx.UserName, projectName, "删除", "协作模式", name, name, "", types.RequestBodyTypeJSON, ctx.Logger)
 
 	// authorization checks
 	if !ctx.Resources.IsSystemAdmin {

--- a/pkg/microservice/aslan/core/collaboration/handler/openapi.go
+++ b/pkg/microservice/aslan/core/collaboration/handler/openapi.go
@@ -193,7 +193,7 @@ func OpenAPICreateCollaborationMode(c *gin.Context) {
 		return
 	}
 
-	internalhandler.InsertOperationLog(c, ctx.Account, args.ProjectKey, "(OpenAPI)"+"新增", "协作模式", detail, detail, string(data), types.RequestBodyTypeJSON, ctx.Logger)
+	internalhandler.InsertOperationLog(c, ctx.UserName, args.ProjectKey, "(OpenAPI)"+"新增", "协作模式", detail, detail, string(data), types.RequestBodyTypeJSON, ctx.Logger)
 
 	// authorization checks
 	if !ctx.Resources.IsSystemAdmin {
@@ -235,7 +235,7 @@ func OpenAPIDeleteCollaborationMode(c *gin.Context) {
 		return
 	}
 	name := c.Param("name")
-	internalhandler.InsertOperationLog(c, ctx.Account, projectKey, "(OpenAPI)删除", "协作模式", name, name, "", types.RequestBodyTypeJSON, ctx.Logger)
+	internalhandler.InsertOperationLog(c, ctx.UserName, projectKey, "(OpenAPI)删除", "协作模式", name, name, "", types.RequestBodyTypeJSON, ctx.Logger)
 
 	// authorization checks
 	if !ctx.Resources.IsSystemAdmin {


### PR DESCRIPTION
### What this PR does / Why we need it:

Unifies the username displayed in operation logs to ensure the same user is recorded consistently across different operations.

### What is changed and how it works?

Updated collaboration mode operation logs, including OpenAPI, to use `ctx.UserName` instead of `ctx.Account`. 

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4875)
<!-- Reviewable:end -->
