### PR TITLE
feat: expose chart template list through OpenAPI

### DIFF
--- a/pkg/microservice/aslan/core/templatestore/handler/openapi.go
+++ b/pkg/microservice/aslan/core/templatestore/handler/openapi.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+
+	templateservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/templatestore/service"
+	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
+)
+
+// @Summary List chart templates
+// @Description List chart templates and their supported system variables
+// @Tags OpenAPI
+// @Accept json
+// @Produce json
+// @Success 200 {object} templateservice.OpenAPIListChartTemplatesResponse
+// @Router /openapi/templates/charts [get]
+func OpenAPIListChartTemplates(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	ctx.Resp, ctx.RespErr = templateservice.OpenAPIListChartTemplates(ctx.Logger)
+}

--- a/pkg/microservice/aslan/core/templatestore/handler/openapi.go
+++ b/pkg/microservice/aslan/core/templatestore/handler/openapi.go
@@ -42,5 +42,13 @@ func OpenAPIListChartTemplates(c *gin.Context) {
 		return
 	}
 
+	// authorization check
+	if !ctx.Resources.IsSystemAdmin {
+		if !ctx.Resources.SystemActions.Template.View {
+			ctx.UnAuthorized = true
+			return
+		}
+	}
+
 	ctx.Resp, ctx.RespErr = templateservice.OpenAPIListChartTemplates(ctx.Logger)
 }

