### PR TITLE
fix: externalize large release plan data

### DIFF
--- a/pkg/cli/initconfig/cmd/init.go
+++ b/pkg/cli/initconfig/cmd/init.go
@@ -190,6 +190,7 @@ func createOrUpdateMongodbIndex(ctx context.Context) {
 		commonrepo.NewLLMIntegrationColl(),
 		commonrepo.NewAgentIntegrationColl(),
 		commonrepo.NewReleasePlanColl(),
+		commonrepo.NewReleasePlanJobSpecChunkColl(),
 		commonrepo.NewReleasePlanLogColl(),
 		commonrepo.NewReleasePlanVersionColl(),
 		commonrepo.NewReleasePlanVersionSnapshotColl(),

--- a/pkg/cli/initconfig/cmd/init.go
+++ b/pkg/cli/initconfig/cmd/init.go
@@ -192,6 +192,7 @@ func createOrUpdateMongodbIndex(ctx context.Context) {
 		commonrepo.NewReleasePlanColl(),
 		commonrepo.NewReleasePlanLogColl(),
 		commonrepo.NewReleasePlanVersionColl(),
+		commonrepo.NewReleasePlanVersionSnapshotColl(),
 		commonrepo.NewEnvServiceVersionColl(),
 		commonrepo.NewLabelColl(),
 		commonrepo.NewSprintTemplateColl(),

--- a/pkg/microservice/aslan/core/common/repository/models/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/models/release_plan.go
@@ -43,7 +43,8 @@ type ReleasePlan struct {
 
 	Approval *Approval `bson:"approval"       yaml:"approval"                   json:"approval,omitempty"`
 
-	Jobs []*ReleaseJob `bson:"jobs"       yaml:"jobs"                   json:"jobs"`
+	Jobs        []*ReleaseJob           `bson:"jobs"       yaml:"jobs"                   json:"jobs"`
+	JobSpecsRef *ReleasePlanJobSpecsRef `bson:"job_specs_ref,omitempty" yaml:"-" json:"-"`
 
 	Status config.ReleasePlanStatus `bson:"status"       yaml:"status"                   json:"status"`
 
@@ -96,6 +97,29 @@ type ReleaseJob struct {
 	Spec      interface{}               `bson:"spec,omitempty" yaml:"spec,omitempty"         json:"spec,omitempty"`
 
 	ReleaseJobRuntime `bson:",inline" yaml:",inline" json:",inline"`
+}
+
+type ReleasePlanJobSpecsRef struct {
+	StorageID      primitive.ObjectID `bson:"storage_id"`
+	Encoding       string             `bson:"encoding"`
+	ChunkCount     int32              `bson:"chunk_count"`
+	OriginalSize   int64              `bson:"original_size"`
+	CompressedSize int64              `bson:"compressed_size"`
+	SHA256         string             `bson:"sha256"`
+	ContentSHA256  string             `bson:"content_sha256"`
+}
+
+type ReleasePlanJobSpecChunk struct {
+	ID        primitive.ObjectID `bson:"_id,omitempty"`
+	StorageID primitive.ObjectID `bson:"storage_id"`
+	PlanID    string             `bson:"plan_id"`
+	Sequence  int32              `bson:"sequence"`
+	Data      []byte             `bson:"data"`
+	CreatedAt int64              `bson:"created_at"`
+}
+
+func (ReleasePlanJobSpecChunk) TableName() string {
+	return "release_plan_job_spec_chunk"
 }
 
 type ReleaseJobRuntime struct {

--- a/pkg/microservice/aslan/core/common/repository/models/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/models/release_plan.go
@@ -154,10 +154,33 @@ type ReleasePlanVersion struct {
 	SectionType     string             `bson:"section_type,omitempty" json:"section_type,omitempty"`
 	Verb            string             `bson:"verb,omitempty" json:"verb,omitempty"`
 	BaseSnapshot    interface{}        `bson:"base_snapshot,omitempty" json:"base_snapshot,omitempty"`
-	Snapshot        interface{}        `bson:"snapshot" json:"snapshot"`
+	Snapshot        interface{}        `bson:"snapshot,omitempty" json:"snapshot"`
+	SnapshotStorage string             `bson:"snapshot_storage,omitempty" json:"-"`
+	HasBaseSnapshot bool               `bson:"has_base_snapshot,omitempty" json:"-"`
 	CreatedAt       int64              `bson:"created_at" json:"created_at"`
 }
 
 func (ReleasePlanVersion) TableName() string {
 	return "release_plan_version"
+}
+
+type ReleasePlanVersionSnapshotKind string
+
+const (
+	ReleasePlanVersionSnapshotKindBase    ReleasePlanVersionSnapshotKind = "base"
+	ReleasePlanVersionSnapshotKindCurrent ReleasePlanVersionSnapshotKind = "current"
+)
+
+type ReleasePlanVersionSnapshot struct {
+	ID           primitive.ObjectID             `bson:"_id,omitempty"`
+	PlanID       string                         `bson:"plan_id"`
+	Version      int64                          `bson:"version"`
+	Kind         ReleasePlanVersionSnapshotKind `bson:"kind"`
+	Data         []byte                         `bson:"data"`
+	OriginalSize int64                          `bson:"original_size"`
+	CreatedAt    int64                          `bson:"created_at"`
+}
+
+func (ReleasePlanVersionSnapshot) TableName() string {
+	return "release_plan_version_snapshot"
 }

--- a/pkg/microservice/aslan/core/common/repository/mongodb/release_plan.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/release_plan.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+	"github.com/koderover/zadig/v2/pkg/tool/log"
 	mongotool "github.com/koderover/zadig/v2/pkg/tool/mongo"
 )
 
@@ -90,8 +91,20 @@ func (c *ReleasePlanColl) Create(ctx context.Context, args *models.ReleasePlan) 
 		return "", errors.New("nil ReleasePlan")
 	}
 
-	res, err := c.InsertOne(ctx, args)
+	storedPlan, chunks, err := prepareReleasePlanForStorage(args, nil)
 	if err != nil {
+		return "", err
+	}
+	chunkColl := NewReleasePlanJobSpecChunkColl()
+	if len(chunks) > 0 {
+		if err := chunkColl.Create(ctx, chunks); err != nil {
+			return "", errors.Wrap(err, "create release plan job spec chunks")
+		}
+	}
+
+	res, err := c.InsertOne(ctx, storedPlan)
+	if err != nil {
+		cleanupReleasePlanJobSpecChunks(ctx, chunkColl, storedPlan.JobSpecsRef, "create release plan")
 		return "", err
 	}
 	id, ok := res.InsertedID.(primitive.ObjectID)
@@ -109,8 +122,20 @@ func (c *ReleasePlanColl) GetByID(ctx context.Context, idString string) (*models
 
 	query := bson.M{"_id": id}
 	result := new(models.ReleasePlan)
-	err = c.FindOne(ctx, query).Decode(result)
-	return result, err
+	if err := c.FindOne(ctx, query).Decode(result); err != nil {
+		return nil, err
+	}
+	if result.JobSpecsRef == nil {
+		return result, nil
+	}
+	chunks, err := NewReleasePlanJobSpecChunkColl().List(ctx, idString, result.JobSpecsRef.StorageID)
+	if err != nil {
+		return nil, errors.Wrap(err, "list release plan job spec chunks")
+	}
+	if err := restoreReleasePlanJobSpecs(result, chunks); err != nil {
+		return nil, errors.Wrap(err, "restore release plan job specs")
+	}
+	return result, nil
 }
 
 func (c *ReleasePlanColl) GetVersionByID(ctx context.Context, idString string) (*models.ReleasePlan, error) {
@@ -139,10 +164,32 @@ func (c *ReleasePlanColl) UpdateByID(ctx context.Context, idString string, args 
 		return fmt.Errorf("invalid id")
 	}
 
+	storedPlan, chunks, err := prepareReleasePlanForStorage(args, args.JobSpecsRef)
+	if err != nil {
+		return err
+	}
+	chunkColl := NewReleasePlanJobSpecChunkColl()
+	if len(chunks) > 0 {
+		if err := chunkColl.Create(ctx, chunks); err != nil {
+			return errors.Wrap(err, "create release plan job spec chunks")
+		}
+	}
+
 	query := bson.M{"_id": id}
-	change := bson.M{"$set": args}
-	_, err = c.UpdateOne(ctx, query, change)
-	return err
+	change := bson.M{"$set": storedPlan}
+	if storedPlan.JobSpecsRef == nil {
+		change["$unset"] = bson.M{"job_specs_ref": ""}
+	}
+	if _, err = c.UpdateOne(ctx, query, change); err != nil {
+		if len(chunks) > 0 {
+			cleanupReleasePlanJobSpecChunks(ctx, chunkColl, storedPlan.JobSpecsRef, "update release plan")
+		}
+		return err
+	}
+	if args.JobSpecsRef != nil && (storedPlan.JobSpecsRef == nil || args.JobSpecsRef.StorageID != storedPlan.JobSpecsRef.StorageID) {
+		cleanupReleasePlanJobSpecChunks(ctx, chunkColl, args.JobSpecsRef, "replace release plan job specs")
+	}
+	return nil
 }
 
 func (c *ReleasePlanColl) DeleteByID(ctx context.Context, idString string) error {
@@ -152,8 +199,25 @@ func (c *ReleasePlanColl) DeleteByID(ctx context.Context, idString string) error
 	}
 
 	query := bson.M{"_id": id}
-	_, err = c.DeleteOne(ctx, query)
-	return err
+	result := new(models.ReleasePlan)
+	err = c.FindOneAndDelete(ctx, query, options.FindOneAndDelete().SetProjection(bson.M{"job_specs_ref": 1})).Decode(result)
+	if err == mongo.ErrNoDocuments {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	cleanupReleasePlanJobSpecChunks(ctx, NewReleasePlanJobSpecChunkColl(), result.JobSpecsRef, "delete release plan")
+	return nil
+}
+
+func cleanupReleasePlanJobSpecChunks(ctx context.Context, coll *ReleasePlanJobSpecChunkColl, ref *models.ReleasePlanJobSpecsRef, operation string) {
+	if ref == nil {
+		return
+	}
+	if err := coll.Delete(ctx, ref.StorageID); err != nil {
+		log.SugaredLogger().Warnf("failed to clean up release plan job spec chunks after %s: %v", operation, err)
+	}
 }
 
 type SortReleasePlanBy string

--- a/pkg/microservice/aslan/core/common/repository/mongodb/release_plan_job_spec.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/release_plan_job_spec.go
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2026 The KodeRover Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongodb
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"reflect"
+	"time"
+
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsoncodec"
+	"go.mongodb.org/mongo-driver/bson/bsonoptions"
+	"go.mongodb.org/mongo-driver/bson/bsonrw"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+	mongotool "github.com/koderover/zadig/v2/pkg/tool/mongo"
+)
+
+const (
+	releasePlanJobSpecsEncodingGZIPBSONV1 = "gzip-bson-v1"
+	releasePlanJobSpecChunkSize           = 4 * 1024 * 1024
+)
+
+var releasePlanJobSpecsBSONRegistry = bson.NewRegistryBuilder().
+	RegisterTypeMapEntry(bsontype.EmbeddedDocument, reflect.TypeOf(bson.M{})).
+	RegisterDefaultEncoder(reflect.Slice, bsoncodec.NewSliceCodec(bsonoptions.SliceCodec().SetEncodeNilAsEmpty(true))).
+	Build()
+
+type releasePlanJobSpecEntry struct {
+	JobID string      `bson:"job_id" json:"job_id"`
+	Spec  interface{} `bson:"spec" json:"spec"`
+}
+
+type releasePlanJobSpecsPayload struct {
+	Jobs []*releasePlanJobSpecEntry `bson:"jobs" json:"jobs"`
+}
+
+type encodedReleasePlanJobSpecs struct {
+	compressed    []byte
+	originalSize  int64
+	sha256        string
+	contentSHA256 string
+}
+
+type ReleasePlanJobSpecChunkColl struct {
+	*mongo.Collection
+
+	coll string
+}
+
+func NewReleasePlanJobSpecChunkColl() *ReleasePlanJobSpecChunkColl {
+	name := models.ReleasePlanJobSpecChunk{}.TableName()
+	return &ReleasePlanJobSpecChunkColl{
+		Collection: mongotool.Database(config.MongoDatabase()).Collection(name),
+		coll:       name,
+	}
+}
+
+func (c *ReleasePlanJobSpecChunkColl) GetCollectionName() string {
+	return c.coll
+}
+
+func (c *ReleasePlanJobSpecChunkColl) EnsureIndex(ctx context.Context) error {
+	indexes := []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "storage_id", Value: 1}, {Key: "sequence", Value: 1}},
+			Options: options.Index().SetUnique(true),
+		},
+		{Keys: bson.D{{Key: "plan_id", Value: 1}}},
+	}
+	_, err := c.Indexes().CreateMany(ctx, indexes, mongotool.CreateIndexOptions(ctx))
+	return err
+}
+
+func (c *ReleasePlanJobSpecChunkColl) Create(ctx context.Context, chunks []*models.ReleasePlanJobSpecChunk) error {
+	if len(chunks) == 0 {
+		return errors.New("empty release plan job spec chunks")
+	}
+	documents := make([]interface{}, 0, len(chunks))
+	for _, chunk := range chunks {
+		if chunk == nil {
+			return errors.New("nil release plan job spec chunk")
+		}
+		documents = append(documents, chunk)
+	}
+	_, err := c.InsertMany(ctx, documents)
+	return err
+}
+
+func (c *ReleasePlanJobSpecChunkColl) List(ctx context.Context, planID string, storageID primitive.ObjectID) ([]*models.ReleasePlanJobSpecChunk, error) {
+	cursor, err := c.Find(ctx, bson.M{"plan_id": planID, "storage_id": storageID}, options.Find().SetSort(bson.D{{Key: "sequence", Value: 1}}))
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	var chunks []*models.ReleasePlanJobSpecChunk
+	if err := cursor.All(ctx, &chunks); err != nil {
+		return nil, err
+	}
+	return chunks, nil
+}
+
+func (c *ReleasePlanJobSpecChunkColl) Delete(ctx context.Context, storageID primitive.ObjectID) error {
+	_, err := c.DeleteMany(ctx, bson.M{"storage_id": storageID})
+	return err
+}
+
+func prepareReleasePlanForStorage(plan *models.ReleasePlan, existingRef *models.ReleasePlanJobSpecsRef) (*models.ReleasePlan, []*models.ReleasePlanJobSpecChunk, error) {
+	storedPlan, payload, err := buildReleasePlanJobSpecsPayload(plan)
+	if err != nil {
+		return nil, nil, err
+	}
+	if payload == nil {
+		return storedPlan, nil, nil
+	}
+
+	encoded, err := encodeReleasePlanJobSpecs(payload)
+	if err != nil {
+		return nil, nil, err
+	}
+	if existingRef != nil && existingRef.Encoding == releasePlanJobSpecsEncodingGZIPBSONV1 && existingRef.ContentSHA256 == encoded.contentSHA256 {
+		ref := *existingRef
+		storedPlan.JobSpecsRef = &ref
+		return storedPlan, nil, nil
+	}
+
+	storageID := primitive.NewObjectID()
+	chunks := splitReleasePlanJobSpecPayload(plan.ID.Hex(), storageID, encoded.compressed, releasePlanJobSpecChunkSize)
+	storedPlan.JobSpecsRef = &models.ReleasePlanJobSpecsRef{
+		StorageID:      storageID,
+		Encoding:       releasePlanJobSpecsEncodingGZIPBSONV1,
+		ChunkCount:     int32(len(chunks)),
+		OriginalSize:   encoded.originalSize,
+		CompressedSize: int64(len(encoded.compressed)),
+		SHA256:         encoded.sha256,
+		ContentSHA256:  encoded.contentSHA256,
+	}
+	return storedPlan, chunks, nil
+}
+
+func buildReleasePlanJobSpecsPayload(plan *models.ReleasePlan) (*models.ReleasePlan, *releasePlanJobSpecsPayload, error) {
+	if plan == nil {
+		return nil, nil, errors.New("nil ReleasePlan")
+	}
+	storedPlan := *plan
+	storedPlan.Jobs = make([]*models.ReleaseJob, len(plan.Jobs))
+	if len(plan.Jobs) == 0 {
+		storedPlan.JobSpecsRef = nil
+		return &storedPlan, nil, nil
+	}
+
+	payload := &releasePlanJobSpecsPayload{Jobs: make([]*releasePlanJobSpecEntry, 0, len(plan.Jobs))}
+	jobIDs := make(map[string]struct{}, len(plan.Jobs))
+	for index, job := range plan.Jobs {
+		if job == nil {
+			return nil, nil, errors.New("nil release plan job")
+		}
+		if _, exists := jobIDs[job.ID]; exists {
+			return nil, nil, fmt.Errorf("duplicate release plan job ID: %s", job.ID)
+		}
+		jobIDs[job.ID] = struct{}{}
+		storedJob := *job
+		storedJob.Spec = nil
+		storedPlan.Jobs[index] = &storedJob
+		payload.Jobs = append(payload.Jobs, &releasePlanJobSpecEntry{JobID: job.ID, Spec: job.Spec})
+	}
+	return &storedPlan, payload, nil
+}
+
+func encodeReleasePlanJobSpecs(payload *releasePlanJobSpecsPayload) (*encodedReleasePlanJobSpecs, error) {
+	bsonPayload, err := bson.MarshalWithRegistry(releasePlanJobSpecsBSONRegistry, payload)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal release plan job specs")
+	}
+	normalizedPayload, err := decodeReleasePlanJobSpecsPayload(bsonPayload)
+	if err != nil {
+		return nil, err
+	}
+	digestPayload, err := json.Marshal(normalizedPayload)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal release plan job specs digest")
+	}
+	contentDigest := sha256.Sum256(digestPayload)
+	digest := sha256.Sum256(bsonPayload)
+
+	var compressed bytes.Buffer
+	writer, err := gzip.NewWriterLevel(&compressed, gzip.BestSpeed)
+	if err != nil {
+		return nil, errors.Wrap(err, "create release plan job specs gzip writer")
+	}
+	if _, err := writer.Write(bsonPayload); err != nil {
+		return nil, errors.Wrap(err, "compress release plan job specs")
+	}
+	if err := writer.Close(); err != nil {
+		return nil, errors.Wrap(err, "finish compressing release plan job specs")
+	}
+
+	return &encodedReleasePlanJobSpecs{
+		compressed:    compressed.Bytes(),
+		originalSize:  int64(len(bsonPayload)),
+		sha256:        hex.EncodeToString(digest[:]),
+		contentSHA256: hex.EncodeToString(contentDigest[:]),
+	}, nil
+}
+
+func splitReleasePlanJobSpecPayload(planID string, storageID primitive.ObjectID, payload []byte, chunkSize int) []*models.ReleasePlanJobSpecChunk {
+	chunkCount := (len(payload) + chunkSize - 1) / chunkSize
+	chunks := make([]*models.ReleasePlanJobSpecChunk, 0, chunkCount)
+	createdAt := time.Now().Unix()
+	for offset := 0; offset < len(payload); offset += chunkSize {
+		end := offset + chunkSize
+		if end > len(payload) {
+			end = len(payload)
+		}
+		chunks = append(chunks, &models.ReleasePlanJobSpecChunk{
+			StorageID: storageID,
+			PlanID:    planID,
+			Sequence:  int32(len(chunks)),
+			Data:      payload[offset:end],
+			CreatedAt: createdAt,
+		})
+	}
+	return chunks
+}
+
+func restoreReleasePlanJobSpecs(plan *models.ReleasePlan, chunks []*models.ReleasePlanJobSpecChunk) error {
+	if plan == nil {
+		return errors.New("nil ReleasePlan")
+	}
+	if plan.JobSpecsRef == nil {
+		return nil
+	}
+	payload, err := decodeReleasePlanJobSpecChunks(plan.ID.Hex(), plan.JobSpecsRef, chunks)
+	if err != nil {
+		return err
+	}
+	return restoreReleasePlanJobSpecEntries(plan.Jobs, payload.Jobs)
+}
+
+func decodeReleasePlanJobSpecChunks(planID string, ref *models.ReleasePlanJobSpecsRef, chunks []*models.ReleasePlanJobSpecChunk) (*releasePlanJobSpecsPayload, error) {
+	if ref.Encoding != releasePlanJobSpecsEncodingGZIPBSONV1 {
+		return nil, fmt.Errorf("unsupported release plan job specs encoding: %s", ref.Encoding)
+	}
+	if ref.StorageID.IsZero() || ref.ChunkCount <= 0 || ref.OriginalSize < 0 || ref.OriginalSize == math.MaxInt64 || ref.CompressedSize < 0 {
+		return nil, errors.New("invalid release plan job specs reference")
+	}
+	if len(chunks) != int(ref.ChunkCount) {
+		return nil, errors.New("release plan job spec chunk count mismatch")
+	}
+
+	var compressed bytes.Buffer
+	for index, chunk := range chunks {
+		if chunk == nil || chunk.StorageID != ref.StorageID || chunk.PlanID != planID || chunk.Sequence != int32(index) {
+			return nil, errors.New("release plan job spec chunk does not match reference")
+		}
+		compressed.Write(chunk.Data)
+	}
+	if int64(compressed.Len()) != ref.CompressedSize {
+		return nil, errors.New("release plan job specs compressed size mismatch")
+	}
+
+	reader, err := gzip.NewReader(bytes.NewReader(compressed.Bytes()))
+	if err != nil {
+		return nil, errors.Wrap(err, "create release plan job specs gzip reader")
+	}
+	defer reader.Close()
+	bsonPayload, err := io.ReadAll(io.LimitReader(reader, ref.OriginalSize+1))
+	if err != nil {
+		return nil, errors.Wrap(err, "decompress release plan job specs")
+	}
+	if int64(len(bsonPayload)) != ref.OriginalSize {
+		return nil, errors.New("release plan job specs original size mismatch")
+	}
+	digest := sha256.Sum256(bsonPayload)
+	if hex.EncodeToString(digest[:]) != ref.SHA256 {
+		return nil, errors.New("release plan job specs checksum mismatch")
+	}
+	return decodeReleasePlanJobSpecsPayload(bsonPayload)
+}
+
+func restoreReleasePlanJobSpecEntries(jobs []*models.ReleaseJob, entries []*releasePlanJobSpecEntry) error {
+	if len(entries) != len(jobs) {
+		return errors.New("release plan job specs does not match release plan jobs")
+	}
+
+	specs := make(map[string]interface{}, len(entries))
+	for _, entry := range entries {
+		if entry == nil {
+			return errors.New("nil release plan job spec entry")
+		}
+		if _, exists := specs[entry.JobID]; exists {
+			return fmt.Errorf("duplicate release plan job spec: %s", entry.JobID)
+		}
+		specs[entry.JobID] = entry.Spec
+	}
+
+	resolvedSpecs := make([]interface{}, len(jobs))
+	for index, job := range jobs {
+		if job == nil {
+			return errors.New("nil release plan job")
+		}
+		spec, exists := specs[job.ID]
+		if !exists {
+			return errors.New("release plan job specs does not match release plan jobs")
+		}
+		resolvedSpecs[index] = spec
+		delete(specs, job.ID)
+	}
+	if len(specs) != 0 {
+		return errors.New("release plan job specs does not match release plan jobs")
+	}
+	for index, job := range jobs {
+		job.Spec = resolvedSpecs[index]
+	}
+	return nil
+}
+
+func decodeReleasePlanJobSpecsPayload(data []byte) (*releasePlanJobSpecsPayload, error) {
+	payload := new(releasePlanJobSpecsPayload)
+	decoder, err := bson.NewDecoder(bsonrw.NewBSONDocumentReader(data))
+	if err != nil {
+		return nil, errors.Wrap(err, "create release plan job specs BSON decoder")
+	}
+	if err := decoder.SetRegistry(releasePlanJobSpecsBSONRegistry); err != nil {
+		return nil, errors.Wrap(err, "set release plan job specs BSON registry")
+	}
+	if err := decoder.Decode(payload); err != nil {
+		return nil, errors.Wrap(err, "unmarshal release plan job specs")
+	}
+	return payload, nil
+}

