### PR TITLE
fix: use environment containers for Helm image info

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/helm.go
+++ b/pkg/microservice/aslan/core/environment/service/helm.go
@@ -17,7 +17,6 @@ limitations under the License.
 package service
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -1012,12 +1011,7 @@ func GetImageInfos(productName, envName, serviceNames string, production bool, l
 			}
 		}
 
-		containers, _, err := repository.ResolveServiceModules(context.Background(), productName, svcName, production, prodSvc.Revision)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve modules for service %s: %s", svcName, err)
-		}
-
-		for _, container := range containers {
+		for _, container := range prodSvc.Containers {
 			if container.ImagePath == nil {
 				return nil, fmt.Errorf("failed to parse image for container:%s", container.Image)
 			}


### PR DESCRIPTION
### Summary
- Read Helm image information from the environment service snapshot.

### Why
- Template modules can be empty for historical services while the environment snapshot still contains the deployed containers.

### Main Changes
- Restore `prodSvc.Containers` as the source used by `GetImageInfos`.
- Keep the environment `deploy_strategy` changes from PR #4889 unchanged.

### Risk / Compatibility
- Low risk: restores the established environment image lookup behavior.

### Test
- `go test ./pkg/microservice/aslan/core/environment/service -run "^$"`
- Full package tests compile but two existing `kube_test.go` cases fail outside this change.

### Contact
Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4891)
<!-- Reviewable:end -->