--- a/pkg/microservice/aslan/core/templatestore/handler/router.go
+++ b/pkg/microservice/aslan/core/templatestore/handler/router.go
@@ -22,6 +22,15 @@ import (
 
 type Router struct{}
 
+type OpenAPIRouter struct{}
+
+func (*OpenAPIRouter) Inject(router *gin.RouterGroup) {
+	charts := router.Group("charts")
+	{
+		charts.GET("", ListChartTemplates)
+	}
+}
+
 func (*Router) Inject(router *gin.RouterGroup) {
 	// ---------------------------------------------------------------------------------------
 	// chart templates

--- a/pkg/microservice/aslan/core/templatestore/handler/router.go
+++ b/pkg/microservice/aslan/core/templatestore/handler/router.go
@@ -27,7 +27,7 @@ type OpenAPIRouter struct{}
 func (*OpenAPIRouter) Inject(router *gin.RouterGroup) {
 	charts := router.Group("charts")
 	{
-		charts.GET("", ListChartTemplates)
+		charts.GET("", OpenAPIListChartTemplates)
 	}
 }
 

--- a/pkg/microservice/aslan/core/templatestore/service/chart.go
+++ b/pkg/microservice/aslan/core/templatestore/service/chart.go
@@ -133,9 +133,8 @@ func getChartTemplateDefaultVariables() []*commonmodels.ChartVariable {
 }
 
 func ListChartTemplates(logger *zap.SugaredLogger) (*ChartTemplateListResp, error) {
-	cs, err := mongodb.NewChartColl().List()
+	cs, err := listChartTemplates(logger)
 	if err != nil {
-		logger.Errorf("Failed to list chart templates, err: %s", err)
 		return nil, err
 	}
 
@@ -158,6 +157,15 @@ func ListChartTemplates(logger *zap.SugaredLogger) (*ChartTemplateListResp, erro
 	}
 
 	return ret, nil
+}
+
+func listChartTemplates(logger *zap.SugaredLogger) ([]*models.Chart, error) {
+	charts, err := mongodb.NewChartColl().List()
+	if err != nil {
+		logger.Errorf("Failed to list chart templates, err: %s", err)
+		return nil, err
+	}
+	return charts, nil
 }
 
 func GetFileContentForTemplate(name, filePath, fileName string, logger *zap.SugaredLogger) ([]byte, error) {

--- a/pkg/microservice/aslan/core/templatestore/service/chart.go
+++ b/pkg/microservice/aslan/core/templatestore/service/chart.go
@@ -133,8 +133,9 @@ func getChartTemplateDefaultVariables() []*commonmodels.ChartVariable {
 }
 
 func ListChartTemplates(logger *zap.SugaredLogger) (*ChartTemplateListResp, error) {
-	cs, err := listChartTemplates(logger)
+	cs, err := mongodb.NewChartColl().List()
 	if err != nil {
+		logger.Errorf("Failed to list chart templates, err: %s", err)
 		return nil, err
 	}
 
@@ -157,15 +158,6 @@ func ListChartTemplates(logger *zap.SugaredLogger) (*ChartTemplateListResp, erro
 	}
 
 	return ret, nil
-}
-
-func listChartTemplates(logger *zap.SugaredLogger) ([]*models.Chart, error) {
-	charts, err := mongodb.NewChartColl().List()
-	if err != nil {
-		logger.Errorf("Failed to list chart templates, err: %s", err)
-		return nil, err
-	}
-	return charts, nil
 }
 
 func GetFileContentForTemplate(name, filePath, fileName string, logger *zap.SugaredLogger) ([]byte, error) {

--- a/pkg/microservice/aslan/core/templatestore/service/openapi.go
+++ b/pkg/microservice/aslan/core/templatestore/service/openapi.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"sort"
+
+	"go.uber.org/zap"
+
+	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+)
+
+type OpenAPIListChartTemplatesResponse struct {
+	SystemVariables []*OpenAPIChartVariable `json:"system_variables"`
+	ChartTemplates  []*OpenAPIChartTemplate `json:"chart_templates"`
+}
+
+type OpenAPIChartVariable struct {
+	Key         string `json:"key"`
+	Value       string `json:"value,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+type OpenAPIChartTemplate struct {
+	Name       string `json:"name"`
+	CodeHostID int    `json:"codehost_id"`
+	Owner      string `json:"owner"`
+	Namespace  string `json:"namespace"`
+	Repo       string `json:"repo"`
+	Path       string `json:"path"`
+	Branch     string `json:"branch"`
+}
+
+func OpenAPIListChartTemplates(logger *zap.SugaredLogger) (*OpenAPIListChartTemplatesResponse, error) {
+	charts, err := listChartTemplates(logger)
+	if err != nil {
+		return nil, err
+	}
+
+	return buildOpenAPIListChartTemplatesResponse(charts), nil
+}
+
+func buildOpenAPIListChartTemplatesResponse(charts []*commonmodels.Chart) *OpenAPIListChartTemplatesResponse {
+	resp := &OpenAPIListChartTemplatesResponse{
+		SystemVariables: make([]*OpenAPIChartVariable, 0, len(ChartTemplateDefaultSystemVariable)),
+		ChartTemplates:  make([]*OpenAPIChartTemplate, 0, len(charts)),
+	}
+
+	variableKeys := make([]string, 0, len(ChartTemplateDefaultSystemVariable))
+	for key := range ChartTemplateDefaultSystemVariable {
+		variableKeys = append(variableKeys, key)
+	}
+	sort.Strings(variableKeys)
+	for _, key := range variableKeys {
+		resp.SystemVariables = append(resp.SystemVariables, &OpenAPIChartVariable{
+			Key:         key,
+			Description: ChartTemplateDefaultSystemVariable[key],
+		})
+	}
+
+	for _, chart := range charts {
+		resp.ChartTemplates = append(resp.ChartTemplates, &OpenAPIChartTemplate{
+			Name:       chart.Name,
+			CodeHostID: chart.CodeHostID,
+			Owner:      chart.Owner,
+			Namespace:  chart.GetNamespace(),
+			Repo:       chart.Repo,
+			Path:       chart.Path,
+			Branch:     chart.Branch,
+		})
+	}
+
+	return resp
+}

--- a/pkg/microservice/aslan/core/templatestore/service/openapi.go
+++ b/pkg/microservice/aslan/core/templatestore/service/openapi.go
@@ -31,7 +31,6 @@ type OpenAPIListChartTemplatesResponse struct {
 
 type OpenAPIChartVariable struct {
 	Key         string `json:"key"`
-	Value       string `json:"value,omitempty"`
 	Description string `json:"description,omitempty"`
 }
 

--- a/pkg/microservice/aslan/core/templatestore/service/openapi.go
+++ b/pkg/microservice/aslan/core/templatestore/service/openapi.go
@@ -20,8 +20,6 @@ import (
 	"sort"
 
 	"go.uber.org/zap"
-
-	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 )
 
 type OpenAPIListChartTemplatesResponse struct {
@@ -45,38 +43,36 @@ type OpenAPIChartTemplate struct {
 }
 
 func OpenAPIListChartTemplates(logger *zap.SugaredLogger) (*OpenAPIListChartTemplatesResponse, error) {
-	charts, err := listChartTemplates(logger)
+	chartTemplates, err := ListChartTemplates(logger)
 	if err != nil {
 		return nil, err
 	}
 
-	return buildOpenAPIListChartTemplatesResponse(charts), nil
+	return buildOpenAPIListChartTemplatesResponse(chartTemplates), nil
 }
 
-func buildOpenAPIListChartTemplatesResponse(charts []*commonmodels.Chart) *OpenAPIListChartTemplatesResponse {
+func buildOpenAPIListChartTemplatesResponse(chartTemplates *ChartTemplateListResp) *OpenAPIListChartTemplatesResponse {
 	resp := &OpenAPIListChartTemplatesResponse{
-		SystemVariables: make([]*OpenAPIChartVariable, 0, len(ChartTemplateDefaultSystemVariable)),
-		ChartTemplates:  make([]*OpenAPIChartTemplate, 0, len(charts)),
+		SystemVariables: make([]*OpenAPIChartVariable, 0, len(chartTemplates.SystemVariables)),
+		ChartTemplates:  make([]*OpenAPIChartTemplate, 0, len(chartTemplates.ChartTemplates)),
 	}
 
-	variableKeys := make([]string, 0, len(ChartTemplateDefaultSystemVariable))
-	for key := range ChartTemplateDefaultSystemVariable {
-		variableKeys = append(variableKeys, key)
-	}
-	sort.Strings(variableKeys)
-	for _, key := range variableKeys {
+	for _, variable := range chartTemplates.SystemVariables {
 		resp.SystemVariables = append(resp.SystemVariables, &OpenAPIChartVariable{
-			Key:         key,
-			Description: ChartTemplateDefaultSystemVariable[key],
+			Key:         variable.Key,
+			Description: variable.Description,
 		})
 	}
+	sort.Slice(resp.SystemVariables, func(i, j int) bool {
+		return resp.SystemVariables[i].Key < resp.SystemVariables[j].Key
+	})
 
-	for _, chart := range charts {
+	for _, chart := range chartTemplates.ChartTemplates {
 		resp.ChartTemplates = append(resp.ChartTemplates, &OpenAPIChartTemplate{
 			Name:       chart.Name,
-			CodeHostID: chart.CodeHostID,
+			CodeHostID: chart.CodehostID,
 			Owner:      chart.Owner,
-			Namespace:  chart.GetNamespace(),
+			Namespace:  chart.Namespace,
 			Repo:       chart.Repo,
 			Path:       chart.Path,
 			Branch:     chart.Branch,

--- a/pkg/microservice/aslan/server/rest/router.go
+++ b/pkg/microservice/aslan/server/rest/router.go
@@ -111,6 +111,7 @@ func (s *engine) injectRouterGroup(router *gin.RouterGroup) {
 		"/openapi/quality":        new(testinghandler.QualityRouter),
 		"/openapi/build":          new(buildhandler.OpenAPIRouter),
 		"/openapi/service":        new(servicehandler.OpenAPIRouter),
+		"/openapi/templates":      new(templatehandler.OpenAPIRouter),
 		"/openapi/release_plan":   new(releaseplanhandler.OpenAPIRouter),
 		"/openapi/delivery":       new(deliveryhandler.OpenAPIRouter),
 		"/openapi/cluster":        new(multiclusterhandler.OpenAPIRouter),


### PR DESCRIPTION
### Summary
- Add authenticated read-only OpenAPI for Helm Chart template discovery.
- Reuse the existing Chart template list service and response structure.
- Require Template.View permission for the OpenAPI endpoint.

### Validation
- go test ./pkg/microservice/aslan/core/templatestore/handler ./pkg/microservice/aslan/server/rest

Signed-off-by: huanghongbo-hhb <huanghongbo@koderover.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4878)
<!-- Reviewable:end -->
