### PR TITLE
fix(workflow): remove execute policy restriction for template delta

### DIFF
--- a/pkg/microservice/aslan/core/workflow/service/workflow/workflow_template_binding.go
+++ b/pkg/microservice/aslan/core/workflow/service/workflow/workflow_template_binding.go
@@ -582,43 +582,7 @@ func validateFrontendWorkflowDelta(base *commonmodels.WorkflowV4, patches []*com
 		}
 		rendered = next
 	}
-	if err := validateJobExecutePolicies(base, rendered); err != nil {
-		return nil, nil, err
-	}
 	return patches, rendered, nil
-}
-
-func validateJobExecutePolicies(template, rendered *commonmodels.WorkflowV4) error {
-	renderedJobs := make(map[string]*commonmodels.Job)
-	for _, stage := range rendered.Stages {
-		if stage == nil {
-			continue
-		}
-		for _, job := range stage.Jobs {
-			if job != nil {
-				renderedJobs[job.Name] = job
-			}
-		}
-	}
-
-	for _, stage := range template.Stages {
-		if stage == nil {
-			continue
-		}
-		for _, templateJob := range stage.Jobs {
-			if templateJob == nil {
-				continue
-			}
-			renderedJob, ok := renderedJobs[templateJob.Name]
-			if !ok {
-				continue
-			}
-			if !reflect.DeepEqual(templateJob.ExecutePolicy, renderedJob.ExecutePolicy) {
-				return fmt.Errorf("job %q execute_policy must be consistent with workflow template", templateJob.Name)
-			}
-		}
-	}
-	return nil
 }
 
 func validateTemplateBindingPatch(patch *commonmodels.JSONPatchOperation) error {


### PR DESCRIPTION
### What this PR does / Why we need it:

Allows template-bound workflows to customize each Job’s execution policy through Delta patches.

Previously, the backend enforced the template’s `execute_policy`, preventing workflow instances from changing or removing it.

### What is changed and how it works?

- Removed the backend validation that required Job execution policies to match the workflow template.
- Delta patches can now directly modify `execute_policy` or replace a Job with a different execution policy.
- Other template binding, JSON Patch, and workflow validation logic remains unchanged.


### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4963)
<!-- Reviewable:end -->
