### PR TITLE
remove service name arg in restart pod openapi

### DIFF
--- a/pkg/microservice/aslan/core/environment/handler/openapi.go
+++ b/pkg/microservice/aslan/core/environment/handler/openapi.go
@@ -1776,19 +1776,14 @@ func openAPIRestartServicePod(c *gin.Context, production bool) {
 		ctx.RespErr = e.ErrInvalidParam.AddErr(err)
 		return
 	}
-	serviceName := c.Param("serviceName")
-	if serviceName == "" {
-		ctx.RespErr = e.ErrInvalidParam.AddDesc("serviceName is empty")
-		return
-	}
 	podName := c.Param("podName")
 	if podName == "" {
 		ctx.RespErr = e.ErrInvalidParam.AddDesc("podName is empty")
 		return
 	}
 
-	detail := fmt.Sprintf("环境名称:%s,服务名称:%s,pod名称:%s", envName, serviceName, podName)
-	detailEn := fmt.Sprintf("Environment Name: %s, Service Name: %s, Pod Name: %s", envName, serviceName, podName)
+	detail := fmt.Sprintf("环境名称:%s,pod名称:%s", envName, podName)
+	detailEn := fmt.Sprintf("Environment Name: %s, Pod Name: %s", envName, podName)
 	internalhandler.InsertDetailedOperationLog(c, ctx.UserName+"(openAPI)", projectName, setting.OperationSceneEnv, "重启", "环境-服务实例", detail, detailEn, "", types.RequestBodyTypeJSON, ctx.Logger, envName)
 
 	if !ctx.Resources.IsSystemAdmin {
@@ -1826,7 +1821,7 @@ func openAPIRestartServicePod(c *gin.Context, production bool) {
 		}
 	}
 
-	ctx.Resp, ctx.RespErr = service.OpenAPIRestartServicePod(projectName, envName, serviceName, podName, production, ctx.Logger)
+	ctx.Resp, ctx.RespErr = service.OpenAPIRestartServicePod(projectName, envName, podName, production, ctx.Logger)
 }
 
 func OpenAPICheckWorkloadsK8sServices(c *gin.Context) {

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -315,7 +315,7 @@ func (*OpenAPIRouter) Inject(router *gin.RouterGroup) {
 		common.GET("/:name/services/:serviceName", OpenAPIGetService)
 		common.GET("/:name/service/:serviceName/pods", OpenAPIListServicePods)
 		common.POST("/:name/service/:serviceName/restart", OpenAPIRestartService)
-		common.POST("/:name/service/:serviceName/pod/:podName/restart", OpenAPIRestartServicePod)
+		common.POST("/:name/pod/:podName/restart", OpenAPIRestartServicePod)
 
 		common.GET("/:name/check/workloads/k8services", OpenAPICheckWorkloadsK8sServices)
 		common.POST("/:name/share/enable", OpenAPIEnableBaseEnv)
@@ -352,7 +352,7 @@ func (*OpenAPIRouter) Inject(router *gin.RouterGroup) {
 		production.GET("/:name/services/:serviceName", OpenAPIGetProductionService)
 		production.GET("/:name/service/:serviceName/pods", OpenAPIListProductionServicePods)
 		production.POST("/:name/service/:serviceName/restart", OpenAPIProductionRestartService)
-		production.POST("/:name/service/:serviceName/pod/:podName/restart", OpenAPIProductionRestartServicePod)
+		production.POST("/:name/pod/:podName/restart", OpenAPIProductionRestartServicePod)
 	}
 
 	helm := router.Group("helm")

--- a/pkg/microservice/aslan/core/environment/service/openapi.go
+++ b/pkg/microservice/aslan/core/environment/service/openapi.go
@@ -195,20 +195,7 @@ func OpenAPIListServicePods(projectName, envName, serviceName string, production
 	return resp, nil
 }
 
-func OpenAPIRestartServicePod(projectName, envName, serviceName, podName string, production bool, logger *zap.SugaredLogger) (*OpenAPIRestartServicePodResponse, error) {
-	serviceResp, err := GetService(envName, projectName, serviceName, production, "", logger)
-	if err != nil {
-		return nil, err
-	}
-
-	scale, pod := findServicePod(serviceResp.Scales, podName)
-	if pod == nil {
-		return nil, e.ErrInvalidParam.AddDesc(fmt.Sprintf("pod %s does not belong to service %s", podName, serviceName))
-	}
-	if scale.Type == setting.Job {
-		return nil, e.ErrInvalidParam.AddDesc(fmt.Sprintf("restart pod is not supported for Job workload %s", scale.Name))
-	}
-
+func OpenAPIRestartServicePod(projectName, envName, podName string, production bool, logger *zap.SugaredLogger) (*OpenAPIRestartServicePodResponse, error) {
 	// Query the pod again to ensure it still exists before performing the restart.
 	if _, err := GetPodDetailInfo(projectName, envName, podName, production, logger); err != nil {
 		return nil, err


### PR DESCRIPTION
### What this PR does / Why we need it:
remove service name arg in restart pod openapi

### What is changed and how it works?
remove service name arg in restart pod openapi

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4883)
<!-- Reviewable:end -->
