### PR TITLE
fix: filter workload pods by controller ownership

### DIFF
--- a/pkg/microservice/aslan/core/common/service/environment.go
+++ b/pkg/microservice/aslan/core/common/service/environment.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/informers"
@@ -664,6 +665,7 @@ func (f *workloadFilter) Match(workload *Workload) bool {
 }
 
 type Workload struct {
+	UID               k8stypes.UID               `json:"-"`
 	EnvName           string                     `json:"env_name"`
 	Name              string                     `json:"name"`
 	Type              string                     `json:"type"`
@@ -725,6 +727,7 @@ func ListWorkloads(envName, productName string, perPage, page int, informer info
 
 	for _, v := range listDeployments {
 		workLoads = append(workLoads, &Workload{
+			UID:        v.UID,
 			Name:       v.Name,
 			Spec:       v.Spec.Template,
 			Selector:   v.Spec.Selector,
@@ -742,6 +745,7 @@ func ListWorkloads(envName, productName string, perPage, page int, informer info
 	}
 	for _, v := range daemonSets {
 		workLoads = append(workLoads, &Workload{
+			UID:        v.UID,
 			Name:       v.Name,
 			Spec:       v.Spec.Template,
 			Selector:   v.Spec.Selector,
@@ -759,6 +763,7 @@ func ListWorkloads(envName, productName string, perPage, page int, informer info
 	}
 	for _, v := range statefulSets {
 		workLoads = append(workLoads, &Workload{
+			UID:        v.UID,
 			Name:       v.Name,
 			Spec:       v.Spec.Template,
 			Selector:   v.Spec.Selector,
@@ -915,10 +920,10 @@ func ListWorkloadDetails(envName, clusterID, namespace, productName string, perP
 			Status:       setting.PodRunning,
 		}
 
-		if workload.Type == setting.Deployment || workload.Type == setting.StatefulSet {
+		if workload.Type == setting.Deployment || workload.Type == setting.StatefulSet || workload.Type == setting.DaemonSet {
 			selector := labels.SelectorFromSet(workload.Selector.MatchLabels)
 			// We call GetSelectedPodsInfo to get the status and readiness to keep same logic with k8s projects
-			productRespInfo.Status, productRespInfo.Ready, _ = kube.GetSelectedPodsInfo(selector, informer, workload.Images, log)
+			productRespInfo.Status, productRespInfo.Ready, _ = kube.GetSelectedPodsInfo(selector, informer, workload.Images, workload.Type, workload.UID, log)
 			productRespInfo.Ingress = &IngressInfo{
 				HostInfo: FindServiceFromIngress(hostInfos, workload, allServices),
 			}

--- a/pkg/microservice/aslan/core/common/service/kube/render_replica_test.go
+++ b/pkg/microservice/aslan/core/common/service/kube/render_replica_test.go
@@ -6,6 +6,11 @@ import (
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestBuildReplicaOverridesByRenderedYaml_ReplicaChanged(t *testing.T) {
@@ -63,4 +68,147 @@ func toOverrideMap(overrides []*commonmodels.WorkLoad) map[string]int32 {
 		ret[ReplicaOverrideKey(item.WorkloadType, item.WorkloadName)] = item.Replicas
 	}
 	return ret
+}
+
+func TestFilterPodsByControllerUID(t *testing.T) {
+	t.Parallel()
+
+	controller := true
+	targetUID := types.UID("target-workload")
+	ownedPod := podWithController("owned", targetUID, &controller)
+	siblingPod := podWithController("sibling", types.UID("sibling-workload"), &controller)
+	orphanPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "orphan"}}
+	nonControllerPod := podWithController("non-controller", targetUID, nil)
+
+	pods := FilterPodsByControllerUID(
+		[]*corev1.Pod{ownedPod, siblingPod, orphanPod, nonControllerPod},
+		targetUID,
+	)
+
+	require.Len(t, pods, 1)
+	require.Equal(t, ownedPod.Name, pods[0].Name)
+}
+
+func TestFilterDeploymentPodsByOwner(t *testing.T) {
+	t.Parallel()
+
+	controller := true
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name: "osl-mm-oms-lane5",
+		UID:  types.UID("lane5-deployment"),
+	}}
+	siblingDeploymentUID := types.UID("main-deployment")
+
+	ownedReplicaSet := replicaSetWithController("osl-mm-oms-lane5-abc", types.UID("lane5-replicaset"), deployment.UID, &controller)
+	siblingReplicaSet := replicaSetWithController("osl-mm-oms-xyz", types.UID("main-replicaset"), siblingDeploymentUID, &controller)
+	ownedPod := podWithController("osl-mm-oms-lane5-abc-1", ownedReplicaSet.UID, &controller)
+	siblingPod := podWithController("osl-mm-oms-xyz-1", siblingReplicaSet.UID, &controller)
+
+	pods := FilterDeploymentPodsByOwner(
+		deployment,
+		[]*appsv1.ReplicaSet{ownedReplicaSet, siblingReplicaSet},
+		[]*corev1.Pod{ownedPod, siblingPod},
+	)
+
+	require.Len(t, pods, 1)
+	require.Equal(t, ownedPod.Name, pods[0].Name)
+}
+
+func TestFilterDeploymentPodsByOwnerExcludesOverlappingSiblingPods(t *testing.T) {
+	t.Parallel()
+
+	controller := true
+	zero := int32(0)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "osl-mm-oms-lane5", UID: types.UID("lane5-deployment")},
+		Spec:       appsv1.DeploymentSpec{Replicas: &zero},
+	}
+	siblingReplicaSet := replicaSetWithController(
+		"osl-mm-oms-main",
+		types.UID("main-replicaset"),
+		types.UID("main-deployment"),
+		&controller,
+	)
+	siblingPod := podWithController("osl-mm-oms-main-1", siblingReplicaSet.UID, &controller)
+
+	pods := FilterDeploymentPodsByOwner(
+		deployment,
+		[]*appsv1.ReplicaSet{siblingReplicaSet},
+		[]*corev1.Pod{siblingPod},
+	)
+
+	require.Empty(t, pods)
+}
+
+func TestFilterDeploymentPodsByOwnerIncludesAllOwnedReplicaSets(t *testing.T) {
+	t.Parallel()
+
+	controller := true
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name: "api",
+		UID:  types.UID("api-deployment"),
+	}}
+	oldReplicaSet := replicaSetWithController("api-old", types.UID("api-old"), deployment.UID, &controller)
+	newReplicaSet := replicaSetWithController("api-new", types.UID("api-new"), deployment.UID, &controller)
+
+	pods := FilterDeploymentPodsByOwner(
+		deployment,
+		[]*appsv1.ReplicaSet{oldReplicaSet, newReplicaSet},
+		[]*corev1.Pod{
+			podWithController("api-old-1", oldReplicaSet.UID, &controller),
+			podWithController("api-new-1", newReplicaSet.UID, &controller),
+		},
+	)
+
+	require.Len(t, pods, 2)
+}
+
+func TestFilterJobsByControllerUID(t *testing.T) {
+	t.Parallel()
+
+	controller := true
+	cronJobUID := types.UID("target-cronjob")
+	ownedJob := jobWithController("target-1", cronJobUID, &controller)
+	siblingJob := jobWithController("sibling-1", types.UID("sibling-cronjob"), &controller)
+	orphanJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "orphan"}}
+
+	jobs := FilterJobsByControllerUID(
+		[]*batchv1.Job{ownedJob, siblingJob, orphanJob},
+		cronJobUID,
+	)
+
+	require.Len(t, jobs, 1)
+	require.Equal(t, ownedJob.Name, jobs[0].Name)
+}
+
+func replicaSetWithController(name string, uid, deploymentUID types.UID, controller *bool) *appsv1.ReplicaSet {
+	return &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{
+		Name: name,
+		UID:  uid,
+		OwnerReferences: []metav1.OwnerReference{{
+			Kind:       "Deployment",
+			UID:        deploymentUID,
+			Controller: controller,
+		}},
+	}}
+}
+
+func podWithController(name string, controllerUID types.UID, controller *bool) *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: name,
+		OwnerReferences: []metav1.OwnerReference{{
+			UID:        controllerUID,
+			Controller: controller,
+		}},
+	}}
+}
+
+func jobWithController(name string, controllerUID types.UID, controller *bool) *batchv1.Job {
+	return &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name: name,
+		OwnerReferences: []metav1.OwnerReference{{
+			UID:        controllerUID,
+			Controller: controller,
+		}},
+	}}
 }

