### PR TITLE
fix(workflow): expose referenced plugin inputs as variables

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_plugin.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_plugin.go
@@ -26,6 +26,7 @@ import (
 	commonservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/types"
+	"github.com/koderover/zadig/v2/pkg/util"
 )
 
 type PluginJobController struct {
@@ -160,6 +161,24 @@ func (j PluginJobController) SetRepoCommitInfo() error {
 
 func (j PluginJobController) GetVariableList(jobName string, getAggregatedVariables, getRuntimeVariables, getPlaceHolderVariables, getServiceSpecificVariables, useUserInputValue bool) ([]*commonmodels.KeyVal, error) {
 	resp := make([]*commonmodels.KeyVal, 0)
+	functionReferences := make(map[string]struct{})
+	for _, input := range j.jobSpec.Plugin.Inputs {
+		for _, reference := range util.FindVariableKeyRef(input.CallFunction) {
+			functionReferences[reference] = struct{}{}
+		}
+	}
+	for _, input := range j.jobSpec.Plugin.Inputs {
+		key := strings.Join([]string{"job", j.name, input.Name}, ".")
+		if _, ok := functionReferences[key]; !ok || input.ParamsType == "repo" || input.ParamsType == "file" {
+			continue
+		}
+		resp = append(resp, &commonmodels.KeyVal{
+			Key:          key,
+			Value:        input.GetValue(),
+			Type:         "string",
+			IsCredential: input.IsCredential,
+		})
+	}
 	if getRuntimeVariables {
 		resp = append(resp, &commonmodels.KeyVal{
 			Key:          strings.Join([]string{"job", j.name, "status"}, "."),


### PR DESCRIPTION
### Summary
- Expose plugin inputs referenced by dynamic variable functions.

### Why
- A function could use `job.<job-name>.<input-name>`, but the referenced input was absent from the available-variable list.

### Main Changes
- Parse plugin input `CallFunction` references with the existing variable parser.
- Return only referenced inputs from the same plugin job; exclude repo/file inputs.

### Risk / Compatibility
- Additive and scoped to existing function references; unrelated plugin inputs remain hidden.

### Test
- Verified referenced inputs are returned, unrelated inputs are omitted, and the Job controller package compiles.
Contact: huanghongbo@koderover.com
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4915)
<!-- Reviewable:end -->