### PR TITLE
fix: validate rendered YAML before saving templates

### DIFF
--- a/pkg/microservice/aslan/core/templatestore/service/yaml.go
+++ b/pkg/microservice/aslan/core/templatestore/service/yaml.go
@@ -966,8 +966,35 @@ func ValidateVariable(content, variable string) error {
 }
 
 func validateYamlTemplateVariableYaml(variableYaml string, templateVariables []*commontypes.ServiceVariableKV) error {
-	if strings.TrimSpace(variableYaml) == "" || len(templateVariables) == 0 {
+	if len(templateVariables) == 0 {
 		return nil
+	}
+	if strings.TrimSpace(variableYaml) == "" {
+		missingKeys := make([]string, 0, len(templateVariables))
+		for _, templateVariable := range templateVariables {
+			if templateVariable != nil {
+				missingKeys = append(missingKeys, templateVariable.Key)
+			}
+		}
+		return fmt.Errorf("template variables missing keys %v", missingKeys)
+	}
+
+	variableMap := make(map[string]interface{})
+	if err := yaml.Unmarshal([]byte(variableYaml), &variableMap); err != nil {
+		return fmt.Errorf("failed to unmarshal template variables, err: %w", err)
+	}
+
+	missingKeys := make([]string, 0)
+	for _, templateVariable := range templateVariables {
+		if templateVariable == nil {
+			continue
+		}
+		if _, ok := variableMap[templateVariable.Key]; !ok {
+			missingKeys = append(missingKeys, templateVariable.Key)
+		}
+	}
+	if len(missingKeys) > 0 {
+		return fmt.Errorf("template variables missing keys %v", missingKeys)
 	}
 
 	if _, err := commontypes.YamlToServiceVariableKV(variableYaml, templateVariables); err != nil {

--- a/pkg/microservice/aslan/core/templatestore/service/yaml.go
+++ b/pkg/microservice/aslan/core/templatestore/service/yaml.go
@@ -802,14 +802,20 @@ func UpdateYamlTemplateVariable(id string, template *template.YamlTemplate, logg
 		return fmt.Errorf("failed to find template by id: %s, err: %w", id, err)
 	}
 
-	if err := validateYamlTemplateVariableYaml(template.VariableYaml, origin.ServiceVariableKVs); err != nil {
+	templateVariables, err := getCurrentYamlTemplateVariableKVs(origin.Content, origin.ServiceVariableKVs)
+	if err != nil {
+		return fmt.Errorf("failed to get current template variables, err: %w", err)
+	}
+
+	validatedKVs, err := validateYamlTemplateVariableYaml(template.VariableYaml, templateVariables)
+	if err != nil {
 		return err
 	}
 	if err := validateYamlTemplateContent(origin.Content, origin.VariableYaml, template.VariableYaml); err != nil {
 		return fmt.Errorf("failed to validate variable, err: %w", err)
 	}
 
-	err = commonrepo.NewYamlTemplateColl().UpdateVariable(id, template.VariableYaml, template.ServiceVariableKVs)
+	err = commonrepo.NewYamlTemplateColl().UpdateVariable(id, template.VariableYaml, validatedKVs)
 	if err != nil {
 		logger.Errorf("update yaml template variable error: %s", err)
 	}
@@ -965,9 +971,36 @@ func ValidateVariable(content, variable string) error {
 	return nil
 }
 
-func validateYamlTemplateVariableYaml(variableYaml string, templateVariables []*commontypes.ServiceVariableKV) error {
+func getCurrentYamlTemplateVariableKVs(content string, originKVs []*commontypes.ServiceVariableKV) ([]*commontypes.ServiceVariableKV, error) {
+	extractVariableYaml, err := yamlutil.ExtractVariableYaml(content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract variable yaml from template content, err: %w", err)
+	}
+
+	extractedKVs, err := commontypes.YamlToServiceVariableKV(extractVariableYaml, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert extracted variables to kv, err: %w", err)
+	}
+
+	_, currentOriginKVs, err := commontypes.ClipServiceVariableKVs(extractedKVs, originKVs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to filter template variables, err: %w", err)
+	}
+
+	_, currentKVs, err := commontypes.MergeServiceVariableKVsIfNotExist(currentOriginKVs, extractedKVs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge current template variables, err: %w", err)
+	}
+	return currentKVs, nil
+}
+
+func validateYamlTemplateVariableYaml(variableYaml string, templateVariables []*commontypes.ServiceVariableKV) ([]*commontypes.ServiceVariableKV, error) {
 	if len(templateVariables) == 0 {
-		return nil
+		validatedKVs, err := commontypes.YamlToServiceVariableKV(variableYaml, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to validate template variables, err: %w", err)
+		}
+		return validatedKVs, nil
 	}
 	if strings.TrimSpace(variableYaml) == "" {
 		missingKeys := make([]string, 0, len(templateVariables))
@@ -976,12 +1009,12 @@ func validateYamlTemplateVariableYaml(variableYaml string, templateVariables []*
 				missingKeys = append(missingKeys, templateVariable.Key)
 			}
 		}
-		return fmt.Errorf("template variables missing keys %v", missingKeys)
+		return nil, fmt.Errorf("template variables missing keys %v", missingKeys)
 	}
 
 	variableMap := make(map[string]interface{})
 	if err := yaml.Unmarshal([]byte(variableYaml), &variableMap); err != nil {
-		return fmt.Errorf("failed to unmarshal template variables, err: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal template variables, err: %w", err)
 	}
 
 	missingKeys := make([]string, 0)
@@ -994,13 +1027,14 @@ func validateYamlTemplateVariableYaml(variableYaml string, templateVariables []*
 		}
 	}
 	if len(missingKeys) > 0 {
-		return fmt.Errorf("template variables missing keys %v", missingKeys)
+		return nil, fmt.Errorf("template variables missing keys %v", missingKeys)
 	}
 
-	if _, err := commontypes.YamlToServiceVariableKV(variableYaml, templateVariables); err != nil {
-		return fmt.Errorf("failed to validate template variables, err: %w", err)
+	validatedKVs, err := commontypes.YamlToServiceVariableKV(variableYaml, templateVariables)
+	if err != nil {
+		return nil, fmt.Errorf("failed to validate template variables, err: %w", err)
 	}
-	return nil
+	return validatedKVs, nil
 }
 
 func validateYamlTemplateContent(content string, variableYamls ...string) error {

--- a/pkg/microservice/aslan/core/templatestore/service/yaml.go
+++ b/pkg/microservice/aslan/core/templatestore/service/yaml.go
@@ -33,6 +33,7 @@ import (
 	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	commmonservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/command"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/kube"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/template"
 	commontypes "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/types"
 	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
@@ -710,6 +711,9 @@ func CreateYamlTemplate(template *template.YamlTemplate, logger *zap.SugaredLogg
 	if err != nil {
 		return fmt.Errorf("failed to convert variable yaml to service variable kv, err: %w", err)
 	}
+	if err := validateYamlTemplateContent(template.Content, extractVariableYmal); err != nil {
+		return fmt.Errorf("failed to validate yaml template, err: %w", err)
+	}
 
 	created := &models.YamlTemplate{
 		Name:               template.Name,
@@ -759,6 +763,9 @@ func UpdateYamlTemplate(id string, template *template.YamlTemplate, logger *zap.
 	if err != nil {
 		return fmt.Errorf("failed to merge service variables, err %w", err)
 	}
+	if err := validateYamlTemplateContent(template.Content, template.VariableYaml); err != nil {
+		return fmt.Errorf("failed to validate yaml template, err: %w", err)
+	}
 
 	updated := &models.YamlTemplate{
 		Name:               template.Name,
@@ -795,9 +802,11 @@ func UpdateYamlTemplateVariable(id string, template *template.YamlTemplate, logg
 		return fmt.Errorf("failed to find template by id: %s, err: %w", id, err)
 	}
 
-	_, err = commonutil.RenderK8sSvcYamlStrict(origin.Content, "FakeProjectName", template.Name, template.VariableYaml)
-	if err != nil {
-		return fmt.Errorf("failed to validate variable, err: %s", err)
+	if err := validateYamlTemplateVariableYaml(template.VariableYaml, origin.ServiceVariableKVs); err != nil {
+		return err
+	}
+	if err := validateYamlTemplateContent(origin.Content, origin.VariableYaml, template.VariableYaml); err != nil {
+		return fmt.Errorf("failed to validate variable, err: %w", err)
 	}
 
 	err = commonrepo.NewYamlTemplateColl().UpdateVariable(id, template.VariableYaml, template.ServiceVariableKVs)
@@ -940,7 +949,7 @@ func GetSystemDefaultVariables() []*models.ChartVariable {
 }
 
 func ValidateVariable(content, variable string) error {
-	if len(content) == 0 || len(variable) == 0 {
+	if len(content) == 0 {
 		return nil
 	}
 
@@ -949,11 +958,37 @@ func ValidateVariable(content, variable string) error {
 		return fmt.Errorf("failed to marshal default system variable, err: %s", err)
 	}
 
-	_, err = commonutil.RenderK8sSvcYamlStrict(content, "FakeProjectName", "ValidateVariable", variable, string(defaultSystemVariableYaml))
-	if err != nil {
-		return fmt.Errorf("failed to validate variable, err: %s", err)
+	if err := validateYamlTemplateContent(content, variable, string(defaultSystemVariableYaml)); err != nil {
+		return fmt.Errorf("failed to validate variable, err: %w", err)
 	}
 
+	return nil
+}
+
+func validateYamlTemplateVariableYaml(variableYaml string, templateVariables []*commontypes.ServiceVariableKV) error {
+	if strings.TrimSpace(variableYaml) == "" || len(templateVariables) == 0 {
+		return nil
+	}
+
+	if _, err := commontypes.YamlToServiceVariableKV(variableYaml, templateVariables); err != nil {
+		return fmt.Errorf("failed to validate template variables, err: %w", err)
+	}
+	return nil
+}
+
+func validateYamlTemplateContent(content string, variableYamls ...string) error {
+	if strings.TrimSpace(content) == "" {
+		return nil
+	}
+
+	renderedYaml, err := commonutil.RenderK8sSvcYamlStrict(content, "FakeProjectName", "ValidateTemplate", variableYamls...)
+	if err != nil {
+		return fmt.Errorf("failed to render yaml template, err: %w", err)
+	}
+
+	if _, _, err := kube.ManifestToUnstructured(renderedYaml); err != nil {
+		return fmt.Errorf("failed to parse rendered yaml template, err: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
### What this PR does / Why we need it:

Prevents invalid YAML templates from being saved successfully. Previously, rendering or YAML parsing errors were only logged during service creation, while the invalid service could still be persisted.

### What is changed and how it works?

- Validate template variables and types before saving.
- Render templates with strict variable checking.
- Parse the rendered result as a Kubernetes manifest.
- Reject template creation or updates when validation fails.
- Add tests for missing variables, invalid YAML, and invalid boolean values.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4876)
<!-- Reviewable:end -->
