### PR TITLE
cherry pick #4949 to release 5.0.0

### DIFF
--- a/pkg/microservice/aslan/core/stat/handler/stat_v2.go
+++ b/pkg/microservice/aslan/core/stat/handler/stat_v2.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	commonutil "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/util"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/stat/service"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/stat/service/ai"
 	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
@@ -37,12 +36,6 @@ func CreateStatDashboardConfig(c *gin.Context) {
 	args := new(service.StatDashboardConfig)
 	if err := c.BindJSON(args); err != nil {
 		ctx.RespErr = e.ErrInvalidParam.AddErr(err)
-		return
-	}
-
-	err := commonutil.CheckZadigProfessionalLicense()
-	if err != nil {
-		ctx.RespErr = err
 		return
 	}
 
@@ -74,24 +67,12 @@ func UpdateStatDashboardConfig(c *gin.Context) {
 		return
 	}
 
-	err := commonutil.CheckZadigProfessionalLicense()
-	if err != nil {
-		ctx.RespErr = err
-		return
-	}
-
 	ctx.RespErr = service.UpdateStatDashboardConfig(c.Param("id"), args, ctx.Logger)
 }
 
 func DeleteStatDashboardConfig(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
-
-	err := commonutil.CheckZadigProfessionalLicense()
-	if err != nil {
-		ctx.RespErr = err
-		return
-	}
 
 	ctx.RespErr = service.DeleteStatDashboardConfig(c.Param("id"), ctx.Logger)
 }
@@ -115,12 +96,6 @@ func GetStatsDashboard(c *gin.Context) {
 		return
 	}
 
-	err := commonutil.CheckZadigEnterpriseLicense()
-	if err != nil {
-		ctx.RespErr = err
-		return
-	}
-
 	resp, err := service.GetStatsDashboard(args.StartTime, args.EndTime, nil, ctx.Logger)
 
 	ctx.Resp = getStatDashboardResp{resp}
@@ -134,12 +109,6 @@ func GetStatsDashboardGeneralData(c *gin.Context) {
 	args := new(getStatDashboardReq)
 	if err := c.ShouldBindQuery(args); err != nil {
 		ctx.RespErr = e.ErrInvalidParam.AddErr(err)
-		return
-	}
-
-	err := commonutil.CheckZadigEnterpriseLicense()
-	if err != nil {
-		ctx.RespErr = err
 		return
 	}
 

--- a/pkg/microservice/aslan/core/system/handler/custom_navigation.go
+++ b/pkg/microservice/aslan/core/system/handler/custom_navigation.go
@@ -63,8 +63,7 @@ func filterNavigationItems(ctx *internalhandler.Context, items []*commonmodels.N
 // isProfessionalLicenseRequiredKey returns true if the given key requires a professional license
 func isProfessionalLicenseRequiredKey(key config.NavigationItemKey) bool {
 	switch key {
-	case config.NavigationKeyWorkflows,
-		config.NavigationKeyDataInsight:
+	case config.NavigationKeyWorkflows:
 		return true
 	default:
 		return false


### PR DESCRIPTION
### Summary
- Cherry-pick #4949 to release 5.0.0.

### Main Changes
- Remove the Professional navigation gate from Data Insight.
- Remove license gates from Data Insight dashboard and configuration APIs.

### Risk / Compatibility
- Existing authentication and authorization checks remain unchanged.
- No API or stored-data contract changes.

### Test
- `git diff --check` passed.
- Go tests were not run because the existing go.sum checksum for `github.com/emicklei/go-restful/v3@v3.11.1` does not match the downloaded module.

### Contact
Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4951)
<!-- Reviewable:end -->
