### PR TITLE
use codehost_name to resolve codehost when loading service via openapi

### DIFF
--- a/pkg/microservice/aslan/core/service/handler/openapi.go
+++ b/pkg/microservice/aslan/core/service/handler/openapi.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/koderover/zadig/v2/pkg/types"
@@ -20,7 +19,7 @@ import (
 // @tags 	OpenAPI
 // @accept 	json
 // @produce json
-// @Param 	codehostId 		path 		int 							  true 		"代码源 ID"
+// @Param 	codehostName 	query 		string 							  true 		"代码源名称"
 // @Param   repoName 		query 		string 							  false 	"代码库名称，repoName 和 repoUUID 至少传一个"
 // @Param   repoUUID 		query 		string 							  false 	"代码库唯一标识"
 // @Param   branchName 		query 		string 							  true 		"服务配置所在分支"
@@ -30,7 +29,7 @@ import (
 // @Param   production 		query 		bool 							  false 	"是否创建生产服务，true 表示生产服务，false 表示测试服务"
 // @Param 	body 			body 		svcservice.OpenAPILoadServiceFromCodeHostReq true 	"K8s YAML 服务创建参数"
 // @success 200 {object} svcservice.OpenAPILoadHelmServiceResp
-// @router /openapi/service/loader/load/:codehostId [post]
+// @router /openapi/service/loader/load [post]
 func LoadServiceTemplateFromCodeHostOpenAPI(c *gin.Context) {
 	ctx, err := internalhandler.NewContextWithAuthorization(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
@@ -38,12 +37,6 @@ func LoadServiceTemplateFromCodeHostOpenAPI(c *gin.Context) {
 	if err != nil {
 		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
 		ctx.UnAuthorized = true
-		return
-	}
-
-	codehostID, err := strconv.Atoi(c.Param("codehostId"))
-	if err != nil {
-		ctx.RespErr = e.ErrInvalidParam.AddDesc("cannot convert codehost id to int")
 		return
 	}
 
@@ -58,7 +51,7 @@ func LoadServiceTemplateFromCodeHostOpenAPI(c *gin.Context) {
 		return
 	}
 
-	req.CodehostID = codehostID
+	req.CodehostName = c.Query("codehostName")
 	req.RepoName = c.Query("repoName")
 	req.RepoUUID = c.Query("repoUUID")
 	req.BranchName = c.Query("branchName")

--- a/pkg/microservice/aslan/core/service/handler/router.go
+++ b/pkg/microservice/aslan/core/service/handler/router.go
@@ -124,7 +124,7 @@ type OpenAPIRouter struct{}
 func (*OpenAPIRouter) Inject(router *gin.RouterGroup) {
 	loader := router.Group("loader")
 	{
-		loader.POST("/load/:codehostId", LoadServiceTemplateFromCodeHostOpenAPI)
+		loader.POST("/load", LoadServiceTemplateFromCodeHostOpenAPI)
 	}
 
 	template := router.Group("template")

--- a/pkg/microservice/aslan/core/service/service/openapi.go
+++ b/pkg/microservice/aslan/core/service/service/openapi.go
@@ -337,8 +337,12 @@ func OpenAPILoadHelmService(ctx *internalhandler.Context, projectKey string, req
 
 	switch createFrom := req.CreateFrom.(type) {
 	case *OpenAPICreateFromRepo:
+		codehost, err := mongodb.NewCodehostColl().GetSystemCodeHostByAlias(createFrom.CodehostName)
+		if err != nil {
+			return nil, e.ErrLoadServiceTemplate.AddDesc(fmt.Sprintf("failed to get codehost by name %s: %s", createFrom.CodehostName, err))
+		}
 		args.CreateFrom = &CreateFromRepo{
-			CodehostID: createFrom.CodehostID,
+			CodehostID: codehost.ID,
 			Owner:      createFrom.Owner,
 			Namespace:  createFrom.Namespace,
 			Repo:       createFrom.Repo,

--- a/pkg/microservice/aslan/core/service/service/openapi.go
+++ b/pkg/microservice/aslan/core/service/service/openapi.go
@@ -8,6 +8,7 @@ import (
 	commonservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service"
 	commontypes "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/types"
 	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
+	"github.com/koderover/zadig/v2/pkg/microservice/systemconfig/core/codehost/repository/mongodb"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
@@ -39,6 +40,11 @@ func OpenAPILoadServiceFromYamlTemplate(username string, req *OpenAPILoadService
 }
 
 func OpenAPILoadServiceFromCodeHost(username string, req *OpenAPILoadServiceFromCodeHostReq, logger *zap.SugaredLogger) error {
+	codehost, err := mongodb.NewCodehostColl().GetSystemCodeHostByAlias(req.CodehostName)
+	if err != nil {
+		return e.ErrLoadServiceTemplate.AddDesc(fmt.Sprintf("failed to get codehost by name %s: %s", req.CodehostName, err))
+	}
+
 	namespace := req.Namespace
 	if namespace == "" {
 		namespace = req.RepoOwner
@@ -50,7 +56,7 @@ func OpenAPILoadServiceFromCodeHost(username string, req *OpenAPILoadServiceFrom
 		ServicePaths: req.ServicePaths,
 	}
 
-	return LoadServiceFromCodeHost(username, req.CodehostID, req.RepoOwner, namespace, req.RepoName, req.RepoUUID, req.BranchName, req.RemoteName, loadArgs, false, false, req.Production, logger)
+	return LoadServiceFromCodeHost(username, codehost.ID, req.RepoOwner, namespace, req.RepoName, req.RepoUUID, req.BranchName, req.RemoteName, loadArgs, false, false, req.Production, logger)
 }
 
 func CreateRawYamlServicesOpenAPI(userName, projectKey string, req *OpenAPICreateYamlServiceReq, logger *zap.SugaredLogger) error {

--- a/pkg/microservice/aslan/core/service/service/types.go
+++ b/pkg/microservice/aslan/core/service/service/types.go
@@ -58,15 +58,15 @@ type OpenAPILoadHelmServiceReq struct {
 	Source LoadSource `json:"source"`
 	// 服务名称。repo/publicRepo 场景可为空，后端会从 Chart.yaml 读取；chartRepo 场景使用 chartName 作为服务名
 	Name string `json:"name"`
-	// 服务来源配置。source=repo 时传 createFrom: {codehostID:int, owner:string, namespace:string, repo:string, branch:string, paths:[]string}；source=publicRepo 时传 createFrom: {repoLink:string, paths:[]string}；source=chartRepo 时传 createFrom: {chartRepoName:string, chartName:string, chartVersion:string}
+	// 服务来源配置。source=repo 时传 createFrom: {codehostName:string, owner:string, namespace:string, repo:string, branch:string, paths:[]string}；source=publicRepo 时传 createFrom: {repoLink:string, paths:[]string}；source=chartRepo 时传 createFrom: {chartRepoName:string, chartName:string, chartVersion:string}
 	CreateFrom interface{} `json:"createFrom"`
 	// 是否创建生产服务
 	Production bool `json:"production"`
 }
 
 type OpenAPICreateFromRepo struct {
-	// 代码源 ID
-	CodehostID int `json:"codehostID"`
+	// 代码源名称
+	CodehostName string `json:"codehostName"`
 	// 仓库拥有者/组织名
 	Owner string `json:"owner"`
 	// 仓库命名空间，GitLab 多层 group 时使用；为空默认使用 owner

--- a/pkg/microservice/aslan/core/service/service/types.go
+++ b/pkg/microservice/aslan/core/service/service/types.go
@@ -247,14 +247,14 @@ type OpenAPILoadServiceFromYamlTemplateReq struct {
 }
 
 type OpenAPILoadServiceFromCodeHostReq struct {
-	CodehostID int    `json:"-"`
-	RepoName   string `json:"-"`
-	RepoUUID   string `json:"-"`
-	BranchName string `json:"-"`
-	RemoteName string `json:"-"`
-	RepoOwner  string `json:"-"`
-	Namespace  string `json:"-"`
-	Production bool   `json:"-"`
+	CodehostName string `json:"-"`
+	RepoName     string `json:"-"`
+	RepoUUID     string `json:"-"`
+	BranchName   string `json:"-"`
+	RemoteName   string `json:"-"`
+	RepoOwner    string `json:"-"`
+	Namespace    string `json:"-"`
+	Production   bool   `json:"-"`
 	// 项目标识
 	ProductName string `json:"product_name"`
 	// 服务路径列表
@@ -262,6 +262,9 @@ type OpenAPILoadServiceFromCodeHostReq struct {
 }
 
 func (req *OpenAPILoadServiceFromCodeHostReq) Validate() error {
+	if req.CodehostName == "" {
+		return fmt.Errorf("codehostName cannot be empty")
+	}
 	if req.RepoName == "" && req.RepoUUID == "" {
 		return fmt.Errorf("repoName and repoUUID cannot be empty at the same time")
 	}


### PR DESCRIPTION
### What this PR does / Why we need it:

The OpenAPI "create K8s YAML service from codebase" endpoint previously identified the code host via the codehostId path parameter. This PR changes it to accept codehost_name instead, and the backend resolves the code host by its alias (system-level) to obtain the codehost_id before loading the service. 

### What is changed and how it works?

- request field CodehostID int → CodehostName string; Validate() now requires codehost_name to be non-empty.
- route changed from /load/:codehostId to /load.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4900)
<!-- Reviewable:end -->
