### PR TITLE
fix: trim Zadig deploy env options from release plan snapshots

### DIFF
--- a/pkg/microservice/aslan/core/release_plan/service/section_snapshot.go
+++ b/pkg/microservice/aslan/core/release_plan/service/section_snapshot.go
@@ -671,7 +671,7 @@ func hasReleasePlanWorkflowSnapshotJobSpecFields(job map[string]interface{}) boo
 		}
 	case config.JobZadigDeploy:
 		if env, ok := getStringField(spec, "env"); ok && env != "" {
-			return hasReleasePlanWorkflowSnapshotKey(spec, "env_options")
+			return true
 		}
 		if hasReleasePlanWorkflowSnapshotKey(spec, "services") {
 			return true
@@ -864,7 +864,14 @@ func buildReleasePlanWorkflowJobsInputSnapshot(path string, value interface{}) i
 			jobResp["service_modules"] = filterReleasePlanWorkflowInputValueAtPath(joinReleasePlanWorkflowInputPath(path, "service_modules"), serviceModules)
 		}
 		if spec, exists := jobMap["spec"]; exists {
-			jobResp["spec"] = filterReleasePlanWorkflowInputValueAtPath(joinReleasePlanWorkflowInputPath(path, "spec"), spec)
+			filteredSpec := filterReleasePlanWorkflowInputValueAtPath(joinReleasePlanWorkflowInputPath(path, "spec"), spec)
+			// Keep selected deployment values, but omit editor candidates from version snapshots.
+			if jobType, ok := getStringField(jobMap, "type"); ok && config.JobType(jobType) == config.JobZadigDeploy {
+				if specMap, ok := getMapField(filteredSpec); ok {
+					delete(specMap, "env_options")
+				}
+			}
+			jobResp["spec"] = filteredSpec
 		}
 		if len(jobResp) > 0 {
 			resp = append(resp, jobResp)


### PR DESCRIPTION
### Summary
- Remove only `env_options` from `zadig-deploy` jobs in release plan version snapshots.
- Keep the current release plan and deployment execution payload unchanged.
- Deploy environment candidates can make `release_plan_version` exceed MongoDB's 16 MB BSON limit.
### Main Changes
- Preserve selected `env`, `services`, and every field for non-`zadig-deploy` jobs.
- Treat `zadig-deploy` snapshots without `env_options` as complete to avoid reloading them.
### Risk / Compatibility
- Existing release plans and versions remain readable.
- The workflow diff frontend must render without `env_options`; deployment execution is unchanged.
### Test
- `gofmt` and `git diff --check` passed.
- Service package test is blocked by the existing `go-restful/v3` checksum mismatch.
### Contact
Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4939)
<!-- Reviewable:end -->
