### PR TITLE
cherry pick #4892 to release 5.0.0

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/workflow_v4.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/workflow_v4.go
@@ -498,38 +498,6 @@ func (c *WorkflowV4Coll) ListByCursor(opt *ListWorkflowV4Option) (*mongo.Cursor,
 	return c.Collection.Find(context.TODO(), query)
 }
 
-// ListNamesByAITarget returns the display names of the workflows that reference the
-// given AI target in an AI job, so that the target is not deleted while still in use.
-func (c *WorkflowV4Coll) ListNamesByAITarget(ctx context.Context, targetType, targetID string) ([]string, error) {
-	query := bson.M{
-		"stages.jobs": bson.M{
-			"$elemMatch": bson.M{
-				"type":             config.JobAI,
-				"spec.target_type": targetType,
-				"spec.target_id":   targetID,
-			},
-		},
-	}
-	cursor, err := c.Collection.Find(ctx, query, options.Find().SetProjection(bson.M{"display_name": 1, "name": 1}))
-	if err != nil {
-		return nil, err
-	}
-	workflows := make([]*models.WorkflowV4, 0)
-	if err := cursor.All(ctx, &workflows); err != nil {
-		return nil, err
-	}
-
-	names := make([]string, 0, len(workflows))
-	for _, workflow := range workflows {
-		name := workflow.DisplayName
-		if name == "" {
-			name = workflow.Name
-		}
-		names = append(names, name)
-	}
-	return names, nil
-}
-
 func (c *WorkflowV4Coll) GetJobNameList(projectName, workflowName, jobType string) ([]string, error) {
 	workflow := new(models.WorkflowV4)
 	query := bson.M{"project": projectName, "name": workflowName}

--- a/pkg/microservice/aslan/core/system/service/agent_integration.go
+++ b/pkg/microservice/aslan/core/system/service/agent_integration.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	templaterepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb/template"
@@ -142,13 +141,6 @@ func toAgentIntegrationBriefs(integrations []*commonmodels.AgentIntegration) ([]
 func DeleteAgentIntegration(ctx context.Context, projectName, id string) error {
 	if _, err := findProjectAgentIntegration(ctx, projectName, id); err != nil {
 		return e.ErrDeleteAgentIntegration.AddErr(err)
-	}
-	workflowNames, err := commonrepo.NewWorkflowV4Coll().ListNamesByAITarget(ctx, config.AITargetTypeAgent, id)
-	if err != nil {
-		return e.ErrDeleteAgentIntegration.AddErr(fmt.Errorf("find workflows referencing the agent: %w", err))
-	}
-	if len(workflowNames) > 0 {
-		return e.ErrDeleteAgentIntegration.AddErr(fmt.Errorf("agent is still used by workflow: %s", strings.Join(workflowNames, ", ")))
 	}
 	if err := commonrepo.NewAgentIntegrationColl().Delete(ctx, id); err != nil {
 		return e.ErrDeleteAgentIntegration.AddErr(err)


### PR DESCRIPTION
### Summary
- Backport the Agent integration deletion fix to release-5.0.0.

### Main Changes
- Remove the workflow-reference check from Agent deletion.
- Remove the now-unused AI target workflow query.

### Risk / Compatibility
- Existing workflows keep the deleted Agent ID and must select another Agent before execution.

### Test
- `go build ./pkg/microservice/aslan/core/system/service ./pkg/microservice/aslan/core/common/repository/mongodb`

### Contact
Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4893)
<!-- Reviewable:end -->
