### PR TITLE
fix: GenEstimatedValues when merge stragegy is reuse-values

### DIFF
--- a/pkg/microservice/aslan/core/environment/service/environment.go
+++ b/pkg/microservice/aslan/core/environment/service/environment.go
@@ -1781,7 +1781,7 @@ func GenEstimatedValues(projectName, envName, namespace, serviceOrReleaseName st
 		tempArg := &commonservice.HelmSvcRenderArg{OverrideValues: arg.OverrideValues}
 		overrideValue := arg.OverrideYaml
 		if valueMergeStrategy == config.ValueMergeStrategyReuseValue {
-			currentValuesMap, err := helmservice.GetValuesMapFromString(currentYaml)
+			envValuesMap, err := helmservice.GetValuesMapFromString(prodSvc.GetServiceRender().GetOverrideYaml())
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate env values map, err: %s", err)
 			}
@@ -1791,7 +1791,7 @@ func GenEstimatedValues(projectName, envName, namespace, serviceOrReleaseName st
 				return nil, fmt.Errorf("failed to generate user supplied values map, err: %s", err)
 			}
 
-			finalValuesMap := helmservice.MergeHelmValues(currentValuesMap, userSuppliedValueMap)
+			finalValuesMap := helmservice.MergeHelmValues(envValuesMap, userSuppliedValueMap)
 			finalYamlBytes, err := yaml.Marshal(finalValuesMap)
 			if err != nil {
 				return nil, fmt.Errorf("failed to calculate final values string, err: %s", err)


### PR DESCRIPTION
### What this PR does / Why we need it:
fix: GenEstimatedValues when merge stragegy is reuse-values

### What is changed and how it works?
fix: GenEstimatedValues when merge stragegy is reuse-values

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4941)
<!-- Reviewable:end -->
