### PR TITLE
feat: support project scope for hosts

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/private_key.go
+++ b/pkg/microservice/aslan/core/common/repository/models/private_key.go
@@ -44,6 +44,7 @@ type PrivateKey struct {
 	Provider     int8                 `bson:"provider"               json:"provider"`
 	Probe        *types.Probe         `bson:"probe"                  json:"probe"`
 	ProjectName  string               `bson:"project_name,omitempty" json:"project_name"`
+	Projects     []string             `bson:"projects"               json:"projects"`
 	UpdateStatus bool                 `bson:"-"                      json:"update_status"`
 	// ScheduleWorkflow equals to true means this vm is agent type, false means this vm is ssh type
 	ScheduleWorkflow bool     `bson:"schedule_workflow"      json:"schedule_workflow"`

--- a/pkg/microservice/aslan/core/common/repository/mongodb/private_key.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/private_key.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/v2/pkg/setting"
 	mongotool "github.com/koderover/zadig/v2/pkg/tool/mongo"
 )
 
@@ -112,11 +113,17 @@ func (c *PrivateKeyColl) List(args *PrivateKeyArgs) ([]*models.PrivateKey, error
 		query["name"] = args.Name
 	}
 
-	if args.ProjectName != "" {
-		query["project_name"] = args.ProjectName
-	}
-	if args.SystemOnly {
+	switch {
+	case args.SystemOnly:
 		query["project_name"] = bson.M{"$exists": false}
+	case args.ProjectName != "":
+		query["$or"] = bson.A{
+			bson.M{"project_name": args.ProjectName},
+			bson.M{
+				"project_name": bson.M{"$exists": false},
+				"projects":     bson.M{"$in": bson.A{args.ProjectName, setting.AllProjects}},
+			},
+		}
 	}
 
 	resp := make([]*models.PrivateKey, 0)


### PR DESCRIPTION
### Summary
- Allow hosts in Resource Management to be assigned to selected projects or all projects.

### Why
- Project host lists previously only matched project-owned hosts, so scoped shared hosts were unavailable.

### Main Changes
- Add a backward-compatible `projects` field to host records.
- Include shared hosts scoped to the current project or `<all_projects>` in project host queries.

### Risk / Compatibility
- Existing `project_name` semantics and permission checks remain unchanged.
- Existing hosts without `projects` are not implicitly exposed to projects.

### Test
- Verified system-only, project-owned, selected-project, and all-project query cases.
- Ran targeted package compilation with `go test -vet=off`.

### Contact
Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4917)
<!-- Reviewable:end -->
