### PR TITLE
fix(security): secure cluster agent access and internal service auth

### DIFF
--- a/pkg/microservice/aslan/core/common/repository/models/k8s_cluster.go
+++ b/pkg/microservice/aslan/core/common/repository/models/k8s_cluster.go
@@ -38,6 +38,9 @@ type K8SCluster struct {
 	CreatedAt              int64                    `json:"createdAt"                 bson:"createdAt"`
 	CreatedBy              string                   `json:"createdBy"                 bson:"createdBy"`
 	Disconnected           bool                     `json:"-"                         bson:"disconnected"`
+	AgentToken             string                   `json:"-"                         bson:"-"`
+	AgentTokenEnc          string                   `json:"-"                         bson:"agent_token_enc,omitempty"`
+	AgentTokenHash         string                   `json:"-"                         bson:"agent_token_hash,omitempty"`
 	Token                  string                   `json:"token"                     bson:"-"`
 	Provider               int8                     `json:"provider"                  bson:"provider"`
 	Local                  bool                     `json:"local"                     bson:"local"`

--- a/pkg/microservice/aslan/core/common/repository/mongodb/k8s_cluster.go
+++ b/pkg/microservice/aslan/core/common/repository/mongodb/k8s_cluster.go
@@ -19,14 +19,15 @@ package mongodb
 import (
 	"context"
 
+	"github.com/koderover/zadig/v2/pkg/tool/crypto"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/v2/pkg/setting"
-	"github.com/koderover/zadig/v2/pkg/tool/crypto"
 	mongotool "github.com/koderover/zadig/v2/pkg/tool/mongo"
 )
 
@@ -108,6 +109,42 @@ func (c *K8SClusterColl) Get(id string) (*models.K8SCluster, error) {
 	err = c.FindOne(context.TODO(), query).Decode(res)
 
 	return res, err
+}
+
+func (c *K8SClusterColl) EnsureAgentToken(id, encToken, hash string) (string, error) {
+	oid, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return "", err
+	}
+
+	res := &models.K8SCluster{}
+	err = c.FindOneAndUpdate(
+		context.TODO(),
+		bson.M{
+			"_id": oid,
+			"$or": []bson.M{
+				{"agent_token_hash": bson.M{"$exists": false}},
+				{"agent_token_hash": ""},
+			},
+		},
+		bson.M{"$set": bson.M{
+			"agent_token_enc":  encToken,
+			"agent_token_hash": hash,
+		}},
+		options.FindOneAndUpdate().SetReturnDocument(options.After),
+	).Decode(res)
+	if err == nil {
+		return res.AgentTokenEnc, nil
+	}
+	if err != mongo.ErrNoDocuments {
+		return "", err
+	}
+
+	res, err = c.Get(id)
+	if err != nil {
+		return "", err
+	}
+	return res.AgentTokenEnc, nil
 }
 
 func (c *K8SClusterColl) HasDuplicateName(id, name string) (bool, error) {
@@ -299,6 +336,16 @@ func (c *K8SClusterColl) GetByToken(token string) (*models.K8SCluster, error) {
 	}
 
 	return c.Get(id)
+}
+
+func (c *K8SClusterColl) GetByAgentToken(token string) (*models.K8SCluster, error) {
+	if token == "" {
+		return nil, mongo.ErrNoDocuments
+	}
+
+	res := &models.K8SCluster{}
+	err := c.FindOne(context.TODO(), bson.M{"agent_token_hash": crypto.Sha256([]byte(token))}).Decode(res)
+	return res, err
 }
 
 func (c *K8SClusterColl) FindActiveClusters() ([]*models.K8SCluster, error) {

--- a/pkg/microservice/aslan/core/common/service/jira/jira.go
+++ b/pkg/microservice/aslan/core/common/service/jira/jira.go
@@ -26,6 +26,7 @@ import (
 	aslanconfig "github.com/koderover/zadig/v2/pkg/microservice/aslan/config"
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
 	"github.com/koderover/zadig/v2/pkg/setting"
+	"github.com/koderover/zadig/v2/pkg/shared/servicetoken"
 	"github.com/koderover/zadig/v2/pkg/tool/jira"
 	"github.com/koderover/zadig/v2/pkg/tool/log"
 )
@@ -44,7 +45,11 @@ type JiraInfo struct {
 }
 
 func GetJiraInfo() (*JiraInfo, error) {
-	resp, err := req.C().R().Get(config.AslanServiceAddress() + "/api/system/project_management")
+	token, err := servicetoken.CurrentInternalToken()
+	if err != nil {
+		return nil, errors.Wrap(err, "get internal service token")
+	}
+	resp, err := req.C().R().SetHeader(setting.InternalServiceTokenHeader, token).Get(config.AslanServiceAddress() + "/api/system/project_management")
 	if err != nil {
 		log.Errorf("GetJiraInfo: send request error %v", err)
 		return nil, errors.Wrap(err, "send request")

--- a/pkg/microservice/aslan/core/common/service/kube/service.go
+++ b/pkg/microservice/aslan/core/common/service/kube/service.go
@@ -514,8 +514,13 @@ func getDindCfg(cluster *models.K8SCluster) (replicas int, limitsCPU, limitsMemo
 }
 
 func ResolveDindNamespace(cluster *models.K8SCluster) string {
-	if cluster != nil && cluster.Local {
-		return config.Namespace()
+	if cluster != nil {
+		if cluster.Local {
+			return config.Namespace()
+		}
+		if cluster.Namespace != "" {
+			return cluster.Namespace
+		}
 	}
 	return setting.AttachedClusterNamespace
 }

--- a/pkg/microservice/aslan/core/common/service/kube/service.go
+++ b/pkg/microservice/aslan/core/common/service/kube/service.go
@@ -19,6 +19,7 @@ package kube
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"net/url"
@@ -62,6 +63,45 @@ type Service struct {
 	*multicluster.Agent
 
 	coll *mongodb.K8SClusterColl
+}
+
+func newAgentToken() (string, error) {
+	random := make([]byte, 32)
+	if _, err := rand.Read(random); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(random), nil
+}
+
+func (s *Service) ensureAgentToken(id string, cluster *models.K8SCluster) error {
+	if cluster.AgentToken != "" {
+		return nil
+	}
+
+	// recover the plaintext token from its encrypted form persisted in mongodb
+	if cluster.AgentTokenEnc != "" {
+		token, err := crypto.AesDecrypt(cluster.AgentTokenEnc)
+		if err != nil {
+			return err
+		}
+		cluster.AgentToken = token
+		return nil
+	}
+
+	token, err := newAgentToken()
+	if err != nil {
+		return err
+	}
+	encToken, err := crypto.AesEncrypt(token)
+	if err != nil {
+		return err
+	}
+	stored, err := s.coll.EnsureAgentToken(id, encToken, crypto.Sha256([]byte(token)))
+	if err != nil {
+		return err
+	}
+	cluster.AgentToken, err = crypto.AesDecrypt(stored)
+	return err
 }
 
 func NewService(hubServerAddr string) (*Service, error) {
@@ -121,6 +161,9 @@ func (s *Service) CreateCluster(cluster *models.K8SCluster, id string, logger *z
 	err = s.coll.Create(cluster, id)
 	if err != nil {
 		return nil, e.ErrCreateCluster.AddErr(err)
+	}
+	if err := s.ensureAgentToken(cluster.ID.Hex(), cluster); err != nil {
+		return nil, err
 	}
 
 	if cluster.Type == setting.KubeConfigClusterType {
@@ -218,7 +261,6 @@ func (s *Service) GetCluster(id string, logger *zap.SugaredLogger) (*models.K8SC
 		logger.Errorf("failed to get cluster by id %s %v", id, err)
 		return nil, e.ErrClusterNotFound.AddErr(err)
 	}
-
 	token, err := crypto.AesEncrypt(cluster.ID.Hex())
 	if err != nil {
 		return nil, err
@@ -257,6 +299,15 @@ func (s *Service) GetClusterByToken(token string, logger *zap.SugaredLogger) (*m
 	return s.GetCluster(id, logger)
 }
 
+func (s *Service) GetClusterByAgentToken(token string, logger *zap.SugaredLogger) (*models.K8SCluster, error) {
+	cluster, err := s.coll.GetByAgentToken(token)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.GetCluster(cluster.ID.Hex(), logger)
+}
+
 func (s *Service) ListConnectedClusters(logger *zap.SugaredLogger) ([]*models.K8SCluster, error) {
 	clusters, err := s.coll.FindConnectedClusters()
 	if err != nil {
@@ -284,6 +335,9 @@ func (s *Service) GetYaml(id, agentImage, aslanURL, hubURI string, useDeployment
 		err     error
 	)
 	if cluster, err = s.GetCluster(id, logger); err != nil {
+		return nil, err
+	}
+	if err = s.ensureAgentToken(id, cluster); err != nil {
 		return nil, err
 	}
 
@@ -356,6 +410,7 @@ func (s *Service) GetYaml(id, agentImage, aslanURL, hubURI string, useDeployment
 		err = YamlTemplate.Execute(buffer, TemplateSchema{
 			HubAgentImage:        agentImage,
 			ClientToken:          token,
+			AslanAgentToken:      cluster.AgentToken,
 			HubServerBaseAddr:    hubBase.String(),
 			AslanBaseAddr:        serverURL,
 			UseDeployment:        useDeployment,
@@ -376,12 +431,12 @@ func (s *Service) GetYaml(id, agentImage, aslanURL, hubURI string, useDeployment
 			Affinity:             cluster.AdvancedConfig.AgentAffinity,
 			DisableHostNetwork:   cluster.AdvancedConfig.AgentDisableHostNetwork,
 			ImagePullPolicy:      configbase.ImagePullPolicy(),
-			SecretKey:            base64.StdEncoding.EncodeToString([]byte(configbase.SecretKey())),
 		})
 	} else {
 		err = YamlTemplateForNamespace.Execute(buffer, TemplateSchema{
 			HubAgentImage:        agentImage,
 			ClientToken:          token,
+			AslanAgentToken:      cluster.AgentToken,
 			HubServerBaseAddr:    hubBase.String(),
 			AslanBaseAddr:        serverURL,
 			UseDeployment:        useDeployment,
@@ -402,7 +457,6 @@ func (s *Service) GetYaml(id, agentImage, aslanURL, hubURI string, useDeployment
 			DisableHostNetwork:   cluster.AdvancedConfig.AgentDisableHostNetwork,
 			IRSARoleARN:          cluster.AdvancedConfig.IRSARoleARM,
 			ImagePullPolicy:      configbase.ImagePullPolicy(),
-			SecretKey:            base64.StdEncoding.EncodeToString([]byte(configbase.SecretKey())),
 		})
 	}
 
@@ -707,6 +761,7 @@ func ValidateClusterRoleYAML(k8sYaml string, logger *zap.SugaredLogger) error {
 type TemplateSchema struct {
 	HubAgentImage        string
 	ClientToken          string
+	AslanAgentToken      string
 	HubServerBaseAddr    string
 	Namespace            string
 	UseDeployment        bool
@@ -724,7 +779,6 @@ type TemplateSchema struct {
 	EnableIRSA           bool
 	IRSARoleARN          string
 	ImagePullPolicy      string
-	SecretKey            string
 	NodeSelector         string
 	Toleration           string
 	Affinity             string
@@ -748,17 +802,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: koderover-agent
-
----
-
-apiVersion: v1
-data:
-  aesKey: {{.SecretKey}}
-kind: Secret
-metadata:
-  name: zadig-aes-key
-  namespace: koderover-agent
-type: Opaque
 
 ---
 
@@ -847,17 +890,14 @@ spec:
         image: {{.HubAgentImage}}
         imagePullPolicy: {{.ImagePullPolicy}}
         env:
-        - name: SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: aesKey
-              name: zadig-aes-key
         - name: AGENT_NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
         - name: HUB_AGENT_TOKEN
           value: "{{.ClientToken}}"
+        - name: ASLAN_AGENT_TOKEN
+          value: "{{.AslanAgentToken}}"
         - name: HUB_SERVER_BASE_ADDR
           value: "{{.HubServerBaseAddr}}"
         - name: ASLAN_BASE_ADDR
@@ -902,16 +942,6 @@ metadata:
 
 ---
 
-apiVersion: v1
-data:
-  aesKey: {{.SecretKey}}
-kind: Secret
-metadata:
-  name: zadig-aes-key
-  namespace: {{.Namespace}}
-type: Opaque
-
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -1043,17 +1073,14 @@ spec:
         image: {{.HubAgentImage}}
         imagePullPolicy: {{.ImagePullPolicy}}
         env:
-        - name: SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: aesKey
-              name: zadig-aes-key
         - name: AGENT_NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
         - name: HUB_AGENT_TOKEN
           value: "{{.ClientToken}}"
+        - name: ASLAN_AGENT_TOKEN
+          value: "{{.AslanAgentToken}}"
         - name: HUB_SERVER_BASE_ADDR
           value: "{{.HubServerBaseAddr}}"
         - name: ASLAN_BASE_ADDR

--- a/pkg/microservice/aslan/core/multicluster/handler/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/handler/clusters.go
@@ -18,13 +18,19 @@ package handler
 
 import (
 	"fmt"
+	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 
 	commonmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/repository/models"
+	commonservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/common/service"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/multicluster/service"
+	systemservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/system/service"
+	userpermission "github.com/koderover/zadig/v2/pkg/microservice/user/core/service/permission"
+	"github.com/koderover/zadig/v2/pkg/setting"
 	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
 	"github.com/koderover/zadig/v2/pkg/tool/log"
@@ -497,9 +503,28 @@ func GetClusterYaml(hubURI string) func(*gin.Context) {
 			if ctx.RespErr != nil {
 				c.JSON(e.ErrorMessage(ctx.RespErr))
 				c.Abort()
-				return
 			}
 		}()
+
+		downloadToken := c.Query(userpermission.ClusterAgentDownloadTokenQuery)
+		if downloadToken == "" {
+			var err error
+			ctx, err = internalhandler.NewContextWithAuthorization(c)
+			if err != nil {
+				c.AbortWithStatus(http.StatusForbidden)
+				return
+			}
+			if !ctx.Resources.IsSystemAdmin {
+				c.AbortWithStatus(http.StatusForbidden)
+				return
+			}
+		} else {
+			valid, err := userpermission.ValidateClusterAgentDownloadToken(c.Param("id"), downloadToken)
+			if err != nil || !valid {
+				c.AbortWithStatus(http.StatusUnauthorized)
+				return
+			}
+		}
 
 		yaml, err := service.GetYaml(
 			c.Param("id"),
@@ -513,9 +538,73 @@ func GetClusterYaml(hubURI string) func(*gin.Context) {
 			return
 		}
 
+		if downloadToken != "" {
+			valid, err := userpermission.ConsumeClusterAgentDownloadToken(c.Param("id"), downloadToken)
+			if err != nil || !valid {
+				c.AbortWithStatus(http.StatusUnauthorized)
+				return
+			}
+		}
+
+		c.Header("Cache-Control", "no-store")
 		c.Data(200, "text/plain", yaml)
 		c.Abort()
 	}
+}
+
+type clusterYamlDownloadTokenResponse struct {
+	Token     string `json:"token"`
+	ExpiresAt int64  `json:"expires_at"`
+	Command   string `json:"command"`
+}
+
+func CreateClusterYamlDownloadToken(c *gin.Context) {
+	ctx, err := internalhandler.NewContextWithAuthorization(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("authorization Info Generation failed: err %s", err)
+		ctx.UnAuthorized = true
+		return
+	}
+	if !ctx.Resources.IsSystemAdmin &&
+		!ctx.Resources.SystemActions.ClusterManagement.Create &&
+		!ctx.Resources.SystemActions.ClusterManagement.Edit {
+		ctx.UnAuthorized = true
+		return
+	}
+
+	if _, err := service.GetCluster(c.Param("id"), ctx.Logger); err != nil {
+		ctx.RespErr = err
+		return
+	}
+
+	serverURL, err := commonservice.GetSystemServerURL()
+	if err != nil {
+		ctx.RespErr = err
+		return
+	}
+	token, expiresAt, err := userpermission.NewClusterAgentDownloadToken(c.Param("id"))
+	if err != nil {
+		ctx.RespErr = err
+		return
+	}
+	command := fmt.Sprintf(`kubectl apply -f "%s/api/aslan/cluster/agent/%s/agent.yaml?type=deploy&%s=%s"`,
+		serverURL, c.Param("id"), userpermission.ClusterAgentDownloadTokenQuery, url.QueryEscape(token))
+	ctx.Resp = &clusterYamlDownloadTokenResponse{Token: token, ExpiresAt: expiresAt, Command: command}
+}
+
+func ListRegistriesForAgent(c *gin.Context) {
+	ctx := internalhandler.NewContext(c)
+	defer func() { internalhandler.JSONResponse(c, ctx) }()
+
+	cluster, err := service.GetClusterByAgentToken(c.GetHeader(setting.Token), ctx.Logger)
+	if err != nil || cluster.Disconnected || cluster.Status == setting.Disconnected {
+		ctx.UnAuthorized = true
+		return
+	}
+
+	ctx.Resp, ctx.RespErr = systemservice.ListRegistriesByProject("", ctx.Logger)
 }
 
 func UpgradeAgent(c *gin.Context) {

--- a/pkg/microservice/aslan/core/multicluster/handler/router.go
+++ b/pkg/microservice/aslan/core/multicluster/handler/router.go
@@ -26,7 +26,9 @@ func (*Router) Inject(router *gin.RouterGroup) {
 
 	Agent := router.Group("agent")
 	{
+		Agent.GET("/registries", ListRegistriesForAgent)
 		Agent.GET("/:id/agent.yaml", GetClusterYaml("/api/hub"))
+		Agent.POST("/:id/agent.yaml/token", CreateClusterYamlDownloadToken)
 		Agent.GET("/:id/upgrade", UpgradeAgent)
 	}
 

--- a/pkg/microservice/aslan/core/multicluster/service/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/service/clusters.go
@@ -911,6 +911,11 @@ func GetYaml(id, hubURI string, useDeployment bool, logger *zap.SugaredLogger) (
 	return s.GetYaml(id, config.HubAgentImage(), serverURL, hubURI, useDeployment, logger)
 }
 
+func GetClusterByAgentToken(token string, logger *zap.SugaredLogger) (*commonmodels.K8SCluster, error) {
+	s, _ := kube.NewService("")
+	return s.GetClusterByAgentToken(token, logger)
+}
+
 func UpgradeAgent(id string, logger *zap.SugaredLogger) error {
 	s, err := kube.NewService("")
 	if err != nil {
@@ -1024,6 +1029,12 @@ func UpgradeAgent(id string, logger *zap.SugaredLogger) error {
 				continue
 			}
 		}
+		if len(errList.Errors) == 0 {
+			if err = removeLegacyAgentJWTSecret(clientset, dindNamespace); err != nil {
+				logger.Errorf("failed to remove legacy JWT signing key from cluster %s: %s", clusterInfo.Name, err)
+				errList = multierror.Append(errList, err)
+			}
+		}
 		updateHubagentErrorMsg := ""
 		if len(errList.Errors) > 0 {
 			updateHubagentErrorMsg = errList.Error()
@@ -1031,6 +1042,53 @@ func UpgradeAgent(id string, logger *zap.SugaredLogger) error {
 
 		return s.UpdateUpgradeAgentInfo(id, updateHubagentErrorMsg)
 	}
+}
+
+func removeLegacyAgentJWTSecret(clientset kubernetes.Interface, namespace string) error {
+	ctx := context.Background()
+	deployment, err := clientset.AppsV1().Deployments(namespace).Get(ctx, "koderover-agent-node-agent", metav1.GetOptions{})
+	if err == nil {
+		if removeSecretKeyEnv(deployment.Spec.Template.Spec.Containers) {
+			if _, err = clientset.AppsV1().Deployments(namespace).Update(ctx, deployment, metav1.UpdateOptions{}); err != nil {
+				return err
+			}
+		}
+	} else if !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	daemonSet, err := clientset.AppsV1().DaemonSets(namespace).Get(ctx, "koderover-agent-node-agent", metav1.GetOptions{})
+	if err == nil {
+		if removeSecretKeyEnv(daemonSet.Spec.Template.Spec.Containers) {
+			if _, err = clientset.AppsV1().DaemonSets(namespace).Update(ctx, daemonSet, metav1.UpdateOptions{}); err != nil {
+				return err
+			}
+		}
+	} else if !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	err = clientset.CoreV1().Secrets(namespace).Delete(ctx, "zadig-aes-key", metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+func removeSecretKeyEnv(containers []corev1.Container) bool {
+	modified := false
+	for i := range containers {
+		env := containers[i].Env[:0]
+		for _, item := range containers[i].Env {
+			if item.Name == setting.ENVSecretKey {
+				modified = true
+				continue
+			}
+			env = append(env, item)
+		}
+		containers[i].Env = env
+	}
+	return modified
 }
 
 func buildConfigs(args *commonmodels.K8SCluster) error {

--- a/pkg/microservice/aslan/core/multicluster/service/clusters.go
+++ b/pkg/microservice/aslan/core/multicluster/service/clusters.go
@@ -1010,12 +1010,12 @@ func UpgradeAgent(id string, logger *zap.SugaredLogger) error {
 			if u.GetKind() == "StatefulSet" && u.GetName() == types.DindStatefulSetName {
 				if err = kubeClient.Get(context.TODO(), client.ObjectKey{
 					Name:      types.DindStatefulSetName,
-					Namespace: setting.AttachedClusterNamespace,
+					Namespace: dindNamespace,
 				}, &appsv1.StatefulSet{}); err != nil {
-					logger.Infof("failed to get dind from %s, start to create dind", setting.AttachedClusterNamespace)
+					logger.Infof("failed to get dind from %s, start to create dind", dindNamespace)
 					err = updater.CreateOrPatchUnstructured(u, kubeClient)
 				} else {
-					err = UpgradeDind(kubeClient, clusterInfo, setting.AttachedClusterNamespace)
+					err = UpgradeDind(kubeClient, clusterInfo, dindNamespace)
 				}
 			} else if u.GetKind() == "Service" && u.GetName() == types.DindStatefulSetName {
 				err = kube.EnsureDindServiceTLS(kubeClient, dindNamespace)

--- a/pkg/microservice/aslan/core/system/handler/openapi.go
+++ b/pkg/microservice/aslan/core/system/handler/openapi.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -33,6 +34,7 @@ import (
 	clusterservice "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/multicluster/service"
 	systemmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/system/repository/models"
 	"github.com/koderover/zadig/v2/pkg/microservice/aslan/core/system/service"
+	userpermission "github.com/koderover/zadig/v2/pkg/microservice/user/core/service/permission"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
 	e "github.com/koderover/zadig/v2/pkg/tool/errors"
@@ -328,7 +330,13 @@ rules:
 		return
 	}
 
-	agentCmd := fmt.Sprintf(`kubectl apply -f "%s/api/aslan/cluster/agent/%s/agent.yaml?type=deploy"`, serverURL, clusterResp.ID.Hex())
+	downloadToken, _, err := userpermission.NewClusterAgentDownloadToken(clusterResp.ID.Hex())
+	if err != nil {
+		ctx.RespErr = fmt.Errorf("failed to create cluster agent download token: %w", err)
+		return
+	}
+	agentCmd := fmt.Sprintf(`kubectl apply -f "%s/api/aslan/cluster/agent/%s/agent.yaml?type=deploy&%s=%s"`,
+		serverURL, clusterResp.ID.Hex(), userpermission.ClusterAgentDownloadTokenQuery, url.QueryEscape(downloadToken))
 
 	resp := service.OpenAPICreateClusterResponse{
 		Cluster: &service.OpenAPICluster{

--- a/pkg/microservice/cron/core/service/client/client.go
+++ b/pkg/microservice/cron/core/service/client/client.go
@@ -19,6 +19,10 @@ package client
 import (
 	"net/http"
 	"net/http/cookiejar"
+	"net/url"
+
+	"github.com/koderover/zadig/v2/pkg/setting"
+	"github.com/koderover/zadig/v2/pkg/shared/servicetoken"
 )
 
 type Client struct {
@@ -30,10 +34,36 @@ type Client struct {
 func NewAslanClient(host string) *Client {
 	jar, _ := cookiejar.New(nil)
 
+	aslanURL, _ := url.Parse(host)
+
 	c := &Client{
 		APIBase: host,
-		Conn:    &http.Client{Transport: http.DefaultTransport, Jar: jar},
+		Conn: &http.Client{
+			Transport: &internalServiceTokenTransport{base: http.DefaultTransport, host: aslanURL.Host},
+			Jar:       jar,
+		},
 	}
 
 	return c
+}
+
+// internalServiceTokenTransport injects the internal service token into every request so the
+// receiving service can validate it instead of granting admin on an empty user id.
+type internalServiceTokenTransport struct {
+	base http.RoundTripper
+	host string
+}
+
+func (t *internalServiceTokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Host != t.host {
+		return t.base.RoundTrip(req)
+	}
+	token, err := servicetoken.CurrentInternalToken()
+	if err != nil {
+		return nil, err
+	}
+	clone := req.Clone(req.Context())
+	clone.Header = req.Header.Clone()
+	clone.Header.Set(setting.InternalServiceTokenHeader, token)
+	return t.base.RoundTrip(clone)
 }

--- a/pkg/microservice/cron/core/service/scheduler/cronjob_handler.go
+++ b/pkg/microservice/cron/core/service/scheduler/cronjob_handler.go
@@ -32,6 +32,7 @@ import (
 	"github.com/koderover/zadig/v2/pkg/microservice/cron/core/service"
 	"github.com/koderover/zadig/v2/pkg/microservice/cron/core/service/client"
 	"github.com/koderover/zadig/v2/pkg/setting"
+	"github.com/koderover/zadig/v2/pkg/shared/servicetoken"
 	"github.com/koderover/zadig/v2/pkg/tool/httpclient"
 	"github.com/koderover/zadig/v2/pkg/tool/log"
 	"github.com/koderover/zadig/v2/pkg/util"
@@ -78,6 +79,7 @@ func InitExistedCronjob(client *client.Client, scheduler *cronlib.CronSchduler, 
 	cl := httpclient.New(
 		httpclient.SetRetryCount(100),
 		httpclient.SetRetryWaitTime(PullInterval),
+		servicetoken.HeaderOption(),
 	)
 	go func() {
 		_, err := cl.Get(listAPI, httpclient.SetResult(&jobList))

--- a/pkg/microservice/hubagent/config/config.go
+++ b/pkg/microservice/hubagent/config/config.go
@@ -28,6 +28,10 @@ func HubAgentToken() string {
 	return viper.GetString(setting.HubAgentToken)
 }
 
+func AslanAgentToken() string {
+	return viper.GetString(setting.AslanAgentToken)
+}
+
 func HubServerBaseAddr() string {
 	return viper.GetString(setting.HubServerBaseAddr)
 }

--- a/pkg/microservice/hubagent/server/server.go
+++ b/pkg/microservice/hubagent/server/server.go
@@ -27,7 +27,6 @@ import (
 	config2 "github.com/koderover/zadig/v2/pkg/microservice/hubagent/config"
 	"github.com/koderover/zadig/v2/pkg/microservice/hubagent/core/service"
 	"github.com/koderover/zadig/v2/pkg/microservice/hubagent/server/rest"
-	"github.com/koderover/zadig/v2/pkg/microservice/user/core/service/login"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/shared/client/aslan"
 	"github.com/koderover/zadig/v2/pkg/tool/clientmanager"
@@ -96,11 +95,7 @@ func Serve(ctx context.Context) error {
 }
 
 func initResource() {
-	token, err := login.GetInternalToken("hub-agent")
-	if err != nil {
-		log.Fatalf("failed to get internal token, err: %s", err)
-	}
-	client := aslan.NewExternal(config2.AslanBaseAddr(), token)
+	client := aslan.NewExternal(config2.AslanBaseAddr(), "")
 
 	scheduleWorkflow := config2.ScheduleWorkflow()
 	if scheduleWorkflow == "" {
@@ -114,7 +109,7 @@ func initResource() {
 	}
 
 	if schedule {
-		ls, err := client.ListRegistries()
+		ls, err := client.ListRegistries(config2.AslanAgentToken())
 		if err != nil {
 			log.Fatalf("failed to list registries from zadig server, error: %s", err)
 		}

--- a/pkg/microservice/picket/client/aslan/client.go
+++ b/pkg/microservice/picket/client/aslan/client.go
@@ -18,6 +18,7 @@ package aslan
 
 import (
 	"github.com/koderover/zadig/v2/pkg/config"
+	"github.com/koderover/zadig/v2/pkg/shared/servicetoken"
 	"github.com/koderover/zadig/v2/pkg/tool/httpclient"
 )
 
@@ -31,7 +32,8 @@ func New() *Client {
 	host := config.AslanServiceAddress()
 
 	c := httpclient.New(
-		httpclient.SetHostURL(host + "/api"),
+		httpclient.SetHostURL(host+"/api"),
+		servicetoken.HeaderOption(),
 	)
 
 	return &Client{

--- a/pkg/microservice/user/core/handler/permission/internal.go
+++ b/pkg/microservice/user/core/handler/permission/internal.go
@@ -50,7 +50,7 @@ func InitializeProject(c *gin.Context) {
 		return
 	}
 
-	err = userhandler.GenerateUserAuthInfo(ctx)
+	err = userhandler.GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -81,7 +81,7 @@ func DeleteProjectRoles(c *gin.Context) {
 		return
 	}
 
-	err := userhandler.GenerateUserAuthInfo(ctx)
+	err := userhandler.GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -112,7 +112,7 @@ func SetProjectVisibility(c *gin.Context) {
 		return
 	}
 
-	err := userhandler.GenerateUserAuthInfo(ctx)
+	err := userhandler.GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)

--- a/pkg/microservice/user/core/handler/permission/role.go
+++ b/pkg/microservice/user/core/handler/permission/role.go
@@ -134,7 +134,7 @@ func CreateRoleImpl(c *gin.Context, ctx *internalhandler.Context) {
 		return
 	}
 
-	err = userhandler.GenerateUserAuthInfo(ctx)
+	err = userhandler.GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -206,7 +206,7 @@ func UpdateRoleImpl(c *gin.Context, ctx *internalhandler.Context) {
 		return
 	}
 
-	err = userhandler.GenerateUserAuthInfo(ctx)
+	err = userhandler.GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -316,7 +316,7 @@ func OpenAPIListRoles(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
-	err := userhandler.GenerateUserAuthInfo(ctx)
+	err := userhandler.GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -382,7 +382,7 @@ func OpenAPIGetRole(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
-	err := userhandler.GenerateUserAuthInfo(ctx)
+	err := userhandler.GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -483,7 +483,7 @@ func DeleteRoleImpl(c *gin.Context, ctx *internalhandler.Context) {
 		return
 	}
 
-	err := userhandler.GenerateUserAuthInfo(ctx)
+	err := userhandler.GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)

--- a/pkg/microservice/user/core/handler/permission/role_binding.go
+++ b/pkg/microservice/user/core/handler/permission/role_binding.go
@@ -37,7 +37,7 @@ func OpenAPIListRoleBindings(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
-	err := userhandler.GenerateUserAuthInfo(ctx)
+	err := userhandler.GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)

--- a/pkg/microservice/user/core/handler/user/authz.go
+++ b/pkg/microservice/user/core/handler/user/authz.go
@@ -22,10 +22,14 @@ import (
 
 	"github.com/gin-gonic/gin"
 	userservice "github.com/koderover/zadig/v2/pkg/microservice/user/core/service/permission"
+	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/shared/client/user"
 	internalhandler "github.com/koderover/zadig/v2/pkg/shared/handler"
+	"github.com/koderover/zadig/v2/pkg/shared/servicetoken"
 	"github.com/koderover/zadig/v2/pkg/types"
 )
+
+var validateServiceToken = servicetoken.ValidateServiceToken
 
 func GetUserAuthInfo(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
@@ -202,7 +206,15 @@ func ListAuthorizedEnvs(c *gin.Context) {
 	}
 }
 
-func GenerateUserAuthInfo(ctx *internalhandler.Context) error {
+func GenerateUserAuthInfo(c *gin.Context, ctx *internalhandler.Context) error {
+	if ctx.UserID == "" {
+		if _, err := validateServiceToken(c.GetHeader(setting.InternalServiceTokenHeader)); err != nil {
+			return fmt.Errorf("failed to validate internal service token: %w", err)
+		}
+		ctx.Resources = &user.AuthorizedResources{IsSystemAdmin: true}
+		return nil
+	}
+
 	resourceAuthInfo, err := userservice.GetUserAuthInfo(ctx.UserID, ctx.Logger)
 	if err != nil {
 		ctx.Logger.Errorf("Failed to generate user auth info for userID: %s, error is: %s", ctx.UserID, err)

--- a/pkg/microservice/user/core/handler/user/user.go
+++ b/pkg/microservice/user/core/handler/user/user.go
@@ -36,7 +36,7 @@ func SyncLdapUser(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	// this is local, so we simply generate user auth info from service
-	err := GenerateUserAuthInfo(ctx)
+	err := GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -76,7 +76,7 @@ func GetUser(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	// this is local, so we simply generate user auth info from service
-	err := GenerateUserAuthInfo(ctx)
+	err := GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -114,7 +114,7 @@ func OpenAPIGetUser(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	// this is local, so we simply generate user auth info from service
-	err := GenerateUserAuthInfo(ctx)
+	err := GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -153,7 +153,7 @@ func OpenAPIDeleteUser(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
-	err := GenerateUserAuthInfo(ctx)
+	err := GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -173,7 +173,7 @@ func DeleteUser(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	// this is local, so we simply generate user auth info from service
-	err := GenerateUserAuthInfo(ctx)
+	err := GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -245,7 +245,7 @@ func ListUsers(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	// this is local, so we simply generate user auth info from service
-	err := GenerateUserAuthInfo(ctx)
+	err := GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -304,7 +304,7 @@ func OpenAPIListUsersBrief(c *gin.Context) {
 	}
 
 	// this is local, so we simply generate user auth info from service
-	err = GenerateUserAuthInfo(ctx)
+	err = GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -365,7 +365,7 @@ func ListUsersBrief(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	// this is local, so we simply generate user auth info from service
-	err := GenerateUserAuthInfo(ctx)
+	err := GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -429,7 +429,7 @@ func CreateUser(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	// this is local, so we simply generate user auth info from service
-	err := GenerateUserAuthInfo(ctx)
+	err := GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -455,7 +455,7 @@ func UpdateUser(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	// this is local, so we simply generate user auth info from service
-	err := GenerateUserAuthInfo(ctx)
+	err := GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)

--- a/pkg/microservice/user/core/handler/user/user_group.go
+++ b/pkg/microservice/user/core/handler/user/user_group.go
@@ -48,7 +48,7 @@ func CreateUserGroup(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	// this is local, so we simply generate user auth info from service
-	err := GenerateUserAuthInfo(ctx)
+	err := GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -99,7 +99,7 @@ func OpenApiListUserGroups(c *gin.Context) {
 	ctx := internalhandler.NewContext(c)
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
-	err := GenerateUserAuthInfo(ctx)
+	err := GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -189,7 +189,7 @@ func GetUserGroup(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	// this is local, so we simply generate user auth info from service
-	err := GenerateUserAuthInfo(ctx)
+	err := GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -213,7 +213,7 @@ func UpdateUserGroupInfo(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	// this is local, so we simply generate user auth info from service
-	err := GenerateUserAuthInfo(ctx)
+	err := GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -248,7 +248,7 @@ func DeleteUserGroup(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	// this is local, so we simply generate user auth info from service
-	err := GenerateUserAuthInfo(ctx)
+	err := GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -285,7 +285,7 @@ func BulkAddUserToUserGroup(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	// this is local, so we simply generate user auth info from service
-	err := GenerateUserAuthInfo(ctx)
+	err := GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)
@@ -320,7 +320,7 @@ func BulkRemoveUserFromUserGroup(c *gin.Context) {
 	defer func() { internalhandler.JSONResponse(c, ctx) }()
 
 	// this is local, so we simply generate user auth info from service
-	err := GenerateUserAuthInfo(ctx)
+	err := GenerateUserAuthInfo(c, ctx)
 	if err != nil {
 		ctx.UnAuthorized = true
 		ctx.RespErr = fmt.Errorf("failed to generate user authorization info, error: %s", err)

--- a/pkg/microservice/user/core/service/login/token.go
+++ b/pkg/microservice/user/core/service/login/token.go
@@ -17,13 +17,9 @@ limitations under the License.
 package login
 
 import (
-	"fmt"
-
 	"github.com/golang-jwt/jwt"
 
 	"github.com/koderover/zadig/v2/pkg/config"
-	userconfig "github.com/koderover/zadig/v2/pkg/microservice/user/config"
-	"github.com/koderover/zadig/v2/pkg/setting"
 )
 
 type Claims struct {
@@ -43,30 +39,6 @@ type FederatedClaims struct {
 }
 
 func CreateToken(claims *Claims) (string, error) {
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	tokenString, err := token.SignedString([]byte(config.SecretKey()))
-	if err != nil {
-		return "", err
-	}
-	return tokenString, nil
-}
-
-func GetInternalToken(name string) (string, error) {
-	claims := &Claims{
-		Name:              name,
-		UID:               "",
-		Email:             fmt.Sprintf("%s@koderover.com", name),
-		PreferredUsername: name,
-		MFAVerified:       true,
-		StandardClaims: jwt.StandardClaims{
-			Audience:  setting.ProductName,
-			ExpiresAt: 0,
-		},
-		FederatedClaims: FederatedClaims{
-			ConnectorId: userconfig.SystemIdentityType,
-			UserId:      name,
-		},
-	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	tokenString, err := token.SignedString([]byte(config.SecretKey()))
 	if err != nil {

--- a/pkg/microservice/user/core/service/permission/authn.go
+++ b/pkg/microservice/user/core/service/permission/authn.go
@@ -32,16 +32,15 @@ import (
 )
 
 const (
-	larkWebhookURLRegExp         = `^\/api\/aslan\/system\/lark\/\w+\/webhook$`
-	dingTalkWebhookURLRegExp     = `^\/api\/aslan\/system\/dingtalk\/\w+\/webhook$`
-	workwxWebhookURLRegExp       = `^\/api\/aslan\/system\/workwx\/\w+\/webhook$`
-	getClusterAgentYamlURLRegExp = `^\/api\/aslan\/cluster\/agent\/\w+\/agent.yaml$`
-	envWorkloadUrlRegExp         = `^\/api\/aslan\/environment\/environments\/[\w-]+\/check\/workloads\/k8services$`
-	envShareEnableURLRegExp      = `^\/api\/aslan\/environment\/environments\/[\w-]+\/check\/sharenv\/enable\/ready$`
-	envShareDisableURLRegExp     = `^\/api\/aslan\/environment\/environments\/[\w-]+\/check\/sharenv\/disable\/ready$`
-	serviceDeployableURLRegExp   = `^\/api\/aslan\/service\/services\/[\w-]+\/environments\/deployable$`
-	generalWebhookURLRegExp      = `^\/api\/aslan\/workflow\/v4\/generalhook\/[\w-]+\/[^/]+\/webhook$`
-	codeHostAuthURLRegExp        = `^\/api\/v1\/codehosts\/\w+\/auth$`
+	larkWebhookURLRegExp       = `^\/api\/aslan\/system\/lark\/\w+\/webhook$`
+	dingTalkWebhookURLRegExp   = `^\/api\/aslan\/system\/dingtalk\/\w+\/webhook$`
+	workwxWebhookURLRegExp     = `^\/api\/aslan\/system\/workwx\/\w+\/webhook$`
+	envWorkloadUrlRegExp       = `^\/api\/aslan\/environment\/environments\/[\w-]+\/check\/workloads\/k8services$`
+	envShareEnableURLRegExp    = `^\/api\/aslan\/environment\/environments\/[\w-]+\/check\/sharenv\/enable\/ready$`
+	envShareDisableURLRegExp   = `^\/api\/aslan\/environment\/environments\/[\w-]+\/check\/sharenv\/disable\/ready$`
+	serviceDeployableURLRegExp = `^\/api\/aslan\/service\/services\/[\w-]+\/environments\/deployable$`
+	generalWebhookURLRegExp    = `^\/api\/aslan\/workflow\/v4\/generalhook\/[\w-]+\/[^/]+\/webhook$`
+	codeHostAuthURLRegExp      = `^\/api\/v1\/codehosts\/\w+\/auth$`
 	// workflowTestTaskReportURLRegExp = `^\/api\/aslan\/testing\/report\/workflowv4\/[\w-]+\/id\/\w+\/job\/[^/]+$`
 	// testingTaskReportURLRegExp      = `^\/api\/aslan\/testing\/testtask\/[\w-]+\/\w+\/[^/]+$`
 )
@@ -139,6 +138,10 @@ func IsPublicURL(reqPath, method string) bool {
 		return true
 	}
 
+	if realPath == "/api/aslan/cluster/agent/registries" && method == http.MethodGet {
+		return true
+	}
+
 	if realPath == "/api/v1/login" && (method == http.MethodGet || method == http.MethodPost) {
 		return true
 	}
@@ -226,11 +229,6 @@ func IsPublicURL(reqPath, method string) bool {
 		return true
 	}
 
-	match, _ = regexp.MatchString(getClusterAgentYamlURLRegExp, realPath)
-	if match && method == http.MethodGet {
-		return true
-	}
-
 	match, _ = regexp.MatchString(codeHostAuthURLRegExp, realPath)
 	if match && method == http.MethodGet {
 		return true
@@ -278,11 +276,6 @@ func ValidateToken(tokenString string) (*login.Claims, bool, error) {
 	}
 
 	if claims, ok := token.Claims.(*login.Claims); ok && token.Valid {
-		// internal tokens bypass runtime revocation checks
-		if isInternalTokenClaims(claims) {
-			return claims, true, nil
-		}
-
 		// short-lived login token: validate against redis cache
 		if claims.ExpiresAt-time.Now().Unix() < 8760*60*60 {
 			cachedToken, err := cache.NewRedisCache(userConfig.RedisUserTokenDB()).GetString(claims.UID)
@@ -313,13 +306,4 @@ func ValidateToken(tokenString string) (*login.Claims, bool, error) {
 		log.Errorf("invalid token detected")
 		return nil, false, fmt.Errorf("invalid token")
 	}
-}
-
-func isInternalTokenClaims(claims *login.Claims) bool {
-	return claims.ExpiresAt == 0 &&
-		(claims.Name == "aslan" && claims.PreferredUsername == "aslan" && claims.FederatedClaims.UserId == "aslan" && claims.Email == "aslan@koderover.com" ||
-			claims.Name == "user" && claims.PreferredUsername == "user" && claims.FederatedClaims.UserId == "user" && claims.Email == "user@koderover.com" ||
-			claims.Name == "cron" && claims.PreferredUsername == "cron" && claims.FederatedClaims.UserId == "cron" && claims.Email == "cron@koderover.com" ||
-			claims.Name == "hub-agent" && claims.PreferredUsername == "hub-agent" && claims.FederatedClaims.UserId == "hub-agent" && claims.Email == "hub-agent@koderover.com" ||
-			claims.Name == "hub-server" && claims.PreferredUsername == "hub-server" && claims.FederatedClaims.UserId == "hub-server" && claims.Email == "hub-server@koderover.com")
 }

--- a/pkg/microservice/user/core/service/permission/authz.go
+++ b/pkg/microservice/user/core/service/permission/authz.go
@@ -35,9 +35,8 @@ import (
 
 // GetUserAuthInfo get user auth info
 func GetUserAuthInfo(uid string, logger *zap.SugaredLogger) (*AuthorizedResources, error) {
-	// system calls
 	if uid == "" {
-		return generateAdminRoleResource(), nil
+		return nil, fmt.Errorf("empty user ID")
 	}
 
 	isSystemAdmin, err := checkUserIsSystemAdmin(uid, repository.DB)

--- a/pkg/microservice/user/core/service/permission/cluster_agent_token.go
+++ b/pkg/microservice/user/core/service/permission/cluster_agent_token.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package permission
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"regexp"
+	"sync"
+	"time"
+
+	globalConfig "github.com/koderover/zadig/v2/pkg/config"
+	"github.com/koderover/zadig/v2/pkg/tool/cache"
+)
+
+const (
+	ClusterAgentDownloadTokenQuery = "download_token"
+	ClusterAgentDownloadTokenTTL   = 5 * time.Minute
+	clusterAgentDownloadTokenKey   = "cluster-agent-yaml-token:"
+)
+
+var clusterAgentYamlURLRegexp = regexp.MustCompile(`^/api/aslan/cluster/agent/([\w-]+)/agent\.yaml$`)
+
+var clusterAgentDownloadTokenCache = sync.OnceValue(func() *cache.RedisCache {
+	return cache.NewIsolatedRedisCache(globalConfig.RedisCommonCacheTokenDB())
+})
+
+func ClusterIDFromAgentYamlPath(path string) (string, bool) {
+	match := clusterAgentYamlURLRegexp.FindStringSubmatch(path)
+	if len(match) != 2 {
+		return "", false
+	}
+	return match[1], true
+}
+
+func NewClusterAgentDownloadToken(clusterID string) (string, int64, error) {
+	expiresAt := time.Now().Add(ClusterAgentDownloadTokenTTL)
+	random := make([]byte, 32)
+	if _, err := rand.Read(random); err != nil {
+		return "", 0, err
+	}
+
+	token := base64.RawURLEncoding.EncodeToString(random)
+	err := clusterAgentDownloadTokenCache().Write(clusterAgentDownloadTokenCacheKey(token), clusterID, ClusterAgentDownloadTokenTTL)
+	if err != nil {
+		return "", 0, err
+	}
+	return token, expiresAt.Unix(), nil
+}
+
+func ValidateClusterAgentDownloadToken(clusterID, token string) (bool, error) {
+	if clusterID == "" || token == "" {
+		return false, nil
+	}
+	storedClusterID, err := clusterAgentDownloadTokenCache().GetString(clusterAgentDownloadTokenCacheKey(token))
+	if err != nil {
+		return false, err
+	}
+	return storedClusterID == clusterID, nil
+}
+
+func ConsumeClusterAgentDownloadToken(clusterID, token string) (bool, error) {
+	if clusterID == "" || token == "" {
+		return false, nil
+	}
+	return clusterAgentDownloadTokenCache().CompareAndDelete(clusterAgentDownloadTokenCacheKey(token), clusterID)
+}
+
+func clusterAgentDownloadTokenCacheKey(token string) string {
+	digest := sha256.Sum256([]byte(token))
+	return clusterAgentDownloadTokenKey + hex.EncodeToString(digest[:])
+}

--- a/pkg/microservice/user/server/grpc/server.go
+++ b/pkg/microservice/user/server/grpc/server.go
@@ -36,6 +36,8 @@ import (
 	"github.com/koderover/zadig/v2/pkg/microservice/user/config"
 	loginsvc "github.com/koderover/zadig/v2/pkg/microservice/user/core/service/login"
 	"github.com/koderover/zadig/v2/pkg/microservice/user/core/service/permission"
+	"github.com/koderover/zadig/v2/pkg/setting"
+	"github.com/koderover/zadig/v2/pkg/shared/servicetoken"
 	"github.com/koderover/zadig/v2/pkg/tool/cache"
 	"github.com/koderover/zadig/v2/pkg/tool/log"
 )
@@ -62,6 +64,27 @@ func (s *AuthServer) Check(ctx context.Context, request *ext_authz_v3.CheckReque
 
 	userToken := ""
 	var claims *loginsvc.Claims
+	if requestURL, err := url.Parse(requestPath); err == nil && method == http.MethodGet {
+		if clusterID, ok := permission.ClusterIDFromAgentYamlPath(requestURL.Path); ok {
+			downloadToken := requestURL.Query().Get(permission.ClusterAgentDownloadTokenQuery)
+			if downloadToken != "" {
+				valid, err := permission.ValidateClusterAgentDownloadToken(clusterID, downloadToken)
+				if err == nil && valid {
+					requestPath = requestURL.Path
+					goto allowed
+				}
+				return denyRequest(
+					requestURL.Path,
+					method,
+					body,
+					http.StatusUnauthorized,
+					"invalid cluster agent download token",
+					"",
+					err,
+				), nil
+			}
+		}
+	}
 
 	if !isPublicRequest {
 		if headers["authorization"] != "" {
@@ -99,6 +122,22 @@ func (s *AuthServer) Check(ctx context.Context, request *ext_authz_v3.CheckReque
 
 		// if no token is provided, respond with 401 unauthorized
 		if userToken == "" {
+			internalToken := headers[strings.ToLower(setting.InternalServiceTokenHeader)]
+			if internalToken != "" {
+				if _, err := servicetoken.ValidateServiceToken(internalToken); err == nil {
+					goto allowed
+				} else {
+					return denyRequest(
+						requestPath,
+						method,
+						body,
+						http.StatusUnauthorized,
+						"invalid internal service token",
+						"",
+						err,
+					), nil
+				}
+			}
 			return denyRequest(
 				requestPath,
 				method,
@@ -122,11 +161,6 @@ func (s *AuthServer) Check(ctx context.Context, request *ext_authz_v3.CheckReque
 					"",
 					err,
 				), nil
-			}
-
-			// validate if internal token
-			if isInternalToken(claims) {
-				goto allowed
 			}
 
 			// if the expiration time is so huge that it is not possible, it is a constant api token, we don't check for the redis.
@@ -192,7 +226,6 @@ allowed:
 		zap.String("path", requestPath),
 		zap.String("method", method),
 		zap.String("body", body),
-		zap.String("token", userToken),
 	)
 
 	return resp, nil
@@ -263,18 +296,6 @@ func isMFAGateBypassURL(requestPath, method string) bool {
 func stripQuery(path string) string {
 	segments := strings.Split(path, "?")
 	return segments[0]
-}
-
-func isInternalToken(claims *loginsvc.Claims) bool {
-	if claims == nil {
-		return false
-	}
-	return claims.ExpiresAt == 0 &&
-		(claims.Name == "aslan" && claims.PreferredUsername == "aslan" && claims.FederatedClaims.UserId == "aslan" && claims.Email == "aslan@koderover.com" ||
-			claims.Name == "user" && claims.PreferredUsername == "user" && claims.FederatedClaims.UserId == "user" && claims.Email == "user@koderover.com" ||
-			claims.Name == "cron" && claims.PreferredUsername == "cron" && claims.FederatedClaims.UserId == "cron" && claims.Email == "cron@koderover.com" ||
-			claims.Name == "hub-agent" && claims.PreferredUsername == "hub-agent" && claims.FederatedClaims.UserId == "hub-agent" && claims.Email == "hub-agent@koderover.com" ||
-			claims.Name == "hub-server" && claims.PreferredUsername == "hub-server" && claims.FederatedClaims.UserId == "hub-server" && claims.Email == "hub-server@koderover.com")
 }
 
 func denyRequest(requestPath, method, body string, statusCode int, reason, responseReason string, err error) *ext_authz_v3.CheckResponse {

--- a/pkg/middleware/gin/request_log.go
+++ b/pkg/middleware/gin/request_log.go
@@ -32,7 +32,15 @@ import (
 
 const timeISO8601 = "2006-01-02T15:04:05.000Z0700"
 
-var sensitiveHeaders = sets.NewString("authorization", "cookie", "token", "session")
+var sensitiveHeaders = sets.NewString(
+	"authorization",
+	"cookie",
+	"token",
+	"session",
+	strings.ToLower(setting.InternalServiceTokenHeader),
+	strings.ToLower(setting.Token),
+	strings.ToLower(setting.Params),
+)
 
 func RequestLog(logger *zap.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {

--- a/pkg/setting/consts.go
+++ b/pkg/setting/consts.go
@@ -78,13 +78,17 @@ const (
 
 	// hubagent
 	HubAgentToken         = "HUB_AGENT_TOKEN"
+	AslanAgentToken       = "ASLAN_AGENT_TOKEN"
 	HubServerBaseAddr     = "HUB_SERVER_BASE_ADDR"
 	KubernetesServiceHost = "KUBERNETES_SERVICE_HOST"
 	KubernetesServicePort = "KUBERNETES_SERVICE_PORT"
 	Token                 = "X-API-Tunnel-Token"
 	Params                = "X-API-Tunnel-Params"
 	AslanBaseAddr         = "ASLAN_BASE_ADDR"
-	ScheduleWorkflow      = "SCHEDULE_WORKFLOW"
+
+	// internal service token
+	InternalServiceTokenHeader = "X-Internal-Service-Token"
+	ScheduleWorkflow           = "SCHEDULE_WORKFLOW"
 
 	// warpdrive
 	WarpDrivePodName    = "WD_POD_NAME"

--- a/pkg/shared/client/aslan/client.go
+++ b/pkg/shared/client/aslan/client.go
@@ -19,6 +19,7 @@ package aslan
 import (
 	"crypto/tls"
 
+	"github.com/koderover/zadig/v2/pkg/shared/servicetoken"
 	"github.com/koderover/zadig/v2/pkg/tool/httpclient"
 )
 
@@ -32,7 +33,8 @@ type Client struct {
 
 func New(host string) *Client {
 	c := httpclient.New(
-		httpclient.SetHostURL(host + "/api"),
+		httpclient.SetHostURL(host+"/api"),
+		servicetoken.HeaderOption(),
 	)
 
 	return &Client{

--- a/pkg/shared/client/label/client.go
+++ b/pkg/shared/client/label/client.go
@@ -18,6 +18,7 @@ package label
 
 import (
 	"github.com/koderover/zadig/v2/pkg/config"
+	"github.com/koderover/zadig/v2/pkg/shared/servicetoken"
 	"github.com/koderover/zadig/v2/pkg/tool/httpclient"
 )
 
@@ -30,7 +31,8 @@ type Client struct {
 func New() *Client {
 	host := config.AslanServiceAddress()
 	c := httpclient.New(
-		httpclient.SetHostURL(host + "/api"),
+		httpclient.SetHostURL(host+"/api"),
+		servicetoken.HeaderOption(),
 	)
 
 	return &Client{

--- a/pkg/shared/client/systemconfig/client.go
+++ b/pkg/shared/client/systemconfig/client.go
@@ -18,6 +18,7 @@ package systemconfig
 
 import (
 	"github.com/koderover/zadig/v2/pkg/config"
+	"github.com/koderover/zadig/v2/pkg/shared/servicetoken"
 	"github.com/koderover/zadig/v2/pkg/tool/httpclient"
 )
 
@@ -30,7 +31,8 @@ type Client struct {
 func New() *Client {
 	host := config.AslanServiceAddress()
 	c := httpclient.New(
-		httpclient.SetHostURL(host + "/api/v1"),
+		httpclient.SetHostURL(host+"/api/v1"),
+		servicetoken.HeaderOption(),
 	)
 
 	return &Client{

--- a/pkg/shared/client/user/client.go
+++ b/pkg/shared/client/user/client.go
@@ -18,6 +18,7 @@ package user
 
 import (
 	"github.com/koderover/zadig/v2/pkg/config"
+	"github.com/koderover/zadig/v2/pkg/shared/servicetoken"
 	"github.com/koderover/zadig/v2/pkg/tool/httpclient"
 )
 
@@ -31,7 +32,8 @@ func New() *Client {
 	host := config.UserServiceAddress()
 
 	c := httpclient.New(
-		httpclient.SetHostURL(host + "/api/v1"),
+		httpclient.SetHostURL(host+"/api/v1"),
+		servicetoken.HeaderOption(),
 	)
 
 	return &Client{

--- a/pkg/shared/handler/base.go
+++ b/pkg/shared/handler/base.go
@@ -36,6 +36,7 @@ import (
 	systemmodels "github.com/koderover/zadig/v2/pkg/microservice/aslan/core/system/repository/models"
 	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/shared/client/user"
+	"github.com/koderover/zadig/v2/pkg/shared/servicetoken"
 	"github.com/koderover/zadig/v2/pkg/tool/log"
 	"github.com/koderover/zadig/v2/pkg/types"
 	"github.com/koderover/zadig/v2/pkg/util/ginzap"
@@ -135,11 +136,20 @@ func NewContext(c *gin.Context) *Context {
 // This function should only be called when one need authorization information for api caller.
 func NewContextWithAuthorization(c *gin.Context) (*Context, error) {
 	logger := ginzap.WithContext(c).Sugar()
-	var resourceAuthInfo *user.AuthorizedResources
-	var err error
 	resp := NewContext(c)
-	// there is a case where the request does not have token (system call), in this case we will have admin access
-	resourceAuthInfo, err = user.New().GetUserAuthInfo(resp.UserID)
+
+	// A request without a user token is an internal (pod-to-pod) service call. It must present a
+	// valid internal service token; we no longer grant admin on an empty user id.
+	if resp.UserID == "" {
+		if _, err := servicetoken.ValidateServiceToken(c.GetHeader(setting.InternalServiceTokenHeader)); err != nil {
+			logger.Warnf("failed to validate internal service token, error: %s", err)
+			return resp, err
+		}
+		resp.Resources = &user.AuthorizedResources{IsSystemAdmin: true}
+		return resp, nil
+	}
+
+	resourceAuthInfo, err := user.New().GetUserAuthInfo(resp.UserID)
 	if err != nil {
 		logger.Errorf("failed to generate user authorization info, error: %s", err)
 		return resp, err

--- a/pkg/shared/servicetoken/header.go
+++ b/pkg/shared/servicetoken/header.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The KodeRover Authors.
+Copyright 2026 The KodeRover Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,24 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package aslan
+package servicetoken
 
 import (
+	"fmt"
+
+	"github.com/go-resty/resty/v2"
+
 	"github.com/koderover/zadig/v2/pkg/setting"
 	"github.com/koderover/zadig/v2/pkg/tool/httpclient"
 )
 
-func (c *Client) ListRegistries(token string) ([]*RegistryInfo, error) {
-	url := "/cluster/agent/registries"
-	res := make([]*RegistryInfo, 0)
-
-	_, err := c.Get(url,
-		httpclient.SetHeader(setting.Token, token),
-		httpclient.SetResult(&res),
-	)
-	if err != nil {
-		return nil, err
+// HeaderOption adds the current service's persisted token to internal HTTP requests.
+func HeaderOption() httpclient.ClientFunc {
+	return func(c *httpclient.Client) {
+		c.Client.OnBeforeRequest(func(_ *resty.Client, request *resty.Request) error {
+			token, err := CurrentInternalToken()
+			if err != nil {
+				return fmt.Errorf("failed to get internal service token: %w", err)
+			}
+			request.SetHeader(setting.InternalServiceTokenHeader, token)
+			return nil
+		})
 	}
-
-	return res, nil
 }

--- a/pkg/shared/servicetoken/service_token.go
+++ b/pkg/shared/servicetoken/service_token.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 The KodeRover Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicetoken
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/koderover/zadig/v2/pkg/config"
+	"github.com/koderover/zadig/v2/pkg/tool/crypto"
+	mongotool "github.com/koderover/zadig/v2/pkg/tool/mongo"
+)
+
+const collectionName = "internal_service_token"
+
+// InternalServiceToken is the persisted form of a per-service internal token. Name is the
+// document ID so concurrent service replicas cannot create different tokens for the same service.
+type InternalServiceToken struct {
+	Name      string `bson:"_id"`
+	Token     string `bson:"token"`
+	TokenHash string `bson:"token_hash"`
+}
+
+var tokenCache sync.Map
+
+// GetInternalToken returns the persisted opaque token for a service, creating it when needed.
+// Service replicas with the same executable name share the same database record and token.
+func GetInternalToken(name string) (string, error) {
+	if name == "" {
+		return "", errors.New("empty service name")
+	}
+	if token, ok := tokenCache.Load(name); ok {
+		return token.(string), nil
+	}
+
+	coll := mongotool.Database(config.MongoDatabase()).Collection(collectionName)
+
+	var existing InternalServiceToken
+	err := coll.FindOne(context.TODO(), bson.M{"_id": name}).Decode(&existing)
+	if err == nil {
+		return cacheToken(existing)
+	} else if err != mongo.ErrNoDocuments {
+		return "", err
+	}
+
+	token, err := newToken()
+	if err != nil {
+		return "", err
+	}
+	_, err = coll.UpdateOne(
+		context.TODO(),
+		bson.M{"_id": name},
+		bson.M{"$setOnInsert": bson.M{"token": token, "token_hash": crypto.Sha256([]byte(token))}},
+		options.Update().SetUpsert(true),
+	)
+	if err != nil && !mongo.IsDuplicateKeyError(err) {
+		return "", err
+	}
+
+	// Read the winner back. This also handles another replica inserting the same service first.
+	if err := coll.FindOne(context.TODO(), bson.M{"_id": name}).Decode(&existing); err != nil {
+		return "", err
+	}
+	return cacheToken(existing)
+}
+
+// CurrentInternalToken gets the token for the current Zadig binary. Container binaries have
+// stable service names such as aslan, user, cron and init.
+func CurrentInternalToken() (string, error) {
+	return GetInternalToken(filepath.Base(os.Args[0]))
+}
+
+// ValidateServiceToken authenticates an internal token by possession and returns the service
+// name it belongs to. An empty, unknown or forged token returns an error.
+func ValidateServiceToken(token string) (string, error) {
+	if token == "" {
+		return "", errors.New("empty internal service token")
+	}
+	coll := mongotool.Database(config.MongoDatabase()).Collection(collectionName)
+	var doc InternalServiceToken
+	err := coll.FindOne(context.TODO(), bson.M{"token_hash": crypto.Sha256([]byte(token))}).Decode(&doc)
+	if err != nil {
+		return "", fmt.Errorf("internal service token not found: %w", err)
+	}
+	if subtle.ConstantTimeCompare([]byte(doc.Token), []byte(token)) != 1 {
+		return "", errors.New("internal service token mismatch")
+	}
+
+	return doc.Name, nil
+}
+
+func cacheToken(doc InternalServiceToken) (string, error) {
+	if crypto.Sha256([]byte(doc.Token)) != doc.TokenHash {
+		return "", errors.New("internal service token is corrupted")
+	}
+	tokenCache.Store(doc.Name, doc.Token)
+	return doc.Token, nil
+}
+
+func newToken() (string, error) {
+	random := make([]byte, 32)
+	if _, err := rand.Read(random); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(random), nil
+}

--- a/pkg/tool/cache/redis_cache.go
+++ b/pkg/tool/cache/redis_cache.go
@@ -51,6 +51,21 @@ func NewRedisCache(db int) *RedisCache {
 	return &RedisCache{redisClient: redisClient}
 }
 
+// NewIsolatedRedisCache creates a client that is not shared with the package-level cache.
+func NewIsolatedRedisCache(db int) *RedisCache {
+	redisConfig := &redis.Options{
+		Addr: fmt.Sprintf("%s:%d", config.RedisHost(), config.RedisPort()),
+		DB:   db,
+	}
+	if config.RedisUserName() != "" {
+		redisConfig.Username = config.RedisUserName()
+	}
+	if config.RedisPassword() != "" {
+		redisConfig.Password = config.RedisPassword()
+	}
+	return &RedisCache{redisClient: redis.NewClient(redisConfig)}
+}
+
 func (c *RedisCache) Write(key, val string, ttl time.Duration) error {
 	_, err := c.redisClient.Set(context.TODO(), key, val, ttl).Result()
 	return err
@@ -116,6 +131,18 @@ func (c *RedisCache) HGetAllString(key string) (map[string]string, error) {
 
 func (c *RedisCache) Delete(key string) error {
 	return c.redisClient.Del(context.TODO(), key).Err()
+}
+
+// CompareAndDelete deletes key only when its value matches expected.
+func (c *RedisCache) CompareAndDelete(key, expected string) (bool, error) {
+	const script = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+end
+return 0`
+
+	deleted, err := c.redisClient.Eval(context.TODO(), script, []string{key}, expected).Int()
+	return deleted == 1, err
 }
 
 func (c *RedisCache) HDelete(key, field string) error {

--- a/pkg/tool/crypto/sha1.go
+++ b/pkg/tool/crypto/sha1.go
@@ -18,11 +18,18 @@ package crypto
 
 import (
 	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 )
 
 func Sha1(b []byte) string {
 	s := sha1.New()
+	s.Write(b)
+	return hex.EncodeToString(s.Sum(nil))
+}
+
+func Sha256(b []byte) string {
+	s := sha256.New()
 	s.Write(b)
 	return hex.EncodeToString(s.Sum(nil))
 }


### PR DESCRIPTION
### What this PR does / Why we need it:

Fixes a pre-auth privilege escalation and RCE risk caused by exposing `SECRET_KEY` in the public agent YAML.

### What is changed and how it works?

- Protects agent YAML with permission checks and short-lived, one-time download tokens.
- Removes `SECRET_KEY` from agent YAML.
- Uses a separate cluster token for hub-agent requests.
- Replaces internal JWTs with persisted random service tokens.
- Prevents requests with an empty user ID from receiving administrator privileges.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4971)
<!-- Reviewable:end -->
