### PR TITLE
fix: hide unauthorized release plan workflow options

### DIFF
--- a/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/handler/release_plan.go
@@ -291,7 +291,7 @@ func GetReleasePlanJobDetail(c *gin.Context) {
 		return
 	}
 
-	ctx.Resp, ctx.RespErr = service.GetReleasePlanJobDetail(c.Param("id"), c.Param("jobID"))
+	ctx.Resp, ctx.RespErr = service.GetReleasePlanJobDetail(c.Param("id"), c.Param("jobID"), ctx.Resources)
 }
 
 func DeleteReleasePlan(c *gin.Context) {

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -49,6 +49,7 @@ import (
 	workwxservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service/workwx"
 	workflowservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/workflow/service/workflow"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/workflow/service/workflow/controller"
+	workflowjobcontroller "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/workflow/service/workflow/controller/job"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/shared/client/user"
 	"github.com/koderover/zadig/v2/pkg/shared/handler"
@@ -528,7 +529,7 @@ func UpdateReleasePlan(c *handler.Context, planID string, args *UpdateReleasePla
 	return nil
 }
 
-func GetReleasePlanJobDetail(planID, jobID string) (*commonmodels.ReleaseJob, error) {
+func GetReleasePlanJobDetail(planID, jobID string, resources *user.AuthorizedResources) (*commonmodels.ReleaseJob, error) {
 	releasePlan, err := mongodb.NewReleasePlanColl().GetByID(context.Background(), planID)
 	if err != nil {
 		return nil, errors.Wrap(err, "GetReleasePlan")
@@ -539,12 +540,88 @@ func GetReleasePlanJobDetail(planID, jobID string) (*commonmodels.ReleaseJob, er
 			if err := updateReleasePlanJobWithLatestRenderedWorkflow(releasePlanJob); err != nil {
 				return nil, err
 			}
+			if err := filterReleasePlanWorkflowJobOptions(releasePlanJob, resources); err != nil {
+				return nil, err
+			}
 
 			return releasePlanJob, nil
 		}
 	}
 
 	return nil, fmt.Errorf("failed to find release plan job with id: %s. Job does not exist", jobID)
+}
+
+func filterReleasePlanWorkflowJobOptions(job *models.ReleaseJob, resources *user.AuthorizedResources) error {
+	if resources.IsSystemAdmin || job == nil || job.Type != config.JobWorkflow {
+		return nil
+	}
+
+	spec, ok := job.Spec.(*models.WorkflowReleaseJobSpec)
+	if !ok {
+		spec = new(models.WorkflowReleaseJobSpec)
+		if err := models.IToi(job.Spec, spec); err != nil {
+			return fmt.Errorf("invalid spec for job: %s. decode error: %s", job.Name, err)
+		}
+	}
+	if spec.Workflow == nil {
+		return fmt.Errorf("workflow is nil")
+	}
+
+	projectActions, hasProjectPermission := resources.ProjectAuthInfo[spec.Workflow.Project]
+	if hasProjectPermission && projectActions.IsProjectAdmin {
+		return nil
+	}
+
+	for _, stage := range spec.Workflow.Stages {
+		for _, workflowJob := range stage.Jobs {
+			hasPermission := false
+			switch workflowJob.JobType {
+			case config.JobZadigDeploy:
+				jobSpec := new(models.ZadigDeployJobSpec)
+				if err := models.IToi(workflowJob.Spec, jobSpec); err != nil {
+					return fmt.Errorf("invalid spec for workflow job: %s. decode error: %s", workflowJob.Name, err)
+				}
+				if hasProjectPermission {
+					if jobSpec.Production {
+						hasPermission = projectActions.ProductionEnv.View
+					} else {
+						hasPermission = projectActions.Env.View
+					}
+				}
+			case config.JobZadigDistributeImage:
+				if hasProjectPermission {
+					hasPermission = projectActions.Service.View
+				}
+			case config.JobZadigRestart:
+				jobSpec := new(models.ZadigRestartJobSpec)
+				if err := models.IToi(workflowJob.Spec, jobSpec); err != nil {
+					return fmt.Errorf("invalid spec for workflow job: %s. decode error: %s", workflowJob.Name, err)
+				}
+				if hasProjectPermission {
+					if jobSpec.Production {
+						hasPermission = projectActions.ProductionEnv.View
+					} else {
+						hasPermission = projectActions.Env.View
+					}
+				}
+			default:
+				continue
+			}
+
+			if hasPermission {
+				continue
+			}
+			controller, err := workflowjobcontroller.CreateJobController(workflowJob, spec.Workflow)
+			if err != nil {
+				return err
+			}
+			controller.ClearOptions()
+			workflowJob.Spec = controller.GetSpec()
+		}
+	}
+
+	job.Spec = spec
+	return nil
 }
 
 func shouldSkipReleasePlanWorkflowEditorSave(originalPlan *models.ReleasePlan, sectionKey string, currentSnapshot interface{}) bool {

--- a/pkg/microservice/aslan/core/release_plan/service/release_plan.go
+++ b/pkg/microservice/aslan/core/release_plan/service/release_plan.go
@@ -564,7 +564,7 @@ func filterReleasePlanWorkflowJobOptions(job *models.ReleaseJob, resources *user
 		}
 	}
 	if spec.Workflow == nil {
-		return fmt.Errorf("workflow is nil")
+		return fmt.Errorf("workflow is nil for release plan job: %s", job.Name)
 	}
 
 	projectActions, hasProjectPermission := resources.ProjectAuthInfo[spec.Workflow.Project]


### PR DESCRIPTION
### Summary
- Fix release-plan workflow details exposing deployment, image-distribution, and restart options without project permissions.

### Changes
- Pass authorized resources into release-plan job detail loading.
- Clear only unauthorized workflow job options; admin and authorized views remain unchanged.

### Risk / Test
- Low risk: response filtering only; execution and stored workflow definitions are unchanged.
- `go test ./pkg/microservice/aslan/core/release_plan/... -count=1`

Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4887)
<!-- Reviewable:end -->
