### PR TITLE
fix: expose Helm environment service state

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/helm.go
+++ b/pkg/microservice/aslan/core/environment/service/helm.go
@@ -17,6 +17,7 @@ limitations under the License.
 package service
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -1011,7 +1012,12 @@ func GetImageInfos(productName, envName, serviceNames string, production bool, l
 			}
 		}
 
-		for _, container := range prodSvc.Containers {
+		containers, _, err := repository.ResolveServiceModules(context.Background(), productName, svcName, production, prodSvc.Revision)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve modules for service %s: %s", svcName, err)
+		}
+
+		for _, container := range containers {
 			if container.ImagePath == nil {
 				return nil, fmt.Errorf("failed to parse image for container:%s", container.Image)
 			}

--- a/pkg/microservice/aslan/core/environment/service/openapi.go
+++ b/pkg/microservice/aslan/core/environment/service/openapi.go
@@ -28,6 +28,7 @@ import (
 	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	templaterepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb/template"
 	commontypes "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/types"
+	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/shared/client/systemconfig"
 	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
@@ -74,10 +75,15 @@ func GetEnvDetail(projectName, envName string, production bool, logger *zap.Suga
 	}
 	for _, servs := range env.Services {
 		for _, serv := range servs {
+			deployStrategy := commonutil.GetServiceDeployStrategy(serv.ServiceName, env.ServiceDeployStrategy)
+			if !serv.FromZadig() {
+				deployStrategy = commonutil.GetReleaseDeployStrategy(serv.ReleaseName, env.ServiceDeployStrategy)
+			}
 			service := &OpenAPIServiceDetail{
-				ServiceName: serv.ServiceName,
-				Containers:  serv.Containers,
-				Type:        serv.Type,
+				ServiceName:    serv.ServiceName,
+				DeployStrategy: deployStrategy,
+				Containers:     serv.Containers,
+				Type:           serv.Type,
 			}
 			if !env.Production {
 				servDetail, err := commonrepo.NewServiceColl().Find(&commonrepo.ServiceFindOption{

--- a/pkg/microservice/aslan/core/environment/service/types.go
+++ b/pkg/microservice/aslan/core/environment/service/types.go
@@ -495,11 +495,12 @@ type OpenAPICreateServiceArgs struct {
 }
 
 type OpenAPIServiceDetail struct {
-	ServiceName string                           `json:"service_name"`
-	Containers  []*commonmodels.Container        `json:"containers"`
-	VariableKVs []*commontypes.ServiceVariableKV `json:"variable_kvs"`
-	Status      string                           `json:"status"`
-	Type        string                           `json:"type"`
+	ServiceName    string                           `json:"service_name"`
+	DeployStrategy setting.ServiceDeployStrategy    `json:"deploy_strategy"`
+	Containers     []*commonmodels.Container        `json:"containers"`
+	VariableKVs    []*commontypes.ServiceVariableKV `json:"variable_kvs"`
+	Status         string                           `json:"status"`
+	Type           string                           `json:"type"`
 }
 
 func (env *OpenAPICreateEnvArgs) Validate() error {


### PR DESCRIPTION
### Summary
- Expose deploy strategy for Zadig services and chart releases.
- Resolve Helm image metadata from revision-bound service modules.

### Risk / Compatibility
- Adds a response field without changing requests; image lookup now uses the current module source of truth.

### Test
- `go test -run '^$' ./pkg/microservice/aslan/core/environment/service`
- `go vet ./pkg/microservice/aslan/core/environment/service`
- Full package tests hit two pre-existing failures in `kube_test.go`.

Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4889)
<!-- Reviewable:end -->
