### PR TITLE
fix: support workspace cache in build template OpenAPI

### DIFF
--- a/pkg/microservice/aslan/core/templatestore/service/openapi_build.go
+++ b/pkg/microservice/aslan/core/templatestore/service/openapi_build.go
@@ -151,7 +151,7 @@ func validateAdvancedSetting(infrastructure string, advanced *types.OpenAPIAdvan
 	if err := commonutil.CheckDefineResourceParam(spec.FindResourceRequestType(), spec); err != nil {
 		return fmt.Errorf("invalid advanced_settings.resource_spec: %w", err)
 	}
-	if advanced.CacheSetting != nil && advanced.CacheSetting.Enabled && strings.TrimSpace(advanced.CacheSetting.CacheDir) == "" {
+	if advanced.CacheSetting != nil && advanced.CacheSetting.Enabled && advanced.CacheSetting.CacheDir != "" && strings.TrimSpace(advanced.CacheSetting.CacheDir) == "" {
 		return fmt.Errorf("advanced_settings.cache_setting.cache_dir cannot be empty when cache is enabled")
 	}
 	if err := validateStorages(advanced.Storages); err != nil {
@@ -394,7 +394,7 @@ func applyOpenAPIBuildTemplate(template *commonmodels.BuildTemplate, req *OpenAP
 	template.CacheEnable = advanced.CacheSetting != nil && advanced.CacheSetting.Enabled
 	template.CacheDirType = ""
 	template.CacheUserDir = ""
-	if resolved.defaultAdvanced {
+	if resolved.defaultAdvanced || template.CacheEnable && advanced.CacheSetting.CacheDir == "" {
 		template.CacheDirType = types.WorkspaceCacheDir
 	} else if template.CacheEnable {
 		template.CacheDirType = types.UserDefinedCacheDir


### PR DESCRIPTION
### Summary
- Fix build-template OpenAPI round trips for workspace caches introduced by #4922.

### Main Changes
- Treat an enabled cache with an empty `cache_dir` as workspace; non-empty paths remain user-defined.
- Continue rejecting whitespace-only cache directories.

### Risk / Test
- API shape and custom-cache behavior are unchanged; no migration is required.
- `go test ./pkg/microservice/aslan/core/templatestore/service -count=1`

### Contact
Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4946)
<!-- Reviewable:end -->
