### PR TITLE
fix: retry workflow job start with unstable

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job.go
@@ -205,7 +205,7 @@ func runJob(ctx context.Context, job *commonmodels.JobTask, workflowCtx *commonm
 
 	// Keep the original execution timestamps when a completed job is skipped
 	// during a workflow retry.
-	if job.Status == config.StatusPassed || job.Status == config.StatusSkipped {
+	if job.Status == config.StatusPassed || job.Status == config.StatusSkipped || job.Status == config.StatusUnstable {
 		setJobFinalStatusContext(job, workflowCtx)
 		return
 	}

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/stage.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/stage.go
@@ -67,7 +67,7 @@ func runStage(ctx context.Context, stage *commonmodels.StageTask, workflowCtx *c
 func RunStages(ctx context.Context, stages []*commonmodels.StageTask, workflowCtx *commonmodels.WorkflowTaskCtx, concurrency int, logger *zap.SugaredLogger, ack func()) {
 	for _, stage := range stages {
 		// should skip passed stage when workflow task be restarted
-		if stage.Status == config.StatusPassed {
+		if stage.Status == config.StatusPassed || stage.Status == config.StatusSkipped || stage.Status == config.StatusUnstable {
 			continue
 		}
 		runStage(ctx, stage, workflowCtx, concurrency, logger, ack)

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_task_v4.go
@@ -1145,7 +1145,7 @@ func RetryWorkflowTaskV4(workflowName string, taskID int64, logger *zap.SugaredL
 	}
 
 	for _, stage := range task.Stages {
-		if stage.Status == config.StatusPassed || stage.Status == config.StatusSkipped {
+		if stage.Status == config.StatusPassed || stage.Status == config.StatusSkipped || stage.Status == config.StatusUnstable {
 			continue
 		}
 		stage.Status = ""
@@ -1154,7 +1154,7 @@ func RetryWorkflowTaskV4(workflowName string, taskID int64, logger *zap.SugaredL
 		stage.Error = ""
 
 		for _, jobTask := range stage.Jobs {
-			if jobTask.Status == config.StatusPassed {
+			if jobTask.Status == config.StatusPassed || jobTask.Status == config.StatusSkipped || jobTask.Status == config.StatusUnstable {
 				continue
 			}
 			jobTask.Status = ""
@@ -1392,7 +1392,7 @@ func manualExecWorkflowTaskV4(task *commonmodels.WorkflowTask, workflowName stri
 
 		// for the manual executed stage itself, we need to re-render the tasks, not getting them from the previous task since it might not be right
 		if stage.Name == stageName {
-			if preStage != nil && !(preStage.Status == config.StatusPassed || preStage.Status == config.StatusSkipped) {
+			if preStage != nil && !(preStage.Status == config.StatusPassed || preStage.Status == config.StatusSkipped || preStage.Status == config.StatusUnstable) {
 				return errors.Errorf("previous stage %s status is not passed or skipped", preStage.Name)
 			}
 


### PR DESCRIPTION
### What this PR does / Why we need it:
fix: retry workflow job start with unstable

### What is changed and how it works?
fix: retry workflow job start with unstable

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4881)
<!-- Reviewable:end -->
