### PR TITLE
fix: update all Helm values paths for duplicate image names

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/delivery_version_v2.go
+++ b/pkg/microservice/aslan/core/common/repository/models/delivery_version_v2.go
@@ -57,16 +57,17 @@ type DeliveryVersionService struct {
 }
 
 type DeliveryVersionImage struct {
-	ContainerName  string         `bson:"container_name"        json:"container_name"`
-	ImageName      string         `bson:"image_name"            json:"image_name"`
-	ImagePath      *ImagePathSpec `bson:"image_path"            json:"image_path"`
-	SourceImage    string         `bson:"source_image"          json:"source_image"`
-	SourceImageTag string         `bson:"source_image_tag"      json:"source_image_tag"`
-	TargetImage    string         `bson:"target_image"          json:"target_image"`
-	TargetImageTag string         `bson:"target_image_tag"      json:"target_image_tag"`
-	PushImage      bool           `bson:"push_image"            json:"push_image"`
-	Status         config.Status  `bson:"status"                json:"status"`
-	Error          string         `bson:"error"                 json:"error"`
+	ContainerName  string           `bson:"container_name"        json:"container_name"`
+	ImageName      string           `bson:"image_name"            json:"image_name"`
+	ImagePath      *ImagePathSpec   `bson:"image_path"            json:"image_path"`
+	ImagePaths     []*ImagePathSpec `bson:"image_paths,omitempty"  json:"image_paths,omitempty"`
+	SourceImage    string           `bson:"source_image"          json:"source_image"`
+	SourceImageTag string           `bson:"source_image_tag"      json:"source_image_tag"`
+	TargetImage    string           `bson:"target_image"          json:"target_image"`
+	TargetImageTag string           `bson:"target_image_tag"      json:"target_image_tag"`
+	PushImage      bool             `bson:"push_image"            json:"push_image"`
+	Status         config.Status    `bson:"status"                json:"status"`
+	Error          string           `bson:"error"                 json:"error"`
 }
 
 func (DeliveryVersionV2) TableName() string {

--- a/pkg/microservice/aslan/core/common/repository/models/service.go
+++ b/pkg/microservice/aslan/core/common/repository/models/service.go
@@ -33,21 +33,21 @@ import (
 // 1. Kubernetes service, and yaml+config is held in aslan: type == "k8s"; source == "spock"; yaml != ""
 // 2. Kubernetes service, and yaml+config is held in gitlab: type == "k8s"; source == "gitlab"; src_path != ""
 type Service struct {
-	ServiceName        string                           `bson:"service_name"                   json:"service_name"`
-	Type               string                           `bson:"type"                           json:"type"`
-	Team               string                           `bson:"team,omitempty"                 json:"team,omitempty"`
-	ProductName        string                           `bson:"product_name"                   json:"product_name"`
-	Revision           int64                            `bson:"revision"                       json:"revision"`
-	Source             string                           `bson:"source,omitempty"               json:"source,omitempty"`
-	GUIConfig          *GUIConfig                       `bson:"gui_config,omitempty"           json:"gui_config,omitempty"`
-	Yaml               string                           `bson:"yaml,omitempty"                 json:"yaml"`
-	RenderedYaml       string                           `bson:"-"                              json:"-"`
-	SrcPath            string                           `bson:"src_path,omitempty"             json:"src_path,omitempty"`
-	Commit             *Commit                          `bson:"commit,omitempty"               json:"commit,omitempty"`
-	KubeYamls          []string                         `bson:"-"                              json:"-"`
-	Hash               string                           `bson:"hash256,omitempty"              json:"hash256,omitempty"`
-	CreateTime         int64                            `bson:"create_time"                    json:"create_time"`
-	CreateBy           string                           `bson:"create_by"                      json:"create_by"`
+	ServiceName  string     `bson:"service_name"                   json:"service_name"`
+	Type         string     `bson:"type"                           json:"type"`
+	Team         string     `bson:"team,omitempty"                 json:"team,omitempty"`
+	ProductName  string     `bson:"product_name"                   json:"product_name"`
+	Revision     int64      `bson:"revision"                       json:"revision"`
+	Source       string     `bson:"source,omitempty"               json:"source,omitempty"`
+	GUIConfig    *GUIConfig `bson:"gui_config,omitempty"           json:"gui_config,omitempty"`
+	Yaml         string     `bson:"yaml,omitempty"                 json:"yaml"`
+	RenderedYaml string     `bson:"-"                              json:"-"`
+	SrcPath      string     `bson:"src_path,omitempty"             json:"src_path,omitempty"`
+	Commit       *Commit    `bson:"commit,omitempty"               json:"commit,omitempty"`
+	KubeYamls    []string   `bson:"-"                              json:"-"`
+	Hash         string     `bson:"hash256,omitempty"              json:"hash256,omitempty"`
+	CreateTime   int64      `bson:"create_time"                    json:"create_time"`
+	CreateBy     string     `bson:"create_by"                      json:"create_by"`
 	// Containers is an in-memory transit field used by the parsing helpers
 	// (SetCurrentContainerImages, parseContainer) and JSON responses for the
 	// frontend. Authoritative storage lives in the service_module collection
@@ -57,7 +57,7 @@ type Service struct {
 	//
 	// Deprecated: do not add new readers of this field. Use
 	// repository.ResolveServiceModules instead.
-	Containers []*Container `bson:"-" json:"containers,omitempty"`
+	Containers         []*Container                     `bson:"-" json:"containers,omitempty"`
 	Description        string                           `bson:"description,omitempty"          json:"description,omitempty"`
 	Visibility         string                           `bson:"visibility,omitempty"           json:"visibility,omitempty"` // DEPRECATED since 1.17.0
 	Status             string                           `bson:"status,omitempty"               json:"status,omitempty"`
@@ -167,12 +167,16 @@ type ImagePathSpec struct {
 }
 
 // Container ...
+//
+// For Helm services, ImagePath is the primary path and ImagePaths contains all
+// paths for the same image.
 type Container struct {
-	Name      string                `bson:"name"                          json:"name"`
-	Type      setting.ContainerType `bson:"type"                          json:"type"`
-	Image     string                `bson:"image"                         json:"image"`
-	ImageName string                `bson:"image_name,omitempty"          json:"image_name,omitempty"`
-	ImagePath *ImagePathSpec        `bson:"image_path,omitempty"          json:"image_path,omitempty"`
+	Name       string                `bson:"name"                    json:"name"`
+	Type       setting.ContainerType `bson:"type"                    json:"type"`
+	Image      string                `bson:"image"                   json:"image"`
+	ImageName  string                `bson:"image_name,omitempty"    json:"image_name,omitempty"`
+	ImagePath  *ImagePathSpec        `bson:"image_path,omitempty"    json:"image_path,omitempty"`
+	ImagePaths []*ImagePathSpec      `bson:"image_paths,omitempty"   json:"image_paths,omitempty"`
 }
 
 // ServiceTmplPipeResp ...router

--- a/pkg/microservice/aslan/core/common/repository/models/service_module.go
+++ b/pkg/microservice/aslan/core/common/repository/models/service_module.go
@@ -75,6 +75,8 @@ type ServiceModule struct {
 	// ExtractImageName, falling back to Name.
 	ImageName string         `bson:"image_name,omitempty"      json:"image_name,omitempty"`
 	ImagePath *ImagePathSpec `bson:"image_path,omitempty"      json:"image_path,omitempty"`
+	// ImagePaths contains all Helm values paths for the same image.
+	ImagePaths []*ImagePathSpec `bson:"image_paths,omitempty"      json:"image_paths,omitempty"`
 
 	// Ignored marks an auto-discovered module as hidden for this revision.
 	// It is used as a tombstone when users delete an auto module, so later YAML

--- a/pkg/microservice/aslan/core/common/service/helm/helm.go
+++ b/pkg/microservice/aslan/core/common/service/helm/helm.go
@@ -403,16 +403,21 @@ func (s *HelmDeployService) GenMergedValues(productSvc *commonmodels.ProductServ
 	// 1. calc weather to add container image into values yaml
 	mergedContainers := []*commonmodels.Container{}
 	for _, container := range productSvc.Containers {
-		if container.ImagePath == nil {
+		imagePaths := container.ImagePaths
+		if len(imagePaths) == 0 && container.ImagePath != nil {
+			imagePaths = []*commonmodels.ImagePathSpec{container.ImagePath}
+		}
+		if len(imagePaths) == 0 || imagePaths[0] == nil {
 			return "", fmt.Errorf("failed to parse image for container:%s", container.Image)
 		}
+		imagePath := imagePaths[0]
 
 		// find corresponding image in values
 		imageSearchRule := &templatemodels.ImageSearchingRule{
-			Repo:      container.ImagePath.Repo,
-			Namespace: container.ImagePath.Namespace,
-			Image:     container.ImagePath.Image,
-			Tag:       container.ImagePath.Tag,
+			Repo:      imagePath.Repo,
+			Namespace: imagePath.Namespace,
+			Image:     imagePath.Image,
+			Tag:       imagePath.Tag,
 		}
 		pattern := imageSearchRule.GetSearchingPattern()
 		imageUrl, err := commonutil.GeneImageURI(pattern, flatValuesMap)
@@ -444,12 +449,21 @@ func (s *HelmDeployService) GenMergedValues(productSvc *commonmodels.ProductServ
 	serviceName := productSvc.ServiceName
 	imageValuesMaps := make([]map[string]interface{}, 0)
 	for _, mergedContainer := range mergedContainers {
-		// prepare image replace info
-		replaceValuesMap, err := commonutil.AssignImageData(mergedContainer.Image, commonutil.GetValidMatchData(mergedContainer.ImagePath))
-		if err != nil {
-			return "", fmt.Errorf("failed to pase image uri %s/%s, err %s", productSvc.ProductName, serviceName, err.Error())
+		// Prepare replacement data for every image path.
+		imagePaths := mergedContainer.ImagePaths
+		if len(imagePaths) == 0 && mergedContainer.ImagePath != nil {
+			imagePaths = []*commonmodels.ImagePathSpec{mergedContainer.ImagePath}
 		}
-		imageValuesMaps = append(imageValuesMaps, replaceValuesMap)
+		for _, imagePath := range imagePaths {
+			if imagePath == nil {
+				continue
+			}
+			replaceValuesMap, err := commonutil.AssignImageData(mergedContainer.Image, commonutil.GetValidMatchData(imagePath))
+			if err != nil {
+				return "", fmt.Errorf("failed to pase image uri %s/%s, err %s", productSvc.ProductName, serviceName, err.Error())
+			}
+			imageValuesMaps = append(imageValuesMaps, replaceValuesMap)
+		}
 	}
 
 	replacedEnvValuesYaml, err := commonutil.ReplaceImage(envValuesYaml, imageValuesMaps...)
@@ -480,15 +494,20 @@ func (s *HelmDeployService) GenMergedValues(productSvc *commonmodels.ProductServ
 		return "", fmt.Errorf("failed to flatten values map, err: %s", err)
 	}
 	for _, container := range productSvc.Containers {
-		if container.ImagePath == nil {
+		imagePaths := container.ImagePaths
+		if len(imagePaths) == 0 && container.ImagePath != nil {
+			imagePaths = []*commonmodels.ImagePathSpec{container.ImagePath}
+		}
+		if len(imagePaths) == 0 || imagePaths[0] == nil {
 			return "", fmt.Errorf("failed to parse image for container:%s", container.Image)
 		}
+		imagePath := imagePaths[0]
 
 		imageSearchRule := &templatemodels.ImageSearchingRule{
-			Repo:      container.ImagePath.Repo,
-			Namespace: container.ImagePath.Namespace,
-			Image:     container.ImagePath.Image,
-			Tag:       container.ImagePath.Tag,
+			Repo:      imagePath.Repo,
+			Namespace: imagePath.Namespace,
+			Image:     imagePath.Image,
+			Tag:       imagePath.Tag,
 		}
 		pattern := imageSearchRule.GetSearchingPattern()
 		imageUrl, err := commonutil.GeneImageURI(pattern, flatValuesMap)
@@ -570,6 +589,9 @@ func (s *HelmDeployService) GenNewEnvService(prod *commonmodels.Product, service
 				} else {
 					if templateContainer.ImagePath != nil {
 						containerMap[templateContainer.Name].ImagePath = templateContainer.ImagePath
+					}
+					if len(templateContainer.ImagePaths) > 0 {
+						containerMap[templateContainer.Name].ImagePaths = templateContainer.ImagePaths
 					}
 					containerMap[templateContainer.Name].Type = templateContainer.Type
 				}

--- a/pkg/microservice/aslan/core/common/service/kube/helm.go
+++ b/pkg/microservice/aslan/core/common/service/kube/helm.go
@@ -985,6 +985,9 @@ func BuildInstallParam(defaultValues string, productInfo *commonmodels.Product, 
 			if tmplContainer.ImagePath != nil {
 				containerMap[tmplContainer.Name].ImagePath = tmplContainer.ImagePath
 			}
+			if len(tmplContainer.ImagePaths) > 0 {
+				containerMap[tmplContainer.Name].ImagePaths = tmplContainer.ImagePaths
+			}
 			containerMap[tmplContainer.Name].Type = tmplContainer.Type
 			if containerMap[tmplContainer.Name].ImageName == "" {
 				containerMap[tmplContainer.Name].ImageName = tmplContainer.ImageName

--- a/pkg/microservice/aslan/core/common/service/repository/service_module.go
+++ b/pkg/microservice/aslan/core/common/service/repository/service_module.go
@@ -140,6 +140,7 @@ func CloneAutoServiceModulesForRevision(ctx context.Context, projectName, servic
 			Image:      record.Image,
 			ImageName:  record.ImageName,
 			ImagePath:  record.ImagePath,
+			ImagePaths: record.ImagePaths,
 			CreateTime: record.CreateTime,
 		})
 	}
@@ -192,10 +193,21 @@ func pickServiceModuleColl(production bool) *mongodb.ServiceModuleColl {
 
 func containersToAutoRecords(projectName, serviceName string, revision int64, containers []*models.Container) []*models.ServiceModule {
 	records := make([]*models.ServiceModule, 0, len(containers))
+	// Merge paths with the same image name into one record.
+	byName := make(map[string]int, len(containers))
 	for _, c := range containers {
 		if c == nil || c.Name == "" || c.Name == "<nil>" {
 			continue
 		}
+		imagePaths := c.ImagePaths
+		if len(imagePaths) == 0 && c.ImagePath != nil {
+			imagePaths = []*models.ImagePathSpec{c.ImagePath}
+		}
+		if idx, ok := byName[c.Name]; ok {
+			records[idx].ImagePaths = append(records[idx].ImagePaths, imagePaths...)
+			continue
+		}
+		byName[c.Name] = len(records)
 		records = append(records, &models.ServiceModule{
 			ProjectName:   projectName,
 			ServiceName:   serviceName,
@@ -206,6 +218,7 @@ func containersToAutoRecords(projectName, serviceName string, revision int64, co
 			Image:         c.Image,
 			ImageName:     normalizeImageName(c.ImageName, c.Name),
 			ImagePath:     c.ImagePath,
+			ImagePaths:    imagePaths,
 		})
 	}
 	return records
@@ -257,11 +270,12 @@ func mergeServiceModules(records []*models.ServiceModule) []*models.Container {
 		}
 		seen[r.Name] = struct{}{}
 		winners = append(winners, &models.Container{
-			Name:      r.Name,
-			Type:      r.Type,
-			Image:     r.Image,
-			ImageName: r.ImageName,
-			ImagePath: r.ImagePath,
+			Name:       r.Name,
+			Type:       r.Type,
+			Image:      r.Image,
+			ImageName:  r.ImageName,
+			ImagePath:  r.ImagePath,
+			ImagePaths: r.ImagePaths,
 		})
 	}
 	return winners

--- a/pkg/microservice/aslan/core/common/util/service.go
+++ b/pkg/microservice/aslan/core/common/util/service.go
@@ -484,6 +484,9 @@ func parseImagesByPattern(nested map[string]interface{}, patterns []map[string]s
 	}
 	ret := make([]*commonmodels.Container, 0)
 	usedImagePath := sets.NewString()
+	// Group all paths for the same image name.
+	byName := make(map[string]*commonmodels.Container)
+	nameOrder := make([]string, 0)
 	for _, searchResult := range matchedPath {
 		// Skip array elements - if any path contains "[" it's from an array
 		isArrayElement := false
@@ -507,17 +510,27 @@ func parseImagesByPattern(nested map[string]interface{}, patterns []map[string]s
 			return nil, err
 		}
 		name := ExtractImageName(imageUrl)
-		ret = append(ret, &commonmodels.Container{
-			Name:      name,
-			ImageName: name,
-			Image:     imageUrl,
-			ImagePath: &commonmodels.ImagePathSpec{
-				Repo:      searchResult[setting.PathSearchComponentRepo],
-				Namespace: searchResult[setting.PathSearchComponentNamespace],
-				Image:     searchResult[setting.PathSearchComponentImage],
-				Tag:       searchResult[setting.PathSearchComponentTag],
-			},
-		})
+		spec := &commonmodels.ImagePathSpec{
+			Repo:      searchResult[setting.PathSearchComponentRepo],
+			Namespace: searchResult[setting.PathSearchComponentNamespace],
+			Image:     searchResult[setting.PathSearchComponentImage],
+			Tag:       searchResult[setting.PathSearchComponentTag],
+		}
+		if existing, ok := byName[name]; ok {
+			existing.ImagePaths = append(existing.ImagePaths, spec)
+			continue
+		}
+		byName[name] = &commonmodels.Container{
+			Name:       name,
+			ImageName:  name,
+			Image:      imageUrl,
+			ImagePath:  spec,
+			ImagePaths: []*commonmodels.ImagePathSpec{spec},
+		}
+		nameOrder = append(nameOrder, name)
+	}
+	for _, name := range nameOrder {
+		ret = append(ret, byName[name])
 	}
 	return ret, nil
 }

--- a/pkg/microservice/aslan/core/delivery/service/openapi.go
+++ b/pkg/microservice/aslan/core/delivery/service/openapi.go
@@ -460,6 +460,7 @@ func OpenAPICreateHelmDeliveryVersion(openAPIReq *OpenAPICreateHelmDeliveryVersi
 					TargetImage:    image.TargetImage,
 					TargetImageTag: image.TargetImageTag,
 					ImagePath:      envImage.ImagePath,
+					ImagePaths:     envImage.ImagePaths,
 					PushImage:      image.PushImage,
 				})
 			}
@@ -551,6 +552,7 @@ func OpenAPICreateHelmDeliveryVersion(openAPIReq *OpenAPICreateHelmDeliveryVersi
 					TargetImage:    image.TargetImage,
 					TargetImageTag: image.TargetImageTag,
 					ImagePath:      originImage.ImagePath,
+					ImagePaths:     originImage.ImagePaths,
 					PushImage:      image.PushImage,
 				})
 			}
@@ -609,6 +611,7 @@ func OpenAPICreateHelmDeliveryVersion(openAPIReq *OpenAPICreateHelmDeliveryVersi
 					TargetImage:    image.TargetImage,
 					TargetImageTag: image.TargetImageTag,
 					ImagePath:      container.ImagePath,
+					ImagePaths:     container.ImagePaths,
 					PushImage:      image.PushImage,
 				})
 			}

--- a/pkg/microservice/aslan/core/delivery/service/version_v2.go
+++ b/pkg/microservice/aslan/core/delivery/service/version_v2.go
@@ -1644,37 +1644,34 @@ type ServiceImageDetails struct {
 func updateValuesImage(service *commonmodels.DeliveryVersionService) ([]byte, error) {
 	retValuesYaml := service.YamlContent
 
-	imagePathSpecs := make([]map[string]string, 0)
 	for _, image := range service.Images {
-		imageSearchRule := &template.ImageSearchingRule{
-			Repo:      image.ImagePath.Repo,
-			Namespace: image.ImagePath.Namespace,
-			Image:     image.ImagePath.Image,
-			Tag:       image.ImagePath.Tag,
+		imagePaths := image.ImagePaths
+		if len(imagePaths) == 0 && image.ImagePath != nil {
+			imagePaths = []*commonmodels.ImagePathSpec{image.ImagePath}
 		}
-		pattern := imageSearchRule.GetSearchingPattern()
-		imagePathSpecs = append(imagePathSpecs, pattern)
-	}
+		for _, imagePath := range imagePaths {
+			if imagePath == nil {
+				continue
+			}
+			imageSearchRule := &template.ImageSearchingRule{
+				Repo:      imagePath.Repo,
+				Namespace: imagePath.Namespace,
+				Image:     imagePath.Image,
+				Tag:       imagePath.Tag,
+			}
+			pattern := imageSearchRule.GetSearchingPattern()
 
-	for _, image := range service.Images {
-		imageSearchRule := &template.ImageSearchingRule{
-			Repo:      image.ImagePath.Repo,
-			Namespace: image.ImagePath.Namespace,
-			Image:     image.ImagePath.Image,
-			Tag:       image.ImagePath.Tag,
-		}
-		pattern := imageSearchRule.GetSearchingPattern()
+			// assign image to values.yaml
+			replaceValuesMap, err := commonutil.AssignImageData(image.TargetImage, pattern)
+			if err != nil {
+				return nil, fmt.Errorf("failed to pase image uri %s, err %s", image.TargetImage, err)
+			}
 
-		// assign image to values.yaml
-		replaceValuesMap, err := commonutil.AssignImageData(image.TargetImage, pattern)
-		if err != nil {
-			return nil, fmt.Errorf("failed to pase image uri %s, err %s", image.TargetImage, err)
-		}
-
-		// replace image into final merged values.yaml
-		retValuesYaml, err = commonutil.ReplaceImage(retValuesYaml, replaceValuesMap)
-		if err != nil {
-			return nil, err
+			// replace image into final merged values.yaml
+			retValuesYaml, err = commonutil.ReplaceImage(retValuesYaml, replaceValuesMap)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/microservice/aslan/core/environment/service/environment_creation.go
+++ b/pkg/microservice/aslan/core/environment/service/environment_creation.go
@@ -115,10 +115,11 @@ func prepareHelmProductCreation(templateProduct *templatemodels.Product, product
 					return e.ErrCreateEnv.AddDesc(errMsg)
 				}
 				container := &commonmodels.Container{
-					Name:      c.Name,
-					ImageName: util.GetImageNameFromContainerInfo(c.ImageName, c.Name),
-					Image:     image,
-					ImagePath: c.ImagePath,
+					Name:       c.Name,
+					ImageName:  util.GetImageNameFromContainerInfo(c.ImageName, c.Name),
+					Image:      image,
+					ImagePath:  c.ImagePath,
+					ImagePaths: c.ImagePaths,
 				}
 				serviceResp.Containers = append(serviceResp.Containers, container)
 			}

--- a/pkg/microservice/aslan/core/environment/service/product.go
+++ b/pkg/microservice/aslan/core/environment/service/product.go
@@ -195,6 +195,9 @@ func GetInitProduct(productTmplName string, envType types.EnvType, isBaseEnv boo
 						ImagePath: c.ImagePath,
 						ImageName: util.GetImageNameFromContainerInfo(c.ImageName, c.Name),
 					}
+					if serviceTmpl.Type == setting.HelmDeployType {
+						container.ImagePaths = c.ImagePaths
+					}
 					serviceResp.Containers = append(serviceResp.Containers, container)
 					serviceResp.VariableYaml = serviceTmpl.VariableYaml
 					serviceResp.VariableKVs = commontypes.ServiceToRenderVariableKVs(serviceTmpl.ServiceVariableKVs)

--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_v4.go
@@ -2902,12 +2902,18 @@ func HelmDeployJobMergeImage(ctx *internalhandler.Context, projectName, envName,
 
 	imageValuesMaps := make([]map[string]interface{}, 0)
 	for _, targetContainer := range mergedContainers {
-		// prepare image replace info
-		replaceValuesMap, err := commonutil.AssignImageData(targetContainer.Image, commonutil.GetValidMatchData(targetContainer.ImagePath))
-		if err != nil {
-			return nil, fmt.Errorf("failed to pase image uri %s/%s, err %s", projectName, serviceName, err.Error())
+		// Prepare replacement data for every image path.
+		imagePaths := targetContainer.ImagePaths
+		if len(imagePaths) == 0 && targetContainer.ImagePath != nil {
+			imagePaths = []*commonmodels.ImagePathSpec{targetContainer.ImagePath}
 		}
-		imageValuesMaps = append(imageValuesMaps, replaceValuesMap)
+		for _, imagePath := range imagePaths {
+			replaceValuesMap, err := commonutil.AssignImageData(targetContainer.Image, commonutil.GetValidMatchData(imagePath))
+			if err != nil {
+				return nil, fmt.Errorf("failed to pase image uri %s/%s, err %s", projectName, serviceName, err.Error())
+			}
+			imageValuesMaps = append(imageValuesMaps, replaceValuesMap)
+		}
 	}
 
 	// replace image into service's values.yaml


### PR DESCRIPTION
### What this PR does / Why we need it:

Fixes an issue where Helm services with the same image name in multiple `values.yaml` paths only updated one location.

### What is changed and how it works?

- Groups paths with the same image name into `ImagePaths`.
- Updates all matching paths during Helm deployment, workflows, and delivery.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4902)
<!-- Reviewable:end -->
