### PR TITLE
cherry pick #4939 to release 5.0.0

### DIFF
--- a/pkg/microservice/aslan/core/release_plan/service/section_snapshot.go
+++ b/pkg/microservice/aslan/core/release_plan/service/section_snapshot.go
@@ -671,7 +671,7 @@ func hasReleasePlanWorkflowSnapshotJobSpecFields(job map[string]interface{}) boo
 		}
 	case config.JobZadigDeploy:
 		if env, ok := getStringField(spec, "env"); ok && env != "" {
-			return hasReleasePlanWorkflowSnapshotKey(spec, "env_options")
+			return true
 		}
 		if hasReleasePlanWorkflowSnapshotKey(spec, "services") {
 			return true
@@ -864,7 +864,14 @@ func buildReleasePlanWorkflowJobsInputSnapshot(path string, value interface{}) i
 			jobResp["service_modules"] = filterReleasePlanWorkflowInputValueAtPath(joinReleasePlanWorkflowInputPath(path, "service_modules"), serviceModules)
 		}
 		if spec, exists := jobMap["spec"]; exists {
-			jobResp["spec"] = filterReleasePlanWorkflowInputValueAtPath(joinReleasePlanWorkflowInputPath(path, "spec"), spec)
+			filteredSpec := filterReleasePlanWorkflowInputValueAtPath(joinReleasePlanWorkflowInputPath(path, "spec"), spec)
+			// Keep selected deployment values, but omit editor candidates from version snapshots.
+			if jobType, ok := getStringField(jobMap, "type"); ok && config.JobType(jobType) == config.JobZadigDeploy {
+				if specMap, ok := getMapField(filteredSpec); ok {
+					delete(specMap, "env_options")
+				}
+			}
+			jobResp["spec"] = filteredSpec
 		}
 		if len(jobResp) > 0 {
 			resp = append(resp, jobResp)


### PR DESCRIPTION
### Summary
- Cherry-pick #4939 to release 5.0.0.

### Main Changes
- Remove Zadig deploy `env_options` from release plan version snapshots while retaining selected deployment values.

### Risk / Compatibility
- Version diff requires frontend rendering to use retained `env` and `services` instead of `env_options`.

### Test
- `gofmt` and `git diff --check` passed.
- Package tests are blocked by the existing `github.com/emicklei/go-restful/v3` checksum mismatch.

### Contact
Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4958)
<!-- Reviewable:end -->
