### PR TITLE
fix: faster service module migration

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/500.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/500.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 
 	internalmodels "github.com/koderover/zadig/v2/pkg/cli/upgradeassistant/internal/repository/models"
 	internalmongodb "github.com/koderover/zadig/v2/pkg/cli/upgradeassistant/internal/repository/mongodb"
@@ -40,10 +39,7 @@ import (
 	"gorm.io/gorm"
 )
 
-const (
-	migration500ProgressEvery          = 200
-	migration500ServiceModuleBatchSize = 200
-)
+const migration500ProgressEvery = 200
 
 type permissionActionSeed500 struct {
 	Name     string
@@ -365,15 +361,7 @@ func backfillServiceModulesForCollection500(
 	label string,
 	production bool,
 ) (int, int, []string, error) {
-	cursor, err := coll.Find(ctx, bson.M{}, options.Find().
-		SetBatchSize(migration500ServiceModuleBatchSize).
-		SetProjection(bson.M{
-			"product_name": 1,
-			"service_name": 1,
-			"revision":     1,
-			"type":         1,
-			"containers":   1,
-		}))
+	cursor, err := coll.Find(ctx, bson.M{})
 	if err != nil {
 		return 0, 0, nil, fmt.Errorf("failed to open cursor over %s: %s", label, err)
 	}
@@ -382,60 +370,6 @@ func backfillServiceModulesForCollection500(
 	migrated := 0
 	skipped := 0
 	errors := make([]string, 0)
-	batch := make([]*commonmodels.Service, 0, migration500ServiceModuleBatchSize)
-	lastProgressLog := 0
-	logProgress := func() {
-		if migrated-lastProgressLog < migration500ProgressEvery {
-			return
-		}
-		log.Infof(
-			"migration 5.0.0: %s progress - %d revisions mirrored, %d skipped",
-			label,
-			migrated,
-			skipped,
-		)
-		lastProgressLog = migrated
-	}
-	flush := func() {
-		if len(batch) == 0 {
-			return
-		}
-
-		if err := servicerepo.BulkSyncAutoServiceModulesForMigration(ctx, batch, production); err == nil {
-			migrated += len(batch)
-			logProgress()
-			batch = batch[:0]
-			return
-		} else {
-			log.Warnf(
-				"migration 5.0.0: failed to bulk sync %s batch, retrying %d revisions individually: %s",
-				label,
-				len(batch),
-				err,
-			)
-		}
-
-		for _, svc := range batch {
-			if err := servicerepo.SyncAutoServiceModulesForMigration(ctx, svc, production); err != nil {
-				message := fmt.Sprintf(
-					"failed to sync %s %s/%s rev %d: %s",
-					label,
-					svc.ProductName,
-					svc.ServiceName,
-					svc.Revision,
-					err,
-				)
-				log.Warnf("migration 5.0.0: %s", message)
-				skipped++
-				errors = append(errors, message)
-				continue
-			}
-			migrated++
-		}
-		logProgress()
-		batch = batch[:0]
-	}
-
 	for cursor.Next(ctx) {
 		var legacy legacyServiceForMigration500
 		if err := cursor.Decode(&legacy); err != nil {
@@ -453,12 +387,31 @@ func backfillServiceModulesForCollection500(
 			Type:        legacy.Type,
 			Containers:  legacy.Containers,
 		}
-		batch = append(batch, svc)
-		if len(batch) >= migration500ServiceModuleBatchSize {
-			flush()
+		if err := servicerepo.SyncAutoServiceModules(ctx, svc, production); err != nil {
+			message := fmt.Sprintf(
+				"failed to sync %s %s/%s rev %d: %s",
+				label,
+				svc.ProductName,
+				svc.ServiceName,
+				svc.Revision,
+				err,
+			)
+			log.Warnf("migration 5.0.0: %s", message)
+			skipped++
+			errors = append(errors, message)
+			continue
+		}
+
+		migrated++
+		if migrated%migration500ProgressEvery == 0 {
+			log.Infof(
+				"migration 5.0.0: %s progress - %d revisions mirrored, %d skipped",
+				label,
+				migrated,
+				skipped,
+			)
 		}
 	}
-	flush()
 
 	if err := cursor.Err(); err != nil {
 		return migrated, skipped, errors, fmt.Errorf("cursor over %s ended in error: %s", label, err)

--- a/pkg/cli/upgradeassistant/cmd/migrate/500.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/500.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 
 	internalmodels "github.com/koderover/zadig/v2/pkg/cli/upgradeassistant/internal/repository/models"
 	internalmongodb "github.com/koderover/zadig/v2/pkg/cli/upgradeassistant/internal/repository/mongodb"
@@ -39,7 +40,10 @@ import (
 	"gorm.io/gorm"
 )
 
-const migration500ProgressEvery = 200
+const (
+	migration500ProgressEvery          = 200
+	migration500ServiceModuleBatchSize = 200
+)
 
 type permissionActionSeed500 struct {
 	Name     string
@@ -361,7 +365,15 @@ func backfillServiceModulesForCollection500(
 	label string,
 	production bool,
 ) (int, int, []string, error) {
-	cursor, err := coll.Find(ctx, bson.M{})
+	cursor, err := coll.Find(ctx, bson.M{}, options.Find().
+		SetBatchSize(migration500ServiceModuleBatchSize).
+		SetProjection(bson.M{
+			"product_name": 1,
+			"service_name": 1,
+			"revision":     1,
+			"type":         1,
+			"containers":   1,
+		}))
 	if err != nil {
 		return 0, 0, nil, fmt.Errorf("failed to open cursor over %s: %s", label, err)
 	}
@@ -370,6 +382,60 @@ func backfillServiceModulesForCollection500(
 	migrated := 0
 	skipped := 0
 	errors := make([]string, 0)
+	batch := make([]*commonmodels.Service, 0, migration500ServiceModuleBatchSize)
+	lastProgressLog := 0
+	logProgress := func() {
+		if migrated-lastProgressLog < migration500ProgressEvery {
+			return
+		}
+		log.Infof(
+			"migration 5.0.0: %s progress - %d revisions mirrored, %d skipped",
+			label,
+			migrated,
+			skipped,
+		)
+		lastProgressLog = migrated
+	}
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+
+		if err := servicerepo.BulkSyncAutoServiceModulesForMigration(ctx, batch, production); err == nil {
+			migrated += len(batch)
+			logProgress()
+			batch = batch[:0]
+			return
+		} else {
+			log.Warnf(
+				"migration 5.0.0: failed to bulk sync %s batch, retrying %d revisions individually: %s",
+				label,
+				len(batch),
+				err,
+			)
+		}
+
+		for _, svc := range batch {
+			if err := servicerepo.SyncAutoServiceModulesForMigration(ctx, svc, production); err != nil {
+				message := fmt.Sprintf(
+					"failed to sync %s %s/%s rev %d: %s",
+					label,
+					svc.ProductName,
+					svc.ServiceName,
+					svc.Revision,
+					err,
+				)
+				log.Warnf("migration 5.0.0: %s", message)
+				skipped++
+				errors = append(errors, message)
+				continue
+			}
+			migrated++
+		}
+		logProgress()
+		batch = batch[:0]
+	}
+
 	for cursor.Next(ctx) {
 		var legacy legacyServiceForMigration500
 		if err := cursor.Decode(&legacy); err != nil {
@@ -387,31 +453,12 @@ func backfillServiceModulesForCollection500(
 			Type:        legacy.Type,
 			Containers:  legacy.Containers,
 		}
-		if err := servicerepo.SyncAutoServiceModules(ctx, svc, production); err != nil {
-			message := fmt.Sprintf(
-				"failed to sync %s %s/%s rev %d: %s",
-				label,
-				svc.ProductName,
-				svc.ServiceName,
-				svc.Revision,
-				err,
-			)
-			log.Warnf("migration 5.0.0: %s", message)
-			skipped++
-			errors = append(errors, message)
-			continue
-		}
-
-		migrated++
-		if migrated%migration500ProgressEvery == 0 {
-			log.Infof(
-				"migration 5.0.0: %s progress - %d revisions mirrored, %d skipped",
-				label,
-				migrated,
-				skipped,
-			)
+		batch = append(batch, svc)
+		if len(batch) >= migration500ServiceModuleBatchSize {
+			flush()
 		}
 	}
+	flush()
 
 	if err := cursor.Err(); err != nil {
 		return migrated, skipped, errors, fmt.Errorf("cursor over %s ended in error: %s", label, err)

--- a/pkg/cli/upgradeassistant/cmd/migrate/500.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/500.go
@@ -308,6 +308,13 @@ func migrateServiceModule500(migrationInfo *internalmodels.Migration) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	if err := commonrepo.NewServiceModuleColl().EnsureIndex(ctx); err != nil {
+		return fmt.Errorf("failed to ensure service_module indexes before backfill, err: %s", err)
+	}
+	if err := commonrepo.NewProductionServiceModuleColl().EnsureIndex(ctx); err != nil {
+		return fmt.Errorf("failed to ensure production_service_module indexes before backfill, err: %s", err)
+	}
+
 	testCount, testSkipped, testErrors, err := backfillServiceModulesForCollection500(
 		ctx,
 		commonrepo.NewServiceColl().Collection,

--- a/pkg/microservice/aslan/core/common/repository/mongodb/service_module.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/service_module.go
@@ -75,9 +75,9 @@ func (c *ServiceModuleColl) GetCollectionName() string {
 
 func (c *ServiceModuleColl) EnsureIndex(ctx context.Context) error {
 	mod := []mongo.IndexModel{
-		// Uniqueness: a given slot (manual or per-revision auto) holds at most
-		// one record per name. Manual and auto with the same name coexist —
-		// the merge layer (ResolveServiceModules) reconciles them.
+		// Uniqueness: a module image path is unique within a manual or
+		// revision-bound service slot. The same module name can have multiple
+		// records when their image paths differ.
 		{
 			Keys: bson.D{
 				bson.E{Key: "project_name", Value: 1},
@@ -85,8 +85,14 @@ func (c *ServiceModuleColl) EnsureIndex(ctx context.Context) error {
 				bson.E{Key: "is_manual", Value: 1},
 				bson.E{Key: "revision_bound", Value: 1},
 				bson.E{Key: "name", Value: 1},
+				bson.E{Key: "image_path.repo", Value: 1},
+				bson.E{Key: "image_path.namespace", Value: 1},
+				bson.E{Key: "image_path.image", Value: 1},
+				bson.E{Key: "image_path.tag", Value: 1},
 			},
-			Options: options.Index().SetUnique(true),
+			Options: options.Index().
+				SetName("uniq_service_module_path").
+				SetUnique(true),
 		},
 		// Hot path: list-all-modules-for-a-service.
 		{

--- a/pkg/microservice/aslan/core/common/repository/mongodb/service_module.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/service_module.go
@@ -31,8 +31,9 @@ import (
 )
 
 const (
-	serviceModuleCollName           = "service_module"
-	productionServiceModuleCollName = "production_service_module"
+	serviceModuleCollName              = "service_module"
+	productionServiceModuleCollName    = "production_service_module"
+	legacyServiceModuleUniqueIndexName = "project_name_1_service_name_1_is_manual_1_revision_bound_1_name_1"
 )
 
 // ServiceModuleColl is the storage for first-class module records.
@@ -109,7 +110,16 @@ func (c *ServiceModuleColl) EnsureIndex(ctx context.Context) error {
 
 	// Remove the previous name-only uniqueness constraint after the new
 	// image-path-aware index has been created successfully.
-	_, _ = c.Indexes().DropOne(ctx, "project_name_1_service_name_1_is_manual_1_revision_bound_1_name_1")
+	indexes, err := c.Indexes().ListSpecifications(ctx)
+	if err != nil {
+		return err
+	}
+	for _, index := range indexes {
+		if index.Name == legacyServiceModuleUniqueIndexName {
+			_, err = c.Indexes().DropOne(ctx, legacyServiceModuleUniqueIndexName)
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/microservice/aslan/core/common/repository/mongodb/service_module.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/service_module.go
@@ -270,6 +270,55 @@ func (c *ServiceModuleColl) ReplaceAutoForRevision(ctx context.Context, projectN
 	return err
 }
 
+// BulkUpsertAutoRecords writes migration records without deleting existing
+// revision snapshots. The unique module key makes interrupted migrations safe
+// to rerun while avoiding the per-revision delete required by normal syncing.
+func (c *ServiceModuleColl) BulkUpsertAutoRecords(ctx context.Context, records []*models.ServiceModule) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	now := time.Now().Unix()
+	writeModels := make([]mongo.WriteModel, 0, len(records))
+	for _, record := range records {
+		if record == nil || record.ProjectName == "" || record.ServiceName == "" || record.RevisionBound == 0 || record.Name == "" {
+			continue
+		}
+		writeModels = append(writeModels, mongo.NewUpdateOneModel().
+			SetFilter(bson.M{
+				"project_name":   record.ProjectName,
+				"service_name":   record.ServiceName,
+				"is_manual":      false,
+				"revision_bound": record.RevisionBound,
+				"name":           record.Name,
+			}).
+			SetUpdate(bson.M{
+				"$set": bson.M{
+					"type":        record.Type,
+					"image":       record.Image,
+					"image_name":  record.ImageName,
+					"image_path":  record.ImagePath,
+					"ignored":     false,
+					"update_time": now,
+				},
+				"$setOnInsert": bson.M{
+					"create_time": now,
+				},
+			}).
+			SetUpsert(true))
+	}
+
+	if len(writeModels) == 0 {
+		return nil
+	}
+	_, err := c.Collection.BulkWrite(
+		mongotool.SessionContext(ctx, c.Session),
+		writeModels,
+		options.BulkWrite().SetOrdered(true),
+	)
+	return err
+}
+
 // DeleteAutoByRevision drops every auto record for a specific revision. Used
 // when a service revision is hard-deleted (rare cleanup path).
 func (c *ServiceModuleColl) DeleteAutoByRevision(ctx context.Context, projectName, serviceName string, revision int64) error {

--- a/pkg/microservice/aslan/core/common/repository/mongodb/service_module.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/service_module.go
@@ -270,55 +270,6 @@ func (c *ServiceModuleColl) ReplaceAutoForRevision(ctx context.Context, projectN
 	return err
 }
 
-// BulkUpsertAutoRecords writes migration records without deleting existing
-// revision snapshots. The unique module key makes interrupted migrations safe
-// to rerun while avoiding the per-revision delete required by normal syncing.
-func (c *ServiceModuleColl) BulkUpsertAutoRecords(ctx context.Context, records []*models.ServiceModule) error {
-	if len(records) == 0 {
-		return nil
-	}
-
-	now := time.Now().Unix()
-	writeModels := make([]mongo.WriteModel, 0, len(records))
-	for _, record := range records {
-		if record == nil || record.ProjectName == "" || record.ServiceName == "" || record.RevisionBound == 0 || record.Name == "" {
-			continue
-		}
-		writeModels = append(writeModels, mongo.NewUpdateOneModel().
-			SetFilter(bson.M{
-				"project_name":   record.ProjectName,
-				"service_name":   record.ServiceName,
-				"is_manual":      false,
-				"revision_bound": record.RevisionBound,
-				"name":           record.Name,
-			}).
-			SetUpdate(bson.M{
-				"$set": bson.M{
-					"type":        record.Type,
-					"image":       record.Image,
-					"image_name":  record.ImageName,
-					"image_path":  record.ImagePath,
-					"ignored":     false,
-					"update_time": now,
-				},
-				"$setOnInsert": bson.M{
-					"create_time": now,
-				},
-			}).
-			SetUpsert(true))
-	}
-
-	if len(writeModels) == 0 {
-		return nil
-	}
-	_, err := c.Collection.BulkWrite(
-		mongotool.SessionContext(ctx, c.Session),
-		writeModels,
-		options.BulkWrite().SetOrdered(true),
-	)
-	return err
-}
-
 // DeleteAutoByRevision drops every auto record for a specific revision. Used
 // when a service revision is hard-deleted (rare cleanup path).
 func (c *ServiceModuleColl) DeleteAutoByRevision(ctx context.Context, projectName, serviceName string, revision int64) error {

--- a/pkg/microservice/aslan/core/common/repository/mongodb/service_module.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/service_module.go
@@ -103,8 +103,14 @@ func (c *ServiceModuleColl) EnsureIndex(ctx context.Context) error {
 			Options: options.Index().SetUnique(false),
 		},
 	}
-	_, err := c.Indexes().CreateMany(ctx, mod, mongotool.CreateIndexOptions(ctx))
-	return err
+	if _, err := c.Indexes().CreateMany(ctx, mod, mongotool.CreateIndexOptions(ctx)); err != nil {
+		return err
+	}
+
+	// Remove the previous name-only uniqueness constraint after the new
+	// image-path-aware index has been created successfully.
+	_, _ = c.Indexes().DropOne(ctx, "project_name_1_service_name_1_is_manual_1_revision_bound_1_name_1")
+	return nil
 }
 
 // ListByServiceRevision returns the records relevant to a single read:

--- a/pkg/microservice/aslan/core/common/service/repository/service_module.go
+++ b/pkg/microservice/aslan/core/common/service/repository/service_module.go
@@ -84,32 +84,6 @@ func SyncAutoServiceModules(ctx context.Context, svc *models.Service, production
 	return coll.ReplaceAutoForRevision(ctx, svc.ProductName, svc.ServiceName, svc.Revision, records)
 }
 
-// SyncAutoServiceModulesForMigration upserts auto-discovered modules without
-// querying ignored tombstones or deleting revision snapshots. Upgrade
-// migrations populate an empty target collection before user traffic.
-func SyncAutoServiceModulesForMigration(ctx context.Context, svc *models.Service, production bool) error {
-	if svc == nil || svc.ServiceName == "" || svc.ProductName == "" || svc.Revision == 0 {
-		return nil
-	}
-
-	records := containersToAutoRecords(svc.ProductName, svc.ServiceName, svc.Revision, svc.Containers)
-	return pickServiceModuleColl(production).BulkUpsertAutoRecords(ctx, records)
-}
-
-// BulkSyncAutoServiceModulesForMigration replaces multiple service revisions
-// in one ordered bulk write. Callers can fall back to the single-revision
-// variant to isolate malformed records when a batch fails.
-func BulkSyncAutoServiceModulesForMigration(ctx context.Context, services []*models.Service, production bool) error {
-	records := make([]*models.ServiceModule, 0)
-	for _, svc := range services {
-		if svc == nil || svc.ServiceName == "" || svc.ProductName == "" || svc.Revision == 0 {
-			continue
-		}
-		records = append(records, containersToAutoRecords(svc.ProductName, svc.ServiceName, svc.Revision, svc.Containers)...)
-	}
-	return pickServiceModuleColl(production).BulkUpsertAutoRecords(ctx, records)
-}
-
 // ListManualServiceModules returns just the manual records for a service,
 // mapped to Container shape. Render paths use this to inject user-declared
 // modules into the substitution pipeline alongside the in-memory parsed

--- a/pkg/microservice/aslan/core/common/service/repository/service_module.go
+++ b/pkg/microservice/aslan/core/common/service/repository/service_module.go
@@ -84,6 +84,32 @@ func SyncAutoServiceModules(ctx context.Context, svc *models.Service, production
 	return coll.ReplaceAutoForRevision(ctx, svc.ProductName, svc.ServiceName, svc.Revision, records)
 }
 
+// SyncAutoServiceModulesForMigration upserts auto-discovered modules without
+// querying ignored tombstones or deleting revision snapshots. Upgrade
+// migrations populate an empty target collection before user traffic.
+func SyncAutoServiceModulesForMigration(ctx context.Context, svc *models.Service, production bool) error {
+	if svc == nil || svc.ServiceName == "" || svc.ProductName == "" || svc.Revision == 0 {
+		return nil
+	}
+
+	records := containersToAutoRecords(svc.ProductName, svc.ServiceName, svc.Revision, svc.Containers)
+	return pickServiceModuleColl(production).BulkUpsertAutoRecords(ctx, records)
+}
+
+// BulkSyncAutoServiceModulesForMigration replaces multiple service revisions
+// in one ordered bulk write. Callers can fall back to the single-revision
+// variant to isolate malformed records when a batch fails.
+func BulkSyncAutoServiceModulesForMigration(ctx context.Context, services []*models.Service, production bool) error {
+	records := make([]*models.ServiceModule, 0)
+	for _, svc := range services {
+		if svc == nil || svc.ServiceName == "" || svc.ProductName == "" || svc.Revision == 0 {
+			continue
+		}
+		records = append(records, containersToAutoRecords(svc.ProductName, svc.ServiceName, svc.Revision, svc.Containers)...)
+	}
+	return pickServiceModuleColl(production).BulkUpsertAutoRecords(ctx, records)
+}
+
 // ListManualServiceModules returns just the manual records for a service,
 // mapped to Container shape. Render paths use this to inject user-declared
 // modules into the substitution pipeline alongside the in-memory parsed


### PR DESCRIPTION
### What this PR does / Why we need it:

Optimizes the 5.0.0 service module backfill, which became progressively slower as the target collection grew due to missing indexes and per-revision database operations.

### What is changed and how it works?

- Ensures service module indexes exist before migration.
- Migrates service revisions in batches of 200 using bulk upserts.
- Removes unnecessary ignored-record queries and deletes because the target collections are initially empty.
- Falls back to per-revision upserts when a batch fails, allowing valid data to continue migrating.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4905)
<!-- Reviewable:end -->
