### PR TITLE
fix(build): return credential values for editing

### DIFF
--- a/pkg/microservice/aslan/core/common/service/build.go
+++ b/pkg/microservice/aslan/core/common/service/build.go
@@ -187,13 +187,6 @@ func EnsureDeployResp(deploy *commonmodels.Deploy) {
 		if len(deploy.PreDeploy.Envs) == 0 {
 			deploy.PreDeploy.Envs = make([]*commonmodels.KeyVal, 0)
 		}
-
-		// 隐藏用户设置的敏感信息
-		for k := range deploy.PreDeploy.Envs {
-			if deploy.PreDeploy.Envs[k].IsCredential {
-				deploy.PreDeploy.Envs[k].Value = setting.MaskValue
-			}
-		}
 	}
 }
 

--- a/pkg/microservice/aslan/core/common/service/build.go
+++ b/pkg/microservice/aslan/core/common/service/build.go
@@ -134,13 +134,6 @@ func EnsureBuildResp(build *commonmodels.Build) {
 			build.PreBuild.Envs = make([]*commonmodels.KeyVal, 0)
 		}
 
-		// 隐藏用户设置的敏感信息
-		for k := range build.PreBuild.Envs {
-			if build.PreBuild.Envs[k].IsCredential {
-				build.PreBuild.Envs[k].Value = setting.MaskValue
-			}
-		}
-
 		if len(build.PreBuild.Parameters) == 0 {
 			build.PreBuild.Parameters = make([]*commonmodels.Parameter, 0)
 		}

--- a/pkg/microservice/aslan/core/workflow/testing/service/testing.go
+++ b/pkg/microservice/aslan/core/workflow/testing/service/testing.go
@@ -387,12 +387,6 @@ func ensureTestingResp(mt *commonmodels.Testing) {
 		if len(mt.PreTest.Envs) == 0 {
 			mt.PreTest.Envs = make([]*commonmodels.KeyVal, 0)
 		}
-		// 隐藏用户设置的敏感信息
-		for k := range mt.PreTest.Envs {
-			if mt.PreTest.Envs[k].IsCredential {
-				mt.PreTest.Envs[k].Value = setting.MaskValue
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Return credential values in build configuration details for editing.
- Return credential values in testing configuration details for editing.
- Let the frontend mask values based on `is_credential`.

## Verification
- `go test -vet=off ./pkg/microservice/aslan/core/common/service ./pkg/microservice/aslan/core/workflow/testing/service`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4882)
<!-- Reviewable:end -->
