### PR TITLE
feat(release-plan): check updates before save

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/release_plan.go
@@ -113,6 +113,23 @@ func (c *ReleasePlanColl) GetByID(ctx context.Context, idString string) (*models
 	return result, err
 }
 
+func (c *ReleasePlanColl) GetVersionByID(ctx context.Context, idString string) (*models.ReleasePlan, error) {
+	id, err := primitive.ObjectIDFromHex(idString)
+	if err != nil {
+		return nil, err
+	}
+
+	query := bson.M{"_id": id}
+	projection := bson.M{
+		"version":     1,
+		"updated_by":  1,
+		"update_time": 1,
+	}
+	result := new(models.ReleasePlan)
+	err = c.FindOne(ctx, query, options.FindOne().SetProjection(projection)).Decode(result)
+	return result, err
+}
+
 func (c *ReleasePlanColl) UpdateByID(ctx context.Context, idString string, args *models.ReleasePlan) error {
 	if args == nil {
 		return errors.New("nil ReleasePlan")

--- a/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
@@ -216,28 +216,78 @@ func UpdateReleasePlan(c *gin.Context) {
 		return
 	}
 
-	// Check permission based on the verb
-	if !ctx.Resources.IsSystemAdmin {
-		permitted := false
-		switch string(req.Verb) {
-		case service.ActionUpdateName, service.ActionUpdateManager, service.ActionUpdateTimeRange,
-			service.ActionUpdateScheduleExecuteTime, service.ActionUpdateDescription, service.ActionUpdateJiraSprint:
-			permitted = ctx.Resources.SystemActions.ReleasePlan.EditMetadata
-		case service.ActionUpdateApproval, service.ActionDeleteApproval:
-			permitted = ctx.Resources.SystemActions.ReleasePlan.EditApproval
-		case service.ActionUpdateReleaseJob, service.ActionCreateReleaseJob, service.ActionDeleteReleaseJob, service.ActionReorderReleaseJob:
-			permitted = ctx.Resources.SystemActions.ReleasePlan.EditSubtasks
-		default:
-			ctx.RespErr = e.ErrInvalidParam.AddDesc(fmt.Sprintf("unknown verb: %s", req.Verb))
-			return
-		}
-		if !permitted {
-			ctx.UnAuthorized = true
-			return
-		}
+	permitted, err := hasReleasePlanEditPermission(ctx, req.Verb)
+	if err != nil {
+		ctx.RespErr = err
+		return
+	}
+	if !permitted {
+		ctx.UnAuthorized = true
+		return
 	}
 
 	ctx.RespErr = service.UpdateReleasePlan(ctx, c.Param("id"), req)
+}
+
+func hasReleasePlanEditPermission(ctx *internalhandler.Context, verb service.UpdateReleasePlanVerb) (bool, error) {
+	if ctx.Resources.IsSystemAdmin {
+		return true, nil
+	}
+
+	switch verb {
+	case service.ActionUpdateName, service.ActionUpdateManager, service.ActionUpdateTimeRange,
+		service.ActionUpdateScheduleExecuteTime, service.ActionUpdateDescription, service.ActionUpdateJiraSprint:
+		return ctx.Resources.SystemActions.ReleasePlan.EditMetadata, nil
+	case service.ActionUpdateApproval, service.ActionDeleteApproval:
+		return ctx.Resources.SystemActions.ReleasePlan.EditApproval, nil
+	case service.ActionUpdateReleaseJob, service.ActionCreateReleaseJob, service.ActionDeleteReleaseJob, service.ActionReorderReleaseJob:
+		return ctx.Resources.SystemActions.ReleasePlan.EditSubtasks, nil
+	default:
+		return false, e.ErrInvalidParam.AddDesc(fmt.Sprintf("unknown verb: %s", verb))
+	}
+}
+
+func CheckReleasePlanUpdate(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.Logger.Errorf("failed to generate authorization info for user: %s, error: %s", ctx.UserID, err)
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	verb := service.UpdateReleasePlanVerb(c.Query("verb"))
+	permitted, err := hasReleasePlanEditPermission(ctx, verb)
+	if err != nil {
+		ctx.RespErr = err
+		return
+	}
+	if !permitted {
+		ctx.UnAuthorized = true
+		return
+	}
+
+	err = commonutil.CheckZadigEnterpriseLicense()
+	if err != nil {
+		ctx.RespErr = err
+		return
+	}
+
+	// This endpoint is called once immediately before saving, rather than polled while editing.
+	versionStr := strings.TrimSpace(c.Query("version"))
+	if versionStr == "" {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("version is required")
+		return
+	}
+	version, err := strconv.ParseInt(versionStr, 10, 64)
+	if err != nil || version <= 0 {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("version must be a positive integer")
+		return
+	}
+
+	ctx.Resp, ctx.RespErr = service.CheckReleasePlanUpdate(c.Param("id"), version)
 }
 
 func GetReleasePlanVersionDiff(c *gin.Context) {

--- a/pkg/microservice/aslan/core/release_plan/handler/router.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/router.go
@@ -30,6 +30,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		v1.GET("/:id/logs", GetReleasePlanLogs)
 		v1.GET("/:id/collaboration/editors", GetReleasePlanCollaborationSnapshot)
 		v1.GET("/:id/collaboration/ws", ReleasePlanCollaborationWS)
+		v1.GET("/:id/check_update", CheckReleasePlanUpdate)
 		v1.PUT("/:id", UpdateReleasePlan)
 		v1.GET("/:id/versions/:version/diff", GetReleasePlanVersionDiff)
 		v1.GET("/:id/job/:jobID", GetReleasePlanJobDetail)

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -410,6 +410,27 @@ type UpdateReleasePlanArgs struct {
 	Spec interface{}           `json:"spec"`
 }
 
+type CheckReleasePlanUpdateResponse struct {
+	HasUpdate      bool   `json:"has_update"`
+	CurrentVersion int64  `json:"current_version"`
+	UpdatedBy      string `json:"updated_by"`
+	UpdateTime     int64  `json:"update_time"`
+}
+
+func CheckReleasePlanUpdate(planID string, version int64) (*CheckReleasePlanUpdateResponse, error) {
+	plan, err := mongodb.NewReleasePlanColl().GetVersionByID(context.Background(), planID)
+	if err != nil {
+		return nil, errors.Wrap(err, "get release plan version")
+	}
+
+	return &CheckReleasePlanUpdateResponse{
+		HasUpdate:      plan.Version != version,
+		CurrentVersion: plan.Version,
+		UpdatedBy:      plan.UpdatedBy,
+		UpdateTime:     plan.UpdateTime,
+	}, nil
+}
+
 func UpdateReleasePlan(c *handler.Context, planID string, args *UpdateReleasePlanArgs) error {
 	planLock := getLock(planID)
 	if err := planLock.Lock(); err != nil {


### PR DESCRIPTION
## What changed
- Add a lightweight release-plan update check endpoint for the save flow.
- Require the same verb-scoped edit permission as the corresponding save operation.
- Validate the client version as a required positive integer.

## API
`GET /api/aslan/release_plan/v1/:id/check_update?version=<version>&verb=<verb>`

The endpoint is intended to be called once immediately before saving. It returns the current version and last update metadata when the client's version is stale.

## Verification
- `go test ./pkg/microservice/aslan/core/release_plan/service ./pkg/microservice/aslan/core/release_plan/handler ./pkg/microservice/aslan/core/common/repository/mongodb -run '^$'`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4880)
<!-- Reviewable:end -->
