### PR TITLE
fix: flush user group cache when users are added during group creation

### DIFF
--- a/pkg/microservice/user/core/service/permission/user_group.go
+++ b/pkg/microservice/user/core/service/permission/user_group.go
@@ -67,6 +67,21 @@ func CreateUserGroup(groupName, desc string, uids []string, logger *zap.SugaredL
 
 	tx.Commit()
 
+	userCache := cache.NewRedisCache(config.RedisCommonCacheTokenDB())
+
+	for _, uid := range uids {
+		userGroupKey := fmt.Sprintf(userconfig.UserGroupCacheKeyFormat, uid)
+		err := userCache.Delete(userGroupKey)
+		if err != nil {
+			log.Warnf("failed to flush uid: %s's group id cache, error: %s", uid, err)
+		}
+
+		go func(userGroupKey string, redisCache *cache.RedisCache) {
+			time.Sleep(2 * time.Second)
+			redisCache.Delete(userGroupKey)
+		}(userGroupKey, userCache)
+	}
+
 	return userGroup, nil
 }
 


### PR DESCRIPTION
### What this PR does / Why we need it:

Invalidate user group caches when creating a user group with members. Otherwise, users with an existing cache may not receive the new group permissions until the cache expires.

### What is changed and how it works?

After the user group and its bindings are committed to the database, the `user_group_{uid}` cache is deleted for each member. A second deletion is scheduled after 2 seconds to handle concurrent requests that may repopulate stale cache data.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4903)
<!-- Reviewable:end -->
