### PR TITLE
fix(user): clear caches when deleting user group

### DIFF
--- a/pkg/microservice/user/core/service/permission/user_group.go
+++ b/pkg/microservice/user/core/service/permission/user_group.go
@@ -255,8 +255,41 @@ func UpdateUserGroupInfo(groupID, name, description string, logger *zap.SugaredL
 }
 
 func DeleteUserGroup(groupID string, logger *zap.SugaredLogger) error {
+	users, err := orm.ListUsersByGroup(groupID, repository.DB)
+	if err != nil {
+		logger.Errorf("failed to list users in user group: %s, error: %s", groupID, err)
+		return err
+	}
+
 	// if no role is assigned to a user group, do a deletion
-	return orm.DeleteUserGroup(groupID, repository.DB)
+	if err := orm.DeleteUserGroup(groupID, repository.DB); err != nil {
+		logger.Errorf("failed to delete user group: %s, error: %s", groupID, err)
+		return err
+	}
+
+	userCache := cache.NewRedisCache(config.RedisCommonCacheTokenDB())
+	gidRoleKey := fmt.Sprintf(GIDRoleKeyFormat, groupID)
+	if err := userCache.Delete(gidRoleKey); err != nil {
+		log.Warnf("failed to flush user-role cache for key: %s, error: %s", gidRoleKey, err)
+	}
+
+	go func(key string, redisCache *cache.RedisCache) {
+		time.Sleep(2 * time.Second)
+		redisCache.Delete(key)
+	}(gidRoleKey, userCache)
+
+	for _, user := range users {
+		userGroupKey := fmt.Sprintf(userconfig.UserGroupCacheKeyFormat, user.UID)
+		if err := userCache.Delete(userGroupKey); err != nil {
+			log.Warnf("failed to flush uid: %s's group id cache, error: %s", user.UID, err)
+		}
+		go func(key string, redisCache *cache.RedisCache) {
+			time.Sleep(2 * time.Second)
+			redisCache.Delete(key)
+		}(userGroupKey, userCache)
+	}
+
+	return nil
 }
 
 func BulkAddUserToUserGroup(groupID string, uids []string, logger *zap.SugaredLogger) error {


### PR DESCRIPTION
### What this PR does / Why we need it:

Clear stale user-group and group-role caches when deleting a user group to prevent users from retaining outdated project permissions.

### What is changed and how it works?

- Query the user group members before deletion.
- Delete the user group from the database.
- Clear the `gid_role_<group_id>` cache.
- Clear each member’s `user_group_<uid>` cache.
- Perform delayed cache deletion after 2 seconds to prevent stale cache recreation.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4966)
<!-- Reviewable:end -->
