### PR TITLE
fix: preserve user contact info when sorting by login time

### DIFF
--- a/pkg/microservice/user/core/repository/orm/user.go
+++ b/pkg/microservice/user/core/repository/orm/user.go
@@ -157,7 +157,7 @@ func ListUsersByLoginTime(page int, perPage int, name string, order setting.List
 	)
 
 	query := db.Model(&models.User{}).
-		Select("user.uid, user.name, user.account, user.identity_type, user.api_token_enabled, "+userMFAEnabledSelectExpr+", IFNULL(user_login.last_login_time, 0) as last_login_time").
+		Select("user.uid, user.name, user.account, user.identity_type, user.email, user.phone, user.api_token_enabled, "+userMFAEnabledSelectExpr+", IFNULL(user_login.last_login_time, 0) as last_login_time").
 		Where("user.name LIKE ?", "%"+name+"%").
 		Joins("LEFT JOIN user_login on user_login.uid = user.uid")
 	query = applyMFAEnabledJoinFilter(query, mfaEnabled)
@@ -188,7 +188,7 @@ func ListUsersByNameAndRoleWithLoginTime(page int, perPage int, name string, rol
 	var users []models.UserWithLoginTime
 	roleUIDSubQuery := uidSubQueryByRoles(roles, namespace, db)
 	query := db.Model(&models.User{}).
-		Select("user.uid, user.name, user.account, user.identity_type, user.api_token_enabled, "+userMFAEnabledSelectExpr+", IFNULL(user_login.last_login_time, 0) AS last_login_time").
+		Select("user.uid, user.name, user.account, user.identity_type, user.email, user.phone, user.api_token_enabled, "+userMFAEnabledSelectExpr+", IFNULL(user_login.last_login_time, 0) AS last_login_time").
 		Joins("LEFT JOIN user_login ON user_login.uid = user.uid").
 		Where("user.uid IN (?)", roleUIDSubQuery).
 		Where("user.name LIKE ?", "%"+name+"%")


### PR DESCRIPTION
### Summary
- Preserve user email and phone fields when sorting the user list by login time.

### Why
- Login-time queries selected only partial user columns, leaving contact fields empty in API responses.

### Main Changes
- Select email and phone in the standard login-time query.
- Apply the same fix to role-filtered login-time queries.

### Risk / Compatibility
- Low risk: only existing response fields are populated; sorting, filtering, and pagination are unchanged.

### Test
- `go test ./pkg/microservice/user/core/repository/orm ./pkg/microservice/user/core/service/permission`

### Contact
Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4940)
<!-- Reviewable:end -->
