### PR TITLE
feat: allow basic license for AI tasks

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_ai.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_ai.go
@@ -25,9 +25,7 @@ import (
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	commonrepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb"
 	templaterepo "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/mongodb/template"
-	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/v2/pkg/setting"
-	e "github.com/koderover/zadig/v2/pkg/tool/errors"
 	"github.com/koderover/zadig/v2/pkg/tool/log"
 	"github.com/koderover/zadig/v2/pkg/types"
 )
@@ -59,9 +57,6 @@ func (j AIJobController) SetWorkflow(wf *commonmodels.WorkflowV4) { j.workflow =
 func (j AIJobController) GetSpec() interface{} { return j.jobSpec }
 
 func (j AIJobController) Validate(isExecution bool) error {
-	if err := util.CheckZadigEnterpriseLicense(); err != nil {
-		return e.ErrLicenseInvalid.AddDesc("")
-	}
 	if err := validateAIJobSpec(j.jobSpec); err != nil {
 		return err
 	}


### PR DESCRIPTION
### Summary
- Allow workflow `ai-task` to run with a valid Basic license.

### Why
- AI tasks should be available in the Basic edition.

### Main Changes
- Add a Basic-and-above license validator.
- Apply it only to `ai-task`; AI Release Specialist remains Enterprise-only.

### Risk / Compatibility
- Existing Professional and Enterprise behavior is unchanged.
- Only the AI task license gate is relaxed.

### Test
- `git diff --check` passed.
- Go tests were not run because the existing go.sum checksum for `github.com/emicklei/go-restful/v3@v3.11.1` does not match the downloaded module.

### Contact
- Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4948)
<!-- Reviewable:end -->
