### PR TITLE
fix: omit model from external agent requests

### DIFF
--- a/pkg/microservice/aslan/core/common/service/llmservice/llm.go
+++ b/pkg/microservice/aslan/core/common/service/llmservice/llm.go
@@ -59,7 +59,7 @@ func NewAgentClient(integration *models.AgentIntegration) (llm.ILLM, error) {
 		Protocol:     integration.Protocol,
 		ProviderName: llm.ProviderOther,
 		BaseURL:      integration.BaseURL,
-		Model:        integration.Model,
+		OmitModel:    true,
 	}
 	switch integration.AuthType {
 	case models.AgentAuthTypeAPIKey:

--- a/pkg/microservice/aslan/core/system/service/agent_integration.go
+++ b/pkg/microservice/aslan/core/system/service/agent_integration.go
@@ -237,9 +237,6 @@ func validateAgentIntegration(integration *commonmodels.AgentIntegration) error 
 	if integration.Protocol != llm.ProtocolOpenAI && integration.Protocol != llm.ProtocolAnthropic {
 		return fmt.Errorf("protocol %s is not supported", integration.Protocol)
 	}
-	if integration.Protocol == llm.ProtocolAnthropic && integration.Model == "" {
-		return fmt.Errorf("model is required for anthropic protocol")
-	}
 	switch integration.AuthType {
 	case commonmodels.AgentAuthTypeAPIKey:
 		if integration.APIKey == "" || integration.APIKey == setting.MaskValue {

--- a/pkg/tool/llm/anthropic.go
+++ b/pkg/tool/llm/anthropic.go
@@ -42,13 +42,14 @@ type AnthropicClient struct {
 	name            string
 	integrationName string
 	model           string
+	omitModel       bool
 	token           string
 	baseURL         string
 	httpClient      *http.Client
 }
 
 type anthropicMessageRequest struct {
-	Model         string             `json:"model"`
+	Model         string             `json:"model,omitempty"`
 	MaxTokens     int                `json:"max_tokens"`
 	Messages      []anthropicMessage `json:"messages"`
 	Temperature   *float32           `json:"temperature,omitempty"`
@@ -95,6 +96,7 @@ func (c *AnthropicClient) Configure(config LLMConfig) error {
 	c.name = string(config.GetProviderName())
 	c.integrationName = config.GetIntegrationName()
 	c.model = config.GetModel()
+	c.omitModel = config.OmitModel
 	c.token = config.GetToken()
 	c.baseURL = baseURL
 	c.httpClient = httpClient
@@ -114,12 +116,15 @@ func (c *AnthropicClient) GetCompletion(ctx context.Context, prompt string, opti
 	requestCtx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
 
-	model := opts.Model
-	if model == "" {
-		model = c.model
-	}
-	if model == "" {
-		return "", errors.New("anthropic model is required")
+	model := ""
+	if !c.omitModel {
+		model = opts.Model
+		if model == "" {
+			model = c.model
+		}
+		if model == "" {
+			return "", errors.New("anthropic model is required")
+		}
 	}
 	maxTokens := opts.MaxTokens
 	if maxTokens == 0 {

--- a/pkg/tool/llm/http.go
+++ b/pkg/tool/llm/http.go
@@ -17,6 +17,10 @@ limitations under the License.
 package llm
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -25,6 +29,10 @@ import (
 type headerTransport struct {
 	base    http.RoundTripper
 	headers map[string]string
+}
+
+type omitModelTransport struct {
+	base http.RoundTripper
 }
 
 func newHTTPClient(proxy string, headers map[string]string, timeout time.Duration) (*http.Client, error) {
@@ -51,5 +59,32 @@ func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	for key, value := range t.headers {
 		cloned.Header.Set(key, value)
 	}
+	return t.base.RoundTrip(cloned)
+}
+
+func (t *omitModelTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read request body: %w", err)
+	}
+	_ = req.Body.Close()
+
+	payload := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("decode request body: %w", err)
+	}
+	delete(payload, "model")
+	body, err = json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("encode request body: %w", err)
+	}
+
+	cloned := req.Clone(req.Context())
+	cloned.Body = io.NopCloser(bytes.NewReader(body))
+	cloned.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	cloned.ContentLength = int64(len(body))
+	cloned.Header.Del("Content-Length")
 	return t.base.RoundTrip(cloned)
 }

--- a/pkg/tool/llm/illm.go
+++ b/pkg/tool/llm/illm.go
@@ -70,6 +70,7 @@ type LLMConfig struct {
 	Protocol     Protocol
 	ProviderName Provider
 	Model        string
+	OmitModel    bool
 	Token        string
 	BaseURL      string
 	Proxy        string

--- a/pkg/tool/llm/openai.go
+++ b/pkg/tool/llm/openai.go
@@ -70,6 +70,9 @@ func (c *OpenAIClient) Configure(config LLMConfig) error {
 	if err != nil {
 		return fmt.Errorf("could not build the openai http client: %w", err)
 	}
+	if config.OmitModel {
+		httpClient.Transport = &omitModelTransport{base: httpClient.Transport}
+	}
 	defaultConfig.HTTPClient = httpClient
 
 	client := openai.NewClientWithConfig(defaultConfig)


### PR DESCRIPTION
### Summary
- External Agent calls no longer send a model parameter.

### Why
- Agent platforms own their underlying model selection.

### Main Changes
- Reuse the existing OpenAI and Anthropic clients with an explicit omit-model mode.
- Keep LLM integration model behavior unchanged.
- Preserve the Agent model field for API and stored-data compatibility.

### Risk / Compatibility
- Existing LLM calls are unaffected; Agent endpoints must route requests without a model field.

### Test
- go test ./pkg/tool/llm
- Built the affected LLM, workflow controller, and system service packages.

### Contact
Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4906)
<!-- Reviewable:end -->
