### PR TITLE
fix: update same-name Helm images by image path

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/service.go
+++ b/pkg/microservice/aslan/core/common/repository/models/service.go
@@ -33,21 +33,21 @@ import (
 // 1. Kubernetes service, and yaml+config is held in aslan: type == "k8s"; source == "spock"; yaml != ""
 // 2. Kubernetes service, and yaml+config is held in gitlab: type == "k8s"; source == "gitlab"; src_path != ""
 type Service struct {
-	ServiceName  string     `bson:"service_name"                   json:"service_name"`
-	Type         string     `bson:"type"                           json:"type"`
-	Team         string     `bson:"team,omitempty"                 json:"team,omitempty"`
-	ProductName  string     `bson:"product_name"                   json:"product_name"`
-	Revision     int64      `bson:"revision"                       json:"revision"`
-	Source       string     `bson:"source,omitempty"               json:"source,omitempty"`
-	GUIConfig    *GUIConfig `bson:"gui_config,omitempty"           json:"gui_config,omitempty"`
-	Yaml         string     `bson:"yaml,omitempty"                 json:"yaml"`
-	RenderedYaml string     `bson:"-"                              json:"-"`
-	SrcPath      string     `bson:"src_path,omitempty"             json:"src_path,omitempty"`
-	Commit       *Commit    `bson:"commit,omitempty"               json:"commit,omitempty"`
-	KubeYamls    []string   `bson:"-"                              json:"-"`
-	Hash         string     `bson:"hash256,omitempty"              json:"hash256,omitempty"`
-	CreateTime   int64      `bson:"create_time"                    json:"create_time"`
-	CreateBy     string     `bson:"create_by"                      json:"create_by"`
+	ServiceName        string                           `bson:"service_name"                   json:"service_name"`
+	Type               string                           `bson:"type"                           json:"type"`
+	Team               string                           `bson:"team,omitempty"                 json:"team,omitempty"`
+	ProductName        string                           `bson:"product_name"                   json:"product_name"`
+	Revision           int64                            `bson:"revision"                       json:"revision"`
+	Source             string                           `bson:"source,omitempty"               json:"source,omitempty"`
+	GUIConfig          *GUIConfig                       `bson:"gui_config,omitempty"           json:"gui_config,omitempty"`
+	Yaml               string                           `bson:"yaml,omitempty"                 json:"yaml"`
+	RenderedYaml       string                           `bson:"-"                              json:"-"`
+	SrcPath            string                           `bson:"src_path,omitempty"             json:"src_path,omitempty"`
+	Commit             *Commit                          `bson:"commit,omitempty"               json:"commit,omitempty"`
+	KubeYamls          []string                         `bson:"-"                              json:"-"`
+	Hash               string                           `bson:"hash256,omitempty"              json:"hash256,omitempty"`
+	CreateTime         int64                            `bson:"create_time"                    json:"create_time"`
+	CreateBy           string                           `bson:"create_by"                      json:"create_by"`
 	// Containers is an in-memory transit field used by the parsing helpers
 	// (SetCurrentContainerImages, parseContainer) and JSON responses for the
 	// frontend. Authoritative storage lives in the service_module collection
@@ -57,7 +57,7 @@ type Service struct {
 	//
 	// Deprecated: do not add new readers of this field. Use
 	// repository.ResolveServiceModules instead.
-	Containers         []*Container                     `bson:"-" json:"containers,omitempty"`
+	Containers []*Container `bson:"-" json:"containers,omitempty"`
 	Description        string                           `bson:"description,omitempty"          json:"description,omitempty"`
 	Visibility         string                           `bson:"visibility,omitempty"           json:"visibility,omitempty"` // DEPRECATED since 1.17.0
 	Status             string                           `bson:"status,omitempty"               json:"status,omitempty"`

--- a/pkg/microservice/aslan/core/common/repository/models/service.go
+++ b/pkg/microservice/aslan/core/common/repository/models/service.go
@@ -33,21 +33,21 @@ import (
 // 1. Kubernetes service, and yaml+config is held in aslan: type == "k8s"; source == "spock"; yaml != ""
 // 2. Kubernetes service, and yaml+config is held in gitlab: type == "k8s"; source == "gitlab"; src_path != ""
 type Service struct {
-	ServiceName        string                           `bson:"service_name"                   json:"service_name"`
-	Type               string                           `bson:"type"                           json:"type"`
-	Team               string                           `bson:"team,omitempty"                 json:"team,omitempty"`
-	ProductName        string                           `bson:"product_name"                   json:"product_name"`
-	Revision           int64                            `bson:"revision"                       json:"revision"`
-	Source             string                           `bson:"source,omitempty"               json:"source,omitempty"`
-	GUIConfig          *GUIConfig                       `bson:"gui_config,omitempty"           json:"gui_config,omitempty"`
-	Yaml               string                           `bson:"yaml,omitempty"                 json:"yaml"`
-	RenderedYaml       string                           `bson:"-"                              json:"-"`
-	SrcPath            string                           `bson:"src_path,omitempty"             json:"src_path,omitempty"`
-	Commit             *Commit                          `bson:"commit,omitempty"               json:"commit,omitempty"`
-	KubeYamls          []string                         `bson:"-"                              json:"-"`
-	Hash               string                           `bson:"hash256,omitempty"              json:"hash256,omitempty"`
-	CreateTime         int64                            `bson:"create_time"                    json:"create_time"`
-	CreateBy           string                           `bson:"create_by"                      json:"create_by"`
+	ServiceName  string     `bson:"service_name"                   json:"service_name"`
+	Type         string     `bson:"type"                           json:"type"`
+	Team         string     `bson:"team,omitempty"                 json:"team,omitempty"`
+	ProductName  string     `bson:"product_name"                   json:"product_name"`
+	Revision     int64      `bson:"revision"                       json:"revision"`
+	Source       string     `bson:"source,omitempty"               json:"source,omitempty"`
+	GUIConfig    *GUIConfig `bson:"gui_config,omitempty"           json:"gui_config,omitempty"`
+	Yaml         string     `bson:"yaml,omitempty"                 json:"yaml"`
+	RenderedYaml string     `bson:"-"                              json:"-"`
+	SrcPath      string     `bson:"src_path,omitempty"             json:"src_path,omitempty"`
+	Commit       *Commit    `bson:"commit,omitempty"               json:"commit,omitempty"`
+	KubeYamls    []string   `bson:"-"                              json:"-"`
+	Hash         string     `bson:"hash256,omitempty"              json:"hash256,omitempty"`
+	CreateTime   int64      `bson:"create_time"                    json:"create_time"`
+	CreateBy     string     `bson:"create_by"                      json:"create_by"`
 	// Containers is an in-memory transit field used by the parsing helpers
 	// (SetCurrentContainerImages, parseContainer) and JSON responses for the
 	// frontend. Authoritative storage lives in the service_module collection
@@ -57,7 +57,7 @@ type Service struct {
 	//
 	// Deprecated: do not add new readers of this field. Use
 	// repository.ResolveServiceModules instead.
-	Containers []*Container `bson:"-" json:"containers,omitempty"`
+	Containers         []*Container                     `bson:"-" json:"containers,omitempty"`
 	Description        string                           `bson:"description,omitempty"          json:"description,omitempty"`
 	Visibility         string                           `bson:"visibility,omitempty"           json:"visibility,omitempty"` // DEPRECATED since 1.17.0
 	Status             string                           `bson:"status,omitempty"               json:"status,omitempty"`
@@ -166,6 +166,14 @@ type ImagePathSpec struct {
 	Tag       string `bson:"tag,omitempty"            json:"tag,omitempty"`
 }
 
+// GetKey returns a stable identity for one image location in Helm values.
+func (i *ImagePathSpec) GetKey() string {
+	if i == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s\x00%s\x00%s\x00%s", i.Repo, i.Namespace, i.Image, i.Tag)
+}
+
 // Container ...
 type Container struct {
 	Name      string                `bson:"name"                          json:"name"`
@@ -173,6 +181,19 @@ type Container struct {
 	Image     string                `bson:"image"                         json:"image"`
 	ImageName string                `bson:"image_name,omitempty"          json:"image_name,omitempty"`
 	ImagePath *ImagePathSpec        `bson:"image_path,omitempty"          json:"image_path,omitempty"`
+}
+
+// GetKey distinguishes containers with the same name at different Helm
+// values paths. For non-Helm containers, the nil image path keeps the legacy
+// name-only identity.
+func (c *Container) GetKey() string {
+	if c == nil {
+		return ""
+	}
+	if c.ImagePath == nil {
+		return c.Name
+	}
+	return fmt.Sprintf("%s\x00%s", c.Name, c.ImagePath.GetKey())
 }
 
 // ServiceTmplPipeResp ...router

--- a/pkg/microservice/aslan/core/common/repository/models/service_module.go
+++ b/pkg/microservice/aslan/core/common/repository/models/service_module.go
@@ -36,8 +36,9 @@ import (
 //     Manual records carry RevisionBound = 0 — they are version-agnostic and
 //     load for every revision of the service.
 //
-// Read-merge rule (see ResolveServiceModules): records are unioned by Name with
-// time-of-creation precedence ("first-come-first-served" by CreateTime).
+// Read-merge rule (see ResolveServiceModules): records are unioned by Name and
+// ImagePath with time-of-creation precedence ("first-come-first-served" by
+// CreateTime).
 // Conflicts are recorded and surfaced to the caller so the UI can warn users.
 type ServiceModule struct {
 	ID          primitive.ObjectID `bson:"_id,omitempty"             json:"id,omitempty"`

--- a/pkg/microservice/aslan/core/common/service/helm/helm.go
+++ b/pkg/microservice/aslan/core/common/service/helm/helm.go
@@ -463,24 +463,21 @@ func (s *HelmDeployService) GenMergedValues(productSvc *commonmodels.ProductServ
 		}
 
 		name := commonutil.ExtractImageName(imageUrl)
+		deployImage := imageMap[container.ImageName]
 
-		if container.ImageName == name {
-			// path present in values: skip when unchanged and no build image
-			if imageMap[name] == "" && container.Image == imageUrl {
-				continue
+		// Write back when the values path is newly introduced, its image differs
+		// from the recorded environment image, or a deploy image is supplied.
+		shouldWriteBack := container.ImageName != name || container.Image != imageUrl || deployImage != ""
+		if shouldWriteBack {
+			// Deploy images are matched by image name, intentionally updating every
+			// same-name container even when they use different values paths.
+			if deployImage != "" {
+				container.Image = deployImage
 			}
-			if imageMap[name] != "" {
-				container.Image = imageMap[name]
-			}
+			// Step 2 writes the selected image back through this container's own
+			// ImagePath, including paths newly introduced by a service revision.
 			mergedContainers = append(mergedContainers, container)
-			continue
 		}
-
-		// path not in values: always write back
-		if imageMap[container.ImageName] != "" {
-			container.Image = imageMap[container.ImageName]
-		}
-		mergedContainers = append(mergedContainers, container)
 	}
 
 	// 2. replace image into values yaml

--- a/pkg/microservice/aslan/core/common/service/helm/helm.go
+++ b/pkg/microservice/aslan/core/common/service/helm/helm.go
@@ -375,6 +375,50 @@ func NewHelmDeployService() *HelmDeployService {
 	return &HelmDeployService{}
 }
 
+// MergeHelmContainers keeps existing environment images while adding or
+// refreshing the containers parsed from the selected service revision.
+func MergeHelmContainers(current, templates []*commonmodels.Container) []*commonmodels.Container {
+	currentByKey := make(map[string]*commonmodels.Container, len(current))
+	currentByName := make(map[string]*commonmodels.Container, len(current))
+	for _, container := range current {
+		if container == nil {
+			continue
+		}
+		currentByKey[container.GetKey()] = container
+		if existing := currentByName[container.Name]; existing != nil {
+			container.Image = existing.Image
+			if container.ImageName == "" {
+				container.ImageName = existing.ImageName
+			}
+		} else {
+			currentByName[container.Name] = container
+		}
+	}
+
+	for _, template := range templates {
+		if template == nil {
+			continue
+		}
+		if existing := currentByKey[template.GetKey()]; existing != nil {
+			existing.ImagePath = template.ImagePath
+			existing.Type = template.Type
+			if existing.ImageName == "" {
+				existing.ImageName = template.ImageName
+			}
+			continue
+		}
+		if existing := currentByName[template.Name]; existing != nil {
+			template.Image = existing.Image
+			if template.ImageName == "" {
+				template.ImageName = existing.ImageName
+			}
+		}
+		currentByKey[template.GetKey()] = template
+		current = append(current, template)
+	}
+	return current
+}
+
 // GeneMergedValues generate values.yaml used to install or upgrade helm chart, like param in after option -f
 // defaultValues: global values yaml
 // productSvc: environment service, contains service's values yaml, override kvs and zadig recorded containers. And productSvc will be updated with correct image and values yaml in this function
@@ -570,47 +614,7 @@ func (s *HelmDeployService) GenNewEnvService(prod *commonmodels.Product, service
 			prodSvc.Revision = tmplSvc.Revision
 		}
 
-		containerMap := make(map[string]*commonmodels.Container)
-		containerNameMap := make(map[string]*commonmodels.Container)
-		for _, container := range prodSvc.Containers {
-			if container == nil {
-				continue
-			}
-			containerMap[container.GetKey()] = container
-			if currentContainer, ok := containerNameMap[container.Name]; ok {
-				container.Image = currentContainer.Image
-				if container.ImageName == "" {
-					container.ImageName = currentContainer.ImageName
-				}
-			} else {
-				containerNameMap[container.Name] = container
-			}
-		}
-
-		for _, templateContainer := range tmplContainers {
-			if templateContainer == nil {
-				continue
-			}
-			key := templateContainer.GetKey()
-			if currentContainer, ok := containerMap[key]; ok {
-				if templateContainer.ImagePath != nil {
-					currentContainer.ImagePath = templateContainer.ImagePath
-				}
-				currentContainer.Type = templateContainer.Type
-				if currentContainer.ImageName == "" {
-					currentContainer.ImageName = templateContainer.ImageName
-				}
-				continue
-			}
-			if currentContainer := containerNameMap[templateContainer.Name]; currentContainer != nil {
-				templateContainer.Image = currentContainer.Image
-				if templateContainer.ImageName == "" {
-					templateContainer.ImageName = currentContainer.ImageName
-				}
-			}
-			containerMap[key] = templateContainer
-			prodSvc.Containers = append(prodSvc.Containers, templateContainer)
-		}
+		prodSvc.Containers = MergeHelmContainers(prodSvc.Containers, tmplContainers)
 	}
 	return prodSvc, tmplSvc, nil
 }

--- a/pkg/microservice/aslan/core/common/service/helm/helm.go
+++ b/pkg/microservice/aslan/core/common/service/helm/helm.go
@@ -375,36 +375,6 @@ func NewHelmDeployService() *HelmDeployService {
 	return &HelmDeployService{}
 }
 
-// MergeHelmContainers uses the service_module result as the authoritative
-// container set for the selected service revision. Existing images are
-// preserved only when name and image path match exactly; a new path keeps the
-// template image instead of inheriting an unrelated same-name image.
-func MergeHelmContainers(current, templates []*commonmodels.Container) []*commonmodels.Container {
-	currentByKey := make(map[string]*commonmodels.Container, len(current))
-	for _, container := range current {
-		if container == nil {
-			continue
-		}
-		currentByKey[container.GetKey()] = container
-	}
-
-	merged := make([]*commonmodels.Container, 0, len(templates))
-	for _, templateContainer := range templates {
-		if templateContainer == nil {
-			continue
-		}
-		currentContainer := currentByKey[templateContainer.GetKey()]
-		if currentContainer != nil {
-			templateContainer.Image = currentContainer.Image
-			if templateContainer.ImageName == "" {
-				templateContainer.ImageName = currentContainer.ImageName
-			}
-		}
-		merged = append(merged, templateContainer)
-	}
-	return merged
-}
-
 // GeneMergedValues generate values.yaml used to install or upgrade helm chart, like param in after option -f
 // defaultValues: global values yaml
 // productSvc: environment service, contains service's values yaml, override kvs and zadig recorded containers. And productSvc will be updated with correct image and values yaml in this function
@@ -592,7 +562,41 @@ func (s *HelmDeployService) GenNewEnvService(prod *commonmodels.Product, service
 		if updateServiceRevision {
 			prodSvc.Revision = tmplSvc.Revision
 		}
-		prodSvc.Containers = MergeHelmContainers(prodSvc.Containers, tmplContainers)
+
+		containerMap := make(map[string]*commonmodels.Container)
+		containerNameMap := make(map[string]*commonmodels.Container)
+		for _, container := range prodSvc.Containers {
+			if container == nil {
+				continue
+			}
+			containerMap[container.GetKey()] = container
+			containerNameMap[container.Name] = container
+		}
+
+		for _, templateContainer := range tmplContainers {
+			if templateContainer == nil {
+				continue
+			}
+			key := templateContainer.GetKey()
+			if currentContainer, ok := containerMap[key]; ok {
+				if templateContainer.ImagePath != nil {
+					currentContainer.ImagePath = templateContainer.ImagePath
+				}
+				currentContainer.Type = templateContainer.Type
+				if currentContainer.ImageName == "" {
+					currentContainer.ImageName = templateContainer.ImageName
+				}
+				continue
+			}
+			if currentContainer := containerNameMap[templateContainer.Name]; currentContainer != nil {
+				templateContainer.Image = currentContainer.Image
+				if templateContainer.ImageName == "" {
+					templateContainer.ImageName = currentContainer.ImageName
+				}
+			}
+			containerMap[key] = templateContainer
+			prodSvc.Containers = append(prodSvc.Containers, templateContainer)
+		}
 	}
 	return prodSvc, tmplSvc, nil
 }

--- a/pkg/microservice/aslan/core/common/service/helm/helm.go
+++ b/pkg/microservice/aslan/core/common/service/helm/helm.go
@@ -466,26 +466,22 @@ func (s *HelmDeployService) GenMergedValues(productSvc *commonmodels.ProductServ
 		name := commonutil.ExtractImageName(imageUrl)
 
 		if container.ImageName == name {
-			// If a build image is provided, override the current image. When no
-			// build image is provided, still replace values when the environment
-			// image differs from the image currently in values (for example, a
-			// newly added same-name values path inheriting the old environment
-			// image).
+			// path present in values: skip when unchanged and no build image
+			if imageMap[name] == "" && container.Image == imageUrl {
+				continue
+			}
 			if imageMap[name] != "" {
 				container.Image = imageMap[name]
-				mergedContainers = append(mergedContainers, container)
-			} else if container.Image != imageUrl {
-				mergedContainers = append(mergedContainers, container)
-			}
-		} else {
-			// not found corresponding image in values
-			// add container image into values
-			if imageMap[container.ImageName] != "" {
-				// if found image in images, and the images are from build job, we should override it
-				container.Image = imageMap[container.ImageName]
 			}
 			mergedContainers = append(mergedContainers, container)
+			continue
 		}
+
+		// path not in values: always write back
+		if imageMap[container.ImageName] != "" {
+			container.Image = imageMap[container.ImageName]
+		}
+		mergedContainers = append(mergedContainers, container)
 	}
 
 	// 2. replace image into values yaml

--- a/pkg/microservice/aslan/core/common/service/helm/helm.go
+++ b/pkg/microservice/aslan/core/common/service/helm/helm.go
@@ -448,19 +448,21 @@ func MergeHelmContainers(current, templates []*commonmodels.Container) []*common
 		if template == nil {
 			continue
 		}
-		if existing := currentByKey[template.GetKey()]; existing != nil {
-			existing.ImagePath = template.ImagePath
-			existing.Type = template.Type
-			if existing.ImageName == "" {
-				existing.ImageName = template.ImageName
-			}
-			continue
-		}
+
 		if existing := currentByName[template.Name]; existing != nil {
 			template.Image = existing.Image
 			if template.ImageName == "" {
 				template.ImageName = existing.ImageName
 			}
+		}
+		if existing := currentByKey[template.GetKey()]; existing != nil {
+			existing.ImagePath = template.ImagePath
+			existing.Type = template.Type
+			existing.Image = template.Image
+			if existing.ImageName == "" {
+				existing.ImageName = template.ImageName
+			}
+			continue
 		}
 		currentByKey[template.GetKey()] = template
 		current = append(current, template)

--- a/pkg/microservice/aslan/core/common/service/helm/helm.go
+++ b/pkg/microservice/aslan/core/common/service/helm/helm.go
@@ -395,20 +395,19 @@ func MergeHelmContainers(current, templates []*commonmodels.Container) []*common
 			continue
 		}
 
+		if existing := currentByKey[template.GetKey()]; existing != nil {
+			existing.ImagePath = template.ImagePath
+			existing.Type = template.Type
+			if existing.ImageName == "" {
+				existing.ImageName = template.ImageName
+			}
+			continue
+		}
 		if existing := currentByName[template.Name]; existing != nil {
 			template.Image = existing.Image
 			if template.ImageName == "" {
 				template.ImageName = existing.ImageName
 			}
-		}
-		if existing := currentByKey[template.GetKey()]; existing != nil {
-			existing.ImagePath = template.ImagePath
-			existing.Type = template.Type
-			existing.Image = template.Image
-			if existing.ImageName == "" {
-				existing.ImageName = template.ImageName
-			}
-			continue
 		}
 		currentByKey[template.GetKey()] = template
 		current = append(current, template)

--- a/pkg/microservice/aslan/core/common/service/helm/helm.go
+++ b/pkg/microservice/aslan/core/common/service/helm/helm.go
@@ -375,6 +375,60 @@ func NewHelmDeployService() *HelmDeployService {
 	return &HelmDeployService{}
 }
 
+// SetContainerImagesFromValues rewrites each container's image with the value
+// resolved from its values path in the supplied yaml (the environment override
+// yaml). Containers whose path is absent from the yaml are left untouched.
+//
+// The override yaml is the authoritative record of the deployed image. Syncing
+// from it before merging prevents a stale Container.Image (for example the
+// template's default tag) from being treated as the environment image and
+// overwriting the deployed tag.
+func SetContainerImagesFromValues(containers []*commonmodels.Container, valuesYaml string) {
+	if valuesYaml == "" {
+		return
+	}
+	valuesMap := make(map[string]interface{})
+	if err := yaml.Unmarshal([]byte(valuesYaml), &valuesMap); err != nil {
+		return
+	}
+	flatValuesMap, err := converter.Flatten(valuesMap)
+	if err != nil {
+		return
+	}
+	for _, container := range containers {
+		if container == nil || container.ImagePath == nil {
+			continue
+		}
+		spec := container.ImagePath
+		if !imagePathInValues(flatValuesMap, spec.Repo, spec.Namespace, spec.Image, spec.Tag) {
+			continue
+		}
+		imageSearchRule := &templatemodels.ImageSearchingRule{
+			Repo:      spec.Repo,
+			Namespace: spec.Namespace,
+			Image:     spec.Image,
+			Tag:       spec.Tag,
+		}
+		imageUrl, err := commonutil.GeneImageURI(imageSearchRule.GetSearchingPattern(), flatValuesMap)
+		if err != nil {
+			continue
+		}
+		container.Image = imageUrl
+	}
+}
+
+func imagePathInValues(flatValuesMap map[string]interface{}, paths ...string) bool {
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		if _, ok := flatValuesMap[p]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // MergeHelmContainers keeps existing environment images while adding or
 // refreshing the containers parsed from the selected service revision.
 func MergeHelmContainers(current, templates []*commonmodels.Container) []*commonmodels.Container {
@@ -385,12 +439,7 @@ func MergeHelmContainers(current, templates []*commonmodels.Container) []*common
 			continue
 		}
 		currentByKey[container.GetKey()] = container
-		if existing := currentByName[container.Name]; existing != nil {
-			container.Image = existing.Image
-			if container.ImageName == "" {
-				container.ImageName = existing.ImageName
-			}
-		} else {
+		if currentByName[container.Name] == nil {
 			currentByName[container.Name] = container
 		}
 	}
@@ -614,6 +663,11 @@ func (s *HelmDeployService) GenNewEnvService(prod *commonmodels.Product, service
 			prodSvc.Revision = tmplSvc.Revision
 		}
 
+		// The override yaml is the authoritative record of the deployed image.
+		// Sync the environment containers from it before merging with the
+		// template, so a revision gap doesn't reset images back to the
+		// template's default tag.
+		SetContainerImagesFromValues(prodSvc.Containers, prodSvc.GetServiceRender().GetOverrideYaml())
 		prodSvc.Containers = MergeHelmContainers(prodSvc.Containers, tmplContainers)
 	}
 	return prodSvc, tmplSvc, nil

--- a/pkg/microservice/aslan/core/common/service/helm/helm.go
+++ b/pkg/microservice/aslan/core/common/service/helm/helm.go
@@ -375,60 +375,6 @@ func NewHelmDeployService() *HelmDeployService {
 	return &HelmDeployService{}
 }
 
-// SetContainerImagesFromValues rewrites each container's image with the value
-// resolved from its values path in the supplied yaml (the environment override
-// yaml). Containers whose path is absent from the yaml are left untouched.
-//
-// The override yaml is the authoritative record of the deployed image. Syncing
-// from it before merging prevents a stale Container.Image (for example the
-// template's default tag) from being treated as the environment image and
-// overwriting the deployed tag.
-func SetContainerImagesFromValues(containers []*commonmodels.Container, valuesYaml string) {
-	if valuesYaml == "" {
-		return
-	}
-	valuesMap := make(map[string]interface{})
-	if err := yaml.Unmarshal([]byte(valuesYaml), &valuesMap); err != nil {
-		return
-	}
-	flatValuesMap, err := converter.Flatten(valuesMap)
-	if err != nil {
-		return
-	}
-	for _, container := range containers {
-		if container == nil || container.ImagePath == nil {
-			continue
-		}
-		spec := container.ImagePath
-		if !imagePathInValues(flatValuesMap, spec.Repo, spec.Namespace, spec.Image, spec.Tag) {
-			continue
-		}
-		imageSearchRule := &templatemodels.ImageSearchingRule{
-			Repo:      spec.Repo,
-			Namespace: spec.Namespace,
-			Image:     spec.Image,
-			Tag:       spec.Tag,
-		}
-		imageUrl, err := commonutil.GeneImageURI(imageSearchRule.GetSearchingPattern(), flatValuesMap)
-		if err != nil {
-			continue
-		}
-		container.Image = imageUrl
-	}
-}
-
-func imagePathInValues(flatValuesMap map[string]interface{}, paths ...string) bool {
-	for _, p := range paths {
-		if p == "" {
-			continue
-		}
-		if _, ok := flatValuesMap[p]; ok {
-			return true
-		}
-	}
-	return false
-}
-
 // MergeHelmContainers keeps existing environment images while adding or
 // refreshing the containers parsed from the selected service revision.
 func MergeHelmContainers(current, templates []*commonmodels.Container) []*commonmodels.Container {
@@ -665,11 +611,6 @@ func (s *HelmDeployService) GenNewEnvService(prod *commonmodels.Product, service
 			prodSvc.Revision = tmplSvc.Revision
 		}
 
-		// The override yaml is the authoritative record of the deployed image.
-		// Sync the environment containers from it before merging with the
-		// template, so a revision gap doesn't reset images back to the
-		// template's default tag.
-		SetContainerImagesFromValues(prodSvc.Containers, prodSvc.GetServiceRender().GetOverrideYaml())
 		prodSvc.Containers = MergeHelmContainers(prodSvc.Containers, tmplContainers)
 	}
 	return prodSvc, tmplSvc, nil

--- a/pkg/microservice/aslan/core/common/service/helm/helm.go
+++ b/pkg/microservice/aslan/core/common/service/helm/helm.go
@@ -426,9 +426,7 @@ func (s *HelmDeployService) GenMergedValues(productSvc *commonmodels.ProductServ
 	imageMap := make(map[string]string)
 	for _, image := range images {
 		name := commonutil.ExtractImageName(image)
-		if _, ok := imageMap[name]; !ok {
-			imageMap[name] = image
-		}
+		imageMap[name] = image
 	}
 
 	valuesMap := make(map[string]interface{})

--- a/pkg/microservice/aslan/core/common/service/helm/helm.go
+++ b/pkg/microservice/aslan/core/common/service/helm/helm.go
@@ -423,10 +423,15 @@ func (s *HelmDeployService) GenMergedValues(productSvc *commonmodels.ProductServ
 		name := commonutil.ExtractImageName(imageUrl)
 
 		if container.ImageName == name {
-			// find corresponding image in values
+			// If a build image is provided, override the current image. When no
+			// build image is provided, still replace values when the environment
+			// image differs from the image currently in values (for example, a
+			// newly added same-name values path inheriting the old environment
+			// image).
 			if imageMap[name] != "" {
-				// if found image in images, and the images are from build job, we should override it
 				container.Image = imageMap[name]
+				mergedContainers = append(mergedContainers, container)
+			} else if container.Image != imageUrl {
 				mergedContainers = append(mergedContainers, container)
 			}
 		} else {

--- a/pkg/microservice/aslan/core/common/service/helm/helm.go
+++ b/pkg/microservice/aslan/core/common/service/helm/helm.go
@@ -375,6 +375,36 @@ func NewHelmDeployService() *HelmDeployService {
 	return &HelmDeployService{}
 }
 
+// MergeHelmContainers uses the service_module result as the authoritative
+// container set for the selected service revision. Existing images are
+// preserved only when name and image path match exactly; a new path keeps the
+// template image instead of inheriting an unrelated same-name image.
+func MergeHelmContainers(current, templates []*commonmodels.Container) []*commonmodels.Container {
+	currentByKey := make(map[string]*commonmodels.Container, len(current))
+	for _, container := range current {
+		if container == nil {
+			continue
+		}
+		currentByKey[container.GetKey()] = container
+	}
+
+	merged := make([]*commonmodels.Container, 0, len(templates))
+	for _, templateContainer := range templates {
+		if templateContainer == nil {
+			continue
+		}
+		currentContainer := currentByKey[templateContainer.GetKey()]
+		if currentContainer != nil {
+			templateContainer.Image = currentContainer.Image
+			if templateContainer.ImageName == "" {
+				templateContainer.ImageName = currentContainer.ImageName
+			}
+		}
+		merged = append(merged, templateContainer)
+	}
+	return merged
+}
+
 // GeneMergedValues generate values.yaml used to install or upgrade helm chart, like param in after option -f
 // defaultValues: global values yaml
 // productSvc: environment service, contains service's values yaml, override kvs and zadig recorded containers. And productSvc will be updated with correct image and values yaml in this function
@@ -540,41 +570,29 @@ func (s *HelmDeployService) GenNewEnvService(prod *commonmodels.Product, service
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "failed to find service %s/%d in product %s", serviceName, svcFindOption.Revision, prod.ProductName)
 		}
+	}
 
-		// Service.Containers no longer persisted — pull modules for the
-		// loaded template revision from the service_module table.
-		tmplContainers, _, rerr := repository.ResolveServiceModules(context.Background(), tmplSvc.ProductName, tmplSvc.ServiceName, prod.Production, tmplSvc.Revision)
-		if rerr != nil {
-			return nil, nil, errors.Wrapf(rerr, "failed to resolve modules for %s/%s rev %d", tmplSvc.ProductName, tmplSvc.ServiceName, tmplSvc.Revision)
+	// Service.Containers is no longer persisted in the template. Resolve the
+	// selected service revision from service_module; when updateServiceRevision
+	// is false, tmplSvc is pinned to the environment's current revision.
+	tmplContainers, _, rerr := repository.ResolveServiceModules(context.Background(), tmplSvc.ProductName, tmplSvc.ServiceName, prod.Production, tmplSvc.Revision)
+	if rerr != nil {
+		return nil, nil, errors.Wrapf(rerr, "failed to resolve modules for %s/%s rev %d", tmplSvc.ProductName, tmplSvc.ServiceName, tmplSvc.Revision)
+	}
+	if prodSvc == nil {
+		prodSvc = &commonmodels.ProductService{
+			ServiceName: serviceName,
+			ReleaseName: serviceName,
+			ProductName: prod.ProductName,
+			Type:        tmplSvc.Type,
+			Revision:    tmplSvc.Revision,
+			Containers:  tmplContainers,
 		}
-		if prodSvc == nil {
-			prodSvc = &commonmodels.ProductService{
-				ServiceName: serviceName,
-				ReleaseName: serviceName,
-				ProductName: prod.ProductName,
-				Type:        tmplSvc.Type,
-				Revision:    tmplSvc.Revision,
-				Containers:  tmplContainers,
-			}
-		} else {
+	} else {
+		if updateServiceRevision {
 			prodSvc.Revision = tmplSvc.Revision
-
-			containerMap := make(map[string]*commonmodels.Container)
-			for _, container := range prodSvc.Containers {
-				containerMap[container.Name] = container
-			}
-
-			for _, templateContainer := range tmplContainers {
-				if containerMap[templateContainer.Name] == nil {
-					prodSvc.Containers = append(prodSvc.Containers, templateContainer)
-				} else {
-					if templateContainer.ImagePath != nil {
-						containerMap[templateContainer.Name].ImagePath = templateContainer.ImagePath
-					}
-					containerMap[templateContainer.Name].Type = templateContainer.Type
-				}
-			}
 		}
+		prodSvc.Containers = MergeHelmContainers(prodSvc.Containers, tmplContainers)
 	}
 	return prodSvc, tmplSvc, nil
 }

--- a/pkg/microservice/aslan/core/common/service/helm/helm.go
+++ b/pkg/microservice/aslan/core/common/service/helm/helm.go
@@ -386,7 +386,9 @@ func (s *HelmDeployService) GenMergedValues(productSvc *commonmodels.ProductServ
 	imageMap := make(map[string]string)
 	for _, image := range images {
 		name := commonutil.ExtractImageName(image)
-		imageMap[name] = image
+		if _, ok := imageMap[name]; !ok {
+			imageMap[name] = image
+		}
 	}
 
 	valuesMap := make(map[string]interface{})
@@ -575,7 +577,14 @@ func (s *HelmDeployService) GenNewEnvService(prod *commonmodels.Product, service
 				continue
 			}
 			containerMap[container.GetKey()] = container
-			containerNameMap[container.Name] = container
+			if currentContainer, ok := containerNameMap[container.Name]; ok {
+				container.Image = currentContainer.Image
+				if container.ImageName == "" {
+					container.ImageName = currentContainer.ImageName
+				}
+			} else {
+				containerNameMap[container.Name] = container
+			}
 		}
 
 		for _, templateContainer := range tmplContainers {

--- a/pkg/microservice/aslan/core/common/service/kube/helm.go
+++ b/pkg/microservice/aslan/core/common/service/kube/helm.go
@@ -973,6 +973,7 @@ func BuildInstallParam(defaultValues string, productInfo *commonmodels.Product, 
 		if err != nil {
 			return ret, fmt.Errorf("failed to resolve modules for %s/%s rev %d: %w", templateSvc.ProductName, templateSvc.ServiceName, templateSvc.Revision, err)
 		}
+		helmservice.SetContainerImagesFromValues(productSvc.Containers, renderChart.GetOverrideYaml())
 		productSvc.Containers = helmservice.MergeHelmContainers(productSvc.Containers, tmplContainers)
 		ret.ServiceObj = templateSvc
 		ret.ReleaseName = util.GeneReleaseName(templateSvc.GetReleaseNaming(), templateSvc.ProductName, namespace, envName, templateSvc.ServiceName)

--- a/pkg/microservice/aslan/core/common/service/kube/helm.go
+++ b/pkg/microservice/aslan/core/common/service/kube/helm.go
@@ -973,23 +973,7 @@ func BuildInstallParam(defaultValues string, productInfo *commonmodels.Product, 
 		if err != nil {
 			return ret, fmt.Errorf("failed to resolve modules for %s/%s rev %d: %w", templateSvc.ProductName, templateSvc.ServiceName, templateSvc.Revision, err)
 		}
-		containerMap := make(map[string]*commonmodels.Container)
-		for _, container := range productSvc.Containers {
-			containerMap[container.Name] = container
-		}
-		for _, tmplContainer := range tmplContainers {
-			if containerMap[tmplContainer.Name] == nil {
-				productSvc.Containers = append(productSvc.Containers, tmplContainer)
-				continue
-			}
-			if tmplContainer.ImagePath != nil {
-				containerMap[tmplContainer.Name].ImagePath = tmplContainer.ImagePath
-			}
-			containerMap[tmplContainer.Name].Type = tmplContainer.Type
-			if containerMap[tmplContainer.Name].ImageName == "" {
-				containerMap[tmplContainer.Name].ImageName = tmplContainer.ImageName
-			}
-		}
+		productSvc.Containers = helmservice.MergeHelmContainers(productSvc.Containers, tmplContainers)
 		ret.ServiceObj = templateSvc
 		ret.ReleaseName = util.GeneReleaseName(templateSvc.GetReleaseNaming(), templateSvc.ProductName, namespace, envName, templateSvc.ServiceName)
 	} else {

--- a/pkg/microservice/aslan/core/common/service/kube/helm.go
+++ b/pkg/microservice/aslan/core/common/service/kube/helm.go
@@ -980,7 +980,14 @@ func BuildInstallParam(defaultValues string, productInfo *commonmodels.Product, 
 				continue
 			}
 			containerMap[container.GetKey()] = container
-			containerNameMap[container.Name] = container
+			if currentContainer, ok := containerNameMap[container.Name]; ok {
+				container.Image = currentContainer.Image
+				if container.ImageName == "" {
+					container.ImageName = currentContainer.ImageName
+				}
+			} else {
+				containerNameMap[container.Name] = container
+			}
 		}
 		for _, tmplContainer := range tmplContainers {
 			if tmplContainer == nil {

--- a/pkg/microservice/aslan/core/common/service/kube/helm.go
+++ b/pkg/microservice/aslan/core/common/service/kube/helm.go
@@ -973,7 +973,6 @@ func BuildInstallParam(defaultValues string, productInfo *commonmodels.Product, 
 		if err != nil {
 			return ret, fmt.Errorf("failed to resolve modules for %s/%s rev %d: %w", templateSvc.ProductName, templateSvc.ServiceName, templateSvc.Revision, err)
 		}
-		helmservice.SetContainerImagesFromValues(productSvc.Containers, renderChart.GetOverrideYaml())
 		productSvc.Containers = helmservice.MergeHelmContainers(productSvc.Containers, tmplContainers)
 		ret.ServiceObj = templateSvc
 		ret.ReleaseName = util.GeneReleaseName(templateSvc.GetReleaseNaming(), templateSvc.ProductName, namespace, envName, templateSvc.ServiceName)

--- a/pkg/microservice/aslan/core/common/service/kube/helm.go
+++ b/pkg/microservice/aslan/core/common/service/kube/helm.go
@@ -973,7 +973,39 @@ func BuildInstallParam(defaultValues string, productInfo *commonmodels.Product, 
 		if err != nil {
 			return ret, fmt.Errorf("failed to resolve modules for %s/%s rev %d: %w", templateSvc.ProductName, templateSvc.ServiceName, templateSvc.Revision, err)
 		}
-		productSvc.Containers = helmservice.MergeHelmContainers(productSvc.Containers, tmplContainers)
+		containerMap := make(map[string]*commonmodels.Container)
+		containerNameMap := make(map[string]*commonmodels.Container)
+		for _, container := range productSvc.Containers {
+			if container == nil {
+				continue
+			}
+			containerMap[container.GetKey()] = container
+			containerNameMap[container.Name] = container
+		}
+		for _, tmplContainer := range tmplContainers {
+			if tmplContainer == nil {
+				continue
+			}
+			key := tmplContainer.GetKey()
+			if currentContainer, ok := containerMap[key]; ok {
+				if tmplContainer.ImagePath != nil {
+					currentContainer.ImagePath = tmplContainer.ImagePath
+				}
+				currentContainer.Type = tmplContainer.Type
+				if currentContainer.ImageName == "" {
+					currentContainer.ImageName = tmplContainer.ImageName
+				}
+				continue
+			}
+			if currentContainer := containerNameMap[tmplContainer.Name]; currentContainer != nil {
+				tmplContainer.Image = currentContainer.Image
+				if tmplContainer.ImageName == "" {
+					tmplContainer.ImageName = currentContainer.ImageName
+				}
+			}
+			containerMap[key] = tmplContainer
+			productSvc.Containers = append(productSvc.Containers, tmplContainer)
+		}
 		ret.ServiceObj = templateSvc
 		ret.ReleaseName = util.GeneReleaseName(templateSvc.GetReleaseNaming(), templateSvc.ProductName, namespace, envName, templateSvc.ServiceName)
 	} else {

--- a/pkg/microservice/aslan/core/common/service/kube/helm.go
+++ b/pkg/microservice/aslan/core/common/service/kube/helm.go
@@ -973,46 +973,7 @@ func BuildInstallParam(defaultValues string, productInfo *commonmodels.Product, 
 		if err != nil {
 			return ret, fmt.Errorf("failed to resolve modules for %s/%s rev %d: %w", templateSvc.ProductName, templateSvc.ServiceName, templateSvc.Revision, err)
 		}
-		containerMap := make(map[string]*commonmodels.Container)
-		containerNameMap := make(map[string]*commonmodels.Container)
-		for _, container := range productSvc.Containers {
-			if container == nil {
-				continue
-			}
-			containerMap[container.GetKey()] = container
-			if currentContainer, ok := containerNameMap[container.Name]; ok {
-				container.Image = currentContainer.Image
-				if container.ImageName == "" {
-					container.ImageName = currentContainer.ImageName
-				}
-			} else {
-				containerNameMap[container.Name] = container
-			}
-		}
-		for _, tmplContainer := range tmplContainers {
-			if tmplContainer == nil {
-				continue
-			}
-			key := tmplContainer.GetKey()
-			if currentContainer, ok := containerMap[key]; ok {
-				if tmplContainer.ImagePath != nil {
-					currentContainer.ImagePath = tmplContainer.ImagePath
-				}
-				currentContainer.Type = tmplContainer.Type
-				if currentContainer.ImageName == "" {
-					currentContainer.ImageName = tmplContainer.ImageName
-				}
-				continue
-			}
-			if currentContainer := containerNameMap[tmplContainer.Name]; currentContainer != nil {
-				tmplContainer.Image = currentContainer.Image
-				if tmplContainer.ImageName == "" {
-					tmplContainer.ImageName = currentContainer.ImageName
-				}
-			}
-			containerMap[key] = tmplContainer
-			productSvc.Containers = append(productSvc.Containers, tmplContainer)
-		}
+		productSvc.Containers = helmservice.MergeHelmContainers(productSvc.Containers, tmplContainers)
 		ret.ServiceObj = templateSvc
 		ret.ReleaseName = util.GeneReleaseName(templateSvc.GetReleaseNaming(), templateSvc.ProductName, namespace, envName, templateSvc.ServiceName)
 	} else {

--- a/pkg/microservice/aslan/core/common/service/repository/service_module.go
+++ b/pkg/microservice/aslan/core/common/service/repository/service_module.go
@@ -25,8 +25,8 @@ import (
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 )
 
-// ModuleConflict reports that two records share a Name. The Winner is the
-// record currently in effect under the precedence rule (see
+// ModuleConflict reports that two records share a Name and ImagePath. The
+// Winner is the record currently in effect under the precedence rule (see
 // ResolveServiceModules); Shadowed lists the records that were displaced.
 // Callers (typically API handlers) should surface these to the UI so users
 // can disambiguate — e.g., "module 'api' has both a manual declaration and
@@ -42,9 +42,9 @@ type ModuleConflict struct {
 // underlying collection (service_module vs production_service_module).
 //
 // Merge rule: time-of-creation precedence ("first-come-first-served"). For
-// every Name in the union of (manual records, auto records bound to
-// `revision`), the record with the smallest CreateTime wins; later records
-// with the same Name are reported as shadowed. Ties (same CreateTime) are
+// every Name + ImagePath in the union of (manual records, auto records bound
+// to `revision`), the record with the smallest CreateTime wins; later records
+// with the same identity are reported as shadowed. Ties (same CreateTime) are
 // broken by ObjectID order — deterministic, but "shouldn't happen in
 // practice."
 //
@@ -252,10 +252,11 @@ func mergeServiceModules(records []*models.ServiceModule) []*models.Container {
 	winners := make([]*models.Container, 0, len(records))
 	seen := make(map[string]struct{}, len(records))
 	for _, r := range records {
-		if _, ok := seen[r.Name]; ok {
+		key := serviceModuleKey(r)
+		if _, ok := seen[key]; ok {
 			continue
 		}
-		seen[r.Name] = struct{}{}
+		seen[key] = struct{}{}
 		winners = append(winners, &models.Container{
 			Name:      r.Name,
 			Type:      r.Type,
@@ -267,30 +268,37 @@ func mergeServiceModules(records []*models.ServiceModule) []*models.Container {
 	return winners
 }
 
+func serviceModuleKey(module *models.ServiceModule) string {
+	if module == nil {
+		return ""
+	}
+	return (&models.Container{Name: module.Name, ImagePath: module.ImagePath}).GetKey()
+}
+
 // TODO: convenience wrapper ResolveServiceModulesFor(ctx, svc, production)
 // that infers project/service/revision from svc — deferred per discussion,
 // callers will pass the explicit args until usage volume justifies it.
 
-// conflictsFromMerge walks the same pre-sorted slice and groups shadowed
-// records under their winning entry. Returned slice is empty when there are
-// no name collisions.
+// conflictsFromMerge walks the same pre-sorted slice and groups records with
+// the same name and image path under their winning entry.
 func conflictsFromMerge(records []*models.ServiceModule) []ModuleConflict {
-	byName := make(map[string][]*models.ServiceModule, len(records))
+	byKey := make(map[string][]*models.ServiceModule, len(records))
 	order := make([]string, 0, len(records))
 	for _, r := range records {
-		if _, ok := byName[r.Name]; !ok {
-			order = append(order, r.Name)
+		key := serviceModuleKey(r)
+		if _, ok := byKey[key]; !ok {
+			order = append(order, key)
 		}
-		byName[r.Name] = append(byName[r.Name], r)
+		byKey[key] = append(byKey[key], r)
 	}
 	conflicts := make([]ModuleConflict, 0)
-	for _, name := range order {
-		group := byName[name]
+	for _, key := range order {
+		group := byKey[key]
 		if len(group) < 2 {
 			continue
 		}
 		conflicts = append(conflicts, ModuleConflict{
-			Name:     name,
+			Name:     group[0].Name,
 			Winner:   group[0],
 			Shadowed: group[1:],
 		})

--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -1111,6 +1111,23 @@ func updateHelmProduct(productName, envName, username, requestID string, overrid
 				continue
 			}
 
+			curUsedSvc := serviceMap[svr.ServiceName]
+			if curUsedSvc != nil {
+				// Service.Containers is not persisted, so resolve the deployed revision's modules for the baseline.
+				curUsedMerged, _, rerr := repository.ResolveServiceModules(
+					context.Background(),
+					curUsedSvc.ProductName,
+					curUsedSvc.ServiceName,
+					productResp.Production,
+					curUsedSvc.Revision,
+				)
+				if rerr != nil {
+					log.Errorf("failed to resolve current service modules for %s/%s rev %d: %s", curUsedSvc.ProductName, curUsedSvc.ServiceName, curUsedSvc.Revision, rerr)
+				} else {
+					curUsedSvc.Containers = curUsedMerged
+				}
+			}
+
 			svr.Containers = kube.CalculateContainer(ps, serviceMap[svr.ServiceName], svr.Containers, productResp)
 		}
 		allServices = append(allServices, svcGroup)


### PR DESCRIPTION
### What this PR does / Why we need it:

Fixes Helm services where multiple components share the same image name but use different values paths. Previously, components were merged by name, causing one component to overwrite another and preventing simultaneous image updates.

### What is changed and how it works?

- Uses `name + image_path` as the identity for Helm service modules.
- Preserves same-name components with different image paths when resolving `service_module` records.
- Updates environment containers by exact `name + image_path` matching.
- Uses the selected service revision from `service_module` as the authoritative container list.
- Ensures image updates are applied to all matching Helm values paths.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4913)
<!-- Reviewable:end -->