--- a/pkg/microservice/aslan/core/common/service/kube/status.go
+++ b/pkg/microservice/aslan/core/common/service/kube/status.go
@@ -18,8 +18,12 @@ package kube
 
 import (
 	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 
@@ -28,10 +32,19 @@ import (
 	"github.com/koderover/zadig/v2/pkg/tool/kube/getter"
 )
 
-func GetSelectedPodsInfo(selector labels.Selector, informer informers.SharedInformerFactory, currentImages []string, log *zap.SugaredLogger) (string, string, []string) {
+func GetSelectedPodsInfo(selector labels.Selector, informer informers.SharedInformerFactory, currentImages []string, workloadType string, workloadUID types.UID, log *zap.SugaredLogger) (string, string, []string) {
 	pods, err := getter.ListPodsWithCache(selector, informer)
 	if err != nil {
 		return setting.PodError, setting.PodNotReady, nil
+	}
+	if workloadType == setting.Deployment {
+		replicaSets, err := informer.Apps().V1().ReplicaSets().Lister().List(selector)
+		if err != nil {
+			return setting.PodError, setting.PodNotReady, nil
+		}
+		pods = filterDeploymentPodsByOwnerUID(workloadUID, replicaSets, pods)
+	} else {
+		pods = FilterPodsByControllerUID(pods, workloadUID)
 	}
 
 	if len(pods) == 0 {
@@ -66,4 +79,80 @@ func GetSelectedPodsInfo(selector labels.Selector, informer informers.SharedInfo
 	}
 
 	return setting.PodRunning, ready, images
+}
+
+// FilterPodsByControllerUID removes pods that only match a workload's labels
+// but are controlled by another workload.
+func FilterPodsByControllerUID(pods []*corev1.Pod, controllerUID types.UID) []*corev1.Pod {
+	if controllerUID == "" {
+		return []*corev1.Pod{}
+	}
+	ret := make([]*corev1.Pod, 0, len(pods))
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		controller := metav1.GetControllerOf(pod)
+		if controller != nil && controller.UID == controllerUID {
+			ret = append(ret, pod)
+		}
+	}
+	return ret
+}
+
+// FilterJobsByControllerUID removes jobs that have the same labels or name
+// pattern but are controlled by another CronJob.
+func FilterJobsByControllerUID(jobs []*batchv1.Job, controllerUID types.UID) []*batchv1.Job {
+	if controllerUID == "" {
+		return []*batchv1.Job{}
+	}
+	ret := make([]*batchv1.Job, 0, len(jobs))
+	for _, job := range jobs {
+		if job == nil {
+			continue
+		}
+		controller := metav1.GetControllerOf(job)
+		if controller != nil && controller.UID == controllerUID {
+			ret = append(ret, job)
+		}
+	}
+	return ret
+}
+
+// FilterDeploymentPodsByOwner validates the complete
+// Pod -> ReplicaSet -> Deployment controller chain. A pod's direct controller
+// is its ReplicaSet, so checking only the Deployment UID is insufficient.
+func FilterDeploymentPodsByOwner(deployment *appsv1.Deployment, replicaSets []*appsv1.ReplicaSet, pods []*corev1.Pod) []*corev1.Pod {
+	if deployment == nil {
+		return []*corev1.Pod{}
+	}
+	return filterDeploymentPodsByOwnerUID(deployment.UID, replicaSets, pods)
+}
+
+func filterDeploymentPodsByOwnerUID(deploymentUID types.UID, replicaSets []*appsv1.ReplicaSet, pods []*corev1.Pod) []*corev1.Pod {
+	if deploymentUID == "" {
+		return []*corev1.Pod{}
+	}
+	ownedReplicaSets := sets.NewString()
+	for _, replicaSet := range replicaSets {
+		if replicaSet == nil {
+			continue
+		}
+		controller := metav1.GetControllerOf(replicaSet)
+		if controller != nil && controller.UID == deploymentUID {
+			ownedReplicaSets.Insert(string(replicaSet.UID))
+		}
+	}
+
+	ret := make([]*corev1.Pod, 0, len(pods))
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		controller := metav1.GetControllerOf(pod)
+		if controller != nil && ownedReplicaSets.Has(string(controller.UID)) {
+			ret = append(ret, pod)
+		}
+	}
+	return ret
 }

--- a/pkg/microservice/aslan/core/common/service/service.go
+++ b/pkg/microservice/aslan/core/common/service/service.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -1598,8 +1599,16 @@ func GetDeploymentWorkloadResource(d *appsv1.Deployment, informer informers.Shar
 	pods, err := getter.ListPodsWithCache(labels.SelectorFromValidatedSet(d.Spec.Selector.MatchLabels), informer)
 	if err != nil {
 		log.Warnf("Failed to get pods, err: %s", err)
+		return wrapper.Deployment(d).WorkloadResource(nil)
 	}
 
+	replicaSets, err := informer.Apps().V1().ReplicaSets().Lister().ReplicaSets(d.Namespace).List(labels.SelectorFromValidatedSet(d.Spec.Selector.MatchLabels))
+	if err != nil {
+		log.Warnf("Failed to get replica sets for deployment %s, err: %s", d.Name, err)
+		return wrapper.Deployment(d).WorkloadResource(nil)
+	}
+
+	pods = kube.FilterDeploymentPodsByOwner(d, replicaSets, pods)
 	return wrapper.Deployment(d).WorkloadResource(pods)
 }
 
@@ -1609,6 +1618,7 @@ func GetCloneSetWorkloadResource(d *v1alpha1.CloneSet, informer informers.Shared
 		log.Warnf("Failed to get pods, err: %s", err)
 	}
 
+	pods = kube.FilterPodsByControllerUID(pods, d.UID)
 	return wrapper.CloneSet(d).WorkloadResource(pods)
 }
 
