### PR TITLE
cherry pick #4938 to release 5.0.0

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gerrit_workflowv4_task.go
@@ -169,6 +169,7 @@ func (gruem *gerritChangeMergedEventMatcherForWorkflowV4) GetHookRepo(hookRepo *
 		PR:            gruem.Event.Change.Number,
 		CommitID:      gruem.Event.NewRev,
 		CommitMessage: gruem.Event.Change.CommitMessage,
+		AuthorName:    gruem.Event.PatchSet.Author.Name,
 		Committer:     hookRepo.Committer,
 		Source:        hookRepo.Source,
 	}
@@ -216,6 +217,7 @@ func (gpcem *gerritPatchsetCreatedEventMatcherForWorkflowV4) GetHookRepo(hookRep
 		PR:            gpcem.Event.Change.Number,
 		CommitID:      gpcem.Event.PatchSet.Revision,
 		CommitMessage: gpcem.Event.Change.CommitMessage,
+		AuthorName:    gpcem.Event.PatchSet.Author.Name,
 		Committer:     hookRepo.Committer,
 		Source:        hookRepo.Source,
 	}

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitee_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitee_workflowv4_task.go
@@ -73,9 +73,11 @@ func (gpem *giteePushEventMatcherForWorkflowV4) Match(hookRepo *commonmodels.Mai
 }
 
 func (gpem *giteePushEventMatcherForWorkflowV4) GetHookRepo(hookRepo *commonmodels.MainHookRepo) *types.Repository {
-	commitMessage := ""
+	commitMessage, authorName := "", ""
 	if len(gpem.event.Commits) > 0 {
-		commitMessage = gpem.event.Commits[len(gpem.event.Commits)-1].Message
+		commit := gpem.event.Commits[len(gpem.event.Commits)-1]
+		commitMessage = commit.Message
+		authorName = commit.Author.Name
 	}
 	return &types.Repository{
 		CodehostID:    hookRepo.CodehostID,
@@ -86,6 +88,7 @@ func (gpem *giteePushEventMatcherForWorkflowV4) GetHookRepo(hookRepo *commonmode
 		TargetBranch:  hookRepo.Branch,
 		CommitID:      gpem.event.After,
 		CommitMessage: commitMessage,
+		AuthorName:    authorName,
 		Committer:     hookRepo.Committer,
 		Source:        hookRepo.Source,
 	}

--- a/pkg/microservice/aslan/core/workflow/service/webhook/github_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/github_workflowv4_task.go
@@ -83,6 +83,7 @@ func (gpem *githubPushEventMatcheForWorkflowV4) GetHookRepo(hookRepo *commonmode
 		TargetBranch:  hookRepo.Branch,
 		CommitID:      *gpem.event.HeadCommit.ID,
 		CommitMessage: *gpem.event.HeadCommit.Message,
+		AuthorName:    gpem.event.HeadCommit.GetAuthor().GetName(),
 		Committer:     hookRepo.Committer,
 		Source:        hookRepo.Source,
 	}

--- a/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflowv4_task.go
+++ b/pkg/microservice/aslan/core/workflow/service/webhook/gitlab_workflowv4_task.go
@@ -107,6 +107,7 @@ func (gmem *gitlabMergeEventMatcherForWorkflowV4) GetHookRepo(hookRepo *commonmo
 		PR:            gmem.event.ObjectAttributes.IID,
 		CommitID:      gmem.event.ObjectAttributes.LastCommit.ID,
 		CommitMessage: gmem.event.ObjectAttributes.LastCommit.Message,
+		AuthorName:    gmem.event.ObjectAttributes.LastCommit.Author.Name,
 		Committer:     hookRepo.Committer,
 		Source:        hookRepo.Source,
 	}
@@ -218,9 +219,11 @@ func (gpem *gitlabPushEventMatcherForWorkflowV4) Match(hookRepo *commonmodels.Ma
 }
 
 func (gpem *gitlabPushEventMatcherForWorkflowV4) GetHookRepo(hookRepo *commonmodels.MainHookRepo) *types.Repository {
-	commitMessage := ""
+	commitMessage, authorName := "", ""
 	if len(gpem.event.Commits) > 0 {
-		commitMessage = gpem.event.Commits[len(gpem.event.Commits)-1].Message
+		commit := gpem.event.Commits[len(gpem.event.Commits)-1]
+		commitMessage = commit.Message
+		authorName = commit.Author.Name
 	}
 	return &types.Repository{
 		CodehostID:    hookRepo.CodehostID,
@@ -231,6 +234,7 @@ func (gpem *gitlabPushEventMatcherForWorkflowV4) GetHookRepo(hookRepo *commonmod
 		TargetBranch:  hookRepo.Branch,
 		CommitID:      gpem.event.After,
 		CommitMessage: commitMessage,
+		AuthorName:    authorName,
 		Committer:     hookRepo.Committer,
 		Source:        hookRepo.Source,
 	}
@@ -268,6 +272,10 @@ func (gtem gitlabTagEventMatcherForWorkflowV4) Match(hookRepo *commonmodels.Main
 }
 
 func (gpem *gitlabTagEventMatcherForWorkflowV4) GetHookRepo(hookRepo *commonmodels.MainHookRepo) *types.Repository {
+	authorName := ""
+	if len(gpem.event.Commits) > 0 {
+		authorName = gpem.event.Commits[len(gpem.event.Commits)-1].Author.Name
+	}
 	return &types.Repository{
 		CodehostID:    hookRepo.CodehostID,
 		RepoName:      hookRepo.RepoName,
@@ -276,6 +284,7 @@ func (gpem *gitlabTagEventMatcherForWorkflowV4) GetHookRepo(hookRepo *commonmode
 		Branch:        hookRepo.Branch,
 		TargetBranch:  hookRepo.Branch,
 		Tag:           hookRepo.Tag,
+		AuthorName:    authorName,
 		Committer:     hookRepo.Committer,
 		Source:        hookRepo.Source,
 	}


### PR DESCRIPTION
### Summary
- Cherry-pick #4938 to release 5.0.0.

### Main Changes
- Populate commit author names for GitHub, GitLab, Gitee, and Gerrit workflow webhooks.

### Risk / Compatibility
- Low risk: fills existing webhook task metadata without changing the payload contract.

### Test
- `go test -vet=off ./pkg/microservice/aslan/core/workflow/service/webhook`
- Default vet is blocked by pre-existing release-5.0.0 format diagnostics.

### Contact
Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4943)
<!-- Reviewable:end -->
