### PR TITLE
feat(auth): support OAuth device authorization

### DIFF
--- a/pkg/microservice/aslan/core/common/service/joblog/job_log.go
+++ b/pkg/microservice/aslan/core/common/service/joblog/job_log.go
@@ -179,7 +179,7 @@ func (m *JobLogManager) IsJobRunning(key string) bool {
 }
 
 func (m *JobLogManager) SetJobStatusRunning(key string, timeout time.Duration) {
-	err := cache.NewRedisCache(pkgconfig.RedisCommonCacheTokenDB()).SetNX(key, "1", timeout+2*time.Minute)
+	_, err := cache.NewRedisCache(pkgconfig.RedisCommonCacheTokenDB()).SetNX(key, "1", timeout+2*time.Minute)
 	if err != nil {
 		log.Errorf("redis setNX err: %s for key: %s", err, key)
 	}

--- a/pkg/microservice/aslan/core/vm/service/log.go
+++ b/pkg/microservice/aslan/core/vm/service/log.go
@@ -58,7 +58,7 @@ func (v *VMJobLogManager) IsJobRunning(key string) bool {
 
 func (v *VMJobLogManager) SetJobStatusRunning(key string) {
 	// use the timeout value of task timeout should be better
-	err := cache.NewRedisCache(utilconfig.RedisCommonCacheTokenDB()).SetNX(v.vmJobKey(key), "1", 24*time.Hour)
+	_, err := cache.NewRedisCache(utilconfig.RedisCommonCacheTokenDB()).SetNX(v.vmJobKey(key), "1", 24*time.Hour)
 	if err != nil {
 		log.Errorf("reids set nx err: %s for key: %s", err, v.vmJobKey(key))
 	}

--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_scanning.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_scanning.go
@@ -1183,7 +1183,6 @@ func (j ScanningJobController) toAIReviewJobTask(
 		&commonmodels.KeyVal{Key: "ZADIG_AI_REVIEW_REPO_DIR", Value: repoDir},
 		&commonmodels.KeyVal{Key: "ZADIG_AI_REVIEW_REMOTE_NAME", Value: repo.RemoteName},
 		&commonmodels.KeyVal{Key: "ZADIG_AI_REVIEW_TARGET_BRANCH", Value: targetBranch},
-		&commonmodels.KeyVal{Key: "ZADIG_AI_REVIEW_PR", Value: strconv.Itoa(repo.PR)},
 		&commonmodels.KeyVal{Key: "ZADIG_AI_REVIEW_OUTPUT_LANGUAGE", Value: systemConfig.OutputLanguage},
 		&commonmodels.KeyVal{Key: "ZADIG_AI_REVIEW_QUALITY_GATE_ENABLED", Value: strconv.FormatBool(scanningInfo.CheckQualityGate)},
 		&commonmodels.KeyVal{Key: "ZADIG_AI_REVIEW_FAIL_ON", Value: aiReviewFailOnValue(scanningInfo.CheckQualityGate, scanningInfo.ReviewFailOn)},
@@ -1240,23 +1239,14 @@ REPORT_PATH="$PWD/.zadig-review/zadig-review-report.json"
 printf '%s' "$ZADIG_AI_REVIEW_RULES_B64" | base64 -d > "$RULE_FILE"
 REMOTE_NAME="$ZADIG_AI_REVIEW_REMOTE_NAME"
 TARGET_BRANCH="$ZADIG_AI_REVIEW_TARGET_BRANCH"
-PR_BRANCH="pr$ZADIG_AI_REVIEW_PR"
+TO_COMMIT="$(git rev-parse HEAD)"
 set --
 if [ -n "$ZADIG_AI_REVIEW_FAIL_ON" ]; then
   set -- --fail-on "$ZADIG_AI_REVIEW_FAIL_ON"
 fi
-#if ! git rev-parse --verify "$PR_BRANCH^{commit}" >/dev/null 2>&1; then
-#  echo "AI review failed: pull or merge request branch $PR_BRANCH was not fetched" >&2
-#  exit 2
-#fi
-#git fetch --no-tags "$REMOTE_NAME" "refs/heads/$TARGET_BRANCH:refs/remotes/$REMOTE_NAME/$TARGET_BRANCH" --deepen=500
-#if ! git merge-base "$REMOTE_NAME/$TARGET_BRANCH" "$PR_BRANCH" >/dev/null 2>&1; then
-#  echo "AI review failed: no merge-base found within the fetched history (maximum deepen: 500 commits)" >&2
-#  exit 2
-#fi
 if zadig-review-agent review \
   --from "$REMOTE_NAME/$TARGET_BRANCH" \
-  --to "$PR_BRANCH" \
+  --to "$TO_COMMIT" \
   --rule "$RULE_FILE" \
   --language "$ZADIG_AI_REVIEW_OUTPUT_LANGUAGE" \
   "$@" \

--- a/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_scanning_test.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/controller/job/job_scanning_test.go
@@ -1,0 +1,20 @@
+package job
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildAIReviewScriptUsesMergedHead(t *testing.T) {
+	script := buildAIReviewScript()
+
+	if !strings.Contains(script, `TO_COMMIT="$(git rev-parse HEAD)"`) {
+		t.Fatal("AI review script must capture the commit produced by the Git step")
+	}
+	if !strings.Contains(script, `--to "$TO_COMMIT"`) {
+		t.Fatal("AI review script must review the merged commit")
+	}
+	if strings.Contains(script, "ZADIG_AI_REVIEW_PR") {
+		t.Fatal("AI review script must not derive the review target from a PR environment variable")
+	}
+}

--- a/pkg/microservice/user/core/handler/oauth/oauth.go
+++ b/pkg/microservice/user/core/handler/oauth/oauth.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	configbase "github.com/koderover/zadig/v2/pkg/config"
 	"github.com/koderover/zadig/v2/pkg/microservice/user/core/service/login"
 	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
 )
@@ -37,14 +36,28 @@ type approvalArgs struct {
 	Decision string `json:"decision"`
 }
 
+type deviceAuthorizationArgs struct {
+	ClientID   string `form:"client_id"`
+	Scope      string `form:"scope"`
+	DeviceName string `form:"device_name"`
+}
+
 func DeviceAuthorization(c *gin.Context) {
-	args := new(login.OAuthDeviceAuthorizationArgs)
+	args := new(deviceAuthorizationArgs)
 	if err := c.ShouldBind(args); err != nil {
 		writeOAuthError(c, &login.OAuthError{Code: login.OAuthErrorInvalidRequest, Description: err.Error()})
 		return
 	}
-	verificationURI := strings.TrimRight(configbase.SystemAddress(), "/") + "/oauth/device"
-	response, err := login.NewOAuthService().CreateDeviceAuthorization(args, verificationURI)
+	if err := validateClientID(args.ClientID); err != nil {
+		writeOAuthError(c, err)
+		return
+	}
+	scope := strings.Join(strings.Fields(args.Scope), " ")
+	if scope != login.OAuthCLIScope && scope != "offline_access zadig.api" {
+		writeOAuthError(c, &login.OAuthError{Code: login.OAuthErrorInvalidRequest, Description: "scope must be zadig.api offline_access"})
+		return
+	}
+	response, err := login.NewOAuthService().CreateDeviceAuthorization(strings.TrimSpace(args.DeviceName))
 	if err != nil {
 		writeOAuthError(c, err)
 		return
@@ -72,7 +85,7 @@ func DecideDeviceAuthorization(c *gin.Context) {
 		writeBrowserError(c, &login.OAuthError{Code: login.OAuthErrorInvalidRequest, Description: err.Error()})
 		return
 	}
-	err := login.NewOAuthService().DecideDeviceAuthorization(c.Param("userCode"), args.Decision, login.OAuthUser{
+	status, err := login.NewOAuthService().DecideDeviceAuthorization(c.Param("userCode"), args.Decision, login.OAuthUser{
 		UID:          ctx.UserID,
 		Name:         ctx.UserName,
 		Account:      ctx.Account,
@@ -83,23 +96,23 @@ func DecideDeviceAuthorization(c *gin.Context) {
 		writeBrowserError(c, err)
 		return
 	}
-	status := login.OAuthDeviceStatusDenied
-	if args.Decision == login.OAuthDecisionApprove {
-		status = login.OAuthDeviceStatusApproved
-	}
 	c.JSON(http.StatusOK, gin.H{"status": status})
 }
 
 func Token(c *gin.Context) {
+	if err := validateClientID(c.PostForm("client_id")); err != nil {
+		writeOAuthError(c, err)
+		return
+	}
 	var (
 		response *login.OAuthTokenResponse
 		err      error
 	)
 	switch c.PostForm("grant_type") {
 	case deviceCodeGrantType:
-		response, err = login.NewOAuthService().ExchangeDeviceCode(c.PostForm("client_id"), c.PostForm("device_code"))
+		response, err = login.NewOAuthService().ExchangeDeviceCode(c.PostForm("device_code"))
 	case refreshTokenGrant:
-		response, err = login.NewOAuthService().RefreshToken(c.PostForm("client_id"), c.PostForm("refresh_token"))
+		response, err = login.NewOAuthService().RefreshToken(c.PostForm("refresh_token"))
 	default:
 		err = &login.OAuthError{Code: "unsupported_grant_type", Description: "unsupported grant_type"}
 	}
@@ -111,11 +124,22 @@ func Token(c *gin.Context) {
 }
 
 func Revoke(c *gin.Context) {
-	if err := login.NewOAuthService().RevokeToken(c.PostForm("client_id"), c.PostForm("token")); err != nil {
+	if err := validateClientID(c.PostForm("client_id")); err != nil {
+		writeOAuthError(c, err)
+		return
+	}
+	if err := login.NewOAuthService().RevokeToken(c.PostForm("token")); err != nil {
 		writeOAuthError(c, err)
 		return
 	}
 	c.Data(http.StatusOK, "application/json", nil)
+}
+
+func validateClientID(clientID string) error {
+	if clientID != login.OAuthCLIClientID {
+		return &login.OAuthError{Code: login.OAuthErrorInvalidClient, Description: "unsupported client_id"}
+	}
+	return nil
 }
 
 func writeOAuthError(c *gin.Context, err error) {

--- a/pkg/microservice/user/core/handler/oauth/oauth.go
+++ b/pkg/microservice/user/core/handler/oauth/oauth.go
@@ -53,7 +53,7 @@ func DeviceAuthorization(c *gin.Context) {
 		return
 	}
 	scope := strings.Join(strings.Fields(args.Scope), " ")
-	if scope != login.OAuthCLIScope && scope != "offline_access zadig.api" {
+	if scope != login.OAuthLocalClientScope && scope != "offline_access zadig.api" {
 		writeOAuthError(c, &login.OAuthError{Code: login.OAuthErrorInvalidRequest, Description: "scope must be zadig.api offline_access"})
 		return
 	}
@@ -136,7 +136,7 @@ func Revoke(c *gin.Context) {
 }
 
 func validateClientID(clientID string) error {
-	if clientID != login.OAuthCLIClientID {
+	if clientID != login.OAuthLocalClientID {
 		return &login.OAuthError{Code: login.OAuthErrorInvalidClient, Description: "unsupported client_id"}
 	}
 	return nil

--- a/pkg/microservice/user/core/handler/oauth/oauth.go
+++ b/pkg/microservice/user/core/handler/oauth/oauth.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oauth
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	configbase "github.com/koderover/zadig/v2/pkg/config"
+	"github.com/koderover/zadig/v2/pkg/microservice/user/core/service/login"
+	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
+)
+
+const (
+	deviceCodeGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+	refreshTokenGrant   = "refresh_token"
+)
+
+type approvalArgs struct {
+	Decision string `json:"decision"`
+}
+
+func DeviceAuthorization(c *gin.Context) {
+	args := new(login.OAuthDeviceAuthorizationArgs)
+	if err := c.ShouldBind(args); err != nil {
+		writeOAuthError(c, &login.OAuthError{Code: login.OAuthErrorInvalidRequest, Description: err.Error()})
+		return
+	}
+	verificationURI := strings.TrimRight(configbase.SystemAddress(), "/") + "/oauth/device"
+	response, err := login.NewOAuthService().CreateDeviceAuthorization(args, verificationURI)
+	if err != nil {
+		writeOAuthError(c, err)
+		return
+	}
+	writeOAuthJSON(c, http.StatusOK, response)
+}
+
+func GetDeviceAuthorization(c *gin.Context) {
+	response, err := login.NewOAuthService().GetDeviceAuthorization(c.Param("userCode"))
+	if err != nil {
+		writeBrowserError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, response)
+}
+
+func DecideDeviceAuthorization(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	if ctx.UserID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized", "message": "authenticated user is required"})
+		return
+	}
+	args := new(approvalArgs)
+	if err := c.ShouldBindJSON(args); err != nil {
+		writeBrowserError(c, &login.OAuthError{Code: login.OAuthErrorInvalidRequest, Description: err.Error()})
+		return
+	}
+	err := login.NewOAuthService().DecideDeviceAuthorization(c.Param("userCode"), args.Decision, login.OAuthUser{
+		UID:          ctx.UserID,
+		Name:         ctx.UserName,
+		Account:      ctx.Account,
+		IdentityType: ctx.IdentityType,
+		MFAVerified:  ctx.MFAVerified,
+	})
+	if err != nil {
+		writeBrowserError(c, err)
+		return
+	}
+	status := login.OAuthDeviceStatusDenied
+	if args.Decision == login.OAuthDecisionApprove {
+		status = login.OAuthDeviceStatusApproved
+	}
+	c.JSON(http.StatusOK, gin.H{"status": status})
+}
+
+func Token(c *gin.Context) {
+	var (
+		response *login.OAuthTokenResponse
+		err      error
+	)
+	switch c.PostForm("grant_type") {
+	case deviceCodeGrantType:
+		response, err = login.NewOAuthService().ExchangeDeviceCode(c.PostForm("client_id"), c.PostForm("device_code"))
+	case refreshTokenGrant:
+		response, err = login.NewOAuthService().RefreshToken(c.PostForm("client_id"), c.PostForm("refresh_token"))
+	default:
+		err = &login.OAuthError{Code: "unsupported_grant_type", Description: "unsupported grant_type"}
+	}
+	if err != nil {
+		writeOAuthError(c, err)
+		return
+	}
+	writeOAuthJSON(c, http.StatusOK, response)
+}
+
+func Revoke(c *gin.Context) {
+	if err := login.NewOAuthService().RevokeToken(c.PostForm("client_id"), c.PostForm("token")); err != nil {
+		writeOAuthError(c, err)
+		return
+	}
+	c.Data(http.StatusOK, "application/json", nil)
+}
+
+func writeOAuthError(c *gin.Context, err error) {
+	status := http.StatusInternalServerError
+	response := &login.OAuthError{Code: "server_error", Description: "oauth request failed"}
+	var oauthErr *login.OAuthError
+	if errors.As(err, &oauthErr) {
+		response = oauthErr
+		status = http.StatusBadRequest
+		if oauthErr.Code == login.OAuthErrorInvalidClient {
+			status = http.StatusUnauthorized
+		}
+	}
+	writeOAuthJSON(c, status, response)
+}
+
+func writeBrowserError(c *gin.Context, err error) {
+	if errors.Is(err, login.ErrOAuthAuthorizationNotFound) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not_found", "message": "device authorization not found"})
+		return
+	}
+	var oauthErr *login.OAuthError
+	if errors.As(err, &oauthErr) {
+		c.JSON(http.StatusBadRequest, oauthErr)
+		return
+	}
+	c.JSON(http.StatusInternalServerError, gin.H{"error": "server_error", "message": "oauth request failed"})
+}
+
+func writeOAuthJSON(c *gin.Context, status int, value interface{}) {
+	c.Header("Cache-Control", "no-store")
+	c.Header("Pragma", "no-cache")
+	c.JSON(status, value)
+}

--- a/pkg/microservice/user/core/handler/router.go
+++ b/pkg/microservice/user/core/handler/router.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/koderover/zadig/v2/pkg/microservice/user/core/handler/login"
+	"github.com/koderover/zadig/v2/pkg/microservice/user/core/handler/oauth"
 	"github.com/koderover/zadig/v2/pkg/microservice/user/core/handler/permission"
 	"github.com/koderover/zadig/v2/pkg/microservice/user/core/handler/user"
 )
@@ -145,6 +146,16 @@ func (*Router) Inject(router *gin.RouterGroup) {
 			internalPolicyApis.POST("setProjectVisibility", permission.SetProjectVisibility)
 		}
 	}
+}
+
+type OAuthRouter struct{}
+
+func (*OAuthRouter) Inject(router *gin.RouterGroup) {
+	router.POST("/oauth/device/authorization", oauth.DeviceAuthorization)
+	router.POST("/oauth/token", oauth.Token)
+	router.POST("/oauth/revoke", oauth.Revoke)
+	router.GET("/api/oauth/device/authorizations/:userCode", oauth.GetDeviceAuthorization)
+	router.POST("/api/oauth/device/authorizations/:userCode/approval", oauth.DecideDeviceAuthorization)
 }
 
 type OpenAPIRouter struct{}

--- a/pkg/microservice/user/core/service/login/mfa.go
+++ b/pkg/microservice/user/core/service/login/mfa.go
@@ -530,6 +530,9 @@ func DisableUserMFA(uid string, args *MFADisableArgs, logger *zap.SugaredLogger)
 		return nil, fmt.Errorf("invalid mfa verification code")
 	}
 
+	if err := NewOAuthService().RevokeUserSessions(uid); err != nil {
+		return nil, fmt.Errorf("failed to revoke OAuth sessions before disabling mfa: %w", err)
+	}
 	if err := orm.DeleteUserMFA(uid, repository.DB); err != nil {
 		return nil, err
 	}
@@ -541,7 +544,6 @@ func DisableUserMFA(uid string, args *MFADisableArgs, logger *zap.SugaredLogger)
 			logger.Warnf("failed to clear user token cache during mfa disable, uid: %s, err: %v", uid, err)
 		}
 	}
-
 	user, err := issueLoginTokenByUID(uid, false, logger)
 	if err != nil {
 		return nil, err
@@ -643,6 +645,9 @@ func GetUserMFAStatus(uid string, logger *zap.SugaredLogger) (*UserMFAStatus, er
 func ResetUserMFA(uid string, logger *zap.SugaredLogger) error {
 	if uid == "" {
 		return fmt.Errorf("uid is empty")
+	}
+	if err := NewOAuthService().RevokeUserSessions(uid); err != nil {
+		return fmt.Errorf("failed to revoke OAuth sessions before resetting mfa: %w", err)
 	}
 	if err := orm.DeleteUserMFA(uid, repository.DB); err != nil {
 		return err

--- a/pkg/microservice/user/core/service/login/mfa.go
+++ b/pkg/microservice/user/core/service/login/mfa.go
@@ -544,6 +544,7 @@ func DisableUserMFA(uid string, args *MFADisableArgs, logger *zap.SugaredLogger)
 			logger.Warnf("failed to clear user token cache during mfa disable, uid: %s, err: %v", uid, err)
 		}
 	}
+
 	user, err := issueLoginTokenByUID(uid, false, logger)
 	if err != nil {
 		return nil, err

--- a/pkg/microservice/user/core/service/login/mfa.go
+++ b/pkg/microservice/user/core/service/login/mfa.go
@@ -530,11 +530,11 @@ func DisableUserMFA(uid string, args *MFADisableArgs, logger *zap.SugaredLogger)
 		return nil, fmt.Errorf("invalid mfa verification code")
 	}
 
-	if err := NewOAuthService().RevokeUserSessions(uid); err != nil {
-		return nil, fmt.Errorf("failed to revoke OAuth sessions before disabling mfa: %w", err)
-	}
 	if err := orm.DeleteUserMFA(uid, repository.DB); err != nil {
 		return nil, err
+	}
+	if err := NewOAuthService().RevokeUserSessions(uid); err != nil && logger != nil {
+		logger.Warnf("failed to revoke OAuth sessions after disabling mfa, uid: %s, err: %v", uid, err)
 	}
 	if cacheErr := setUserMFAEnabledCache(uid, false); cacheErr != nil && logger != nil {
 		logger.Warnf("failed to sync user mfa cache during disable, uid: %s, err: %v", uid, cacheErr)
@@ -647,11 +647,11 @@ func ResetUserMFA(uid string, logger *zap.SugaredLogger) error {
 	if uid == "" {
 		return fmt.Errorf("uid is empty")
 	}
-	if err := NewOAuthService().RevokeUserSessions(uid); err != nil {
-		return fmt.Errorf("failed to revoke OAuth sessions before resetting mfa: %w", err)
-	}
 	if err := orm.DeleteUserMFA(uid, repository.DB); err != nil {
 		return err
+	}
+	if err := NewOAuthService().RevokeUserSessions(uid); err != nil && logger != nil {
+		logger.Warnf("failed to revoke OAuth sessions after resetting mfa, uid: %s, err: %v", uid, err)
 	}
 	if cacheErr := setUserMFAEnabledCache(uid, false); cacheErr != nil && logger != nil {
 		logger.Warnf("failed to sync user mfa cache during reset, uid: %s, err: %v", uid, cacheErr)

--- a/pkg/microservice/user/core/service/login/oauth.go
+++ b/pkg/microservice/user/core/service/login/oauth.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package login
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"io"
+	"time"
+
+	userconfig "github.com/koderover/zadig/v2/pkg/microservice/user/config"
+	"github.com/koderover/zadig/v2/pkg/tool/cache"
+)
+
+const (
+	OAuthCLIClientID          = "zadig-cli"
+	OAuthCLIScope             = "zadig.api offline_access"
+	OAuthTokenUseCLIAccess    = "cli_access"
+	OAuthDeviceStatusPending  = "pending"
+	OAuthDeviceStatusApproved = "approved"
+	OAuthDeviceStatusDenied   = "denied"
+	OAuthDecisionApprove      = "approve"
+	OAuthDecisionDeny         = "deny"
+
+	OAuthErrorInvalidRequest       = "invalid_request"
+	OAuthErrorInvalidClient        = "invalid_client"
+	OAuthErrorInvalidGrant         = "invalid_grant"
+	OAuthErrorAuthorizationPending = "authorization_pending"
+	OAuthErrorSlowDown             = "slow_down"
+	OAuthErrorAccessDenied         = "access_denied"
+	OAuthErrorExpiredToken         = "expired_token"
+
+	OAuthDeviceAuthorizationTTL = 10 * time.Minute
+	OAuthDevicePollInterval     = 5 * time.Second
+	OAuthAccessTokenTTL         = time.Hour
+	OAuthRefreshTokenTTL        = 30 * 24 * time.Hour
+	OAuthSessionTTL             = 180 * 24 * time.Hour
+
+	oauthRedisKeyPrefix = "zadig:oauth:"
+)
+
+var (
+	ErrOAuthAuthorizationNotFound = errors.New("oauth device authorization not found")
+	ErrOAuthInvalidSession        = errors.New("oauth session is invalid")
+)
+
+type OAuthError struct {
+	Code        string `json:"error"`
+	Description string `json:"error_description,omitempty"`
+}
+
+func (e *OAuthError) Error() string {
+	return e.Code + ": " + e.Description
+}
+
+type OAuthDeviceAuthorizationArgs struct {
+	ClientID   string `form:"client_id"`
+	Scope      string `form:"scope"`
+	DeviceName string `form:"device_name"`
+}
+
+type OAuthDeviceAuthorizationResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int64  `json:"expires_in"`
+	Interval                int64  `json:"interval"`
+}
+
+type OAuthDeviceAuthorizationInfo struct {
+	ClientName string    `json:"client_name"`
+	DeviceName string    `json:"device_name"`
+	UserCode   string    `json:"user_code"`
+	ExpiresAt  time.Time `json:"expires_at"`
+	Status     string    `json:"status"`
+}
+
+type OAuthTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int64  `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+	Scope        string `json:"scope"`
+}
+
+type OAuthUser struct {
+	UID          string `json:"uid"`
+	Name         string `json:"name"`
+	Account      string `json:"account"`
+	IdentityType string `json:"identity_type"`
+	MFAVerified  bool   `json:"mfa_verified"`
+}
+
+type oauthDevice struct {
+	DeviceCodeHash string     `json:"device_code_hash"`
+	UserCode       string     `json:"user_code"`
+	ClientID       string     `json:"client_id"`
+	Scope          string     `json:"scope"`
+	DeviceName     string     `json:"device_name"`
+	Status         string     `json:"status"`
+	User           *OAuthUser `json:"user,omitempty"`
+	ExpiresAt      time.Time  `json:"expires_at"`
+}
+
+type oauthSession struct {
+	ID        string    `json:"id"`
+	ClientID  string    `json:"client_id"`
+	Scope     string    `json:"scope"`
+	User      OAuthUser `json:"user"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+type OAuthService struct {
+	cache *cache.RedisCache
+}
+
+func NewOAuthService() *OAuthService {
+	return &OAuthService{cache: cache.NewRedisCache(userconfig.RedisUserTokenDB())}
+}
+
+func randomOAuthValue(size int) (string, error) {
+	buffer := make([]byte, size)
+	if _, err := io.ReadFull(rand.Reader, buffer); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buffer), nil
+}
+
+func randomOAuthUserCode() (string, error) {
+	const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+	random := make([]byte, 8)
+	if _, err := io.ReadFull(rand.Reader, random); err != nil {
+		return "", err
+	}
+	for i := range random {
+		random[i] = alphabet[int(random[i])%len(alphabet)]
+	}
+	return string(random[:4]) + "-" + string(random[4:]), nil
+}
+
+func hashOAuthValue(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+func oauthKey(kind, id string) string {
+	return oauthRedisKeyPrefix + kind + ":" + id
+}

--- a/pkg/microservice/user/core/service/login/oauth.go
+++ b/pkg/microservice/user/core/service/login/oauth.go
@@ -30,9 +30,10 @@ import (
 )
 
 const (
-	OAuthCLIClientID       = "zadig-cli"
-	OAuthCLIScope          = "zadig.api offline_access"
-	OAuthTokenUseCLIAccess = "cli_access"
+	OAuthLocalClientID       = "zadig-cli"
+	OAuthLocalClientName     = "Zadig CLI / MCP"
+	OAuthLocalClientScope    = "zadig.api offline_access"
+	OAuthLocalTokenUseAccess = "cli_access"
 
 	OAuthErrorInvalidRequest = "invalid_request"
 	OAuthErrorInvalidClient  = "invalid_client"

--- a/pkg/microservice/user/core/service/login/oauth.go
+++ b/pkg/microservice/user/core/service/login/oauth.go
@@ -30,35 +30,37 @@ import (
 )
 
 const (
-	OAuthCLIClientID          = "zadig-cli"
-	OAuthCLIScope             = "zadig.api offline_access"
-	OAuthTokenUseCLIAccess    = "cli_access"
-	OAuthDeviceStatusPending  = "pending"
-	OAuthDeviceStatusApproved = "approved"
-	OAuthDeviceStatusDenied   = "denied"
-	OAuthDecisionApprove      = "approve"
-	OAuthDecisionDeny         = "deny"
+	OAuthCLIClientID       = "zadig-cli"
+	OAuthCLIScope          = "zadig.api offline_access"
+	OAuthTokenUseCLIAccess = "cli_access"
 
-	OAuthErrorInvalidRequest       = "invalid_request"
-	OAuthErrorInvalidClient        = "invalid_client"
-	OAuthErrorInvalidGrant         = "invalid_grant"
-	OAuthErrorAuthorizationPending = "authorization_pending"
-	OAuthErrorSlowDown             = "slow_down"
-	OAuthErrorAccessDenied         = "access_denied"
-	OAuthErrorExpiredToken         = "expired_token"
+	OAuthErrorInvalidRequest = "invalid_request"
+	OAuthErrorInvalidClient  = "invalid_client"
 
-	OAuthDeviceAuthorizationTTL = 10 * time.Minute
-	OAuthDevicePollInterval     = 5 * time.Second
-	OAuthAccessTokenTTL         = time.Hour
-	OAuthRefreshTokenTTL        = 30 * 24 * time.Hour
-	OAuthSessionTTL             = 180 * 24 * time.Hour
+	oauthDeviceStatusPending  = "pending"
+	oauthDeviceStatusApproved = "approved"
+	oauthDeviceStatusDenied   = "denied"
+	oauthDecisionApprove      = "approve"
+	oauthDecisionDeny         = "deny"
+
+	oauthErrorInvalidGrant         = "invalid_grant"
+	oauthErrorAuthorizationPending = "authorization_pending"
+	oauthErrorSlowDown             = "slow_down"
+	oauthErrorAccessDenied         = "access_denied"
+	oauthErrorExpiredToken         = "expired_token"
+
+	oauthDeviceAuthorizationTTL = 10 * time.Minute
+	oauthDevicePollInterval     = 5 * time.Second
+	oauthAccessTokenTTL         = time.Hour
+	oauthRefreshTokenTTL        = 30 * 24 * time.Hour
+	oauthSessionTTL             = 180 * 24 * time.Hour
 
 	oauthRedisKeyPrefix = "zadig:oauth:"
 )
 
 var (
 	ErrOAuthAuthorizationNotFound = errors.New("oauth device authorization not found")
-	ErrOAuthInvalidSession        = errors.New("oauth session is invalid")
+	errOAuthInvalidSession        = errors.New("oauth session is invalid")
 )
 
 type OAuthError struct {
@@ -68,12 +70,6 @@ type OAuthError struct {
 
 func (e *OAuthError) Error() string {
 	return e.Code + ": " + e.Description
-}
-
-type OAuthDeviceAuthorizationArgs struct {
-	ClientID   string `form:"client_id"`
-	Scope      string `form:"scope"`
-	DeviceName string `form:"device_name"`
 }
 
 type OAuthDeviceAuthorizationResponse struct {
@@ -112,8 +108,6 @@ type OAuthUser struct {
 type oauthDevice struct {
 	DeviceCodeHash string     `json:"device_code_hash"`
 	UserCode       string     `json:"user_code"`
-	ClientID       string     `json:"client_id"`
-	Scope          string     `json:"scope"`
 	DeviceName     string     `json:"device_name"`
 	Status         string     `json:"status"`
 	User           *OAuthUser `json:"user,omitempty"`
@@ -122,8 +116,6 @@ type oauthDevice struct {
 
 type oauthSession struct {
 	ID        string    `json:"id"`
-	ClientID  string    `json:"client_id"`
-	Scope     string    `json:"scope"`
 	User      OAuthUser `json:"user"`
 	ExpiresAt time.Time `json:"expires_at"`
 }

--- a/pkg/microservice/user/core/service/login/oauth.go
+++ b/pkg/microservice/user/core/service/login/oauth.go
@@ -52,9 +52,9 @@ const (
 
 	oauthDeviceAuthorizationTTL = 10 * time.Minute
 	oauthDevicePollInterval     = 5 * time.Second
-	oauthAccessTokenTTL         = time.Hour
-	oauthRefreshTokenTTL        = 30 * 24 * time.Hour
-	oauthSessionTTL             = 180 * 24 * time.Hour
+	oauthAccessTokenTTL         = 2 * time.Hour
+	oauthRefreshTokenTTL        = 7 * 24 * time.Hour
+	oauthSessionTTL             = 365 * 24 * time.Hour
 
 	oauthRedisKeyPrefix = "zadig:oauth:"
 )

--- a/pkg/microservice/user/core/service/login/oauth.go
+++ b/pkg/microservice/user/core/service/login/oauth.go
@@ -50,11 +50,12 @@ const (
 	oauthErrorAccessDenied         = "access_denied"
 	oauthErrorExpiredToken         = "expired_token"
 
-	oauthDeviceAuthorizationTTL = 10 * time.Minute
-	oauthDevicePollInterval     = 5 * time.Second
-	oauthAccessTokenTTL         = 2 * time.Hour
-	oauthRefreshTokenTTL        = 7 * 24 * time.Hour
-	oauthSessionTTL             = 365 * 24 * time.Hour
+	oauthDeviceAuthorizationTTL  = 10 * time.Minute
+	oauthDevicePollInterval      = 5 * time.Second
+	oauthAccessTokenTTL          = 2 * time.Hour
+	oauthRefreshTokenTTL         = 7 * 24 * time.Hour
+	oauthRefreshTokenGracePeriod = time.Minute
+	oauthSessionTTL              = 365 * 24 * time.Hour
 
 	oauthRedisKeyPrefix = "zadig:oauth:"
 )

--- a/pkg/microservice/user/core/service/login/oauth_device.go
+++ b/pkg/microservice/user/core/service/login/oauth_device.go
@@ -72,7 +72,7 @@ func (s *OAuthService) GetDeviceAuthorization(userCode string) (*OAuthDeviceAuth
 		return nil, err
 	}
 	return &OAuthDeviceAuthorizationInfo{
-		ClientName: "Zadig CLI",
+		ClientName: OAuthLocalClientName,
 		DeviceName: device.DeviceName,
 		UserCode:   device.UserCode,
 		ExpiresAt:  device.ExpiresAt,
@@ -138,21 +138,34 @@ func (s *OAuthService) ExchangeDeviceCode(deviceCode string) (*OAuthTokenRespons
 		s.deleteDevice(device)
 		return nil, &OAuthError{Code: oauthErrorAccessDenied, Description: "authorization was denied"}
 	case oauthDeviceStatusApproved:
-		payload, err := s.cache.TakeString(oauthKey("device", hash))
-		if errors.Is(err, redis.Nil) {
-			return nil, &OAuthError{Code: oauthErrorExpiredToken, Description: "device code is invalid or already used"}
-		}
+		exchangeKey := oauthKey("exchange", hash)
+		claimed, err := s.cache.WriteIfNotExists(exchangeKey, "1", time.Until(device.ExpiresAt))
 		if err != nil {
 			return nil, err
 		}
+		if !claimed {
+			return nil, &OAuthError{Code: oauthErrorExpiredToken, Description: "device code is invalid or already used"}
+		}
+		payload, err := s.cache.GetString(oauthKey("device", hash))
+		if errors.Is(err, redis.Nil) {
+			_ = s.cache.Delete(exchangeKey)
+			return nil, &OAuthError{Code: oauthErrorExpiredToken, Description: "device code is invalid or already used"}
+		}
+		if err != nil {
+			_ = s.cache.Delete(exchangeKey)
+			return nil, err
+		}
 		if err := json.Unmarshal([]byte(payload), device); err != nil {
+			_ = s.cache.Delete(exchangeKey)
 			return nil, err
 		}
 		tokens, err := s.createOAuthSession(device)
-		if err == nil {
-			s.deleteDevice(device)
+		if err != nil {
+			_ = s.cache.Delete(exchangeKey)
+			return nil, err
 		}
-		return tokens, err
+		s.deleteDevice(device)
+		return tokens, nil
 	default:
 		return nil, &OAuthError{Code: oauthErrorInvalidGrant, Description: "invalid authorization state"}
 	}

--- a/pkg/microservice/user/core/service/login/oauth_device.go
+++ b/pkg/microservice/user/core/service/login/oauth_device.go
@@ -25,60 +25,44 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
+
+	configbase "github.com/koderover/zadig/v2/pkg/config"
 )
 
-func (s *OAuthService) CreateDeviceAuthorization(args *OAuthDeviceAuthorizationArgs, verificationURI string) (*OAuthDeviceAuthorizationResponse, error) {
-	if args == nil || strings.TrimSpace(args.ClientID) != OAuthCLIClientID {
-		return nil, &OAuthError{Code: OAuthErrorInvalidClient, Description: "unsupported client_id"}
-	}
-	scope := strings.Join(strings.Fields(args.Scope), " ")
-	if scope != OAuthCLIScope && scope != "offline_access zadig.api" {
-		return nil, &OAuthError{Code: OAuthErrorInvalidRequest, Description: "scope must be zadig.api offline_access"}
-	}
-	if verificationURI == "" || len(args.DeviceName) > 128 {
-		return nil, &OAuthError{Code: OAuthErrorInvalidRequest, Description: "invalid authorization request"}
-	}
+func (s *OAuthService) CreateDeviceAuthorization(deviceName string) (*OAuthDeviceAuthorizationResponse, error) {
 	deviceCode, err := randomOAuthValue(32)
 	if err != nil {
 		return nil, err
 	}
 	device := &oauthDevice{
 		DeviceCodeHash: hashOAuthValue(deviceCode),
-		ClientID:       OAuthCLIClientID,
-		Scope:          OAuthCLIScope,
-		DeviceName:     strings.TrimSpace(args.DeviceName),
-		Status:         OAuthDeviceStatusPending,
-		ExpiresAt:      time.Now().UTC().Add(OAuthDeviceAuthorizationTTL),
+		DeviceName:     deviceName,
+		Status:         oauthDeviceStatusPending,
+		ExpiresAt:      time.Now().UTC().Add(oauthDeviceAuthorizationTTL),
 	}
-	created := false
-	for attempt := 0; attempt < 5; attempt++ {
-		device.UserCode, err = randomOAuthUserCode()
-		if err != nil {
-			return nil, err
-		}
-		reserved, reserveErr := s.cache.WriteIfNotExists(oauthKey("user-code", device.UserCode), device.DeviceCodeHash, OAuthDeviceAuthorizationTTL)
-		if reserveErr != nil {
-			return nil, reserveErr
-		}
-		if reserved {
-			if err = s.writeDevice(device); err != nil {
-				_ = s.cache.Delete(oauthKey("user-code", device.UserCode))
-				return nil, err
-			}
-			created = true
-			break
-		}
+	device.UserCode, err = randomOAuthUserCode()
+	if err != nil {
+		return nil, err
 	}
-	if !created {
+	reserved, err := s.cache.WriteIfNotExists(oauthKey("user-code", device.UserCode), device.DeviceCodeHash, oauthDeviceAuthorizationTTL)
+	if err != nil {
+		return nil, err
+	}
+	if !reserved {
 		return nil, fmt.Errorf("failed to allocate OAuth user code")
 	}
+	if err := s.writeDevice(device); err != nil {
+		_ = s.cache.Delete(oauthKey("user-code", device.UserCode))
+		return nil, err
+	}
+	verificationURI := strings.TrimRight(configbase.SystemAddress(), "/") + "/oauth/device"
 	return &OAuthDeviceAuthorizationResponse{
 		DeviceCode:              deviceCode,
 		UserCode:                device.UserCode,
 		VerificationURI:         verificationURI,
 		VerificationURIComplete: verificationURI + "?code=" + url.QueryEscape(device.UserCode),
-		ExpiresIn:               int64(OAuthDeviceAuthorizationTTL / time.Second),
-		Interval:                int64(OAuthDevicePollInterval / time.Second),
+		ExpiresIn:               int64(oauthDeviceAuthorizationTTL / time.Second),
+		Interval:                int64(oauthDevicePollInterval / time.Second),
 	}, nil
 }
 
@@ -96,73 +80,67 @@ func (s *OAuthService) GetDeviceAuthorization(userCode string) (*OAuthDeviceAuth
 	}, nil
 }
 
-func (s *OAuthService) DecideDeviceAuthorization(userCode, decision string, user OAuthUser) error {
-	if decision != OAuthDecisionApprove && decision != OAuthDecisionDeny {
-		return &OAuthError{Code: OAuthErrorInvalidRequest, Description: "decision must be approve or deny"}
-	}
-	if decision == OAuthDecisionApprove && user.UID == "" {
-		return &OAuthError{Code: OAuthErrorInvalidRequest, Description: "authenticated user is required"}
+func (s *OAuthService) DecideDeviceAuthorization(userCode, decision string, user OAuthUser) (string, error) {
+	if decision != oauthDecisionApprove && decision != oauthDecisionDeny {
+		return "", &OAuthError{Code: OAuthErrorInvalidRequest, Description: "decision must be approve or deny"}
 	}
 	device, err := s.deviceByUserCode(userCode)
 	if err != nil {
-		return err
+		return "", err
 	}
-	if device.Status != OAuthDeviceStatusPending {
-		return &OAuthError{Code: OAuthErrorInvalidRequest, Description: "authorization request has already been decided"}
+	if device.Status != oauthDeviceStatusPending {
+		return "", &OAuthError{Code: OAuthErrorInvalidRequest, Description: "authorization request has already been decided"}
 	}
 	decisionKey := oauthKey("decision", device.DeviceCodeHash)
 	decided, err := s.cache.WriteIfNotExists(decisionKey, "1", time.Until(device.ExpiresAt))
 	if err != nil {
-		return err
+		return "", err
 	}
 	if !decided {
-		return &OAuthError{Code: OAuthErrorInvalidRequest, Description: "authorization request has already been decided"}
+		return "", &OAuthError{Code: OAuthErrorInvalidRequest, Description: "authorization request has already been decided"}
 	}
 	switch decision {
-	case OAuthDecisionApprove:
-		device.Status, device.User = OAuthDeviceStatusApproved, &user
-	case OAuthDecisionDeny:
-		device.Status = OAuthDeviceStatusDenied
+	case oauthDecisionApprove:
+		device.Status, device.User = oauthDeviceStatusApproved, &user
+	case oauthDecisionDeny:
+		device.Status = oauthDeviceStatusDenied
 	}
 	if err := s.writeDevice(device); err != nil {
 		_ = s.cache.Delete(decisionKey)
-		return err
+		return "", err
 	}
-	return nil
+	return device.Status, nil
 }
 
-func (s *OAuthService) ExchangeDeviceCode(clientID, deviceCode string) (*OAuthTokenResponse, error) {
-	if clientID != OAuthCLIClientID {
-		return nil, &OAuthError{Code: OAuthErrorInvalidClient, Description: "unsupported client_id"}
-	}
+func (s *OAuthService) ExchangeDeviceCode(deviceCode string) (*OAuthTokenResponse, error) {
 	if deviceCode == "" {
 		return nil, &OAuthError{Code: OAuthErrorInvalidRequest, Description: "device_code is required"}
 	}
 	hash := hashOAuthValue(deviceCode)
 	device, err := s.deviceByHash(hash)
 	if errors.Is(err, ErrOAuthAuthorizationNotFound) {
-		return nil, &OAuthError{Code: OAuthErrorExpiredToken, Description: "device code is invalid or expired"}
+		return nil, &OAuthError{Code: oauthErrorExpiredToken, Description: "device code is invalid or expired"}
 	}
 	if err != nil {
 		return nil, err
 	}
-	allowed, err := s.cache.WriteIfNotExists(oauthKey("poll", hash), "1", OAuthDevicePollInterval)
+	allowed, err := s.cache.WriteIfNotExists(oauthKey("poll", hash), "1", oauthDevicePollInterval)
 	if err != nil {
 		return nil, err
 	}
 	if !allowed {
-		return nil, &OAuthError{Code: OAuthErrorSlowDown, Description: "polling too frequently"}
+		return nil, &OAuthError{Code: oauthErrorSlowDown, Description: "polling too frequently"}
 	}
 	switch device.Status {
-	case OAuthDeviceStatusPending:
-		return nil, &OAuthError{Code: OAuthErrorAuthorizationPending, Description: "authorization is pending"}
-	case OAuthDeviceStatusDenied:
+	case oauthDeviceStatusPending:
+		return nil, &OAuthError{Code: oauthErrorAuthorizationPending, Description: "authorization is pending"}
+	case oauthDeviceStatusDenied:
 		s.deleteDevice(device)
-		return nil, &OAuthError{Code: OAuthErrorAccessDenied, Description: "authorization was denied"}
-	case OAuthDeviceStatusApproved:
+		return nil, &OAuthError{Code: oauthErrorAccessDenied, Description: "authorization was denied"}
+	case oauthDeviceStatusApproved:
 		payload, err := s.cache.TakeString(oauthKey("device", hash))
 		if errors.Is(err, redis.Nil) {
-			return nil, &OAuthError{Code: OAuthErrorExpiredToken, Description: "device code is invalid or already used"}
+			return nil, &OAuthError{Code: oauthErrorExpiredToken, Description: "device code is invalid or already used"}
 		}
 		if err != nil {
 			return nil, err
@@ -176,7 +154,7 @@ func (s *OAuthService) ExchangeDeviceCode(clientID, deviceCode string) (*OAuthTo
 		}
 		return tokens, err
 	default:
-		return nil, &OAuthError{Code: OAuthErrorInvalidGrant, Description: "invalid authorization state"}
+		return nil, &OAuthError{Code: oauthErrorInvalidGrant, Description: "invalid authorization state"}
 	}
 }
 

--- a/pkg/microservice/user/core/service/login/oauth_device.go
+++ b/pkg/microservice/user/core/service/login/oauth_device.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package login
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func (s *OAuthService) CreateDeviceAuthorization(args *OAuthDeviceAuthorizationArgs, verificationURI string) (*OAuthDeviceAuthorizationResponse, error) {
+	if args == nil || strings.TrimSpace(args.ClientID) != OAuthCLIClientID {
+		return nil, &OAuthError{Code: OAuthErrorInvalidClient, Description: "unsupported client_id"}
+	}
+	scope := strings.Join(strings.Fields(args.Scope), " ")
+	if scope != OAuthCLIScope && scope != "offline_access zadig.api" {
+		return nil, &OAuthError{Code: OAuthErrorInvalidRequest, Description: "scope must be zadig.api offline_access"}
+	}
+	if verificationURI == "" || len(args.DeviceName) > 128 {
+		return nil, &OAuthError{Code: OAuthErrorInvalidRequest, Description: "invalid authorization request"}
+	}
+	deviceCode, err := randomOAuthValue(32)
+	if err != nil {
+		return nil, err
+	}
+	device := &oauthDevice{
+		DeviceCodeHash: hashOAuthValue(deviceCode),
+		ClientID:       OAuthCLIClientID,
+		Scope:          OAuthCLIScope,
+		DeviceName:     strings.TrimSpace(args.DeviceName),
+		Status:         OAuthDeviceStatusPending,
+		ExpiresAt:      time.Now().UTC().Add(OAuthDeviceAuthorizationTTL),
+	}
+	created := false
+	for attempt := 0; attempt < 5; attempt++ {
+		device.UserCode, err = randomOAuthUserCode()
+		if err != nil {
+			return nil, err
+		}
+		reserved, reserveErr := s.cache.WriteIfNotExists(oauthKey("user-code", device.UserCode), device.DeviceCodeHash, OAuthDeviceAuthorizationTTL)
+		if reserveErr != nil {
+			return nil, reserveErr
+		}
+		if reserved {
+			if err = s.writeDevice(device); err != nil {
+				_ = s.cache.Delete(oauthKey("user-code", device.UserCode))
+				return nil, err
+			}
+			created = true
+			break
+		}
+	}
+	if !created {
+		return nil, fmt.Errorf("failed to allocate OAuth user code")
+	}
+	return &OAuthDeviceAuthorizationResponse{
+		DeviceCode:              deviceCode,
+		UserCode:                device.UserCode,
+		VerificationURI:         verificationURI,
+		VerificationURIComplete: verificationURI + "?code=" + url.QueryEscape(device.UserCode),
+		ExpiresIn:               int64(OAuthDeviceAuthorizationTTL / time.Second),
+		Interval:                int64(OAuthDevicePollInterval / time.Second),
+	}, nil
+}
+
+func (s *OAuthService) GetDeviceAuthorization(userCode string) (*OAuthDeviceAuthorizationInfo, error) {
+	device, err := s.deviceByUserCode(userCode)
+	if err != nil {
+		return nil, err
+	}
+	return &OAuthDeviceAuthorizationInfo{
+		ClientName: "Zadig CLI",
+		DeviceName: device.DeviceName,
+		UserCode:   device.UserCode,
+		ExpiresAt:  device.ExpiresAt,
+		Status:     device.Status,
+	}, nil
+}
+
+func (s *OAuthService) DecideDeviceAuthorization(userCode, decision string, user OAuthUser) error {
+	if decision != OAuthDecisionApprove && decision != OAuthDecisionDeny {
+		return &OAuthError{Code: OAuthErrorInvalidRequest, Description: "decision must be approve or deny"}
+	}
+	if decision == OAuthDecisionApprove && user.UID == "" {
+		return &OAuthError{Code: OAuthErrorInvalidRequest, Description: "authenticated user is required"}
+	}
+	device, err := s.deviceByUserCode(userCode)
+	if err != nil {
+		return err
+	}
+	if device.Status != OAuthDeviceStatusPending {
+		return &OAuthError{Code: OAuthErrorInvalidRequest, Description: "authorization request has already been decided"}
+	}
+	decisionKey := oauthKey("decision", device.DeviceCodeHash)
+	decided, err := s.cache.WriteIfNotExists(decisionKey, "1", time.Until(device.ExpiresAt))
+	if err != nil {
+		return err
+	}
+	if !decided {
+		return &OAuthError{Code: OAuthErrorInvalidRequest, Description: "authorization request has already been decided"}
+	}
+	switch decision {
+	case OAuthDecisionApprove:
+		device.Status, device.User = OAuthDeviceStatusApproved, &user
+	case OAuthDecisionDeny:
+		device.Status = OAuthDeviceStatusDenied
+	}
+	if err := s.writeDevice(device); err != nil {
+		_ = s.cache.Delete(decisionKey)
+		return err
+	}
+	return nil
+}
+
+func (s *OAuthService) ExchangeDeviceCode(clientID, deviceCode string) (*OAuthTokenResponse, error) {
+	if clientID != OAuthCLIClientID {
+		return nil, &OAuthError{Code: OAuthErrorInvalidClient, Description: "unsupported client_id"}
+	}
+	if deviceCode == "" {
+		return nil, &OAuthError{Code: OAuthErrorInvalidRequest, Description: "device_code is required"}
+	}
+	hash := hashOAuthValue(deviceCode)
+	device, err := s.deviceByHash(hash)
+	if errors.Is(err, ErrOAuthAuthorizationNotFound) {
+		return nil, &OAuthError{Code: OAuthErrorExpiredToken, Description: "device code is invalid or expired"}
+	}
+	if err != nil {
+		return nil, err
+	}
+	allowed, err := s.cache.WriteIfNotExists(oauthKey("poll", hash), "1", OAuthDevicePollInterval)
+	if err != nil {
+		return nil, err
+	}
+	if !allowed {
+		return nil, &OAuthError{Code: OAuthErrorSlowDown, Description: "polling too frequently"}
+	}
+	switch device.Status {
+	case OAuthDeviceStatusPending:
+		return nil, &OAuthError{Code: OAuthErrorAuthorizationPending, Description: "authorization is pending"}
+	case OAuthDeviceStatusDenied:
+		s.deleteDevice(device)
+		return nil, &OAuthError{Code: OAuthErrorAccessDenied, Description: "authorization was denied"}
+	case OAuthDeviceStatusApproved:
+		payload, err := s.cache.TakeString(oauthKey("device", hash))
+		if errors.Is(err, redis.Nil) {
+			return nil, &OAuthError{Code: OAuthErrorExpiredToken, Description: "device code is invalid or already used"}
+		}
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal([]byte(payload), device); err != nil {
+			return nil, err
+		}
+		tokens, err := s.createOAuthSession(device)
+		if err == nil {
+			s.deleteDevice(device)
+		}
+		return tokens, err
+	default:
+		return nil, &OAuthError{Code: OAuthErrorInvalidGrant, Description: "invalid authorization state"}
+	}
+}
+
+func (s *OAuthService) deviceByUserCode(userCode string) (*oauthDevice, error) {
+	hash, err := s.cache.GetString(oauthKey("user-code", strings.ToUpper(strings.TrimSpace(userCode))))
+	if errors.Is(err, redis.Nil) {
+		return nil, ErrOAuthAuthorizationNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return s.deviceByHash(hash)
+}
+
+func (s *OAuthService) deviceByHash(hash string) (*oauthDevice, error) {
+	device := new(oauthDevice)
+	if err := s.readJSON(oauthKey("device", hash), device); err != nil {
+		return nil, err
+	}
+	if !time.Now().Before(device.ExpiresAt) {
+		return nil, ErrOAuthAuthorizationNotFound
+	}
+	return device, nil
+}
+
+func (s *OAuthService) writeDevice(device *oauthDevice) error {
+	return s.writeJSON(oauthKey("device", device.DeviceCodeHash), device, time.Until(device.ExpiresAt))
+}
+
+func (s *OAuthService) deleteDevice(device *oauthDevice) {
+	_ = s.cache.Delete(oauthKey("device", device.DeviceCodeHash))
+	_ = s.cache.Delete(oauthKey("user-code", device.UserCode))
+	_ = s.cache.Delete(oauthKey("poll", device.DeviceCodeHash))
+	_ = s.cache.Delete(oauthKey("decision", device.DeviceCodeHash))
+}
+
+func (s *OAuthService) writeJSON(key string, value interface{}, ttl time.Duration) error {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return s.cache.Write(key, string(payload), ttl)
+}
+
+func (s *OAuthService) readJSON(key string, value interface{}) error {
+	payload, err := s.cache.GetString(key)
+	if errors.Is(err, redis.Nil) {
+		return ErrOAuthAuthorizationNotFound
+	}
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal([]byte(payload), value)
+}

--- a/pkg/microservice/user/core/service/login/oauth_device.go
+++ b/pkg/microservice/user/core/service/login/oauth_device.go
@@ -44,7 +44,7 @@ func (s *OAuthService) CreateDeviceAuthorization(deviceName string) (*OAuthDevic
 	if err != nil {
 		return nil, err
 	}
-	reserved, err := s.cache.WriteIfNotExists(oauthKey("user-code", device.UserCode), device.DeviceCodeHash, oauthDeviceAuthorizationTTL)
+	reserved, err := s.cache.SetNX(oauthKey("user-code", device.UserCode), device.DeviceCodeHash, oauthDeviceAuthorizationTTL)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (s *OAuthService) DecideDeviceAuthorization(userCode, decision string, user
 		return "", &OAuthError{Code: OAuthErrorInvalidRequest, Description: "authorization request has already been decided"}
 	}
 	decisionKey := oauthKey("decision", device.DeviceCodeHash)
-	decided, err := s.cache.WriteIfNotExists(decisionKey, "1", time.Until(device.ExpiresAt))
+	decided, err := s.cache.SetNX(decisionKey, "1", time.Until(device.ExpiresAt))
 	if err != nil {
 		return "", err
 	}
@@ -124,7 +124,7 @@ func (s *OAuthService) ExchangeDeviceCode(deviceCode string) (*OAuthTokenRespons
 	if err != nil {
 		return nil, err
 	}
-	allowed, err := s.cache.WriteIfNotExists(oauthKey("poll", hash), "1", oauthDevicePollInterval)
+	allowed, err := s.cache.SetNX(oauthKey("poll", hash), "1", oauthDevicePollInterval)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func (s *OAuthService) ExchangeDeviceCode(deviceCode string) (*OAuthTokenRespons
 		return nil, &OAuthError{Code: oauthErrorAccessDenied, Description: "authorization was denied"}
 	case oauthDeviceStatusApproved:
 		exchangeKey := oauthKey("exchange", hash)
-		claimed, err := s.cache.WriteIfNotExists(exchangeKey, "1", time.Until(device.ExpiresAt))
+		claimed, err := s.cache.SetNX(exchangeKey, "1", time.Until(device.ExpiresAt))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/microservice/user/core/service/login/oauth_session.go
+++ b/pkg/microservice/user/core/service/login/oauth_session.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package login
+
+import (
+	"errors"
+	"time"
+
+	"github.com/golang-jwt/jwt"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/koderover/zadig/v2/pkg/setting"
+)
+
+func (s *OAuthService) RefreshToken(clientID, refreshToken string) (*OAuthTokenResponse, error) {
+	if clientID != OAuthCLIClientID {
+		return nil, &OAuthError{Code: OAuthErrorInvalidClient, Description: "unsupported client_id"}
+	}
+	if refreshToken == "" {
+		return nil, &OAuthError{Code: OAuthErrorInvalidRequest, Description: "refresh_token is required"}
+	}
+	oldHash := hashOAuthValue(refreshToken)
+	sessionID, err := s.cache.GetString(oauthKey("refresh", oldHash))
+	if errors.Is(err, redis.Nil) {
+		return nil, &OAuthError{Code: OAuthErrorInvalidGrant, Description: "refresh token is invalid or expired"}
+	}
+	if err != nil {
+		return nil, err
+	}
+	session, err := s.session(sessionID)
+	if err != nil {
+		if errors.Is(err, ErrOAuthInvalidSession) {
+			return nil, &OAuthError{Code: OAuthErrorInvalidGrant, Description: "refresh token is invalid or expired"}
+		}
+		return nil, err
+	}
+	if session.ClientID != clientID {
+		return nil, &OAuthError{Code: OAuthErrorInvalidGrant, Description: "refresh token is invalid or expired"}
+	}
+	newRefreshToken, err := randomOAuthValue(32)
+	if err != nil {
+		return nil, err
+	}
+	newHash := hashOAuthValue(newRefreshToken)
+	now := time.Now().UTC()
+	accessToken, err := createOAuthAccessToken(session, now)
+	if err != nil {
+		return nil, err
+	}
+	consumedSessionID, err := s.cache.TakeString(oauthKey("refresh", oldHash))
+	if errors.Is(err, redis.Nil) {
+		return nil, &OAuthError{Code: OAuthErrorInvalidGrant, Description: "refresh token is invalid or already used"}
+	}
+	if err != nil {
+		return nil, err
+	}
+	if consumedSessionID != session.ID {
+		return nil, &OAuthError{Code: OAuthErrorInvalidGrant, Description: "refresh token is invalid or already used"}
+	}
+	refreshTTL := OAuthRefreshTokenTTL
+	if remaining := session.ExpiresAt.Sub(now); remaining < refreshTTL {
+		refreshTTL = remaining
+	}
+	if err := s.cache.Write(oauthKey("refresh", newHash), session.ID, refreshTTL); err != nil {
+		return nil, err
+	}
+	return &OAuthTokenResponse{
+		AccessToken: accessToken, TokenType: "Bearer", ExpiresIn: int64(OAuthAccessTokenTTL / time.Second),
+		RefreshToken: newRefreshToken, Scope: session.Scope,
+	}, nil
+}
+
+func (s *OAuthService) RevokeToken(clientID, refreshToken string) error {
+	if clientID != OAuthCLIClientID {
+		return &OAuthError{Code: OAuthErrorInvalidClient, Description: "unsupported client_id"}
+	}
+	if refreshToken == "" {
+		return &OAuthError{Code: OAuthErrorInvalidRequest, Description: "token is required"}
+	}
+	refreshTokenKey := oauthKey("refresh", hashOAuthValue(refreshToken))
+	sessionID, err := s.cache.GetString(refreshTokenKey)
+	if errors.Is(err, redis.Nil) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err := s.deleteSession(sessionID); err != nil {
+		return err
+	}
+	return s.cache.Delete(refreshTokenKey)
+}
+
+func (s *OAuthService) ValidateSession(sessionID, uid string) error {
+	session, err := s.session(sessionID)
+	if err != nil {
+		return err
+	}
+	if session.User.UID != uid || session.ClientID != OAuthCLIClientID {
+		return ErrOAuthInvalidSession
+	}
+	return nil
+}
+
+func (s *OAuthService) RevokeUserSessions(uid string) error {
+	if uid == "" {
+		return nil
+	}
+	key := oauthKey("user-sessions", uid)
+	sessionIDs, err := s.cache.ListSetMembers(key)
+	if err != nil {
+		return err
+	}
+	for _, sessionID := range sessionIDs {
+		if err := s.deleteSession(sessionID); err != nil {
+			return err
+		}
+	}
+	return s.cache.Delete(key)
+}
+
+func (s *OAuthService) createOAuthSession(device *oauthDevice) (*OAuthTokenResponse, error) {
+	if device.User == nil {
+		return nil, &OAuthError{Code: OAuthErrorInvalidGrant, Description: "authorization has no user"}
+	}
+	sessionID, err := randomOAuthValue(24)
+	if err != nil {
+		return nil, err
+	}
+	refreshToken, err := randomOAuthValue(32)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	session := &oauthSession{
+		ID:        sessionID,
+		ClientID:  device.ClientID,
+		Scope:     device.Scope,
+		User:      *device.User,
+		ExpiresAt: now.Add(OAuthSessionTTL),
+	}
+	accessToken, err := createOAuthAccessToken(session, now)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.writeJSON(oauthKey("session", session.ID), session, time.Until(session.ExpiresAt)); err != nil {
+		return nil, err
+	}
+	refreshTokenKey := oauthKey("refresh", hashOAuthValue(refreshToken))
+	if err := s.cache.Write(refreshTokenKey, session.ID, OAuthRefreshTokenTTL); err != nil {
+		_ = s.cache.Delete(oauthKey("session", session.ID))
+		return nil, err
+	}
+	if err := s.cache.AddElementsToSet(oauthKey("user-sessions", session.User.UID), []string{session.ID}, OAuthSessionTTL); err != nil {
+		_ = s.cache.Delete(refreshTokenKey)
+		_ = s.cache.Delete(oauthKey("session", session.ID))
+		return nil, err
+	}
+	return &OAuthTokenResponse{
+		AccessToken: accessToken, TokenType: "Bearer", ExpiresIn: int64(OAuthAccessTokenTTL / time.Second),
+		RefreshToken: refreshToken, Scope: session.Scope,
+	}, nil
+}
+
+func (s *OAuthService) session(sessionID string) (*oauthSession, error) {
+	session := new(oauthSession)
+	if err := s.readJSON(oauthKey("session", sessionID), session); err != nil {
+		if errors.Is(err, ErrOAuthAuthorizationNotFound) {
+			return nil, ErrOAuthInvalidSession
+		}
+		return nil, err
+	}
+	if !time.Now().Before(session.ExpiresAt) {
+		return nil, ErrOAuthInvalidSession
+	}
+	return session, nil
+}
+
+func (s *OAuthService) deleteSession(sessionID string) error {
+	session, err := s.session(sessionID)
+	if errors.Is(err, ErrOAuthInvalidSession) {
+		return s.cache.Delete(oauthKey("session", sessionID))
+	}
+	if err != nil {
+		return err
+	}
+	if err := s.cache.Delete(oauthKey("session", sessionID)); err != nil {
+		return err
+	}
+	return s.cache.RemoveElementsFromSet(oauthKey("user-sessions", session.User.UID), []string{sessionID})
+}
+
+func createOAuthAccessToken(session *oauthSession, now time.Time) (string, error) {
+	return CreateToken(&Claims{
+		Name:              session.User.Name,
+		UID:               session.User.UID,
+		PreferredUsername: session.User.Account,
+		MFAVerified:       session.User.MFAVerified,
+		TokenUse:          OAuthTokenUseCLIAccess,
+		ClientID:          session.ClientID,
+		SessionID:         session.ID,
+		FederatedClaims:   FederatedClaims{ConnectorId: session.User.IdentityType, UserId: session.User.Account},
+		StandardClaims: jwt.StandardClaims{
+			Audience: setting.ProductName, IssuedAt: now.Unix(), ExpiresAt: now.Add(OAuthAccessTokenTTL).Unix(),
+		},
+	})
+}

--- a/pkg/microservice/user/core/service/login/oauth_session.go
+++ b/pkg/microservice/user/core/service/login/oauth_session.go
@@ -62,7 +62,7 @@ func (s *OAuthService) RefreshToken(refreshToken string) (*OAuthTokenResponse, e
 	}
 	return &OAuthTokenResponse{
 		AccessToken: accessToken, TokenType: "Bearer", ExpiresIn: int64(accessTTL / time.Second),
-		RefreshToken: newRefreshToken, Scope: OAuthCLIScope,
+		RefreshToken: newRefreshToken, Scope: OAuthLocalClientScope,
 	}, nil
 }
 
@@ -146,7 +146,7 @@ func (s *OAuthService) createOAuthSession(device *oauthDevice) (*OAuthTokenRespo
 	}
 	return &OAuthTokenResponse{
 		AccessToken: accessToken, TokenType: "Bearer", ExpiresIn: int64(accessTTL / time.Second),
-		RefreshToken: refreshToken, Scope: OAuthCLIScope,
+		RefreshToken: refreshToken, Scope: OAuthLocalClientScope,
 	}, nil
 }
 
@@ -188,8 +188,8 @@ func createOAuthAccessToken(session *oauthSession, now time.Time) (string, time.
 		UID:               session.User.UID,
 		PreferredUsername: session.User.Account,
 		MFAVerified:       session.User.MFAVerified,
-		TokenUse:          OAuthTokenUseCLIAccess,
-		ClientID:          OAuthCLIClientID,
+		TokenUse:          OAuthLocalTokenUseAccess,
+		ClientID:          OAuthLocalClientID,
 		SessionID:         session.ID,
 		FederatedClaims:   FederatedClaims{ConnectorId: session.User.IdentityType, UserId: session.User.Account},
 		StandardClaims: jwt.StandardClaims{

--- a/pkg/microservice/user/core/service/login/oauth_session.go
+++ b/pkg/microservice/user/core/service/login/oauth_session.go
@@ -49,7 +49,7 @@ func (s *OAuthService) RefreshToken(refreshToken string) (*OAuthTokenResponse, e
 		return nil, err
 	}
 	now := time.Now().UTC()
-	accessToken, err := createOAuthAccessToken(session, now)
+	accessToken, accessTTL, err := createOAuthAccessToken(session, now)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func (s *OAuthService) RefreshToken(refreshToken string) (*OAuthTokenResponse, e
 		return nil, err
 	}
 	return &OAuthTokenResponse{
-		AccessToken: accessToken, TokenType: "Bearer", ExpiresIn: int64(oauthAccessTokenTTL / time.Second),
+		AccessToken: accessToken, TokenType: "Bearer", ExpiresIn: int64(accessTTL / time.Second),
 		RefreshToken: newRefreshToken, Scope: OAuthCLIScope,
 	}, nil
 }
@@ -127,7 +127,7 @@ func (s *OAuthService) createOAuthSession(device *oauthDevice) (*OAuthTokenRespo
 		User:      *device.User,
 		ExpiresAt: now.Add(oauthSessionTTL),
 	}
-	accessToken, err := createOAuthAccessToken(session, now)
+	accessToken, accessTTL, err := createOAuthAccessToken(session, now)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func (s *OAuthService) createOAuthSession(device *oauthDevice) (*OAuthTokenRespo
 		return nil, err
 	}
 	return &OAuthTokenResponse{
-		AccessToken: accessToken, TokenType: "Bearer", ExpiresIn: int64(oauthAccessTokenTTL / time.Second),
+		AccessToken: accessToken, TokenType: "Bearer", ExpiresIn: int64(accessTTL / time.Second),
 		RefreshToken: refreshToken, Scope: OAuthCLIScope,
 	}, nil
 }
@@ -178,8 +178,12 @@ func (s *OAuthService) deleteSession(sessionID string) error {
 	return s.cache.RemoveElementsFromSet(oauthKey("user-sessions", session.User.UID), []string{sessionID})
 }
 
-func createOAuthAccessToken(session *oauthSession, now time.Time) (string, error) {
-	return CreateToken(&Claims{
+func createOAuthAccessToken(session *oauthSession, now time.Time) (string, time.Duration, error) {
+	accessTTL := oauthAccessTokenTTL
+	if remaining := session.ExpiresAt.Sub(now); remaining < accessTTL {
+		accessTTL = remaining
+	}
+	token, err := CreateToken(&Claims{
 		Name:              session.User.Name,
 		UID:               session.User.UID,
 		PreferredUsername: session.User.Account,
@@ -189,7 +193,8 @@ func createOAuthAccessToken(session *oauthSession, now time.Time) (string, error
 		SessionID:         session.ID,
 		FederatedClaims:   FederatedClaims{ConnectorId: session.User.IdentityType, UserId: session.User.Account},
 		StandardClaims: jwt.StandardClaims{
-			Audience: setting.ProductName, IssuedAt: now.Unix(), ExpiresAt: now.Add(oauthAccessTokenTTL).Unix(),
+			Audience: setting.ProductName, IssuedAt: now.Unix(), ExpiresAt: now.Add(accessTTL).Unix(),
 		},
 	})
+	return token, accessTTL, err
 }

--- a/pkg/microservice/user/core/service/login/oauth_session.go
+++ b/pkg/microservice/user/core/service/login/oauth_session.go
@@ -26,68 +26,47 @@ import (
 	"github.com/koderover/zadig/v2/pkg/setting"
 )
 
-func (s *OAuthService) RefreshToken(clientID, refreshToken string) (*OAuthTokenResponse, error) {
-	if clientID != OAuthCLIClientID {
-		return nil, &OAuthError{Code: OAuthErrorInvalidClient, Description: "unsupported client_id"}
-	}
+func (s *OAuthService) RefreshToken(refreshToken string) (*OAuthTokenResponse, error) {
 	if refreshToken == "" {
 		return nil, &OAuthError{Code: OAuthErrorInvalidRequest, Description: "refresh_token is required"}
 	}
-	oldHash := hashOAuthValue(refreshToken)
-	sessionID, err := s.cache.GetString(oauthKey("refresh", oldHash))
+	sessionID, err := s.cache.TakeString(oauthKey("refresh", hashOAuthValue(refreshToken)))
 	if errors.Is(err, redis.Nil) {
-		return nil, &OAuthError{Code: OAuthErrorInvalidGrant, Description: "refresh token is invalid or expired"}
+		return nil, &OAuthError{Code: oauthErrorInvalidGrant, Description: "refresh token is invalid or expired"}
 	}
 	if err != nil {
 		return nil, err
 	}
 	session, err := s.session(sessionID)
 	if err != nil {
-		if errors.Is(err, ErrOAuthInvalidSession) {
-			return nil, &OAuthError{Code: OAuthErrorInvalidGrant, Description: "refresh token is invalid or expired"}
+		if errors.Is(err, errOAuthInvalidSession) {
+			return nil, &OAuthError{Code: oauthErrorInvalidGrant, Description: "refresh token is invalid or expired"}
 		}
 		return nil, err
-	}
-	if session.ClientID != clientID {
-		return nil, &OAuthError{Code: OAuthErrorInvalidGrant, Description: "refresh token is invalid or expired"}
 	}
 	newRefreshToken, err := randomOAuthValue(32)
 	if err != nil {
 		return nil, err
 	}
-	newHash := hashOAuthValue(newRefreshToken)
 	now := time.Now().UTC()
 	accessToken, err := createOAuthAccessToken(session, now)
 	if err != nil {
 		return nil, err
 	}
-	consumedSessionID, err := s.cache.TakeString(oauthKey("refresh", oldHash))
-	if errors.Is(err, redis.Nil) {
-		return nil, &OAuthError{Code: OAuthErrorInvalidGrant, Description: "refresh token is invalid or already used"}
-	}
-	if err != nil {
-		return nil, err
-	}
-	if consumedSessionID != session.ID {
-		return nil, &OAuthError{Code: OAuthErrorInvalidGrant, Description: "refresh token is invalid or already used"}
-	}
-	refreshTTL := OAuthRefreshTokenTTL
+	refreshTTL := oauthRefreshTokenTTL
 	if remaining := session.ExpiresAt.Sub(now); remaining < refreshTTL {
 		refreshTTL = remaining
 	}
-	if err := s.cache.Write(oauthKey("refresh", newHash), session.ID, refreshTTL); err != nil {
+	if err := s.cache.Write(oauthKey("refresh", hashOAuthValue(newRefreshToken)), session.ID, refreshTTL); err != nil {
 		return nil, err
 	}
 	return &OAuthTokenResponse{
-		AccessToken: accessToken, TokenType: "Bearer", ExpiresIn: int64(OAuthAccessTokenTTL / time.Second),
-		RefreshToken: newRefreshToken, Scope: session.Scope,
+		AccessToken: accessToken, TokenType: "Bearer", ExpiresIn: int64(oauthAccessTokenTTL / time.Second),
+		RefreshToken: newRefreshToken, Scope: OAuthCLIScope,
 	}, nil
 }
 
-func (s *OAuthService) RevokeToken(clientID, refreshToken string) error {
-	if clientID != OAuthCLIClientID {
-		return &OAuthError{Code: OAuthErrorInvalidClient, Description: "unsupported client_id"}
-	}
+func (s *OAuthService) RevokeToken(refreshToken string) error {
 	if refreshToken == "" {
 		return &OAuthError{Code: OAuthErrorInvalidRequest, Description: "token is required"}
 	}
@@ -110,16 +89,13 @@ func (s *OAuthService) ValidateSession(sessionID, uid string) error {
 	if err != nil {
 		return err
 	}
-	if session.User.UID != uid || session.ClientID != OAuthCLIClientID {
-		return ErrOAuthInvalidSession
+	if session.User.UID != uid {
+		return errOAuthInvalidSession
 	}
 	return nil
 }
 
 func (s *OAuthService) RevokeUserSessions(uid string) error {
-	if uid == "" {
-		return nil
-	}
 	key := oauthKey("user-sessions", uid)
 	sessionIDs, err := s.cache.ListSetMembers(key)
 	if err != nil {
@@ -135,7 +111,7 @@ func (s *OAuthService) RevokeUserSessions(uid string) error {
 
 func (s *OAuthService) createOAuthSession(device *oauthDevice) (*OAuthTokenResponse, error) {
 	if device.User == nil {
-		return nil, &OAuthError{Code: OAuthErrorInvalidGrant, Description: "authorization has no user"}
+		return nil, &OAuthError{Code: oauthErrorInvalidGrant, Description: "authorization has no user"}
 	}
 	sessionID, err := randomOAuthValue(24)
 	if err != nil {
@@ -148,10 +124,8 @@ func (s *OAuthService) createOAuthSession(device *oauthDevice) (*OAuthTokenRespo
 	now := time.Now().UTC()
 	session := &oauthSession{
 		ID:        sessionID,
-		ClientID:  device.ClientID,
-		Scope:     device.Scope,
 		User:      *device.User,
-		ExpiresAt: now.Add(OAuthSessionTTL),
+		ExpiresAt: now.Add(oauthSessionTTL),
 	}
 	accessToken, err := createOAuthAccessToken(session, now)
 	if err != nil {
@@ -161,18 +135,18 @@ func (s *OAuthService) createOAuthSession(device *oauthDevice) (*OAuthTokenRespo
 		return nil, err
 	}
 	refreshTokenKey := oauthKey("refresh", hashOAuthValue(refreshToken))
-	if err := s.cache.Write(refreshTokenKey, session.ID, OAuthRefreshTokenTTL); err != nil {
+	if err := s.cache.Write(refreshTokenKey, session.ID, oauthRefreshTokenTTL); err != nil {
 		_ = s.cache.Delete(oauthKey("session", session.ID))
 		return nil, err
 	}
-	if err := s.cache.AddElementsToSet(oauthKey("user-sessions", session.User.UID), []string{session.ID}, OAuthSessionTTL); err != nil {
+	if err := s.cache.AddElementsToSet(oauthKey("user-sessions", session.User.UID), []string{session.ID}, oauthSessionTTL); err != nil {
 		_ = s.cache.Delete(refreshTokenKey)
 		_ = s.cache.Delete(oauthKey("session", session.ID))
 		return nil, err
 	}
 	return &OAuthTokenResponse{
-		AccessToken: accessToken, TokenType: "Bearer", ExpiresIn: int64(OAuthAccessTokenTTL / time.Second),
-		RefreshToken: refreshToken, Scope: session.Scope,
+		AccessToken: accessToken, TokenType: "Bearer", ExpiresIn: int64(oauthAccessTokenTTL / time.Second),
+		RefreshToken: refreshToken, Scope: OAuthCLIScope,
 	}, nil
 }
 
@@ -180,20 +154,20 @@ func (s *OAuthService) session(sessionID string) (*oauthSession, error) {
 	session := new(oauthSession)
 	if err := s.readJSON(oauthKey("session", sessionID), session); err != nil {
 		if errors.Is(err, ErrOAuthAuthorizationNotFound) {
-			return nil, ErrOAuthInvalidSession
+			return nil, errOAuthInvalidSession
 		}
 		return nil, err
 	}
 	if !time.Now().Before(session.ExpiresAt) {
-		return nil, ErrOAuthInvalidSession
+		return nil, errOAuthInvalidSession
 	}
 	return session, nil
 }
 
 func (s *OAuthService) deleteSession(sessionID string) error {
 	session, err := s.session(sessionID)
-	if errors.Is(err, ErrOAuthInvalidSession) {
-		return s.cache.Delete(oauthKey("session", sessionID))
+	if errors.Is(err, errOAuthInvalidSession) {
+		return nil
 	}
 	if err != nil {
 		return err
@@ -211,11 +185,11 @@ func createOAuthAccessToken(session *oauthSession, now time.Time) (string, error
 		PreferredUsername: session.User.Account,
 		MFAVerified:       session.User.MFAVerified,
 		TokenUse:          OAuthTokenUseCLIAccess,
-		ClientID:          session.ClientID,
+		ClientID:          OAuthCLIClientID,
 		SessionID:         session.ID,
 		FederatedClaims:   FederatedClaims{ConnectorId: session.User.IdentityType, UserId: session.User.Account},
 		StandardClaims: jwt.StandardClaims{
-			Audience: setting.ProductName, IssuedAt: now.Unix(), ExpiresAt: now.Add(OAuthAccessTokenTTL).Unix(),
+			Audience: setting.ProductName, IssuedAt: now.Unix(), ExpiresAt: now.Add(oauthAccessTokenTTL).Unix(),
 		},
 	})
 }

--- a/pkg/microservice/user/core/service/login/oauth_session.go
+++ b/pkg/microservice/user/core/service/login/oauth_session.go
@@ -30,7 +30,7 @@ func (s *OAuthService) RefreshToken(refreshToken string) (*OAuthTokenResponse, e
 	if refreshToken == "" {
 		return nil, &OAuthError{Code: OAuthErrorInvalidRequest, Description: "refresh_token is required"}
 	}
-	sessionID, err := s.cache.TakeString(oauthKey("refresh", hashOAuthValue(refreshToken)))
+	sessionID, err := s.cache.GetDelString(oauthKey("refresh", hashOAuthValue(refreshToken)))
 	if errors.Is(err, redis.Nil) {
 		return nil, &OAuthError{Code: oauthErrorInvalidGrant, Description: "refresh token is invalid or expired"}
 	}

--- a/pkg/microservice/user/core/service/login/oauth_session.go
+++ b/pkg/microservice/user/core/service/login/oauth_session.go
@@ -30,7 +30,8 @@ func (s *OAuthService) RefreshToken(refreshToken string) (*OAuthTokenResponse, e
 	if refreshToken == "" {
 		return nil, &OAuthError{Code: OAuthErrorInvalidRequest, Description: "refresh_token is required"}
 	}
-	sessionID, err := s.cache.GetDelString(oauthKey("refresh", hashOAuthValue(refreshToken)))
+	refreshTokenKey := oauthKey("refresh", hashOAuthValue(refreshToken))
+	sessionID, err := s.cache.GetString(refreshTokenKey)
 	if errors.Is(err, redis.Nil) {
 		return nil, &OAuthError{Code: oauthErrorInvalidGrant, Description: "refresh token is invalid or expired"}
 	}
@@ -57,8 +58,18 @@ func (s *OAuthService) RefreshToken(refreshToken string) (*OAuthTokenResponse, e
 	if remaining := session.ExpiresAt.Sub(now); remaining < refreshTTL {
 		refreshTTL = remaining
 	}
-	if err := s.cache.Write(oauthKey("refresh", hashOAuthValue(newRefreshToken)), session.ID, refreshTTL); err != nil {
+	rotated, err := s.cache.RotateKeyWithGrace(
+		refreshTokenKey,
+		oauthKey("refresh", hashOAuthValue(newRefreshToken)),
+		session.ID,
+		refreshTTL,
+		oauthRefreshTokenGracePeriod,
+	)
+	if err != nil {
 		return nil, err
+	}
+	if !rotated {
+		return nil, &OAuthError{Code: oauthErrorInvalidGrant, Description: "refresh token is invalid or expired"}
 	}
 	return &OAuthTokenResponse{
 		AccessToken: accessToken, TokenType: "Bearer", ExpiresIn: int64(accessTTL / time.Second),

--- a/pkg/microservice/user/core/service/login/token.go
+++ b/pkg/microservice/user/core/service/login/token.go
@@ -33,6 +33,9 @@ type Claims struct {
 	UID               string          `json:"uid"`
 	PreferredUsername string          `json:"preferred_username"`
 	MFAVerified       bool            `json:"mfa_verified"`
+	TokenUse          string          `json:"token_use,omitempty"`
+	ClientID          string          `json:"client_id,omitempty"`
+	SessionID         string          `json:"session_id,omitempty"`
 	FederatedClaims   FederatedClaims `json:"federated_claims"`
 	jwt.StandardClaims
 }

--- a/pkg/microservice/user/core/service/permission/authn.go
+++ b/pkg/microservice/user/core/service/permission/authn.go
@@ -282,7 +282,7 @@ func ValidateToken(tokenString string) (*login.Claims, bool, error) {
 		if isInternalTokenClaims(claims) {
 			return claims, true, nil
 		}
-		if claims.TokenUse == login.OAuthTokenUseCLIAccess {
+		if claims.TokenUse == login.OAuthLocalTokenUseAccess {
 			if err := login.NewOAuthService().ValidateSession(claims.SessionID, claims.UID); err != nil {
 				log.Errorf("Failed to validate OAuth session, uid: %s, err: %s", claims.UID, err)
 				return nil, false, err

--- a/pkg/microservice/user/core/service/permission/authn.go
+++ b/pkg/microservice/user/core/service/permission/authn.go
@@ -282,6 +282,13 @@ func ValidateToken(tokenString string) (*login.Claims, bool, error) {
 		if isInternalTokenClaims(claims) {
 			return claims, true, nil
 		}
+		if claims.TokenUse == login.OAuthTokenUseCLIAccess {
+			if err := login.NewOAuthService().ValidateSession(claims.SessionID, claims.UID); err != nil {
+				log.Errorf("Failed to validate OAuth session, uid: %s, err: %s", claims.UID, err)
+				return nil, false, err
+			}
+			return claims, true, nil
+		}
 
 		// short-lived login token: validate against redis cache
 		if claims.ExpiresAt-time.Now().Unix() < 8760*60*60 {

--- a/pkg/microservice/user/core/service/permission/user.go
+++ b/pkg/microservice/user/core/service/permission/user.go
@@ -750,6 +750,10 @@ func getLoginId(user *models.User, loginType config.LoginType) string {
 }
 
 func DeleteUserByUID(uid string, logger *zap.SugaredLogger) error {
+	if err := login.NewOAuthService().RevokeUserSessions(uid); err != nil {
+		return fmt.Errorf("failed to revoke OAuth sessions for deleted user %s: %w", uid, err)
+	}
+
 	tx := repository.DB.Begin()
 	defer func() {
 		if r := recover(); r != nil {
@@ -797,7 +801,6 @@ func DeleteUserByUID(uid string, logger *zap.SugaredLogger) error {
 	if err := zadigCache.NewRedisCache(config.RedisUserTokenDB()).Delete(uid); err != nil {
 		logger.Warnf("failed to invalidate token for deleted user %s: %v", uid, err)
 	}
-
 	return nil
 }
 
@@ -1017,6 +1020,9 @@ func UpdatePassword(args *Password, logger *zap.SugaredLogger) error {
 		UID:      user.UID,
 		Password: string(hashedPassword),
 	}
+	if err := login.NewOAuthService().RevokeUserSessions(user.UID); err != nil {
+		return fmt.Errorf("failed to revoke OAuth sessions before password update: %w", err)
+	}
 	err = orm.UpdateUserLogin(user.UID, userLogin, repository.DB)
 	if err != nil {
 		logger.Errorf("UpdatePassword UpdateUserLogin:%v error, error msg:%s", userLogin, err.Error())
@@ -1048,6 +1054,9 @@ func Reset(args *ResetParams, logger *zap.SugaredLogger) error {
 	userLogin := &models.UserLogin{
 		UID:      user.UID,
 		Password: string(hashedPassword),
+	}
+	if err := login.NewOAuthService().RevokeUserSessions(user.UID); err != nil {
+		return fmt.Errorf("failed to revoke OAuth sessions before password reset: %w", err)
 	}
 	err = orm.UpdateUserLogin(user.UID, userLogin, repository.DB)
 	if err != nil {

--- a/pkg/microservice/user/core/service/permission/user.go
+++ b/pkg/microservice/user/core/service/permission/user.go
@@ -801,6 +801,7 @@ func DeleteUserByUID(uid string, logger *zap.SugaredLogger) error {
 	if err := zadigCache.NewRedisCache(config.RedisUserTokenDB()).Delete(uid); err != nil {
 		logger.Warnf("failed to invalidate token for deleted user %s: %v", uid, err)
 	}
+
 	return nil
 }
 

--- a/pkg/microservice/user/core/service/permission/user.go
+++ b/pkg/microservice/user/core/service/permission/user.go
@@ -750,10 +750,6 @@ func getLoginId(user *models.User, loginType config.LoginType) string {
 }
 
 func DeleteUserByUID(uid string, logger *zap.SugaredLogger) error {
-	if err := login.NewOAuthService().RevokeUserSessions(uid); err != nil {
-		return fmt.Errorf("failed to revoke OAuth sessions for deleted user %s: %w", uid, err)
-	}
-
 	tx := repository.DB.Begin()
 	defer func() {
 		if r := recover(); r != nil {
@@ -792,6 +788,10 @@ func DeleteUserByUID(uid string, logger *zap.SugaredLogger) error {
 	}
 	if err := tx.Commit().Error; err != nil {
 		return err
+	}
+
+	if err := login.NewOAuthService().RevokeUserSessions(uid); err != nil {
+		logger.Warnf("failed to revoke OAuth sessions for deleted user %s: %v", uid, err)
 	}
 
 	if err := login.SyncUserMFAEnabledCache(uid, false); err != nil {
@@ -1021,13 +1021,13 @@ func UpdatePassword(args *Password, logger *zap.SugaredLogger) error {
 		UID:      user.UID,
 		Password: string(hashedPassword),
 	}
-	if err := login.NewOAuthService().RevokeUserSessions(user.UID); err != nil {
-		return fmt.Errorf("failed to revoke OAuth sessions before password update: %w", err)
-	}
 	err = orm.UpdateUserLogin(user.UID, userLogin, repository.DB)
 	if err != nil {
 		logger.Errorf("UpdatePassword UpdateUserLogin:%v error, error msg:%s", userLogin, err.Error())
 		return err
+	}
+	if err := login.NewOAuthService().RevokeUserSessions(user.UID); err != nil {
+		logger.Warnf("failed to revoke OAuth sessions after password update, uid: %s, err: %v", user.UID, err)
 	}
 	return nil
 }
@@ -1056,13 +1056,13 @@ func Reset(args *ResetParams, logger *zap.SugaredLogger) error {
 		UID:      user.UID,
 		Password: string(hashedPassword),
 	}
-	if err := login.NewOAuthService().RevokeUserSessions(user.UID); err != nil {
-		return fmt.Errorf("failed to revoke OAuth sessions before password reset: %w", err)
-	}
 	err = orm.UpdateUserLogin(user.UID, userLogin, repository.DB)
 	if err != nil {
 		logger.Errorf("UpdatePassword UpdateUserLogin:%v error, error msg:%s", userLogin, err.Error())
 		return err
+	}
+	if err := login.NewOAuthService().RevokeUserSessions(user.UID); err != nil {
+		logger.Warnf("failed to revoke OAuth sessions after password reset, uid: %s, err: %v", user.UID, err)
 	}
 	return nil
 }

--- a/pkg/microservice/user/server/grpc/server.go
+++ b/pkg/microservice/user/server/grpc/server.go
@@ -57,6 +57,9 @@ func (s *AuthServer) Check(ctx context.Context, request *ext_authz_v3.CheckReque
 	body := request.GetAttributes().GetRequest().GetHttp().GetBody()
 	headers := request.GetAttributes().GetRequest().GetHttp().GetHeaders()
 	method := request.GetAttributes().GetRequest().GetHttp().GetMethod()
+	if strings.HasPrefix(stripQuery(requestPath), "/oauth/") {
+		body = ""
+	}
 
 	isPublicRequest := permission.IsPublicURL(requestPath, method)
 
@@ -130,7 +133,7 @@ func (s *AuthServer) Check(ctx context.Context, request *ext_authz_v3.CheckReque
 			}
 
 			// if the expiration time is so huge that it is not possible, it is a constant api token, we don't check for the redis.
-			if claims.ExpiresAt-time.Now().Unix() < 8760*60*60 {
+			if claims.TokenUse != loginsvc.OAuthTokenUseCLIAccess && claims.ExpiresAt-time.Now().Unix() < 8760*60*60 {
 				// check if the given token is removed from the cache
 				token, err := cache.NewRedisCache(config.RedisUserTokenDB()).GetString(claims.UID)
 				if err != nil {
@@ -185,6 +188,9 @@ func (s *AuthServer) Check(ctx context.Context, request *ext_authz_v3.CheckReque
 	}
 
 allowed:
+	if claims != nil && claims.TokenUse == loginsvc.OAuthTokenUseCLIAccess {
+		userToken = ""
+	}
 	resp := &ext_authz_v3.CheckResponse{}
 	resp.Status = &rpc_status.Status{Code: int32(code.Code_OK)}
 	resp.HttpResponse = &ext_authz_v3.CheckResponse_OkResponse{OkResponse: &ext_authz_v3.OkHttpResponse{}}

--- a/pkg/microservice/user/server/grpc/server.go
+++ b/pkg/microservice/user/server/grpc/server.go
@@ -133,7 +133,7 @@ func (s *AuthServer) Check(ctx context.Context, request *ext_authz_v3.CheckReque
 			}
 
 			// if the expiration time is so huge that it is not possible, it is a constant api token, we don't check for the redis.
-			if claims.TokenUse != loginsvc.OAuthTokenUseCLIAccess && claims.ExpiresAt-time.Now().Unix() < 8760*60*60 {
+			if claims.TokenUse != loginsvc.OAuthLocalTokenUseAccess && claims.ExpiresAt-time.Now().Unix() < 8760*60*60 {
 				// check if the given token is removed from the cache
 				token, err := cache.NewRedisCache(config.RedisUserTokenDB()).GetString(claims.UID)
 				if err != nil {
@@ -188,7 +188,7 @@ func (s *AuthServer) Check(ctx context.Context, request *ext_authz_v3.CheckReque
 	}
 
 allowed:
-	if claims != nil && claims.TokenUse == loginsvc.OAuthTokenUseCLIAccess {
+	if claims != nil && claims.TokenUse == loginsvc.OAuthLocalTokenUseAccess {
 		userToken = ""
 	}
 	resp := &ext_authz_v3.CheckResponse{}

--- a/pkg/microservice/user/server/grpc/server.go
+++ b/pkg/microservice/user/server/grpc/server.go
@@ -188,8 +188,9 @@ func (s *AuthServer) Check(ctx context.Context, request *ext_authz_v3.CheckReque
 	}
 
 allowed:
+	tokenForLog := userToken
 	if claims != nil && claims.TokenUse == loginsvc.OAuthLocalTokenUseAccess {
-		userToken = ""
+		tokenForLog = ""
 	}
 	resp := &ext_authz_v3.CheckResponse{}
 	resp.Status = &rpc_status.Status{Code: int32(code.Code_OK)}
@@ -198,7 +199,7 @@ allowed:
 		zap.String("path", requestPath),
 		zap.String("method", method),
 		zap.String("body", body),
-		zap.String("token", userToken),
+		zap.String("token", tokenForLog),
 	)
 
 	return resp, nil

--- a/pkg/microservice/user/server/rest/router.go
+++ b/pkg/microservice/user/server/rest/router.go
@@ -22,7 +22,7 @@ import (
 )
 
 func (s *engine) injectRouterGroup(router *gin.RouterGroup) {
-	new(handler.OAuthRouter).Inject(router.Group(""))
+	new(handler.OAuthRouter).Inject(router)
 
 	for name, r := range map[string]injector{
 		"/openapi/": new(handler.OpenAPIRouter),

--- a/pkg/microservice/user/server/rest/router.go
+++ b/pkg/microservice/user/server/rest/router.go
@@ -22,6 +22,7 @@ import (
 )
 
 func (s *engine) injectRouterGroup(router *gin.RouterGroup) {
+	new(handler.OAuthRouter).Inject(router.Group(""))
 
 	for name, r := range map[string]injector{
 		"/openapi/": new(handler.OpenAPIRouter),

--- a/pkg/microservice/user/server/rest/router.go
+++ b/pkg/microservice/user/server/rest/router.go
@@ -22,18 +22,12 @@ import (
 )
 
 func (s *engine) injectRouterGroup(router *gin.RouterGroup) {
-	new(handler.OAuthRouter).Inject(router)
-
 	for name, r := range map[string]injector{
+		"/":         new(handler.OAuthRouter),
 		"/openapi/": new(handler.OpenAPIRouter),
+		"/api/v1":   new(handler.Router),
 	} {
 		r.Inject(router.Group(name))
-	}
-
-	for _, r := range []injector{
-		new(handler.Router),
-	} {
-		r.Inject(router.Group("/api/v1"))
 	}
 }
 

--- a/pkg/shared/handler/base.go
+++ b/pkg/shared/handler/base.go
@@ -52,6 +52,7 @@ type Context struct {
 	UserName     string
 	UserID       string
 	IdentityType string
+	MFAVerified  bool
 	RequestID    string
 	Resources    *user.AuthorizedResources
 	LarkPlugin   *LarkPluginContext
@@ -126,6 +127,7 @@ func NewContext(c *gin.Context) *Context {
 		UserID:       claims.UID,
 		Account:      claims.Account,
 		IdentityType: claims.FederatedClaims.ConnectorId,
+		MFAVerified:  claims.MFAVerified,
 		Logger:       ginzap.WithContext(c).Sugar(),
 		RequestID:    c.GetString(setting.RequestID),
 	}

--- a/pkg/tool/cache/redis_cache.go
+++ b/pkg/tool/cache/redis_cache.go
@@ -74,6 +74,10 @@ func (c *RedisCache) SetNX(key, val string, ttl time.Duration) error {
 	return err
 }
 
+func (c *RedisCache) WriteIfNotExists(key, val string, ttl time.Duration) (bool, error) {
+	return c.redisClient.SetNX(context.TODO(), key, val, ttl).Result()
+}
+
 func (c *RedisCache) Exists(key string) (bool, error) {
 	exists, err := c.redisClient.Exists(context.TODO(), key).Result()
 	if err != nil {
@@ -89,6 +93,10 @@ func (c *RedisCache) Exists(key string) (bool, error) {
 
 func (c *RedisCache) GetString(key string) (string, error) {
 	return c.redisClient.Get(context.TODO(), key).Result()
+}
+
+func (c *RedisCache) TakeString(key string) (string, error) {
+	return c.redisClient.GetDel(context.TODO(), key).Result()
 }
 
 func (c *RedisCache) MGet(keys []string) ([]interface{}, error) {

--- a/pkg/tool/cache/redis_cache.go
+++ b/pkg/tool/cache/redis_cache.go
@@ -105,10 +105,6 @@ func (c *RedisCache) GetString(key string) (string, error) {
 	return c.redisClient.Get(context.TODO(), key).Result()
 }
 
-func (c *RedisCache) GetDelString(key string) (string, error) {
-	return c.redisClient.GetDel(context.TODO(), key).Result()
-}
-
 func (c *RedisCache) MGet(keys []string) ([]interface{}, error) {
 	if len(keys) == 0 {
 		return []interface{}{}, nil
@@ -146,6 +142,26 @@ return 0`
 
 	deleted, err := c.redisClient.Eval(context.TODO(), script, []string{key}, expected).Int()
 	return deleted == 1, err
+}
+
+// RotateKeyWithGrace writes the replacement key and limits the old key to a fixed retry window.
+func (c *RedisCache) RotateKeyWithGrace(oldKey, newKey, value string, newTTL, gracePeriod time.Duration) (bool, error) {
+	const script = `
+if redis.call("GET", KEYS[1]) ~= ARGV[1] then
+  return 0
+end
+redis.call("SET", KEYS[2], ARGV[1], "PX", ARGV[2])
+local ttl = redis.call("PTTL", KEYS[1])
+local grace = tonumber(ARGV[3])
+if ttl < 0 or ttl > grace then
+  redis.call("PEXPIRE", KEYS[1], grace)
+end
+return 1`
+
+	rotated, err := c.redisClient.Eval(
+		context.TODO(), script, []string{oldKey, newKey}, value, newTTL.Milliseconds(), gracePeriod.Milliseconds(),
+	).Int()
+	return rotated == 1, err
 }
 
 func (c *RedisCache) HDelete(key, field string) error {

--- a/pkg/tool/cache/redis_cache.go
+++ b/pkg/tool/cache/redis_cache.go
@@ -69,12 +69,7 @@ func (c *RedisCache) HWrite(key, field, val string, ttl time.Duration) error {
 	return err
 }
 
-func (c *RedisCache) SetNX(key, val string, ttl time.Duration) error {
-	_, err := c.redisClient.SetNX(context.TODO(), key, val, ttl).Result()
-	return err
-}
-
-func (c *RedisCache) WriteIfNotExists(key, val string, ttl time.Duration) (bool, error) {
+func (c *RedisCache) SetNX(key, val string, ttl time.Duration) (bool, error) {
 	return c.redisClient.SetNX(context.TODO(), key, val, ttl).Result()
 }
 
@@ -95,7 +90,7 @@ func (c *RedisCache) GetString(key string) (string, error) {
 	return c.redisClient.Get(context.TODO(), key).Result()
 }
 
-func (c *RedisCache) TakeString(key string) (string, error) {
+func (c *RedisCache) GetDelString(key string) (string, error) {
 	return c.redisClient.GetDel(context.TODO(), key).Result()
 }
 

--- a/pkg/tool/workwx/client.go
+++ b/pkg/tool/workwx/client.go
@@ -107,7 +107,7 @@ func (c *Client) getAccessToken(skipCache bool) (string, error) {
 	}
 
 	expirationTime := time.Duration(resp.ExpiresIn - expireThreshold)
-	err = redisCache.SetNX(accessTokenKey, resp.AccessToken, expirationTime*time.Second)
+	_, err = redisCache.SetNX(accessTokenKey, resp.AccessToken, expirationTime*time.Second)
 	if err != nil {
 		log.Warn("failed to save the created workwx access token into redis, err: %s", err)
 	}


### PR DESCRIPTION
### Summary
- Add OAuth Device Authorization for Zadig CLI.

### Main Changes
- Add device authorization, token exchange/refresh, and revocation endpoints.
- Issue short-lived CLI access tokens backed by revocable Redis sessions.
- Revoke sessions on password, MFA, and user deletion security changes.
- Keep OAuth credentials out of ext-authz request logs.

### Compatibility
- Existing Web and API Tokens are unchanged; only `cli_access` tokens use OAuth session validation.

### Test
- `go test ./pkg/microservice/user/... -count=1`; `git diff --check`
Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4962)
<!-- Reviewable:end -->
