### PR TITLE
fix(workflow): preserve WorkWX approval node details

### DIFF
--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -809,6 +810,11 @@ func waitForWorkWXApprove(ctx context.Context, spec *commonmodels.JobTaskApprova
 			}
 			if detail == nil {
 				continue
+			}
+			approvalNodeDetails := detail.ApprovalNodeDetails()
+			if !reflect.DeepEqual(spec.WorkWXApproval.ApprovalNodeDetails, approvalNodeDetails) {
+				spec.WorkWXApproval.ApprovalNodeDetails = approvalNodeDetails
+				ack()
 			}
 
 			switch detail.Status {

--- a/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
+++ b/pkg/microservice/aslan/core/common/service/workflowcontroller/jobcontroller/job_approval.go
@@ -783,6 +783,7 @@ func waitForWorkWXApprove(ctx context.Context, spec *commonmodels.JobTaskApprova
 		return config.StatusFailed, fmt.Errorf("create approval instance failed, error: %s", err)
 	}
 	spec.WorkWXApproval.InstanceID = instanceID
+	spec.WorkWXApproval.ApprovalNodeDetails = workwx.PendingApprovalNodeDetails(approval.ApprovalNodes)
 	ack()
 	log.Infof("waitForWorkWXApprove: create instance success, id %s", instanceID)
 
@@ -812,7 +813,7 @@ func waitForWorkWXApprove(ctx context.Context, spec *commonmodels.JobTaskApprova
 				continue
 			}
 			approvalNodeDetails := detail.ApprovalNodeDetails()
-			if !reflect.DeepEqual(spec.WorkWXApproval.ApprovalNodeDetails, approvalNodeDetails) {
+			if len(approvalNodeDetails) > 0 && !reflect.DeepEqual(spec.WorkWXApproval.ApprovalNodeDetails, approvalNodeDetails) {
 				spec.WorkWXApproval.ApprovalNodeDetails = approvalNodeDetails
 				ack()
 			}

--- a/pkg/tool/workwx/types.go
+++ b/pkg/tool/workwx/types.go
@@ -254,6 +254,54 @@ type ApprovalDetail struct {
 		UserID       string `json:"userid"`
 		DepartmentID string `json:"partyid"`
 	} `json:"applyer"`
+	Records []*ApprovalRecord `json:"sp_record"`
+}
+
+type ApprovalRecord struct {
+	Status       ApprovalNodeStatus      `json:"sp_status"`
+	ApproverAttr ApprovalRel             `json:"approverattr"`
+	Details      []*ApprovalRecordDetail `json:"details"`
+}
+
+type ApprovalRecordDetail struct {
+	Approver struct {
+		UserID string `json:"userid"`
+	} `json:"approver"`
+	Speech    string                `json:"speech"`
+	Status    ApprovalSubNodeStatus `json:"sp_status"`
+	Timestamp int64                 `json:"sptime"`
+}
+
+func (d *ApprovalDetail) ApprovalNodeDetails() []*ApprovalNode {
+	nodes := make([]*ApprovalNode, 0, len(d.Records))
+	for _, record := range d.Records {
+		if record == nil {
+			continue
+		}
+
+		node := &ApprovalNode{
+			Type:     ApprovalTypeApprove,
+			ApvRel:   record.ApproverAttr,
+			Status:   record.Status,
+			SubNodes: make([]*ApprovalSubNode, 0, len(record.Details)),
+		}
+		for _, detail := range record.Details {
+			if detail == nil {
+				continue
+			}
+
+			subNode := &ApprovalSubNode{
+				Speech:    detail.Speech,
+				Status:    detail.Status,
+				Timestamp: detail.Timestamp,
+			}
+			subNode.UserInfo.UserID = detail.Approver.UserID
+			node.SubNodes = append(node.SubNodes, subNode)
+		}
+		nodes = append(nodes, node)
+	}
+
+	return nodes
 }
 
 type EncryptedWebhookMessage struct {

--- a/pkg/tool/workwx/types.go
+++ b/pkg/tool/workwx/types.go
@@ -272,6 +272,43 @@ type ApprovalRecordDetail struct {
 	Timestamp int64                 `json:"sptime"`
 }
 
+func PendingApprovalNodeDetails(nodes []*ApprovalNode) []*ApprovalNode {
+	details := make([]*ApprovalNode, 0, len(nodes))
+	for _, node := range nodes {
+		if node == nil {
+			continue
+		}
+
+		detail := &ApprovalNode{
+			Type:     node.Type,
+			ApvRel:   node.ApvRel,
+			Status:   ApprovalNodeStatusWaiting,
+			SubNodes: make([]*ApprovalSubNode, 0, len(node.UserID)),
+		}
+		for _, userID := range node.UserID {
+			subNode := &ApprovalSubNode{Status: ApprovalSubNodeStatusWaiting}
+			subNode.UserInfo.UserID = userID
+			detail.SubNodes = append(detail.SubNodes, subNode)
+		}
+		details = append(details, detail)
+	}
+
+	return details
+}
+
+func approvalRelFromRecord(attr ApprovalRel) ApprovalRel {
+	// sp_record.approverattr uses 1 for OR and 2 for AND, while
+	// process.apv_rel (and Zadig) uses 1 for AND and 2 for OR.
+	switch attr {
+	case ApprovalRelAnd:
+		return ApprovalRelOr
+	case ApprovalRelOr:
+		return ApprovalRelAnd
+	default:
+		return attr
+	}
+}
+
 func (d *ApprovalDetail) ApprovalNodeDetails() []*ApprovalNode {
 	nodes := make([]*ApprovalNode, 0, len(d.Records))
 	for _, record := range d.Records {
@@ -281,7 +318,7 @@ func (d *ApprovalDetail) ApprovalNodeDetails() []*ApprovalNode {
 
 		node := &ApprovalNode{
 			Type:     ApprovalTypeApprove,
-			ApvRel:   record.ApproverAttr,
+			ApvRel:   approvalRelFromRecord(record.ApproverAttr),
 			Status:   record.Status,
 			SubNodes: make([]*ApprovalSubNode, 0, len(record.Details)),
 		}


### PR DESCRIPTION
### What this PR does / Why we need it:

Fixes missing `approval_node_details` for WorkWX approval jobs after approval status handling switched to active polling.

### What is changed and how it works?

Parses approval records from the WorkWX approval detail response, converts them to the existing approval node structure, and persists them only when the details change.

### Does this PR introduce a user-facing change?

- [ ] API change
- [ ] database schema change
- [ ] upgrade assistant change  
- [ ] change in non-functional attributes such as efficiency or availability
- [ ] fix of a previous issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koderover/zadig/4977)
<!-- Reviewable:end -->