--- a/pkg/microservice/aslan/core/common/repository/mongodb/release_plan_version.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/release_plan_version.go
@@ -67,7 +67,14 @@ func (c *ReleasePlanVersionColl) Create(ctx context.Context, args *models.Releas
 		return errors.New("nil ReleasePlanVersion")
 	}
 
-	_, err := c.InsertOne(ctx, args)
+	storedVersion, snapshots, err := prepareReleasePlanVersionForStorage(args)
+	if err != nil {
+		return err
+	}
+	if err := NewReleasePlanVersionSnapshotColl().Create(ctx, snapshots); err != nil {
+		return errors.Wrap(err, "create release plan version snapshots")
+	}
+	_, err = c.InsertOne(ctx, storedVersion)
 	return err
 }
 
@@ -76,10 +83,17 @@ func (c *ReleasePlanVersionColl) Upsert(ctx context.Context, args *models.Releas
 		return errors.New("nil ReleasePlanVersion")
 	}
 
-	_, err := c.ReplaceOne(ctx, bson.M{
+	storedVersion, snapshots, err := prepareReleasePlanVersionForStorage(args)
+	if err != nil {
+		return err
+	}
+	if err := NewReleasePlanVersionSnapshotColl().Upsert(ctx, snapshots); err != nil {
+		return errors.Wrap(err, "upsert release plan version snapshots")
+	}
+	_, err = c.ReplaceOne(ctx, bson.M{
 		"plan_id": args.PlanID,
 		"version": args.Version,
-	}, args, options.Replace().SetUpsert(true))
+	}, storedVersion, options.Replace().SetUpsert(true))
 	return err
 }
 
