### PR TITLE
fix: pass serviceName in renderset variables request body

### DIFF
--- a/pkg/microservice/aslan/core/environment/handler/renderset.go
+++ b/pkg/microservice/aslan/core/environment/handler/renderset.go
@@ -108,6 +108,10 @@ func GetServiceRenderCharts(c *gin.Context) {
 	ctx.Resp, _, ctx.RespErr = commonservice.GetSvcRenderArgs(projectKey, envName, arg.GetSvcRendersArgs, ctx.Logger)
 }
 
+type getServiceVariablesRequest struct {
+	ServiceName string `json:"serviceName"`
+}
+
 // @Summary Get service variables
 // @Description Get service variables
 // @Tags 	environment
@@ -115,9 +119,9 @@ func GetServiceRenderCharts(c *gin.Context) {
 // @Produce json
 // @Param 	projectName	query		string										true	"project name"
 // @Param 	envName		query		string										false	"env name"
-// @Param 	serviceName	query		string										true	"service name"
+// @Param 	body 		body 		getServiceVariablesRequest 					true 	"body"
 // @Success 200 		{array} 	commonservice.K8sSvcRenderArg
-// @Router /api/aslan/environment/rendersets/variables [get]
+// @Router /api/aslan/environment/rendersets/variables [post]
 func GetServiceVariables(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
@@ -175,7 +179,13 @@ func GetServiceVariables(c *gin.Context) {
 		}
 	}
 
-	ctx.Resp, _, ctx.RespErr = commonservice.GetK8sSvcRenderArgs(projectKey, envName, c.Query("serviceName"), production, ctx.Logger)
+	arg := &getServiceVariablesRequest{}
+	if err := c.ShouldBindJSON(arg); err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddErr(err)
+		return
+	}
+
+	ctx.Resp, _, ctx.RespErr = commonservice.GetK8sSvcRenderArgs(projectKey, envName, arg.ServiceName, production, ctx.Logger)
 }
 
 func GetProductDefaultValues(c *gin.Context) {

--- a/pkg/microservice/aslan/core/environment/handler/router.go
+++ b/pkg/microservice/aslan/core/environment/handler/router.go
@@ -258,7 +258,7 @@ func (*Router) Inject(router *gin.RouterGroup) {
 		rendersets.GET("/default-values", GetProductDefaultValues)
 		rendersets.GET("/globalVariables", GetGlobalVariables)
 		rendersets.GET("/yamlContent", GetYamlContent)
-		rendersets.GET("/variables", GetServiceVariables)
+		rendersets.POST("/variables", GetServiceVariables)
 	}
 
 	// ---------------------------------------------------------------------------------------


### PR DESCRIPTION
### What this PR does / Why we need it:

Update the renderset variables API to pass `serviceName` in the request body.

### What is changed and how it works?

- Change `/api/aslan/environment/rendersets/variables` from `GET` to `POST`.
- Bind `serviceName` from the POST JSON body when fetching service variables.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4885)
<!-- Reviewable:end -->
