### PR TITLE
fix: remove obsolete release plan edit action

### DIFF
--- a/pkg/cli/upgradeassistant/cmd/migrate/500.go
+++ b/pkg/cli/upgradeassistant/cmd/migrate/500.go
@@ -119,6 +119,11 @@ func migrateLogOperationPermission500(migrationInfo *internalmodels.Migration) e
 		}
 	}
 
+	if err := tx.Where("action = ? AND resource = ?", "edit_release_plan", "ReleasePlan").Delete(&usermodels.Action{}).Error; err != nil {
+		tx.Rollback()
+		return fmt.Errorf("failed to remove obsolete release plan edit action, err: %s", err)
+	}
+
 	if err := tx.Commit().Error; err != nil {
 		return fmt.Errorf("failed to commit migration 5.0.0 permissions, err: %s", err)
 	}

--- a/pkg/microservice/user/core/init/dm_action_initialization.sql
+++ b/pkg/microservice/user/core/init/dm_action_initialization.sql
@@ -67,7 +67,6 @@ VALUES
     ('删除', 'delete_template', 'Template', 2),
     ('查看', 'get_release_plan', 'ReleasePlan', 2),
     ('新建', 'create_release_plan', 'ReleasePlan', 2),
-    ('编辑', 'edit_release_plan', 'ReleasePlan', 2),
     ('删除', 'delete_release_plan', 'ReleasePlan', 2),
     ('查看', 'get_business_directory', 'BusinessDirectory', 2),
     ('新建', 'create_business_directory', 'BusinessDirectory', 2),


### PR DESCRIPTION
### Summary
- Remove the obsolete `edit_release_plan` permission from fresh Dameng databases and 4.3.0 -> 5.0.0 upgrades.

### Changes
- Remove the legacy action from DM initialization.
- Delete the legacy action in the existing 5.0.0 permission migration transaction.

### Risk
- Idempotent deletion; obsolete role bindings are removed by the existing foreign-key cascade.
### Test
- `go test ./pkg/cli/upgradeassistant/cmd/migrate ./pkg/cli/upgradeassistant/internal/repository/orm ./pkg/microservice/user/core`
### Contact
- Contact: huanghongbo@koderover.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4968)
<!-- Reviewable:end -->