@@ -1618,6 +1628,7 @@ func GetDaemonSetWorkloadResource(daemonSet *appsv1.DaemonSet, informer informer
 		log.Warnf("Failed to get pods, err: %s", err)
 	}
 
+	pods = kube.FilterPodsByControllerUID(pods, daemonSet.UID)
 	return wrapper.DaemonSet(daemonSet).WorkloadResource(pods)
 }
 
@@ -1627,6 +1638,7 @@ func getStatefulSetWorkloadResource(sts *appsv1.StatefulSet, informer informers.
 		log.Warnf("Failed to get pods, err: %s", err)
 	}
 
+	pods = kube.FilterPodsByControllerUID(pods, sts.UID)
 	return wrapper.StatefulSet(sts).WorkloadResource(pods)
 }
 
@@ -1636,26 +1648,25 @@ func getJobWorkloadResource(job *batchv1.Job, informer informers.SharedInformerF
 		log.Warnf("Failed to get pods, err: %s", err)
 	}
 
+	pods = kube.FilterPodsByControllerUID(pods, job.UID)
 	return wrapper.Job(job).WorkloadResource(pods)
 }
 
 func getCronJobWorkLoadResource(cornJob *batchv1.CronJob, cronJobBeta *v1beta1.CronJob, informer informers.SharedInformerFactory, log *zap.SugaredLogger) *internalresource.CronJob {
 	cronJobName := wrapper.CronJob(cornJob, cronJobBeta).Name
+	var cronJobUID k8stypes.UID
+	if cornJob != nil {
+		cronJobUID = cornJob.UID
+	} else if cronJobBeta != nil {
+		cronJobUID = cronJobBeta.UID
+	}
 	jobs, err := informer.Batch().V1().Jobs().Lister().List(labels.NewSelector())
 	if err != nil {
 		log.Errorf("failed to list jobs, err: %s", err)
 		return nil
 	}
 	// find jobs created by particular cronjob
-	matchJobs := make([]*batchv1.Job, 0)
-	for _, job := range jobs {
-		for _, owner := range job.OwnerReferences {
-			if owner.Name == cronJobName && owner.Kind == setting.CronJob {
-				matchJobs = append(matchJobs, job)
-				break
-			}
-		}
-	}
+	matchJobs := kube.FilterJobsByControllerUID(jobs, cronJobUID)
 
 	pods := make([]*corev1.Pod, 0)
 	for _, job := range matchJobs {
@@ -1664,6 +1675,7 @@ func getCronJobWorkLoadResource(cornJob *batchv1.CronJob, cronJobBeta *v1beta1.C
 			log.Errorf("failed to find related pods for cronjob: %s, err: %s", cronJobName, err)
 			continue
 		}
+		cronGeneratedPods = kube.FilterPodsByControllerUID(cronGeneratedPods, job.UID)
 		pods = append(pods, cronGeneratedPods...)
 	}
 

--- a/pkg/microservice/aslan/core/environment/service/service.go
+++ b/pkg/microservice/aslan/core/environment/service/service.go
@@ -267,7 +267,7 @@ func GetServiceWorkloads(svcTmpl *commonmodels.Service, env *commonmodels.Produc
 				continue
 			}
 			wj := wrapper.Job(job)
-			_, ready, _ := kube.GetSelectedPodsInfo(labels.SelectorFromSet(job.Spec.Selector.MatchLabels), inf, wj.ImageInfos(), log)
+			_, ready, _ := kube.GetSelectedPodsInfo(labels.SelectorFromSet(job.Spec.Selector.MatchLabels), inf, wj.ImageInfos(), setting.Job, job.UID, log)
 			ret = append(ret, &commonservice.Workload{
 				Name:       wj.Name,
 				Spec:       wj.Spec.Template,

--- a/pkg/tool/clientmanager/kube.go
+++ b/pkg/tool/clientmanager/kube.go
@@ -430,6 +430,7 @@ func (cm *KubeClientManager) createInformerFactory(clusterID, namespace string) 
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(clientset, time.Minute, opts...)
 	// register the resources to be watched
 	informerFactory.Apps().V1().Deployments().Lister()
+	informerFactory.Apps().V1().ReplicaSets().Lister()
 	informerFactory.Apps().V1().DaemonSets().Lister()
 	informerFactory.Apps().V1().StatefulSets().Lister()
 	informerFactory.Core().V1().Services().Lister()


### PR DESCRIPTION
### What this PR does / Why we need it:
fix: filter workload pods by controller ownership

### What is changed and how it works?
fix: filter workload pods by controller ownership

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4957)
<!-- Reviewable:end -->