@@ -88,7 +102,10 @@ func (c *ReleasePlanVersionColl) Delete(ctx context.Context, planID string, vers
 		"plan_id": planID,
 		"version": version,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	return NewReleasePlanVersionSnapshotColl().Delete(ctx, planID, version)
 }
 
 func (c *ReleasePlanVersionColl) Get(planID string, version int64) (*models.ReleasePlanVersion, error) {
@@ -97,7 +114,13 @@ func (c *ReleasePlanVersionColl) Get(planID string, version int64) (*models.Rele
 		"plan_id": planID,
 		"version": version,
 	}).Decode(resp)
-	return resp, err
+	if err != nil {
+		return nil, err
+	}
+	if err := loadReleasePlanVersionSnapshots(context.Background(), resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 func (c *ReleasePlanVersionColl) GetLatestBySectionsBefore(planID string, sectionKeys []string, beforeVersion int64) (*models.ReleasePlanVersion, error) {
@@ -109,5 +132,22 @@ func (c *ReleasePlanVersionColl) GetLatestBySectionsBefore(planID string, sectio
 			"$in": sectionKeys,
 		},
 	}, options.FindOne().SetSort(bson.D{{Key: "version", Value: -1}})).Decode(resp)
-	return resp, err
+	if err != nil {
+		return nil, err
+	}
+	if err := loadReleasePlanVersionSnapshots(context.Background(), resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func loadReleasePlanVersionSnapshots(ctx context.Context, version *models.ReleasePlanVersion) error {
+	if version.SnapshotStorage == "" {
+		return nil
+	}
+	snapshots, err := NewReleasePlanVersionSnapshotColl().List(ctx, version.PlanID, version.Version)
+	if err != nil {
+		return errors.Wrap(err, "list release plan version snapshots")
+	}
+	return restoreReleasePlanVersionSnapshots(version, snapshots)
 }

--- a/pkg/microservice/aslan/core/common/repository/mongodb/release_plan_version_snapshot.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/release_plan_version_snapshot.go
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2026 The KodeRover Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongodb
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
+	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+	mongotool "github.com/koderover/zadig/v2/pkg/tool/mongo"
+)
+
+const releasePlanVersionSnapshotStorageGZIPJSONV1 = "external-gzip-json-v1"
+
+type ReleasePlanVersionSnapshotColl struct {
+	*mongo.Collection
+
+	coll string
+}
+
+func NewReleasePlanVersionSnapshotColl() *ReleasePlanVersionSnapshotColl {
+	name := models.ReleasePlanVersionSnapshot{}.TableName()
+	return &ReleasePlanVersionSnapshotColl{
+		Collection: mongotool.Database(config.MongoDatabase()).Collection(name),
+		coll:       name,
+	}
+}
+
+func (c *ReleasePlanVersionSnapshotColl) GetCollectionName() string {
+	return c.coll
+}
+
+func (c *ReleasePlanVersionSnapshotColl) EnsureIndex(ctx context.Context) error {
+	_, err := c.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "plan_id", Value: 1},
+			{Key: "version", Value: 1},
+			{Key: "kind", Value: 1},
+		},
+		Options: options.Index().SetUnique(true),
+	}, mongotool.CreateIndexOptions(ctx))
+	return err
+}
+
+func (c *ReleasePlanVersionSnapshotColl) Create(ctx context.Context, snapshots []*models.ReleasePlanVersionSnapshot) error {
+	if len(snapshots) == 0 {
+		return errors.New("empty release plan version snapshots")
+	}
+	documents := make([]interface{}, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		if snapshot == nil {
+			return errors.New("nil release plan version snapshot")
+		}
+		documents = append(documents, snapshot)
+	}
+	_, err := c.InsertMany(ctx, documents)
+	return err
+}
+
+func (c *ReleasePlanVersionSnapshotColl) Upsert(ctx context.Context, snapshots []*models.ReleasePlanVersionSnapshot) error {
+	if len(snapshots) == 0 {
+		return errors.New("empty release plan version snapshots")
+	}
+	writes := make([]mongo.WriteModel, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		if snapshot == nil {
+			return errors.New("nil release plan version snapshot")
+		}
+		writes = append(writes, mongo.NewReplaceOneModel().
+			SetFilter(bson.M{"plan_id": snapshot.PlanID, "version": snapshot.Version, "kind": snapshot.Kind}).
+			SetReplacement(snapshot).
+			SetUpsert(true))
+	}
+	_, err := c.BulkWrite(ctx, writes)
+	return err
+}
+
+func (c *ReleasePlanVersionSnapshotColl) Delete(ctx context.Context, planID string, version int64) error {
+	_, err := c.DeleteMany(ctx, bson.M{"plan_id": planID, "version": version})
+	return err
+}
+
+func (c *ReleasePlanVersionSnapshotColl) List(ctx context.Context, planID string, version int64) ([]*models.ReleasePlanVersionSnapshot, error) {
+	cursor, err := c.Find(ctx, bson.M{"plan_id": planID, "version": version})
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	resp := make([]*models.ReleasePlanVersionSnapshot, 0, 2)
+	if err := cursor.All(ctx, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func prepareReleasePlanVersionForStorage(version *models.ReleasePlanVersion) (*models.ReleasePlanVersion, []*models.ReleasePlanVersionSnapshot, error) {
+	if version == nil {
+		return nil, nil, errors.New("nil ReleasePlanVersion")
+	}
+	if version.Snapshot == nil {
+		return nil, nil, errors.New("nil release plan version snapshot")
+	}
+
+	storedVersion := *version
+	storedVersion.SnapshotStorage = releasePlanVersionSnapshotStorageGZIPJSONV1
+	storedVersion.HasBaseSnapshot = version.BaseSnapshot != nil
+	storedVersion.BaseSnapshot = nil
+	storedVersion.Snapshot = nil
+
+	snapshots := make([]*models.ReleasePlanVersionSnapshot, 0, 2)
+	if version.BaseSnapshot != nil {
+		snapshot, err := newReleasePlanVersionSnapshot(version, models.ReleasePlanVersionSnapshotKindBase, version.BaseSnapshot)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "encode base snapshot")
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+	currentSnapshot, err := newReleasePlanVersionSnapshot(version, models.ReleasePlanVersionSnapshotKindCurrent, version.Snapshot)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "encode current snapshot")
+	}
+	snapshots = append(snapshots, currentSnapshot)
+	return &storedVersion, snapshots, nil
+}
+
+func newReleasePlanVersionSnapshot(version *models.ReleasePlanVersion, kind models.ReleasePlanVersionSnapshotKind, value interface{}) (*models.ReleasePlanVersionSnapshot, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal snapshot")
+	}
+
+	var compressed bytes.Buffer
+	writer, err := gzip.NewWriterLevel(&compressed, gzip.BestSpeed)
+	if err != nil {
+		return nil, errors.Wrap(err, "create gzip writer")
+	}
+	if _, err := writer.Write(payload); err != nil {
+		return nil, errors.Wrap(err, "compress snapshot")
+	}
+	if err := writer.Close(); err != nil {
+		return nil, errors.Wrap(err, "finish compressing snapshot")
+	}
+
+	return &models.ReleasePlanVersionSnapshot{
+		PlanID:       version.PlanID,
+		Version:      version.Version,
+		Kind:         kind,
+		Data:         compressed.Bytes(),
+		OriginalSize: int64(len(payload)),
+		CreatedAt:    version.CreatedAt,
+	}, nil
+}
+
+func restoreReleasePlanVersionSnapshots(version *models.ReleasePlanVersion, snapshots []*models.ReleasePlanVersionSnapshot) error {
+	if version == nil {
+		return errors.New("nil ReleasePlanVersion")
+	}
+	if version.SnapshotStorage == "" {
+		return nil
+	}
+	if version.SnapshotStorage != releasePlanVersionSnapshotStorageGZIPJSONV1 {
+		return fmt.Errorf("unsupported release plan version snapshot storage: %s", version.SnapshotStorage)
+	}
+
+	values := make(map[models.ReleasePlanVersionSnapshotKind]interface{}, len(snapshots))
+	for _, snapshot := range snapshots {
+		if snapshot == nil {
+			continue
+		}
+		if snapshot.PlanID != version.PlanID || snapshot.Version != version.Version {
+			return errors.New("release plan version snapshot does not match version")
+		}
+		if _, exists := values[snapshot.Kind]; exists {
+			return fmt.Errorf("duplicate %s snapshot", snapshot.Kind)
+		}
+		value, err := decodeReleasePlanVersionSnapshot(snapshot)
+		if err != nil {
+			return errors.Wrapf(err, "decode %s snapshot", snapshot.Kind)
+		}
+		values[snapshot.Kind] = value
+	}
+
+	currentSnapshot, exists := values[models.ReleasePlanVersionSnapshotKindCurrent]
+	if !exists {
+		return errors.New("missing current snapshot")
+	}
+	version.Snapshot = currentSnapshot
+	if version.HasBaseSnapshot {
+		baseSnapshot, exists := values[models.ReleasePlanVersionSnapshotKindBase]
+		if !exists {
+			return errors.New("missing base snapshot")
+		}
+		version.BaseSnapshot = baseSnapshot
+	}
+	return nil
+}
+
+func decodeReleasePlanVersionSnapshot(snapshot *models.ReleasePlanVersionSnapshot) (interface{}, error) {
+	if snapshot == nil {
+		return nil, errors.New("nil release plan version snapshot")
+	}
+	reader, err := gzip.NewReader(bytes.NewReader(snapshot.Data))
+	if err != nil {
+		return nil, errors.Wrap(err, "create gzip reader")
+	}
+	defer reader.Close()
+
+	payload, err := io.ReadAll(io.LimitReader(reader, snapshot.OriginalSize+1))
+	if err != nil {
+		return nil, errors.Wrap(err, "decompress snapshot")
+	}
+	if int64(len(payload)) != snapshot.OriginalSize {
+		return nil, errors.New("snapshot size mismatch")
+	}
+	var value interface{}
+	if err := json.Unmarshal(payload, &value); err != nil {
+		return nil, errors.Wrap(err, "unmarshal snapshot")
+	}
+	return value, nil
+}


### PR DESCRIPTION
### Summary
- Store release plan version snapshots and Job Specs as compressed external documents.
- Keep complete diff content while preventing main documents from exceeding MongoDB's 16 MB limit.
### Main Changes
- Compress base/current snapshots independently for version diffs.
- Compress Job Specs with gzip, split them into 4 MiB chunks, and hydrate them on repository reads.
- Reuse unchanged chunks and clean replaced or deleted chunks.
### Risk / Compatibility
- Legacy inline plans and versions remain readable; new externalized plans require upgraded Aslan.
- Avoid mixed old/new Aslan writes during rollout.
### Test
- `go test ./pkg/microservice/aslan/core/common/repository/mongodb -count=1`
- Release-plan service test is blocked by the existing `go-restful/v3` checksum mismatch.
### Contact
Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4934)
<!-- Reviewable:end -->
