### PR TITLE
feat: add project update and group OpenAPIs

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/mongodb/project_group.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/project_group.go
@@ -99,23 +99,6 @@ func (c *ProjectGroupColl) Delete(name string) error {
 	return err
 }
 
-func (c *ProjectGroupColl) DeleteByID(id string) error {
-	objectID, err := primitive.ObjectIDFromHex(id)
-	if err != nil {
-		return errors.New("invalid group id")
-	}
-
-	result, err := c.DeleteOne(context.Background(), bson.M{"_id": objectID})
-	if err != nil {
-		return err
-	}
-	if result.DeletedCount == 0 {
-		return mongo.ErrNoDocuments
-	}
-
-	return nil
-}
-
 type ProjectGroupOpts struct {
 	Name string
 	ID   string

--- a/pkg/microservice/aslan/core/common/repository/mongodb/project_group.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/project_group.go
@@ -82,10 +82,38 @@ func (c *ProjectGroupColl) Update(args *models.ProjectGroup) error {
 	return err
 }
 
+func (c *ProjectGroupColl) UpdateProjectName(projectKey, projectName string) error {
+	filter := bson.M{"projects.project_key": projectKey}
+	update := bson.M{"$set": bson.M{"projects.$[project].project_name": projectName}}
+	arrayFilters := options.ArrayFilters{
+		Filters: []interface{}{bson.M{"project.project_key": projectKey}},
+	}
+
+	_, err := c.UpdateMany(context.Background(), filter, update, options.Update().SetArrayFilters(arrayFilters))
+	return err
+}
+
 func (c *ProjectGroupColl) Delete(name string) error {
 	filter := bson.M{"name": name}
 	_, err := c.DeleteOne(context.Background(), filter)
 	return err
+}
+
+func (c *ProjectGroupColl) DeleteByID(id string) error {
+	objectID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return errors.New("invalid group id")
+	}
+
+	result, err := c.DeleteOne(context.Background(), bson.M{"_id": objectID})
+	if err != nil {
+		return err
+	}
+	if result.DeletedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+
+	return nil
 }
 
 type ProjectGroupOpts struct {

--- a/pkg/microservice/aslan/core/common/repository/mongodb/template/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/template/product.go
@@ -457,6 +457,8 @@ func (c *ProductColl) Update(productName string, args *template.Product) error {
 	return err
 }
 
+// UpdateMetadata updates only fields exposed by the project update OpenAPI to
+// avoid overwriting unrelated project state with a stale full Product model.
 func (c *ProductColl) UpdateMetadata(productName string, args *ProjectMetadataUpdate) error {
 	if args == nil {
 		return errors.New("nil project metadata")

--- a/pkg/microservice/aslan/core/common/repository/mongodb/template/product.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/template/product.go
@@ -44,6 +44,15 @@ type ProjectInfo struct {
 	ProductFeature *templatemodels.ProductFeature `bson:"product_feature"`
 }
 
+type ProjectMetadataUpdate struct {
+	ProjectName                  string
+	ProjectNamePinyin            string
+	ProjectNamePinyinFirstLetter string
+	Description                  string
+	Public                       bool
+	UpdateBy                     string
+}
+
 type ProductColl struct {
 	*mongo.Collection
 	mongo.Session
@@ -446,6 +455,33 @@ func (c *ProductColl) Update(productName string, args *template.Product) error {
 
 	_, err := c.UpdateOne(mongotool.SessionContext(context.TODO(), c.Session), query, change)
 	return err
+}
+
+func (c *ProductColl) UpdateMetadata(productName string, args *ProjectMetadataUpdate) error {
+	if args == nil {
+		return errors.New("nil project metadata")
+	}
+
+	result, err := c.UpdateOne(
+		mongotool.SessionContext(context.TODO(), c.Session),
+		bson.M{"product_name": productName},
+		bson.M{"$set": bson.M{
+			"project_name":                     args.ProjectName,
+			"project_name_pinyin":              args.ProjectNamePinyin,
+			"project_name_pinyin_first_letter": args.ProjectNamePinyinFirstLetter,
+			"description":                      args.Description,
+			"public":                           args.Public,
+			"update_by":                        args.UpdateBy,
+			"update_time":                      time.Now().Unix(),
+		}},
+	)
+	if err != nil {
+		return err
+	}
+	if result.MatchedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
 }
 
 type ProductArgs struct {

--- a/pkg/microservice/aslan/core/project/handler/openapi.go
+++ b/pkg/microservice/aslan/core/project/handler/openapi.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -318,7 +319,20 @@ func OpenAPIGetProjectGroup(c *gin.Context) {
 		return
 	}
 
-	ctx.Resp, ctx.RespErr = service.GetProjectGroupOpenAPI(groupID, ctx.Logger)
+	var authorizedProjects []string
+	if !ctx.Resources.IsSystemAdmin {
+		authorizedProjects = make([]string, 0)
+		projects, found, err := internalhandler.ListAuthorizedProjects(ctx.UserID)
+		if err != nil {
+			ctx.RespErr = e.ErrInternalError.AddDesc(err.Error())
+			return
+		}
+		if found {
+			authorizedProjects = projects
+		}
+	}
+
+	ctx.Resp, ctx.RespErr = service.GetProjectGroupOpenAPI(groupID, authorizedProjects, ctx.Logger)
 }
 
 func OpenAPICreateProjectGroup(c *gin.Context) {
@@ -356,7 +370,14 @@ func OpenAPICreateProjectGroup(c *gin.Context) {
 	}
 
 	internalhandler.InsertOperationLog(c, ctx.UserName+"(openAPI)", "", "新增", "分组", args.GroupName, args.GroupName, string(data), types.RequestBodyTypeJSON, ctx.Logger)
-	ctx.RespErr = service.CreateProjectGroupOpenAPI(args, ctx.UserName, ctx.Logger)
+	projectKeys := make([]string, 0)
+	if args.ProjectKeys != nil {
+		projectKeys = *args.ProjectKeys
+	}
+	ctx.RespErr = service.CreateProjectGroup(&service.ProjectGroupArgs{
+		GroupName:   strings.TrimSpace(args.GroupName),
+		ProjectKeys: projectKeys,
+	}, ctx.UserName, ctx.Logger)
 }
 
 func OpenAPIUpdateProjectGroup(c *gin.Context) {
@@ -400,7 +421,11 @@ func OpenAPIUpdateProjectGroup(c *gin.Context) {
 	}
 
 	internalhandler.InsertOperationLog(c, ctx.UserName+"(openAPI)", "", "编辑", "分组", args.GroupName, args.GroupName, string(data), types.RequestBodyTypeJSON, ctx.Logger)
-	ctx.RespErr = service.UpdateProjectGroupOpenAPI(groupID, args, ctx.UserName, ctx.Logger)
+	ctx.RespErr = service.UpdateProjectGroup(&service.ProjectGroupArgs{
+		GroupID:     groupID,
+		GroupName:   strings.TrimSpace(args.GroupName),
+		ProjectKeys: *args.ProjectKeys,
+	}, ctx.UserName, ctx.Logger)
 }
 
 func OpenAPIDeleteProjectGroup(c *gin.Context) {
@@ -422,14 +447,14 @@ func OpenAPIDeleteProjectGroup(c *gin.Context) {
 		return
 	}
 
-	groupID := c.Query("groupID")
-	if !primitive.IsValidObjectID(groupID) {
-		ctx.RespErr = e.ErrDeleteProjectGroup.AddDesc("invalid groupID")
+	groupName := strings.TrimSpace(c.Query("groupName"))
+	if groupName == "" {
+		ctx.RespErr = e.ErrDeleteProjectGroup.AddDesc("groupName is empty")
 		return
 	}
 
-	internalhandler.InsertOperationLog(c, ctx.UserName+"(openAPI)", "", "删除", "分组", groupID, groupID, "", types.RequestBodyTypeJSON, ctx.Logger)
-	ctx.RespErr = service.DeleteProjectGroupOpenAPI(groupID, ctx.Logger)
+	internalhandler.InsertOperationLog(c, ctx.UserName+"(openAPI)", "", "删除", "分组", groupName, groupName, "", types.RequestBodyTypeJSON, ctx.Logger)
+	ctx.RespErr = service.DeleteProjectGroup(groupName, ctx.Logger)
 }
 
 func OpenAPIDeleteProject(c *gin.Context) {

--- a/pkg/microservice/aslan/core/project/handler/openapi.go
+++ b/pkg/microservice/aslan/core/project/handler/openapi.go
@@ -24,6 +24,9 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/project/service"
 	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
@@ -236,6 +239,197 @@ func OpenAPIGetProjectDetail(c *gin.Context) {
 	}
 
 	ctx.Resp, ctx.RespErr = service.GetProjectDetailOpenAPI(projectKey, ctx.Logger)
+}
+
+func OpenAPIUpdateProject(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	projectKey := c.Query("projectKey")
+	if projectKey == "" {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("projectKey is empty")
+		return
+	}
+
+	if !ctx.Resources.IsSystemAdmin {
+		projectAuthInfo, ok := ctx.Resources.ProjectAuthInfo[projectKey]
+		if !ok || !projectAuthInfo.IsProjectAdmin {
+			ctx.UnAuthorized = true
+			return
+		}
+	}
+
+	args := new(service.OpenAPIUpdateProjectReq)
+	data, err := internalhandler.GetRawData(c)
+	if err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("invalid update project request body")
+		return
+	}
+	if err := c.ShouldBindJSON(args); err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("invalid update project request body")
+		return
+	}
+	if err := args.Validate(); err != nil {
+		ctx.RespErr = e.ErrInvalidParam.AddErr(err)
+		return
+	}
+
+	internalhandler.InsertOperationLog(c, ctx.UserName+"(openAPI)", projectKey, "更新", "项目管理-项目", projectKey, projectKey, string(data), types.RequestBodyTypeJSON, ctx.Logger)
+	ctx.RespErr = service.UpdateProjectOpenAPI(projectKey, ctx.UserName, args, ctx.Logger)
+}
+
+func OpenAPIListProjectGroups(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	ctx.Resp, ctx.RespErr = service.ListProjectGroupsOpenAPI(ctx.Logger)
+}
+
+func OpenAPIGetProjectGroup(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	if err := commonutil.CheckZadigEnterpriseLicense(); err != nil {
+		ctx.RespErr = err
+		return
+	}
+
+	groupID := c.Query("groupID")
+	if !primitive.IsValidObjectID(groupID) {
+		ctx.RespErr = e.ErrInvalidParam.AddDesc("invalid groupID")
+		return
+	}
+
+	ctx.Resp, ctx.RespErr = service.GetProjectGroupOpenAPI(groupID, ctx.Logger)
+}
+
+func OpenAPICreateProjectGroup(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.Project.Create {
+		ctx.UnAuthorized = true
+		return
+	}
+	if err := commonutil.CheckZadigEnterpriseLicense(); err != nil {
+		ctx.RespErr = err
+		return
+	}
+
+	args := new(service.OpenAPIProjectGroupReq)
+	data, err := internalhandler.GetRawData(c)
+	if err != nil {
+		ctx.RespErr = e.ErrCreateProjectGroup.AddDesc("invalid create project group request body")
+		return
+	}
+	if err := c.ShouldBindJSON(args); err != nil {
+		ctx.RespErr = e.ErrCreateProjectGroup.AddDesc("invalid create project group request body")
+		return
+	}
+	if err := args.Validate(); err != nil {
+		ctx.RespErr = e.ErrCreateProjectGroup.AddErr(err)
+		return
+	}
+
+	internalhandler.InsertOperationLog(c, ctx.UserName+"(openAPI)", "", "新增", "分组", args.GroupName, args.GroupName, string(data), types.RequestBodyTypeJSON, ctx.Logger)
+	ctx.RespErr = service.CreateProjectGroupOpenAPI(args, ctx.UserName, ctx.Logger)
+}
+
+func OpenAPIUpdateProjectGroup(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.Project.Create {
+		ctx.UnAuthorized = true
+		return
+	}
+	if err := commonutil.CheckZadigEnterpriseLicense(); err != nil {
+		ctx.RespErr = err
+		return
+	}
+
+	groupID := c.Query("groupID")
+	if !primitive.IsValidObjectID(groupID) {
+		ctx.RespErr = e.ErrUpdateProjectGroup.AddDesc("invalid groupID")
+		return
+	}
+
+	args := new(service.OpenAPIProjectGroupReq)
+	data, err := internalhandler.GetRawData(c)
+	if err != nil {
+		ctx.RespErr = e.ErrUpdateProjectGroup.AddDesc("invalid update project group request body")
+		return
+	}
+	if err := c.ShouldBindJSON(args); err != nil {
+		ctx.RespErr = e.ErrUpdateProjectGroup.AddDesc("invalid update project group request body")
+		return
+	}
+	if err := args.ValidateForUpdate(); err != nil {
+		ctx.RespErr = e.ErrUpdateProjectGroup.AddErr(err)
+		return
+	}
+
+	internalhandler.InsertOperationLog(c, ctx.UserName+"(openAPI)", "", "编辑", "分组", args.GroupName, args.GroupName, string(data), types.RequestBodyTypeJSON, ctx.Logger)
+	ctx.RespErr = service.UpdateProjectGroupOpenAPI(groupID, args, ctx.UserName, ctx.Logger)
+}
+
+func OpenAPIDeleteProjectGroup(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+
+	if !ctx.Resources.IsSystemAdmin && !ctx.Resources.SystemActions.Project.Create {
+		ctx.UnAuthorized = true
+		return
+	}
+	if err := commonutil.CheckZadigEnterpriseLicense(); err != nil {
+		ctx.RespErr = err
+		return
+	}
+
+	groupID := c.Query("groupID")
+	if !primitive.IsValidObjectID(groupID) {
+		ctx.RespErr = e.ErrDeleteProjectGroup.AddDesc("invalid groupID")
+		return
+	}
+
+	internalhandler.InsertOperationLog(c, ctx.UserName+"(openAPI)", "", "删除", "分组", groupID, groupID, "", types.RequestBodyTypeJSON, ctx.Logger)
+	ctx.RespErr = service.DeleteProjectGroupOpenAPI(groupID, ctx.Logger)
 }
 
 func OpenAPIDeleteProject(c *gin.Context) {

--- a/pkg/microservice/aslan/core/project/handler/openapi.go
+++ b/pkg/microservice/aslan/core/project/handler/openapi.go
@@ -370,13 +370,9 @@ func OpenAPICreateProjectGroup(c *gin.Context) {
 	}
 
 	internalhandler.InsertOperationLog(c, ctx.UserName+"(openAPI)", "", "新增", "分组", args.GroupName, args.GroupName, string(data), types.RequestBodyTypeJSON, ctx.Logger)
-	projectKeys := make([]string, 0)
-	if args.ProjectKeys != nil {
-		projectKeys = *args.ProjectKeys
-	}
 	ctx.RespErr = service.CreateProjectGroup(&service.ProjectGroupArgs{
 		GroupName:   strings.TrimSpace(args.GroupName),
-		ProjectKeys: projectKeys,
+		ProjectKeys: args.ProjectKeys,
 	}, ctx.UserName, ctx.Logger)
 }
 
@@ -424,7 +420,7 @@ func OpenAPIUpdateProjectGroup(c *gin.Context) {
 	ctx.RespErr = service.UpdateProjectGroup(&service.ProjectGroupArgs{
 		GroupID:     groupID,
 		GroupName:   strings.TrimSpace(args.GroupName),
-		ProjectKeys: *args.ProjectKeys,
+		ProjectKeys: args.ProjectKeys,
 	}, ctx.UserName, ctx.Logger)
 }
 

--- a/pkg/microservice/aslan/core/project/handler/router.go
+++ b/pkg/microservice/aslan/core/project/handler/router.go
@@ -128,11 +128,21 @@ func (*OpenAPIRouter) Inject(router *gin.RouterGroup) {
 	product := router.Group("project")
 	{
 		product.POST("", OpenAPICreateProductTemplate)
+		product.PUT("", OpenAPIUpdateProject)
 		product.POST("/init/yaml", OpenAPIInitializeYamlProject)
 		product.POST("/init/helm", OpenAPIInitializeHelmProject)
 		product.GET("", OpenAPIListProject)
 		product.GET("/detail", OpenAPIGetProjectDetail)
 		product.DELETE("", OpenAPIDeleteProject)
 		product.GET("/globalVariable", OpenAPIGetGlobalVariables)
+	}
+
+	group := router.Group("group")
+	{
+		group.GET("", OpenAPIListProjectGroups)
+		group.GET("/detail", OpenAPIGetProjectGroup)
+		group.POST("", OpenAPICreateProjectGroup)
+		group.PUT("", OpenAPIUpdateProjectGroup)
+		group.DELETE("", OpenAPIDeleteProjectGroup)
 	}
 }

--- a/pkg/microservice/aslan/core/project/service/openapi.go
+++ b/pkg/microservice/aslan/core/project/service/openapi.go
@@ -439,6 +439,8 @@ func GetProjectDetailOpenAPI(projectName string, logger *zap.SugaredLogger) (*Op
 	}, nil
 }
 
+// UpdateProjectOpenAPI persists project metadata before synchronizing derived
+// permission and project-group data on a best-effort basis.
 func UpdateProjectOpenAPI(projectName, userName string, args *OpenAPIUpdateProjectReq, logger *zap.SugaredLogger) error {
 	name := strings.TrimSpace(args.ProjectName)
 	pinyin, pinyinFirstLetter := util.GetPinyinFromChinese(name)
@@ -486,6 +488,7 @@ func GetProjectGroupOpenAPI(groupID string, logger *zap.SugaredLogger) (*OpenAPI
 	return convertProjectGroupToOpenAPI(group), nil
 }
 
+// CreateProjectGroupOpenAPI only adapts the OpenAPI request to the shared group service.
 func CreateProjectGroupOpenAPI(args *OpenAPIProjectGroupReq, userName string, logger *zap.SugaredLogger) error {
 	projectKeys := make([]string, 0)
 	if args.ProjectKeys != nil {
@@ -498,6 +501,7 @@ func CreateProjectGroupOpenAPI(args *OpenAPIProjectGroupReq, userName string, lo
 	}, userName, logger)
 }
 
+// UpdateProjectGroupOpenAPI only adapts the OpenAPI request to the shared group service.
 func UpdateProjectGroupOpenAPI(groupID string, args *OpenAPIProjectGroupReq, userName string, logger *zap.SugaredLogger) error {
 	return UpdateProjectGroup(&ProjectGroupArgs{
 		GroupID:     groupID,

--- a/pkg/microservice/aslan/core/project/service/openapi.go
+++ b/pkg/microservice/aslan/core/project/service/openapi.go
@@ -39,6 +39,7 @@ import (
 	envService "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/environment/service"
 	svcService "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/service/service"
 	"github.com/koderover/zadig/v2/pkg/setting"
+	"github.com/koderover/zadig/v2/pkg/shared/client/user"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
 	"github.com/koderover/zadig/v2/pkg/util"
 )
@@ -439,22 +440,27 @@ func GetProjectDetailOpenAPI(projectName string, logger *zap.SugaredLogger) (*Op
 }
 
 func UpdateProjectOpenAPI(projectName, userName string, args *OpenAPIUpdateProjectReq, logger *zap.SugaredLogger) error {
-	project, err := templaterepo.NewProductColl().Find(projectName)
+	name := strings.TrimSpace(args.ProjectName)
+	pinyin, pinyinFirstLetter := util.GetPinyinFromChinese(name)
+	err := templaterepo.NewProductColl().UpdateMetadata(projectName, &templaterepo.ProjectMetadataUpdate{
+		ProjectName:                  name,
+		ProjectNamePinyin:            pinyin,
+		ProjectNamePinyinFirstLetter: pinyinFirstLetter,
+		Description:                  args.Description,
+		Public:                       *args.IsPublic,
+		UpdateBy:                     userName,
+	})
 	if err != nil {
-		logger.Errorf("OpenAPI: failed to find project %s, error: %s", projectName, err)
+		logger.Errorf("OpenAPI: failed to update project %s, error: %s", projectName, err)
 		return e.ErrUpdateProduct.AddErr(err)
 	}
-
-	applyOpenAPIProjectUpdate(project, args, userName)
-
-	return UpdateProject(projectName, project, logger)
-}
-
-func applyOpenAPIProjectUpdate(project *template.Product, args *OpenAPIUpdateProjectReq, userName string) {
-	project.ProjectName = strings.TrimSpace(args.ProjectName)
-	project.Description = args.Description
-	project.Public = *args.IsPublic
-	project.UpdateBy = userName
+	if err := user.New().SetProjectVisibility(projectName, *args.IsPublic); err != nil {
+		logger.Warnf("failed to update project visibility binding, project: %s, error: %v", projectName, err)
+	}
+	if err := commonrepo.NewProjectGroupColl().UpdateProjectName(projectName, name); err != nil {
+		logger.Warnf("failed to update project group project name, project: %s, error: %v", projectName, err)
+	}
+	return nil
 }
 
 func ListProjectGroupsOpenAPI(logger *zap.SugaredLogger) (*OpenAPIProjectGroupListResp, error) {

--- a/pkg/microservice/aslan/core/project/service/openapi.go
+++ b/pkg/microservice/aslan/core/project/service/openapi.go
@@ -20,8 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.uber.org/zap"
 
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
@@ -36,6 +39,7 @@ import (
 	envService "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/environment/service"
 	svcService "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/service/service"
 	"github.com/koderover/zadig/v2/pkg/setting"
+	e "github.com/koderover/zadig/v2/pkg/tool/errors"
 	"github.com/koderover/zadig/v2/pkg/util"
 )
 
@@ -432,6 +436,118 @@ func GetProjectDetailOpenAPI(projectName string, logger *zap.SugaredLogger) (*Op
 		CreateTime:  project.CreateTime,
 		CreatedBy:   project.UpdateBy,
 	}, nil
+}
+
+func UpdateProjectOpenAPI(projectName, userName string, args *OpenAPIUpdateProjectReq, logger *zap.SugaredLogger) error {
+	project, err := templaterepo.NewProductColl().Find(projectName)
+	if err != nil {
+		logger.Errorf("OpenAPI: failed to find project %s, error: %s", projectName, err)
+		return e.ErrUpdateProduct.AddErr(err)
+	}
+
+	applyOpenAPIProjectUpdate(project, args, userName)
+
+	return UpdateProject(projectName, project, logger)
+}
+
+func applyOpenAPIProjectUpdate(project *template.Product, args *OpenAPIUpdateProjectReq, userName string) {
+	project.ProjectName = strings.TrimSpace(args.ProjectName)
+	project.Description = args.Description
+	project.Public = *args.IsPublic
+	project.UpdateBy = userName
+}
+
+func ListProjectGroupsOpenAPI(logger *zap.SugaredLogger) (*OpenAPIProjectGroupListResp, error) {
+	groups, err := commonrepo.NewProjectGroupColl().List()
+	if err != nil {
+		logger.Errorf("OpenAPI: failed to list project groups, error: %s", err)
+		return nil, fmt.Errorf("failed to list project groups, error: %w", err)
+	}
+
+	return convertProjectGroupsToOpenAPI(groups), nil
+}
+
+func GetProjectGroupOpenAPI(groupID string, logger *zap.SugaredLogger) (*OpenAPIProjectGroupDetailResp, error) {
+	group, err := commonrepo.NewProjectGroupColl().Find(commonrepo.ProjectGroupOpts{ID: groupID})
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, e.ErrInvalidParam.AddDesc("project group not found")
+		}
+		logger.Errorf("OpenAPI: failed to find project group %s, error: %s", groupID, err)
+		return nil, fmt.Errorf("failed to find project group %s, error: %w", groupID, err)
+	}
+
+	return convertProjectGroupToOpenAPI(group), nil
+}
+
+func CreateProjectGroupOpenAPI(args *OpenAPIProjectGroupReq, userName string, logger *zap.SugaredLogger) error {
+	projectKeys := make([]string, 0)
+	if args.ProjectKeys != nil {
+		projectKeys = *args.ProjectKeys
+	}
+
+	return CreateProjectGroup(&ProjectGroupArgs{
+		GroupName:   strings.TrimSpace(args.GroupName),
+		ProjectKeys: projectKeys,
+	}, userName, logger)
+}
+
+func UpdateProjectGroupOpenAPI(groupID string, args *OpenAPIProjectGroupReq, userName string, logger *zap.SugaredLogger) error {
+	return UpdateProjectGroup(&ProjectGroupArgs{
+		GroupID:     groupID,
+		GroupName:   strings.TrimSpace(args.GroupName),
+		ProjectKeys: *args.ProjectKeys,
+	}, userName, logger)
+}
+
+func DeleteProjectGroupOpenAPI(groupID string, logger *zap.SugaredLogger) error {
+	if err := commonrepo.NewProjectGroupColl().DeleteByID(groupID); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return e.ErrDeleteProjectGroup.AddDesc("project group not found")
+		}
+		return e.ErrDeleteProjectGroup.AddErr(fmt.Errorf("failed to delete project group %s, error: %w", groupID, err))
+	}
+
+	return nil
+}
+
+func convertProjectGroupsToOpenAPI(groups []*commonmodels.ProjectGroup) *OpenAPIProjectGroupListResp {
+	resp := &OpenAPIProjectGroupListResp{
+		Groups: make([]*OpenAPIProjectGroupBrief, 0, len(groups)),
+	}
+	for _, group := range groups {
+		resp.Groups = append(resp.Groups, &OpenAPIProjectGroupBrief{
+			GroupID:      group.ID.Hex(),
+			GroupName:    group.Name,
+			ProjectCount: len(group.Projects),
+		})
+	}
+	sort.Slice(resp.Groups, func(i, j int) bool {
+		return resp.Groups[i].GroupName < resp.Groups[j].GroupName
+	})
+
+	return resp
+}
+
+func convertProjectGroupToOpenAPI(group *commonmodels.ProjectGroup) *OpenAPIProjectGroupDetailResp {
+	resp := &OpenAPIProjectGroupDetailResp{
+		GroupID:     group.ID.Hex(),
+		GroupName:   group.Name,
+		Projects:    make([]*OpenAPIProjectGroupProject, 0, len(group.Projects)),
+		CreatedTime: group.CreatedTime,
+		CreatedBy:   group.CreatedBy,
+		UpdateTime:  group.UpdateTime,
+		UpdateBy:    group.UpdateBy,
+	}
+	for _, project := range group.Projects {
+		resp.Projects = append(resp.Projects, &OpenAPIProjectGroupProject{
+			ProjectKey:  project.ProjectKey,
+			ProjectName: project.ProjectName,
+			DeployType:  project.ProjectDeployType,
+		})
+	}
+
+	return resp
 }
 
 func DeleteProjectOpenAPI(userName, requestID, projectName string, isDelete bool, logger *zap.SugaredLogger) error {

--- a/pkg/microservice/aslan/core/project/service/openapi.go
+++ b/pkg/microservice/aslan/core/project/service/openapi.go
@@ -475,7 +475,7 @@ func ListProjectGroupsOpenAPI(logger *zap.SugaredLogger) (*OpenAPIProjectGroupLi
 	return convertProjectGroupsToOpenAPI(groups), nil
 }
 
-func GetProjectGroupOpenAPI(groupID string, logger *zap.SugaredLogger) (*OpenAPIProjectGroupDetailResp, error) {
+func GetProjectGroupOpenAPI(groupID string, authorizedProjects []string, logger *zap.SugaredLogger) (*OpenAPIProjectGroupDetailResp, error) {
 	group, err := commonrepo.NewProjectGroupColl().Find(commonrepo.ProjectGroupOpts{ID: groupID})
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
@@ -485,40 +485,7 @@ func GetProjectGroupOpenAPI(groupID string, logger *zap.SugaredLogger) (*OpenAPI
 		return nil, fmt.Errorf("failed to find project group %s, error: %w", groupID, err)
 	}
 
-	return convertProjectGroupToOpenAPI(group), nil
-}
-
-// CreateProjectGroupOpenAPI only adapts the OpenAPI request to the shared group service.
-func CreateProjectGroupOpenAPI(args *OpenAPIProjectGroupReq, userName string, logger *zap.SugaredLogger) error {
-	projectKeys := make([]string, 0)
-	if args.ProjectKeys != nil {
-		projectKeys = *args.ProjectKeys
-	}
-
-	return CreateProjectGroup(&ProjectGroupArgs{
-		GroupName:   strings.TrimSpace(args.GroupName),
-		ProjectKeys: projectKeys,
-	}, userName, logger)
-}
-
-// UpdateProjectGroupOpenAPI only adapts the OpenAPI request to the shared group service.
-func UpdateProjectGroupOpenAPI(groupID string, args *OpenAPIProjectGroupReq, userName string, logger *zap.SugaredLogger) error {
-	return UpdateProjectGroup(&ProjectGroupArgs{
-		GroupID:     groupID,
-		GroupName:   strings.TrimSpace(args.GroupName),
-		ProjectKeys: *args.ProjectKeys,
-	}, userName, logger)
-}
-
-func DeleteProjectGroupOpenAPI(groupID string, logger *zap.SugaredLogger) error {
-	if err := commonrepo.NewProjectGroupColl().DeleteByID(groupID); err != nil {
-		if errors.Is(err, mongo.ErrNoDocuments) {
-			return e.ErrDeleteProjectGroup.AddDesc("project group not found")
-		}
-		return e.ErrDeleteProjectGroup.AddErr(fmt.Errorf("failed to delete project group %s, error: %w", groupID, err))
-	}
-
-	return nil
+	return convertProjectGroupToOpenAPI(group, authorizedProjects), nil
 }
 
 func convertProjectGroupsToOpenAPI(groups []*commonmodels.ProjectGroup) *OpenAPIProjectGroupListResp {
@@ -539,7 +506,7 @@ func convertProjectGroupsToOpenAPI(groups []*commonmodels.ProjectGroup) *OpenAPI
 	return resp
 }
 
-func convertProjectGroupToOpenAPI(group *commonmodels.ProjectGroup) *OpenAPIProjectGroupDetailResp {
+func convertProjectGroupToOpenAPI(group *commonmodels.ProjectGroup, authorizedProjects []string) *OpenAPIProjectGroupDetailResp {
 	resp := &OpenAPIProjectGroupDetailResp{
 		GroupID:     group.ID.Hex(),
 		GroupName:   group.Name,
@@ -549,7 +516,16 @@ func convertProjectGroupToOpenAPI(group *commonmodels.ProjectGroup) *OpenAPIProj
 		UpdateTime:  group.UpdateTime,
 		UpdateBy:    group.UpdateBy,
 	}
+	authorizedProjectSet := make(map[string]struct{}, len(authorizedProjects))
+	for _, project := range authorizedProjects {
+		authorizedProjectSet[project] = struct{}{}
+	}
 	for _, project := range group.Projects {
+		if authorizedProjects != nil {
+			if _, ok := authorizedProjectSet[project.ProjectKey]; !ok {
+				continue
+			}
+		}
 		resp.Projects = append(resp.Projects, &OpenAPIProjectGroupProject{
 			ProjectKey:  project.ProjectKey,
 			ProjectName: project.ProjectName,

--- a/pkg/microservice/aslan/core/project/service/product.go
+++ b/pkg/microservice/aslan/core/project/service/product.go
@@ -878,6 +878,10 @@ func ensureProductTmpl(args *template.Product) error {
 	if !config.ServiceNameRegex.MatchString(args.ProductName) {
 		return fmt.Errorf("product name must match %s", config.ServiceNameRegexString)
 	}
+	// Project keys are stored in the user service's role.namespace varchar(32) column.
+	if len(args.ProductName) > 32 {
+		return errors.New("project key cannot exceed 32 characters")
+	}
 
 	serviceNames := sets.NewString()
 	for _, sg := range args.Services {

--- a/pkg/microservice/aslan/core/project/service/product.go
+++ b/pkg/microservice/aslan/core/project/service/product.go
@@ -596,6 +596,9 @@ func UpdateProject(name string, args *template.Product, log *zap.SugaredLogger) 
 		log.Errorf("Project.Update error: %v", err)
 		return e.ErrUpdateProduct.AddDesc(err.Error())
 	}
+	if err := commonrepo.NewProjectGroupColl().UpdateProjectName(name, args.ProjectName); err != nil {
+		log.Warnf("failed to update project group project name, project: %s, error: %v", name, err)
+	}
 	return nil
 }
 

--- a/pkg/microservice/aslan/core/project/service/product.go
+++ b/pkg/microservice/aslan/core/project/service/product.go
@@ -1289,13 +1289,56 @@ func GetGlobalVariableCandidates(productName string, production bool, log *zap.S
 	return ret, nil
 }
 
-// CreateProjectGroup is shared by the console and OpenAPI handlers so both
-// entry points enforce the same group invariants.
 func CreateProjectGroup(args *ProjectGroupArgs, user string, logger *zap.SugaredLogger) error {
-	group, err := buildProjectGroup(args.GroupName, args.ProjectKeys, nil, user)
+	groups, err := commonrepo.NewProjectGroupColl().List()
 	if err != nil {
-		logger.Errorf("failed to build project group %s, error: %v", args.GroupName, err)
-		return e.ErrCreateProjectGroup.AddErr(err)
+		errMsg := fmt.Errorf("failed to list project groups, error: %v", err)
+		logger.Errorf(errMsg.Error())
+		return e.ErrCreateProjectGroup.AddErr(errMsg)
+	}
+
+	// find all project keys that have been set
+	set := sets.NewString()
+	for _, group := range groups {
+		for _, project := range group.Projects {
+			set.Insert(project.ProjectKey)
+		}
+	}
+
+	projects, err := templaterepo.NewProductColl().List()
+	if err != nil {
+		errMsg := fmt.Errorf("failed to list projects, error: %v", err)
+		logger.Errorf(errMsg.Error())
+		return e.ErrCreateProjectGroup.AddErr(errMsg)
+	}
+
+	pm := make(map[string]*template.Product)
+	for _, project := range projects {
+		pm[project.ProductName] = project
+	}
+
+	group := &commonmodels.ProjectGroup{
+		Name:        args.GroupName,
+		CreatedTime: time.Now().Unix(),
+		UpdateTime:  time.Now().Unix(),
+		CreatedBy:   user,
+		UpdateBy:    user,
+		Projects:    make([]*commonmodels.ProjectDetail, 0),
+	}
+	for _, project := range args.ProjectKeys {
+		if set.Has(project) {
+			return e.ErrCreateProjectGroup.AddErr(fmt.Errorf("failed to set project %s to group %s, project Key %s has been set in other groups", project, args.GroupName, project))
+		}
+
+		if p, ok := pm[project]; ok {
+			group.Projects = append(group.Projects, &commonmodels.ProjectDetail{
+				ProjectKey:        p.ProductName,
+				ProjectName:       p.ProjectName,
+				ProjectDeployType: p.ProductFeature.DeployType,
+			})
+		} else {
+			return e.ErrCreateProjectGroup.AddErr(fmt.Errorf("project Key %s not in current project list", project))
+		}
 	}
 
 	if err := commonrepo.NewProjectGroupColl().Create(group); err != nil {
@@ -1306,22 +1349,72 @@ func CreateProjectGroup(args *ProjectGroupArgs, user string, logger *zap.Sugared
 	return nil
 }
 
-// UpdateProjectGroup shares the same validation and construction path as
-// CreateProjectGroup for both the console and OpenAPI handlers.
 func UpdateProjectGroup(args *ProjectGroupArgs, user string, logger *zap.SugaredLogger) error {
 	if args.GroupID == "" {
 		return e.ErrUpdateProjectGroup.AddDesc("group id can not be empty")
+	}
+
+	groups, err := commonrepo.NewProjectGroupColl().List()
+	if err != nil {
+		errMsg := fmt.Errorf("failed to list project groups, error: %v", err)
+		logger.Errorf(errMsg.Error())
+		return e.ErrCreateProjectGroup.AddErr(errMsg)
 	}
 
 	oldGroup, err := commonrepo.NewProjectGroupColl().Find(commonrepo.ProjectGroupOpts{ID: args.GroupID})
 	if err != nil {
 		return e.ErrUpdateProjectGroup.AddErr(fmt.Errorf("failed to find project group %s, error: %v", args.GroupName, err))
 	}
-	group, err := buildProjectGroup(args.GroupName, args.ProjectKeys, oldGroup, user)
-	if err != nil {
-		logger.Errorf("failed to build project group %s, error: %v", args.GroupName, err)
-		return e.ErrUpdateProjectGroup.AddErr(err)
+
+	// find all project keys that have been set
+	set := sets.NewString()
+	for _, group := range groups {
+		if oldGroup.Name != args.GroupName && group.Name == args.GroupName {
+			return fmt.Errorf("group name %s has been used", args.GroupName)
+		}
+		if group.Name != oldGroup.Name {
+			for _, project := range group.Projects {
+				set.Insert(project.ProjectKey)
+			}
+		}
 	}
+
+	projects, err := templaterepo.NewProductColl().List()
+	if err != nil {
+		errMsg := fmt.Errorf("failed to list projects, error: %v", err)
+		logger.Errorf(errMsg.Error())
+		return e.ErrUpdateProjectGroup.AddErr(errMsg)
+	}
+
+	pm := make(map[string]*template.Product)
+	for _, project := range projects {
+		pm[project.ProductName] = project
+	}
+	group := &commonmodels.ProjectGroup{
+		Name:       args.GroupName,
+		UpdateTime: time.Now().Unix(),
+		UpdateBy:   user,
+		Projects:   make([]*commonmodels.ProjectDetail, 0),
+	}
+	for _, project := range args.ProjectKeys {
+		if set.Has(project) {
+			return e.ErrCreateProjectGroup.AddErr(fmt.Errorf("failed to set project %s to group %s, project Key %s has been set in other groups", project, args.GroupName, project))
+		}
+
+		if p, ok := pm[project]; ok {
+			group.Projects = append(group.Projects, &commonmodels.ProjectDetail{
+				ProjectKey:        p.ProductName,
+				ProjectName:       p.ProjectName,
+				ProjectDeployType: p.ProductFeature.DeployType,
+			})
+		} else {
+			return e.ErrUpdateProjectGroup.AddErr(fmt.Errorf("project Key %s not in current project list", project))
+		}
+	}
+
+	group.ID = oldGroup.ID
+	group.CreatedTime = oldGroup.CreatedTime
+	group.CreatedBy = oldGroup.CreatedBy
 
 	if err := commonrepo.NewProjectGroupColl().Update(group); err != nil {
 		errMsg := fmt.Errorf("failed to update project group, groupName:%s, error: %v", oldGroup.Name, err)
@@ -1329,63 +1422,6 @@ func UpdateProjectGroup(args *ProjectGroupArgs, user string, logger *zap.Sugared
 		return e.ErrUpdateProjectGroup.AddErr(errMsg)
 	}
 	return nil
-}
-
-func buildProjectGroup(name string, projectKeys []string, current *commonmodels.ProjectGroup, user string) (*commonmodels.ProjectGroup, error) {
-	groups, err := commonrepo.NewProjectGroupColl().List()
-	if err != nil {
-		return nil, fmt.Errorf("failed to list project groups, error: %v", err)
-	}
-
-	assignedProjectKeys := sets.NewString()
-	for _, group := range groups {
-		if group.Name == name && (current == nil || group.ID != current.ID) {
-			return nil, fmt.Errorf("group name %s has been used", name)
-		}
-		if current == nil || group.ID != current.ID {
-			for _, project := range group.Projects {
-				assignedProjectKeys.Insert(project.ProjectKey)
-			}
-		}
-	}
-
-	projects, err := templaterepo.NewProductColl().List()
-	if err != nil {
-		return nil, fmt.Errorf("failed to list projects, error: %v", err)
-	}
-	projectByKey := make(map[string]*template.Product, len(projects))
-	for _, project := range projects {
-		projectByKey[project.ProductName] = project
-	}
-
-	group := &commonmodels.ProjectGroup{
-		Name:       name,
-		UpdateTime: time.Now().Unix(),
-		UpdateBy:   user,
-		Projects:   make([]*commonmodels.ProjectDetail, 0, len(projectKeys)),
-	}
-	if current == nil {
-		group.CreatedBy = user
-	} else {
-		group.ID = current.ID
-		group.CreatedTime = current.CreatedTime
-		group.CreatedBy = current.CreatedBy
-	}
-	for _, projectKey := range projectKeys {
-		if assignedProjectKeys.Has(projectKey) {
-			return nil, fmt.Errorf("failed to set project %s to group %s, project Key %s has been set in other groups", projectKey, name, projectKey)
-		}
-		project, ok := projectByKey[projectKey]
-		if !ok {
-			return nil, fmt.Errorf("project Key %s not in current project list", projectKey)
-		}
-		group.Projects = append(group.Projects, &commonmodels.ProjectDetail{
-			ProjectKey:        project.ProductName,
-			ProjectName:       project.ProjectName,
-			ProjectDeployType: project.ProductFeature.DeployType,
-		})
-	}
-	return group, nil
 }
 
 func DeleteProjectGroup(name string, logger *zap.SugaredLogger) error {

--- a/pkg/microservice/aslan/core/project/service/product.go
+++ b/pkg/microservice/aslan/core/project/service/product.go
@@ -596,6 +596,8 @@ func UpdateProject(name string, args *template.Product, log *zap.SugaredLogger) 
 		log.Errorf("Project.Update error: %v", err)
 		return e.ErrUpdateProduct.AddDesc(err.Error())
 	}
+	// Project groups keep a denormalized display name. Its synchronization is
+	// non-blocking because the project update above is the source of truth.
 	if err := commonrepo.NewProjectGroupColl().UpdateProjectName(name, args.ProjectName); err != nil {
 		log.Warnf("failed to update project group project name, project: %s, error: %v", name, err)
 	}
@@ -1283,6 +1285,8 @@ func GetGlobalVariableCandidates(productName string, production bool, log *zap.S
 	return ret, nil
 }
 
+// CreateProjectGroup is shared by the console and OpenAPI handlers so both
+// entry points enforce the same group invariants.
 func CreateProjectGroup(args *ProjectGroupArgs, user string, logger *zap.SugaredLogger) error {
 	group, err := buildProjectGroup(args.GroupName, args.ProjectKeys, nil, user)
 	if err != nil {
@@ -1298,6 +1302,8 @@ func CreateProjectGroup(args *ProjectGroupArgs, user string, logger *zap.Sugared
 	return nil
 }
 
+// UpdateProjectGroup shares the same validation and construction path as
+// CreateProjectGroup for both the console and OpenAPI handlers.
 func UpdateProjectGroup(args *ProjectGroupArgs, user string, logger *zap.SugaredLogger) error {
 	if args.GroupID == "" {
 		return e.ErrUpdateProjectGroup.AddDesc("group id can not be empty")

--- a/pkg/microservice/aslan/core/project/service/product.go
+++ b/pkg/microservice/aslan/core/project/service/product.go
@@ -1284,55 +1284,10 @@ func GetGlobalVariableCandidates(productName string, production bool, log *zap.S
 }
 
 func CreateProjectGroup(args *ProjectGroupArgs, user string, logger *zap.SugaredLogger) error {
-	groups, err := commonrepo.NewProjectGroupColl().List()
+	group, err := buildProjectGroup(args.GroupName, args.ProjectKeys, nil, user)
 	if err != nil {
-		errMsg := fmt.Errorf("failed to list project groups, error: %v", err)
-		logger.Errorf(errMsg.Error())
-		return e.ErrCreateProjectGroup.AddErr(errMsg)
-	}
-
-	// find all project keys that have been set
-	set := sets.NewString()
-	for _, group := range groups {
-		for _, project := range group.Projects {
-			set.Insert(project.ProjectKey)
-		}
-	}
-
-	projects, err := templaterepo.NewProductColl().List()
-	if err != nil {
-		errMsg := fmt.Errorf("failed to list projects, error: %v", err)
-		logger.Errorf(errMsg.Error())
-		return e.ErrCreateProjectGroup.AddErr(errMsg)
-	}
-
-	pm := make(map[string]*template.Product)
-	for _, project := range projects {
-		pm[project.ProductName] = project
-	}
-
-	group := &commonmodels.ProjectGroup{
-		Name:        args.GroupName,
-		CreatedTime: time.Now().Unix(),
-		UpdateTime:  time.Now().Unix(),
-		CreatedBy:   user,
-		UpdateBy:    user,
-		Projects:    make([]*commonmodels.ProjectDetail, 0),
-	}
-	for _, project := range args.ProjectKeys {
-		if set.Has(project) {
-			return e.ErrCreateProjectGroup.AddErr(fmt.Errorf("failed to set project %s to group %s, project Key %s has been set in other groups", project, args.GroupName, project))
-		}
-
-		if p, ok := pm[project]; ok {
-			group.Projects = append(group.Projects, &commonmodels.ProjectDetail{
-				ProjectKey:        p.ProductName,
-				ProjectName:       p.ProjectName,
-				ProjectDeployType: p.ProductFeature.DeployType,
-			})
-		} else {
-			return e.ErrCreateProjectGroup.AddErr(fmt.Errorf("project Key %s not in current project list", project))
-		}
+		logger.Errorf("failed to build project group %s, error: %v", args.GroupName, err)
+		return e.ErrCreateProjectGroup.AddErr(err)
 	}
 
 	if err := commonrepo.NewProjectGroupColl().Create(group); err != nil {
@@ -1348,67 +1303,15 @@ func UpdateProjectGroup(args *ProjectGroupArgs, user string, logger *zap.Sugared
 		return e.ErrUpdateProjectGroup.AddDesc("group id can not be empty")
 	}
 
-	groups, err := commonrepo.NewProjectGroupColl().List()
-	if err != nil {
-		errMsg := fmt.Errorf("failed to list project groups, error: %v", err)
-		logger.Errorf(errMsg.Error())
-		return e.ErrCreateProjectGroup.AddErr(errMsg)
-	}
-
 	oldGroup, err := commonrepo.NewProjectGroupColl().Find(commonrepo.ProjectGroupOpts{ID: args.GroupID})
 	if err != nil {
 		return e.ErrUpdateProjectGroup.AddErr(fmt.Errorf("failed to find project group %s, error: %v", args.GroupName, err))
 	}
-
-	// find all project keys that have been set
-	set := sets.NewString()
-	for _, group := range groups {
-		if oldGroup.Name != args.GroupName && group.Name == args.GroupName {
-			return fmt.Errorf("group name %s has been used", args.GroupName)
-		}
-		if group.Name != oldGroup.Name {
-			for _, project := range group.Projects {
-				set.Insert(project.ProjectKey)
-			}
-		}
-	}
-
-	projects, err := templaterepo.NewProductColl().List()
+	group, err := buildProjectGroup(args.GroupName, args.ProjectKeys, oldGroup, user)
 	if err != nil {
-		errMsg := fmt.Errorf("failed to list projects, error: %v", err)
-		logger.Errorf(errMsg.Error())
-		return e.ErrUpdateProjectGroup.AddErr(errMsg)
+		logger.Errorf("failed to build project group %s, error: %v", args.GroupName, err)
+		return e.ErrUpdateProjectGroup.AddErr(err)
 	}
-
-	pm := make(map[string]*template.Product)
-	for _, project := range projects {
-		pm[project.ProductName] = project
-	}
-	group := &commonmodels.ProjectGroup{
-		Name:       args.GroupName,
-		UpdateTime: time.Now().Unix(),
-		UpdateBy:   user,
-		Projects:   make([]*commonmodels.ProjectDetail, 0),
-	}
-	for _, project := range args.ProjectKeys {
-		if set.Has(project) {
-			return e.ErrCreateProjectGroup.AddErr(fmt.Errorf("failed to set project %s to group %s, project Key %s has been set in other groups", project, args.GroupName, project))
-		}
-
-		if p, ok := pm[project]; ok {
-			group.Projects = append(group.Projects, &commonmodels.ProjectDetail{
-				ProjectKey:        p.ProductName,
-				ProjectName:       p.ProjectName,
-				ProjectDeployType: p.ProductFeature.DeployType,
-			})
-		} else {
-			return e.ErrUpdateProjectGroup.AddErr(fmt.Errorf("project Key %s not in current project list", project))
-		}
-	}
-
-	group.ID = oldGroup.ID
-	group.CreatedTime = oldGroup.CreatedTime
-	group.CreatedBy = oldGroup.CreatedBy
 
 	if err := commonrepo.NewProjectGroupColl().Update(group); err != nil {
 		errMsg := fmt.Errorf("failed to update project group, groupName:%s, error: %v", oldGroup.Name, err)
@@ -1416,6 +1319,63 @@ func UpdateProjectGroup(args *ProjectGroupArgs, user string, logger *zap.Sugared
 		return e.ErrUpdateProjectGroup.AddErr(errMsg)
 	}
 	return nil
+}
+
+func buildProjectGroup(name string, projectKeys []string, current *commonmodels.ProjectGroup, user string) (*commonmodels.ProjectGroup, error) {
+	groups, err := commonrepo.NewProjectGroupColl().List()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list project groups, error: %v", err)
+	}
+
+	assignedProjectKeys := sets.NewString()
+	for _, group := range groups {
+		if group.Name == name && (current == nil || group.ID != current.ID) {
+			return nil, fmt.Errorf("group name %s has been used", name)
+		}
+		if current == nil || group.ID != current.ID {
+			for _, project := range group.Projects {
+				assignedProjectKeys.Insert(project.ProjectKey)
+			}
+		}
+	}
+
+	projects, err := templaterepo.NewProductColl().List()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list projects, error: %v", err)
+	}
+	projectByKey := make(map[string]*template.Product, len(projects))
+	for _, project := range projects {
+		projectByKey[project.ProductName] = project
+	}
+
+	group := &commonmodels.ProjectGroup{
+		Name:       name,
+		UpdateTime: time.Now().Unix(),
+		UpdateBy:   user,
+		Projects:   make([]*commonmodels.ProjectDetail, 0, len(projectKeys)),
+	}
+	if current == nil {
+		group.CreatedBy = user
+	} else {
+		group.ID = current.ID
+		group.CreatedTime = current.CreatedTime
+		group.CreatedBy = current.CreatedBy
+	}
+	for _, projectKey := range projectKeys {
+		if assignedProjectKeys.Has(projectKey) {
+			return nil, fmt.Errorf("failed to set project %s to group %s, project Key %s has been set in other groups", projectKey, name, projectKey)
+		}
+		project, ok := projectByKey[projectKey]
+		if !ok {
+			return nil, fmt.Errorf("project Key %s not in current project list", projectKey)
+		}
+		group.Projects = append(group.Projects, &commonmodels.ProjectDetail{
+			ProjectKey:        project.ProductName,
+			ProjectName:       project.ProjectName,
+			ProjectDeployType: project.ProductFeature.DeployType,
+		})
+	}
+	return group, nil
 }
 
 func DeleteProjectGroup(name string, logger *zap.SugaredLogger) error {

--- a/pkg/microservice/aslan/core/project/service/types.go
+++ b/pkg/microservice/aslan/core/project/service/types.go
@@ -117,8 +117,8 @@ func (req OpenAPIUpdateProjectReq) Validate() error {
 }
 
 type OpenAPIProjectGroupReq struct {
-	GroupName   string    `json:"group_name"`
-	ProjectKeys *[]string `json:"project_keys"`
+	GroupName   string   `json:"group_name"`
+	ProjectKeys []string `json:"project_keys"`
 }
 
 func (req OpenAPIProjectGroupReq) Validate() error {
@@ -127,13 +127,11 @@ func (req OpenAPIProjectGroupReq) Validate() error {
 	}
 
 	projectKeys := make(map[string]struct{})
-	if req.ProjectKeys != nil {
-		for _, projectKey := range *req.ProjectKeys {
-			if _, ok := projectKeys[projectKey]; ok {
-				return errors.New("project_keys cannot contain duplicate project keys")
-			}
-			projectKeys[projectKey] = struct{}{}
+	for _, projectKey := range req.ProjectKeys {
+		if _, ok := projectKeys[projectKey]; ok {
+			return errors.New("project_keys cannot contain duplicate project keys")
 		}
+		projectKeys[projectKey] = struct{}{}
 	}
 
 	return nil

--- a/pkg/microservice/aslan/core/project/service/types.go
+++ b/pkg/microservice/aslan/core/project/service/types.go
@@ -19,6 +19,7 @@ package service
 import (
 	"errors"
 	"regexp"
+	"strings"
 
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/v2/pkg/setting"
@@ -96,6 +97,83 @@ type OpenAPIProjectDetailResp struct {
 type OpenAPIProjectListResp struct {
 	Total    int             `json:"total"`
 	Projects []*ProjectBrief `json:"projects"`
+}
+
+type OpenAPIUpdateProjectReq struct {
+	ProjectName string `json:"project_name"`
+	Description string `json:"description"`
+	IsPublic    *bool  `json:"is_public"`
+}
+
+func (req OpenAPIUpdateProjectReq) Validate() error {
+	if strings.TrimSpace(req.ProjectName) == "" {
+		return errors.New("project_name cannot be empty")
+	}
+	if req.IsPublic == nil {
+		return errors.New("is_public cannot be empty")
+	}
+
+	return nil
+}
+
+type OpenAPIProjectGroupReq struct {
+	GroupName   string    `json:"group_name"`
+	ProjectKeys *[]string `json:"project_keys"`
+}
+
+func (req OpenAPIProjectGroupReq) Validate() error {
+	if strings.TrimSpace(req.GroupName) == "" {
+		return errors.New("group_name cannot be empty")
+	}
+
+	projectKeys := make(map[string]struct{})
+	if req.ProjectKeys != nil {
+		for _, projectKey := range *req.ProjectKeys {
+			if _, ok := projectKeys[projectKey]; ok {
+				return errors.New("project_keys cannot contain duplicate project keys")
+			}
+			projectKeys[projectKey] = struct{}{}
+		}
+	}
+
+	return nil
+}
+
+func (req OpenAPIProjectGroupReq) ValidateForUpdate() error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+	if req.ProjectKeys == nil {
+		return errors.New("project_keys is required")
+	}
+
+	return nil
+}
+
+type OpenAPIProjectGroupListResp struct {
+	Groups []*OpenAPIProjectGroupBrief `json:"groups"`
+}
+
+type OpenAPIProjectGroupBrief struct {
+	GroupID      string `json:"group_id"`
+	GroupName    string `json:"group_name"`
+	ProjectCount int    `json:"project_count"`
+}
+
+type OpenAPIProjectGroupDetailResp struct {
+	GroupID     string                        `json:"group_id"`
+	GroupName   string                        `json:"group_name"`
+	Projects    []*OpenAPIProjectGroupProject `json:"projects"`
+	CreatedTime int64                         `json:"created_time"`
+	CreatedBy   string                        `json:"created_by"`
+	UpdateTime  int64                         `json:"update_time"`
+	UpdateBy    string                        `json:"update_by"`
+}
+
+type OpenAPIProjectGroupProject struct {
+	ProjectKey  string `json:"project_key"`
+	ProjectName string `json:"project_name"`
+	DeployType  string `json:"deploy_type"`
 }
 
 type ProjectBrief struct {


### PR DESCRIPTION
### Summary
- Add OpenAPIs for updating projects and managing project groups.

### Why
- Allow external integrations to update project metadata and maintain project grouping.

### Main Changes
- Update only project metadata fields to avoid overwriting unrelated project state.
- Reuse one validation and assembly path for project group creation and updates.
- Persist project metadata before best-effort visibility and group-name synchronization.

### Risk / Compatibility
- Existing API contracts are unchanged; derived-data synchronization failures are logged as warnings.

### Test
- go test -vet=off ./pkg/microservice/aslan/core/project/... ./pkg/microservice/aslan/core/common/repository/mongodb/template ./pkg/microservice/aslan/core/common/repository/mongodb

### Contact
- Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4918)
<!-- Reviewable:end -->
